### PR TITLE
[receiver/mongodbreceiver] Mongodbreceiver metric enhancements

### DIFF
--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -59,5 +59,9 @@ The full list of settings exposed for this receiver are documented [here](./conf
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 
+The metrics `mongodb.global_lock.time` and `mongodb.index.access.count` will only be collected when using a mongodb instance 4.0+.
+
+For mongodb, is it recommended to set up a least privilege user (LPU) with a [`clusterMonitor` role](https://www.mongodb.com/docs/v5.0/reference/built-in-roles/#mongodb-authrole-clusterMonitor) in order to collect metrics. An example setup can be found in [lpu.sh](./testdata/integration/scripts/lpu.sh).
+
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -23,6 +23,10 @@ This receiver supports MongoDB versions:
 - 4.0+
 - 5.0
 
+Mongodb recommends to set up a least privilege user (LPU) with a [`clusterMonitor` role](https://www.mongodb.com/docs/v5.0/reference/built-in-roles/#mongodb-authrole-clusterMonitor) in order to collect metrics. Please refer to [lpu.sh](./testdata/integration/scripts/lpu.sh) for an example of how to configure these permissions.
+
+Collecting metrics `mongodb.global_lock.time` and `mongodb.index.access.count` are only available for mongodb 4.0+.
+
 ## Configuration
 
 The following settings are optional:
@@ -58,10 +62,6 @@ The full list of settings exposed for this receiver are documented [here](./conf
 ## Metrics
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
-
-The metrics `mongodb.global_lock.time` and `mongodb.index.access.count` will only be collected when using a mongodb instance 4.0+.
-
-For mongodb, is it recommended to set up a least privilege user (LPU) with a [`clusterMonitor` role](https://www.mongodb.com/docs/v5.0/reference/built-in-roles/#mongodb-authrole-clusterMonitor) in order to collect metrics. An example setup can be found in [lpu.sh](./testdata/integration/scripts/lpu.sh).
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/mongodbreceiver/client.go
+++ b/receiver/mongodbreceiver/client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
@@ -99,7 +100,7 @@ func (c *mongodbClient) ListCollectionNames(ctx context.Context, database string
 func (c *mongodbClient) IndexStats(ctx context.Context, database, collectionName string) ([]bson.M, error) {
 	db := c.Client.Database(database)
 	collection := db.Collection(collectionName)
-	cursor, err := collection.Aggregate(context.Background(), mongo.Pipeline{bson.D{{"$indexStats", bson.M{}}}})
+	cursor, err := collection.Aggregate(context.Background(), mongo.Pipeline{bson.D{primitive.E{Key: "$indexStats", Value: bson.M{}}}})
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/mongodbreceiver/client.go
+++ b/receiver/mongodbreceiver/client.go
@@ -29,10 +29,13 @@ import (
 // client is an interface that exposes functionality towards a mongo environment
 type client interface {
 	ListDatabaseNames(ctx context.Context, filters interface{}, opts ...*options.ListDatabasesOptions) ([]string, error)
+	ListCollectionNames(ctx context.Context, DBName string) ([]string, error)
 	Disconnect(context.Context) error
 	GetVersion(context.Context) (*version.Version, error)
 	ServerStatus(ctx context.Context, DBName string) (bson.M, error)
 	DBStats(ctx context.Context, DBName string) (bson.M, error)
+	TopStats(ctx context.Context) (bson.M, error)
+	IndexStats(ctx context.Context, DBName, collectionName string) ([]bson.M, error)
 }
 
 // mongodbClient is a mongodb metric scraper client
@@ -77,6 +80,36 @@ func (c *mongodbClient) ServerStatus(ctx context.Context, database string) (bson
 // more information can be found here: https://docs.mongodb.com/manual/reference/command/dbStats/
 func (c *mongodbClient) DBStats(ctx context.Context, database string) (bson.M, error) {
 	return c.RunCommand(ctx, database, bson.M{"dbStats": 1})
+}
+
+// TopStats is an admin command that return the result of db.adminCommand({ top: 1 })
+// more information can be found here: https://www.mongodb.com/docs/manual/reference/command/top/
+func (c *mongodbClient) TopStats(ctx context.Context) (bson.M, error) {
+	return c.RunCommand(ctx, "admin", bson.M{"top": 1})
+}
+
+// ListCollectionNames returns a list of collection names for a given database
+// more information can be found here: https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.9.0/mongo#Database.ListCollectionNames
+func (c *mongodbClient) ListCollectionNames(ctx context.Context, database string) ([]string, error) {
+	return c.Database(database).ListCollectionNames(ctx, bson.M{})
+}
+
+// IndexStats returns the index stats per collection for a given database
+// more information can be found here: https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexStats/
+func (c *mongodbClient) IndexStats(ctx context.Context, database, collectionName string) ([]bson.M, error) {
+	db := c.Client.Database(database)
+	collection := db.Collection(collectionName)
+	cursor, err := collection.Aggregate(context.Background(), mongo.Pipeline{bson.D{{"$indexStats", bson.M{}}}})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var indexStats []bson.M
+	if err = cursor.All(context.Background(), &indexStats); err != nil {
+		return nil, err
+	}
+	return indexStats, nil
 }
 
 // GetVersion returns a result of the version of mongo the client is connected to so adjustments in collection protocol can

--- a/receiver/mongodbreceiver/client.go
+++ b/receiver/mongodbreceiver/client.go
@@ -90,9 +90,11 @@ func (c *mongodbClient) TopStats(ctx context.Context) (bson.M, error) {
 }
 
 // ListCollectionNames returns a list of collection names for a given database
+// SetAuthorizedCollections allows a user without the required privilege to run the command ListCollections.
 // more information can be found here: https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.9.0/mongo#Database.ListCollectionNames
 func (c *mongodbClient) ListCollectionNames(ctx context.Context, database string) ([]string, error) {
-	return c.Database(database).ListCollectionNames(ctx, bson.M{})
+	lcOpts := options.ListCollections().SetAuthorizedCollections(true)
+	return c.Database(database).ListCollectionNames(context.Background(), bson.D{}, lcOpts)
 }
 
 // IndexStats returns the index stats per collection for a given database

--- a/receiver/mongodbreceiver/client_test.go
+++ b/receiver/mongodbreceiver/client_test.go
@@ -16,6 +16,7 @@ package mongodbreceiver // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"testing"
 
@@ -36,6 +37,11 @@ type fakeClient struct{ mock.Mock }
 
 func (fc *fakeClient) ListDatabaseNames(ctx context.Context, filters interface{}, opts ...*options.ListDatabasesOptions) ([]string, error) {
 	args := fc.Called(ctx, filters, opts)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (fc *fakeClient) ListCollectionNames(ctx context.Context, dbName string) ([]string, error) {
+	args := fc.Called(ctx, dbName)
 	return args.Get(0).([]string), args.Error(1)
 }
 
@@ -61,6 +67,16 @@ func (fc *fakeClient) ServerStatus(ctx context.Context, dbName string) (bson.M, 
 func (fc *fakeClient) DBStats(ctx context.Context, dbName string) (bson.M, error) {
 	args := fc.Called(ctx, dbName)
 	return args.Get(0).(bson.M), args.Error(1)
+}
+
+func (fc *fakeClient) TopStats(ctx context.Context) (bson.M, error) {
+	args := fc.Called(ctx)
+	return args.Get(0).(bson.M), args.Error(1)
+}
+
+func (fc *fakeClient) IndexStats(ctx context.Context, dbName, collectionName string) ([]bson.M, error) {
+	args := fc.Called(ctx, dbName, collectionName)
+	return args.Get(0).([]bson.M), args.Error(1)
 }
 
 func TestListDatabaseNames(t *testing.T) {
@@ -96,6 +112,7 @@ type commandString = string
 const (
 	dbStatsType      commandString = "dbStats"
 	serverStatusType commandString = "serverStatus"
+	topType          commandString = "top"
 )
 
 func TestRunCommands(t *testing.T) {
@@ -105,6 +122,8 @@ func TestRunCommands(t *testing.T) {
 	loadedDbStats, err := loadDBStats()
 	require.NoError(t, err)
 	loadedServerStatus, err := loadServerStatus()
+	require.NoError(t, err)
+	loadedTop, err := loadTop()
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -129,6 +148,14 @@ func TestRunCommands(t *testing.T) {
 				require.Equal(t, int32(0), m["mem"].(bson.M)["mapped"])
 			},
 		},
+		{
+			desc:     "top success",
+			cmd:      topType,
+			response: loadedTop,
+			validate: func(t *testing.T, m bson.M) {
+				require.Equal(t, int32(540), m["totals"].(bson.M)["local.oplog.rs"].(bson.M)["commands"].(bson.M)["time"])
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -142,8 +169,10 @@ func TestRunCommands(t *testing.T) {
 			var result bson.M
 			if tc.cmd == serverStatusType {
 				result, err = client.ServerStatus(context.Background(), "test")
-			} else {
+			} else if tc.cmd == dbStatsType {
 				result, err = client.DBStats(context.Background(), "test")
+			} else if tc.cmd == topType {
+				result, err = client.TopStats(context.Background())
 			}
 			require.NoError(t, err)
 			if tc.validate != nil {
@@ -235,6 +264,30 @@ func loadServerStatus() (bson.D, error) {
 
 func loadServerStatusAsMap() (bson.M, error) {
 	return loadTestFileAsMap("./testdata/serverStatus.json")
+}
+
+func loadTop() (bson.D, error) {
+	return loadTestFile("./testdata/top.json")
+}
+
+func loadTopAsMap() (bson.M, error) {
+	return loadTestFileAsMap("./testdata/top.json")
+}
+
+func loadIndexStatsAsMap(collectionName string) ([]bson.M, error) {
+	indexStats := []bson.M{}
+	if collectionName == "products" {
+		indexStats0, _ := loadTestFileAsMap("./testdata/productsIndexStats0.json")
+		indexStats = append(indexStats, indexStats0)
+	} else if collectionName == "orders" {
+		indexStats0, _ := loadTestFileAsMap("./testdata/ordersIndexStats0.json")
+		indexStats1, _ := loadTestFileAsMap("./testdata/ordersIndexStats1.json")
+		indexStats2, _ := loadTestFileAsMap("./testdata/ordersIndexStats2.json")
+		indexStats = append(indexStats, indexStats0, indexStats1, indexStats2)
+	} else {
+		return nil, errors.New("failed to load index stats from an unknown collection name")
+	}
+	return indexStats, nil
 }
 
 func loadBuildInfo() (bson.D, error) {

--- a/receiver/mongodbreceiver/client_test.go
+++ b/receiver/mongodbreceiver/client_test.go
@@ -167,11 +167,12 @@ func TestRunCommands(t *testing.T) {
 				logger: zap.NewNop(),
 			}
 			var result bson.M
-			if tc.cmd == serverStatusType {
+			switch tc.cmd {
+			case serverStatusType:
 				result, err = client.ServerStatus(context.Background(), "test")
-			} else if tc.cmd == dbStatsType {
+			case dbStatsType:
 				result, err = client.DBStats(context.Background(), "test")
-			} else if tc.cmd == topType {
+			case topType:
 				result, err = client.TopStats(context.Background())
 			}
 			require.NoError(t, err)
@@ -276,15 +277,16 @@ func loadTopAsMap() (bson.M, error) {
 
 func loadIndexStatsAsMap(collectionName string) ([]bson.M, error) {
 	indexStats := []bson.M{}
-	if collectionName == "products" {
+	switch collectionName {
+	case "products":
 		indexStats0, _ := loadTestFileAsMap("./testdata/productsIndexStats0.json")
 		indexStats = append(indexStats, indexStats0)
-	} else if collectionName == "orders" {
+	case "orders":
 		indexStats0, _ := loadTestFileAsMap("./testdata/ordersIndexStats0.json")
 		indexStats1, _ := loadTestFileAsMap("./testdata/ordersIndexStats1.json")
 		indexStats2, _ := loadTestFileAsMap("./testdata/ordersIndexStats2.json")
 		indexStats = append(indexStats, indexStats0, indexStats1, indexStats2)
-	} else {
+	default:
 		return nil, errors.New("failed to load index stats from an unknown collection name")
 	}
 	return indexStats, nil

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -15,9 +15,7 @@ These are the metrics available for this scraper.
 | **mongodb.cursor.timeout.count** | The number of cursors that have timed out. | {cursors} | Sum(Int) | <ul> </ul> |
 | **mongodb.data.size** | The size of the collection. Data compression does not affect this value. | By | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.database.count** | The number of existing databases. | {databases} | Sum(Int) | <ul> </ul> |
-| **mongodb.document.delete.count** | The number of documents deleted. | {documents} | Sum(Int) | <ul> <li>database</li> </ul> |
-| **mongodb.document.insert.count** | The number of documents inserted. | {documents} | Sum(Int) | <ul> <li>database</li> </ul> |
-| **mongodb.document.update.count** | The number of documents updated. | {documents} | Sum(Int) | <ul> <li>database</li> </ul> |
+| **mongodb.document.operation.count** | The number of documents operations executed. | {documents} | Sum(Int) | <ul> <li>database</li> <li>operation</li> </ul> |
 | **mongodb.extent.count** | The number of extents. | {extents} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.global_lock.time** | The time the global lock has been held. | ms | Sum(Int) | <ul> </ul> |
 | **mongodb.index.access.count** | The number of times an index has been accessed. | {accesses} | Sum(Int) | <ul> <li>database</li> <li>collection</li> </ul> |

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -10,7 +10,6 @@ These are the metrics available for this scraper.
 | ---- | ----------- | ---- | ---- | ---------- |
 | **mongodb.cache.operations** | The number of cache operations of the instance. | {operations} | Sum(Int) | <ul> <li>type</li> </ul> |
 | **mongodb.collection.count** | The number of collections. | {collections} | Sum(Int) | <ul> <li>database</li> </ul> |
-| **mongodb.connection.available** | The number of unused connections. | {connections} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.connection.count** | The number of connections. | {connections} | Sum(Int) | <ul> <li>database</li> <li>connection_type</li> </ul> |
 | **mongodb.cursor.count** | The number of open cursors maintained for clients. | {cursors} | Sum(Int) | <ul> </ul> |
 | **mongodb.cursor.timeout.count** | The number of cursors that have timed out. | {cursors} | Sum(Int) | <ul> </ul> |
@@ -20,10 +19,8 @@ These are the metrics available for this scraper.
 | **mongodb.document.insert.count** | The number of documents inserted. | {documents} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.document.update.count** | The number of documents updated. | {documents} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.extent.count** | The number of extents. | {extents} | Sum(Int) | <ul> <li>database</li> </ul> |
-| **mongodb.flush.count** | The number of times the database has flushed writes to disk. | {flushes} | Sum(Int) | <ul> <li>database</li> </ul> |
-| **mongodb.flush.time** | The total amount of time spent flushing writes to disk. | ms | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.global_lock.time** | The time the global lock has been held. | ms | Sum(Int) | <ul> </ul> |
-| **mongodb.index.access.count** | The number of times an index has been accessed. | {accesses} | Sum(Int) | <ul> <li>database</li> <li>type</li> </ul> |
+| **mongodb.index.access.count** | The number of times an index has been accessed. | {accesses} | Sum(Int) | <ul> <li>database</li> <li>collection</li> </ul> |
 | **mongodb.index.count** | The number of indexes. | {indexes} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.index.size** | Sum of the space allocated to all indexes in the database, including free index space. | By | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.memory.usage** | The amount of memory used. | By | Sum(Int) | <ul> <li>database</li> <li>memory_type</li> </ul> |
@@ -55,6 +52,7 @@ metrics:
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
+| collection | The name of a collection. |  |
 | connection_type (type) | The status of the connection. | active, available, current |
 | database | The name of a database. |  |
 | memory_type (type) | The type of memory used. | resident, virtual |

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -10,15 +10,30 @@ These are the metrics available for this scraper.
 | ---- | ----------- | ---- | ---- | ---------- |
 | **mongodb.cache.operations** | The number of cache operations of the instance. | {operations} | Sum(Int) | <ul> <li>type</li> </ul> |
 | **mongodb.collection.count** | The number of collections. | {collections} | Sum(Int) | <ul> <li>database</li> </ul> |
+| **mongodb.connection.available** | The number of unused connections. | {connections} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.connection.count** | The number of connections. | {connections} | Sum(Int) | <ul> <li>database</li> <li>connection_type</li> </ul> |
+| **mongodb.cursor.count** | The number of open cursors maintained for clients. | {cursors} | Sum(Int) | <ul> </ul> |
+| **mongodb.cursor.timeout.count** | The number of cursors that have timed out. | {cursors} | Sum(Int) | <ul> </ul> |
 | **mongodb.data.size** | The size of the collection. Data compression does not affect this value. | By | Sum(Int) | <ul> <li>database</li> </ul> |
+| **mongodb.database.count** | The number of existing databases. | {databases} | Sum(Int) | <ul> </ul> |
+| **mongodb.document.delete.count** | The number of documents deleted. | {documents} | Sum(Int) | <ul> <li>database</li> </ul> |
+| **mongodb.document.insert.count** | The number of documents inserted. | {documents} | Sum(Int) | <ul> <li>database</li> </ul> |
+| **mongodb.document.update.count** | The number of documents updated. | {documents} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.extent.count** | The number of extents. | {extents} | Sum(Int) | <ul> <li>database</li> </ul> |
+| **mongodb.flush.count** | The number of times the database has flushed writes to disk. | {flushes} | Sum(Int) | <ul> <li>database</li> </ul> |
+| **mongodb.flush.time** | The total amount of time spent flushing writes to disk. | ms | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.global_lock.time** | The time the global lock has been held. | ms | Sum(Int) | <ul> </ul> |
+| **mongodb.index.access.count** | The number of times an index has been accessed. | {accesses} | Sum(Int) | <ul> <li>database</li> <li>type</li> </ul> |
 | **mongodb.index.count** | The number of indexes. | {indexes} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.index.size** | Sum of the space allocated to all indexes in the database, including free index space. | By | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.memory.usage** | The amount of memory used. | By | Sum(Int) | <ul> <li>database</li> <li>memory_type</li> </ul> |
+| **mongodb.network.io.receive** | The number of bytes received. | By | Sum(Int) | <ul> </ul> |
+| **mongodb.network.io.transmit** | The number of by transmitted. | By | Sum(Int) | <ul> </ul> |
+| **mongodb.network.request.count** | The number of requests received by the server. | {requests} | Sum(Int) | <ul> </ul> |
 | **mongodb.object.count** | The number of objects. | {objects} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.operation.count** | The number of operations executed. | {operations} | Sum(Int) | <ul> <li>operation</li> </ul> |
+| **mongodb.operation.time** | The total time spent performing operations. | ms | Sum(Int) | <ul> <li>operation</li> </ul> |
+| **mongodb.session.count** | The total number of active sessions. | {sessions} | Sum(Int) | <ul> </ul> |
 | **mongodb.storage.size** | The total amount of storage allocated to this collection. If collection data is compressed it reflects the compressed size. | By | Sum(Int) | <ul> <li>database</li> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -15,7 +15,7 @@ These are the metrics available for this scraper.
 | **mongodb.cursor.timeout.count** | The number of cursors that have timed out. | {cursors} | Sum(Int) | <ul> </ul> |
 | **mongodb.data.size** | The size of the collection. Data compression does not affect this value. | By | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.database.count** | The number of existing databases. | {databases} | Sum(Int) | <ul> </ul> |
-| **mongodb.document.operation.count** | The number of documents operations executed. | {documents} | Sum(Int) | <ul> <li>database</li> <li>operation</li> </ul> |
+| **mongodb.document.operation.count** | The number of document operations executed. | {documents} | Sum(Int) | <ul> <li>database</li> <li>operation</li> </ul> |
 | **mongodb.extent.count** | The number of extents. | {extents} | Sum(Int) | <ul> <li>database</li> </ul> |
 | **mongodb.global_lock.time** | The time the global lock has been held. | ms | Sum(Int) | <ul> </ul> |
 | **mongodb.index.access.count** | The number of times an index has been accessed. | {accesses} | Sum(Int) | <ul> <li>database</li> <li>collection</li> </ul> |

--- a/receiver/mongodbreceiver/integration_test.go
+++ b/receiver/mongodbreceiver/integration_test.go
@@ -142,6 +142,10 @@ func getContainer(t *testing.T, req testcontainers.ContainerRequest) testcontain
 		})
 	require.NoError(t, err)
 
+	code, err := container.Exec(context.Background(), []string{"/setup.sh"})
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+
 	err = container.Start(context.Background())
 	require.NoError(t, err)
 	return container

--- a/receiver/mongodbreceiver/integration_test.go
+++ b/receiver/mongodbreceiver/integration_test.go
@@ -42,7 +42,7 @@ var (
 			Dockerfile: "Dockerfile.mongodb.2_6",
 		},
 		ExposedPorts: []string{"27017:27017"},
-		WaitingFor:   wait.ForListeningPort("27017").WithStartupTimeout(8 * time.Minute),
+		WaitingFor:   wait.ForListeningPort("27017").WithStartupTimeout(2 * time.Minute),
 	}
 	containerRequest3_0 = testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
@@ -50,7 +50,7 @@ var (
 			Dockerfile: "Dockerfile.mongodb.3_0",
 		},
 		ExposedPorts: []string{"27117:27017"},
-		WaitingFor:   wait.ForListeningPort("27017").WithStartupTimeout(8 * time.Minute),
+		WaitingFor:   wait.ForListeningPort("27017").WithStartupTimeout(2 * time.Minute),
 	}
 	containerRequest4_0 = testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
@@ -97,7 +97,7 @@ func TestMongodbIntegration(t *testing.T) {
 		require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
 		require.Eventuallyf(t, func() bool {
 			return len(consumer.AllMetrics()) > 0
-		}, 8*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
+		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
 		require.NoError(t, rcvr.Shutdown(context.Background()))
 
 		actualMetrics := consumer.AllMetrics()[0]
@@ -135,7 +135,7 @@ func TestMongodbIntegration(t *testing.T) {
 		require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
 		require.Eventuallyf(t, func() bool {
 			return len(consumer.AllMetrics()) > 0
-		}, 8*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
+		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
 		require.NoError(t, rcvr.Shutdown(context.Background()))
 
 		actualMetrics := consumer.AllMetrics()[0]

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
@@ -17,18 +17,33 @@ type MetricSettings struct {
 
 // MetricsSettings provides settings for mongodbreceiver metrics.
 type MetricsSettings struct {
-	MongodbCacheOperations MetricSettings `mapstructure:"mongodb.cache.operations"`
-	MongodbCollectionCount MetricSettings `mapstructure:"mongodb.collection.count"`
-	MongodbConnectionCount MetricSettings `mapstructure:"mongodb.connection.count"`
-	MongodbDataSize        MetricSettings `mapstructure:"mongodb.data.size"`
-	MongodbExtentCount     MetricSettings `mapstructure:"mongodb.extent.count"`
-	MongodbGlobalLockTime  MetricSettings `mapstructure:"mongodb.global_lock.time"`
-	MongodbIndexCount      MetricSettings `mapstructure:"mongodb.index.count"`
-	MongodbIndexSize       MetricSettings `mapstructure:"mongodb.index.size"`
-	MongodbMemoryUsage     MetricSettings `mapstructure:"mongodb.memory.usage"`
-	MongodbObjectCount     MetricSettings `mapstructure:"mongodb.object.count"`
-	MongodbOperationCount  MetricSettings `mapstructure:"mongodb.operation.count"`
-	MongodbStorageSize     MetricSettings `mapstructure:"mongodb.storage.size"`
+	MongodbCacheOperations     MetricSettings `mapstructure:"mongodb.cache.operations"`
+	MongodbCollectionCount     MetricSettings `mapstructure:"mongodb.collection.count"`
+	MongodbConnectionAvailable MetricSettings `mapstructure:"mongodb.connection.available"`
+	MongodbConnectionCount     MetricSettings `mapstructure:"mongodb.connection.count"`
+	MongodbCursorCount         MetricSettings `mapstructure:"mongodb.cursor.count"`
+	MongodbCursorTimeoutCount  MetricSettings `mapstructure:"mongodb.cursor.timeout.count"`
+	MongodbDataSize            MetricSettings `mapstructure:"mongodb.data.size"`
+	MongodbDatabaseCount       MetricSettings `mapstructure:"mongodb.database.count"`
+	MongodbDocumentDeleteCount MetricSettings `mapstructure:"mongodb.document.delete.count"`
+	MongodbDocumentInsertCount MetricSettings `mapstructure:"mongodb.document.insert.count"`
+	MongodbDocumentUpdateCount MetricSettings `mapstructure:"mongodb.document.update.count"`
+	MongodbExtentCount         MetricSettings `mapstructure:"mongodb.extent.count"`
+	MongodbFlushCount          MetricSettings `mapstructure:"mongodb.flush.count"`
+	MongodbFlushTime           MetricSettings `mapstructure:"mongodb.flush.time"`
+	MongodbGlobalLockTime      MetricSettings `mapstructure:"mongodb.global_lock.time"`
+	MongodbIndexAccessCount    MetricSettings `mapstructure:"mongodb.index.access.count"`
+	MongodbIndexCount          MetricSettings `mapstructure:"mongodb.index.count"`
+	MongodbIndexSize           MetricSettings `mapstructure:"mongodb.index.size"`
+	MongodbMemoryUsage         MetricSettings `mapstructure:"mongodb.memory.usage"`
+	MongodbNetworkIoReceive    MetricSettings `mapstructure:"mongodb.network.io.receive"`
+	MongodbNetworkIoTransmit   MetricSettings `mapstructure:"mongodb.network.io.transmit"`
+	MongodbNetworkRequestCount MetricSettings `mapstructure:"mongodb.network.request.count"`
+	MongodbObjectCount         MetricSettings `mapstructure:"mongodb.object.count"`
+	MongodbOperationCount      MetricSettings `mapstructure:"mongodb.operation.count"`
+	MongodbOperationTime       MetricSettings `mapstructure:"mongodb.operation.time"`
+	MongodbSessionCount        MetricSettings `mapstructure:"mongodb.session.count"`
+	MongodbStorageSize         MetricSettings `mapstructure:"mongodb.storage.size"`
 }
 
 func DefaultMetricsSettings() MetricsSettings {
@@ -39,16 +54,46 @@ func DefaultMetricsSettings() MetricsSettings {
 		MongodbCollectionCount: MetricSettings{
 			Enabled: true,
 		},
+		MongodbConnectionAvailable: MetricSettings{
+			Enabled: true,
+		},
 		MongodbConnectionCount: MetricSettings{
+			Enabled: true,
+		},
+		MongodbCursorCount: MetricSettings{
+			Enabled: true,
+		},
+		MongodbCursorTimeoutCount: MetricSettings{
 			Enabled: true,
 		},
 		MongodbDataSize: MetricSettings{
 			Enabled: true,
 		},
+		MongodbDatabaseCount: MetricSettings{
+			Enabled: true,
+		},
+		MongodbDocumentDeleteCount: MetricSettings{
+			Enabled: true,
+		},
+		MongodbDocumentInsertCount: MetricSettings{
+			Enabled: true,
+		},
+		MongodbDocumentUpdateCount: MetricSettings{
+			Enabled: true,
+		},
 		MongodbExtentCount: MetricSettings{
 			Enabled: true,
 		},
+		MongodbFlushCount: MetricSettings{
+			Enabled: true,
+		},
+		MongodbFlushTime: MetricSettings{
+			Enabled: true,
+		},
 		MongodbGlobalLockTime: MetricSettings{
+			Enabled: true,
+		},
+		MongodbIndexAccessCount: MetricSettings{
 			Enabled: true,
 		},
 		MongodbIndexCount: MetricSettings{
@@ -60,10 +105,25 @@ func DefaultMetricsSettings() MetricsSettings {
 		MongodbMemoryUsage: MetricSettings{
 			Enabled: true,
 		},
+		MongodbNetworkIoReceive: MetricSettings{
+			Enabled: true,
+		},
+		MongodbNetworkIoTransmit: MetricSettings{
+			Enabled: true,
+		},
+		MongodbNetworkRequestCount: MetricSettings{
+			Enabled: true,
+		},
 		MongodbObjectCount: MetricSettings{
 			Enabled: true,
 		},
 		MongodbOperationCount: MetricSettings{
+			Enabled: true,
+		},
+		MongodbOperationTime: MetricSettings{
+			Enabled: true,
+		},
+		MongodbSessionCount: MetricSettings{
 			Enabled: true,
 		},
 		MongodbStorageSize: MetricSettings{
@@ -302,6 +362,59 @@ func newMetricMongodbCollectionCount(settings MetricSettings) metricMongodbColle
 	return m
 }
 
+type metricMongodbConnectionAvailable struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.connection.available metric with initial data.
+func (m *metricMongodbConnectionAvailable) init() {
+	m.data.SetName("mongodb.connection.available")
+	m.data.SetDescription("The number of unused connections.")
+	m.data.SetUnit("{connections}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricMongodbConnectionAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbConnectionAvailable) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbConnectionAvailable) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbConnectionAvailable(settings MetricSettings) metricMongodbConnectionAvailable {
+	m := metricMongodbConnectionAvailable{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMongodbConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -349,6 +462,108 @@ func (m *metricMongodbConnectionCount) emit(metrics pmetric.MetricSlice) {
 
 func newMetricMongodbConnectionCount(settings MetricSettings) metricMongodbConnectionCount {
 	m := metricMongodbConnectionCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbCursorCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.cursor.count metric with initial data.
+func (m *metricMongodbCursorCount) init() {
+	m.data.SetName("mongodb.cursor.count")
+	m.data.SetDescription("The number of open cursors maintained for clients.")
+	m.data.SetUnit("{cursors}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbCursorCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbCursorCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbCursorCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbCursorCount(settings MetricSettings) metricMongodbCursorCount {
+	m := metricMongodbCursorCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbCursorTimeoutCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.cursor.timeout.count metric with initial data.
+func (m *metricMongodbCursorTimeoutCount) init() {
+	m.data.SetName("mongodb.cursor.timeout.count")
+	m.data.SetDescription("The number of cursors that have timed out.")
+	m.data.SetUnit("{cursors}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbCursorTimeoutCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbCursorTimeoutCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbCursorTimeoutCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbCursorTimeoutCount(settings MetricSettings) metricMongodbCursorTimeoutCount {
+	m := metricMongodbCursorTimeoutCount{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -409,6 +624,216 @@ func newMetricMongodbDataSize(settings MetricSettings) metricMongodbDataSize {
 	return m
 }
 
+type metricMongodbDatabaseCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.database.count metric with initial data.
+func (m *metricMongodbDatabaseCount) init() {
+	m.data.SetName("mongodb.database.count")
+	m.data.SetDescription("The number of existing databases.")
+	m.data.SetUnit("{databases}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbDatabaseCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbDatabaseCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbDatabaseCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbDatabaseCount(settings MetricSettings) metricMongodbDatabaseCount {
+	m := metricMongodbDatabaseCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbDocumentDeleteCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.document.delete.count metric with initial data.
+func (m *metricMongodbDocumentDeleteCount) init() {
+	m.data.SetName("mongodb.document.delete.count")
+	m.data.SetDescription("The number of documents deleted.")
+	m.data.SetUnit("{documents}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricMongodbDocumentDeleteCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbDocumentDeleteCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbDocumentDeleteCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbDocumentDeleteCount(settings MetricSettings) metricMongodbDocumentDeleteCount {
+	m := metricMongodbDocumentDeleteCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbDocumentInsertCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.document.insert.count metric with initial data.
+func (m *metricMongodbDocumentInsertCount) init() {
+	m.data.SetName("mongodb.document.insert.count")
+	m.data.SetDescription("The number of documents inserted.")
+	m.data.SetUnit("{documents}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricMongodbDocumentInsertCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbDocumentInsertCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbDocumentInsertCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbDocumentInsertCount(settings MetricSettings) metricMongodbDocumentInsertCount {
+	m := metricMongodbDocumentInsertCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbDocumentUpdateCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.document.update.count metric with initial data.
+func (m *metricMongodbDocumentUpdateCount) init() {
+	m.data.SetName("mongodb.document.update.count")
+	m.data.SetDescription("The number of documents updated.")
+	m.data.SetUnit("{documents}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricMongodbDocumentUpdateCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbDocumentUpdateCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbDocumentUpdateCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbDocumentUpdateCount(settings MetricSettings) metricMongodbDocumentUpdateCount {
+	m := metricMongodbDocumentUpdateCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMongodbExtentCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -462,6 +887,112 @@ func newMetricMongodbExtentCount(settings MetricSettings) metricMongodbExtentCou
 	return m
 }
 
+type metricMongodbFlushCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.flush.count metric with initial data.
+func (m *metricMongodbFlushCount) init() {
+	m.data.SetName("mongodb.flush.count")
+	m.data.SetDescription("The number of times the database has flushed writes to disk.")
+	m.data.SetUnit("{flushes}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricMongodbFlushCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbFlushCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbFlushCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbFlushCount(settings MetricSettings) metricMongodbFlushCount {
+	m := metricMongodbFlushCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbFlushTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.flush.time metric with initial data.
+func (m *metricMongodbFlushTime) init() {
+	m.data.SetName("mongodb.flush.time")
+	m.data.SetDescription("The total amount of time spent flushing writes to disk.")
+	m.data.SetUnit("ms")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricMongodbFlushTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbFlushTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbFlushTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbFlushTime(settings MetricSettings) metricMongodbFlushTime {
+	m := metricMongodbFlushTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMongodbGlobalLockTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -506,6 +1037,60 @@ func (m *metricMongodbGlobalLockTime) emit(metrics pmetric.MetricSlice) {
 
 func newMetricMongodbGlobalLockTime(settings MetricSettings) metricMongodbGlobalLockTime {
 	m := metricMongodbGlobalLockTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbIndexAccessCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.index.access.count metric with initial data.
+func (m *metricMongodbIndexAccessCount) init() {
+	m.data.SetName("mongodb.index.access.count")
+	m.data.SetDescription("The number of times an index has been accessed.")
+	m.data.SetUnit("{accesses}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricMongodbIndexAccessCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, typeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(typeAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbIndexAccessCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbIndexAccessCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbIndexAccessCount(settings MetricSettings) metricMongodbIndexAccessCount {
+	m := metricMongodbIndexAccessCount{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -673,6 +1258,159 @@ func newMetricMongodbMemoryUsage(settings MetricSettings) metricMongodbMemoryUsa
 	return m
 }
 
+type metricMongodbNetworkIoReceive struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.network.io.receive metric with initial data.
+func (m *metricMongodbNetworkIoReceive) init() {
+	m.data.SetName("mongodb.network.io.receive")
+	m.data.SetDescription("The number of bytes received.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbNetworkIoReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbNetworkIoReceive) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbNetworkIoReceive) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbNetworkIoReceive(settings MetricSettings) metricMongodbNetworkIoReceive {
+	m := metricMongodbNetworkIoReceive{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbNetworkIoTransmit struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.network.io.transmit metric with initial data.
+func (m *metricMongodbNetworkIoTransmit) init() {
+	m.data.SetName("mongodb.network.io.transmit")
+	m.data.SetDescription("The number of by transmitted.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbNetworkIoTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbNetworkIoTransmit) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbNetworkIoTransmit) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbNetworkIoTransmit(settings MetricSettings) metricMongodbNetworkIoTransmit {
+	m := metricMongodbNetworkIoTransmit{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbNetworkRequestCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.network.request.count metric with initial data.
+func (m *metricMongodbNetworkRequestCount) init() {
+	m.data.SetName("mongodb.network.request.count")
+	m.data.SetDescription("The number of requests received by the server.")
+	m.data.SetUnit("{requests}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbNetworkRequestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbNetworkRequestCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbNetworkRequestCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbNetworkRequestCount(settings MetricSettings) metricMongodbNetworkRequestCount {
+	m := metricMongodbNetworkRequestCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMongodbObjectCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -779,6 +1517,110 @@ func newMetricMongodbOperationCount(settings MetricSettings) metricMongodbOperat
 	return m
 }
 
+type metricMongodbOperationTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.operation.time metric with initial data.
+func (m *metricMongodbOperationTime) init() {
+	m.data.SetName("mongodb.operation.time")
+	m.data.SetDescription("The total time spent performing operations.")
+	m.data.SetUnit("ms")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricMongodbOperationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbOperationTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbOperationTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbOperationTime(settings MetricSettings) metricMongodbOperationTime {
+	m := metricMongodbOperationTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbSessionCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.session.count metric with initial data.
+func (m *metricMongodbSessionCount) init() {
+	m.data.SetName("mongodb.session.count")
+	m.data.SetDescription("The total number of active sessions.")
+	m.data.SetUnit("{sessions}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbSessionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbSessionCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbSessionCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbSessionCount(settings MetricSettings) metricMongodbSessionCount {
+	m := metricMongodbSessionCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMongodbStorageSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -835,23 +1677,38 @@ func newMetricMongodbStorageSize(settings MetricSettings) metricMongodbStorageSi
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                    pcommon.Timestamp   // start time that will be applied to all recorded data points.
-	metricsCapacity              int                 // maximum observed number of metrics per resource.
-	resourceCapacity             int                 // maximum observed number of resource attributes.
-	metricsBuffer                pmetric.Metrics     // accumulates metrics data before emitting.
-	buildInfo                    component.BuildInfo // contains version information
-	metricMongodbCacheOperations metricMongodbCacheOperations
-	metricMongodbCollectionCount metricMongodbCollectionCount
-	metricMongodbConnectionCount metricMongodbConnectionCount
-	metricMongodbDataSize        metricMongodbDataSize
-	metricMongodbExtentCount     metricMongodbExtentCount
-	metricMongodbGlobalLockTime  metricMongodbGlobalLockTime
-	metricMongodbIndexCount      metricMongodbIndexCount
-	metricMongodbIndexSize       metricMongodbIndexSize
-	metricMongodbMemoryUsage     metricMongodbMemoryUsage
-	metricMongodbObjectCount     metricMongodbObjectCount
-	metricMongodbOperationCount  metricMongodbOperationCount
-	metricMongodbStorageSize     metricMongodbStorageSize
+	startTime                        pcommon.Timestamp   // start time that will be applied to all recorded data points.
+	metricsCapacity                  int                 // maximum observed number of metrics per resource.
+	resourceCapacity                 int                 // maximum observed number of resource attributes.
+	metricsBuffer                    pmetric.Metrics     // accumulates metrics data before emitting.
+	buildInfo                        component.BuildInfo // contains version information
+	metricMongodbCacheOperations     metricMongodbCacheOperations
+	metricMongodbCollectionCount     metricMongodbCollectionCount
+	metricMongodbConnectionAvailable metricMongodbConnectionAvailable
+	metricMongodbConnectionCount     metricMongodbConnectionCount
+	metricMongodbCursorCount         metricMongodbCursorCount
+	metricMongodbCursorTimeoutCount  metricMongodbCursorTimeoutCount
+	metricMongodbDataSize            metricMongodbDataSize
+	metricMongodbDatabaseCount       metricMongodbDatabaseCount
+	metricMongodbDocumentDeleteCount metricMongodbDocumentDeleteCount
+	metricMongodbDocumentInsertCount metricMongodbDocumentInsertCount
+	metricMongodbDocumentUpdateCount metricMongodbDocumentUpdateCount
+	metricMongodbExtentCount         metricMongodbExtentCount
+	metricMongodbFlushCount          metricMongodbFlushCount
+	metricMongodbFlushTime           metricMongodbFlushTime
+	metricMongodbGlobalLockTime      metricMongodbGlobalLockTime
+	metricMongodbIndexAccessCount    metricMongodbIndexAccessCount
+	metricMongodbIndexCount          metricMongodbIndexCount
+	metricMongodbIndexSize           metricMongodbIndexSize
+	metricMongodbMemoryUsage         metricMongodbMemoryUsage
+	metricMongodbNetworkIoReceive    metricMongodbNetworkIoReceive
+	metricMongodbNetworkIoTransmit   metricMongodbNetworkIoTransmit
+	metricMongodbNetworkRequestCount metricMongodbNetworkRequestCount
+	metricMongodbObjectCount         metricMongodbObjectCount
+	metricMongodbOperationCount      metricMongodbOperationCount
+	metricMongodbOperationTime       metricMongodbOperationTime
+	metricMongodbSessionCount        metricMongodbSessionCount
+	metricMongodbStorageSize         metricMongodbStorageSize
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -866,21 +1723,36 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		startTime:                    pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                pmetric.NewMetrics(),
-		buildInfo:                    buildInfo,
-		metricMongodbCacheOperations: newMetricMongodbCacheOperations(settings.MongodbCacheOperations),
-		metricMongodbCollectionCount: newMetricMongodbCollectionCount(settings.MongodbCollectionCount),
-		metricMongodbConnectionCount: newMetricMongodbConnectionCount(settings.MongodbConnectionCount),
-		metricMongodbDataSize:        newMetricMongodbDataSize(settings.MongodbDataSize),
-		metricMongodbExtentCount:     newMetricMongodbExtentCount(settings.MongodbExtentCount),
-		metricMongodbGlobalLockTime:  newMetricMongodbGlobalLockTime(settings.MongodbGlobalLockTime),
-		metricMongodbIndexCount:      newMetricMongodbIndexCount(settings.MongodbIndexCount),
-		metricMongodbIndexSize:       newMetricMongodbIndexSize(settings.MongodbIndexSize),
-		metricMongodbMemoryUsage:     newMetricMongodbMemoryUsage(settings.MongodbMemoryUsage),
-		metricMongodbObjectCount:     newMetricMongodbObjectCount(settings.MongodbObjectCount),
-		metricMongodbOperationCount:  newMetricMongodbOperationCount(settings.MongodbOperationCount),
-		metricMongodbStorageSize:     newMetricMongodbStorageSize(settings.MongodbStorageSize),
+		startTime:                        pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                    pmetric.NewMetrics(),
+		buildInfo:                        buildInfo,
+		metricMongodbCacheOperations:     newMetricMongodbCacheOperations(settings.MongodbCacheOperations),
+		metricMongodbCollectionCount:     newMetricMongodbCollectionCount(settings.MongodbCollectionCount),
+		metricMongodbConnectionAvailable: newMetricMongodbConnectionAvailable(settings.MongodbConnectionAvailable),
+		metricMongodbConnectionCount:     newMetricMongodbConnectionCount(settings.MongodbConnectionCount),
+		metricMongodbCursorCount:         newMetricMongodbCursorCount(settings.MongodbCursorCount),
+		metricMongodbCursorTimeoutCount:  newMetricMongodbCursorTimeoutCount(settings.MongodbCursorTimeoutCount),
+		metricMongodbDataSize:            newMetricMongodbDataSize(settings.MongodbDataSize),
+		metricMongodbDatabaseCount:       newMetricMongodbDatabaseCount(settings.MongodbDatabaseCount),
+		metricMongodbDocumentDeleteCount: newMetricMongodbDocumentDeleteCount(settings.MongodbDocumentDeleteCount),
+		metricMongodbDocumentInsertCount: newMetricMongodbDocumentInsertCount(settings.MongodbDocumentInsertCount),
+		metricMongodbDocumentUpdateCount: newMetricMongodbDocumentUpdateCount(settings.MongodbDocumentUpdateCount),
+		metricMongodbExtentCount:         newMetricMongodbExtentCount(settings.MongodbExtentCount),
+		metricMongodbFlushCount:          newMetricMongodbFlushCount(settings.MongodbFlushCount),
+		metricMongodbFlushTime:           newMetricMongodbFlushTime(settings.MongodbFlushTime),
+		metricMongodbGlobalLockTime:      newMetricMongodbGlobalLockTime(settings.MongodbGlobalLockTime),
+		metricMongodbIndexAccessCount:    newMetricMongodbIndexAccessCount(settings.MongodbIndexAccessCount),
+		metricMongodbIndexCount:          newMetricMongodbIndexCount(settings.MongodbIndexCount),
+		metricMongodbIndexSize:           newMetricMongodbIndexSize(settings.MongodbIndexSize),
+		metricMongodbMemoryUsage:         newMetricMongodbMemoryUsage(settings.MongodbMemoryUsage),
+		metricMongodbNetworkIoReceive:    newMetricMongodbNetworkIoReceive(settings.MongodbNetworkIoReceive),
+		metricMongodbNetworkIoTransmit:   newMetricMongodbNetworkIoTransmit(settings.MongodbNetworkIoTransmit),
+		metricMongodbNetworkRequestCount: newMetricMongodbNetworkRequestCount(settings.MongodbNetworkRequestCount),
+		metricMongodbObjectCount:         newMetricMongodbObjectCount(settings.MongodbObjectCount),
+		metricMongodbOperationCount:      newMetricMongodbOperationCount(settings.MongodbOperationCount),
+		metricMongodbOperationTime:       newMetricMongodbOperationTime(settings.MongodbOperationTime),
+		metricMongodbSessionCount:        newMetricMongodbSessionCount(settings.MongodbSessionCount),
+		metricMongodbStorageSize:         newMetricMongodbStorageSize(settings.MongodbStorageSize),
 	}
 	for _, op := range options {
 		op(mb)
@@ -942,15 +1814,30 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricMongodbCacheOperations.emit(ils.Metrics())
 	mb.metricMongodbCollectionCount.emit(ils.Metrics())
+	mb.metricMongodbConnectionAvailable.emit(ils.Metrics())
 	mb.metricMongodbConnectionCount.emit(ils.Metrics())
+	mb.metricMongodbCursorCount.emit(ils.Metrics())
+	mb.metricMongodbCursorTimeoutCount.emit(ils.Metrics())
 	mb.metricMongodbDataSize.emit(ils.Metrics())
+	mb.metricMongodbDatabaseCount.emit(ils.Metrics())
+	mb.metricMongodbDocumentDeleteCount.emit(ils.Metrics())
+	mb.metricMongodbDocumentInsertCount.emit(ils.Metrics())
+	mb.metricMongodbDocumentUpdateCount.emit(ils.Metrics())
 	mb.metricMongodbExtentCount.emit(ils.Metrics())
+	mb.metricMongodbFlushCount.emit(ils.Metrics())
+	mb.metricMongodbFlushTime.emit(ils.Metrics())
 	mb.metricMongodbGlobalLockTime.emit(ils.Metrics())
+	mb.metricMongodbIndexAccessCount.emit(ils.Metrics())
 	mb.metricMongodbIndexCount.emit(ils.Metrics())
 	mb.metricMongodbIndexSize.emit(ils.Metrics())
 	mb.metricMongodbMemoryUsage.emit(ils.Metrics())
+	mb.metricMongodbNetworkIoReceive.emit(ils.Metrics())
+	mb.metricMongodbNetworkIoTransmit.emit(ils.Metrics())
+	mb.metricMongodbNetworkRequestCount.emit(ils.Metrics())
 	mb.metricMongodbObjectCount.emit(ils.Metrics())
 	mb.metricMongodbOperationCount.emit(ils.Metrics())
+	mb.metricMongodbOperationTime.emit(ils.Metrics())
+	mb.metricMongodbSessionCount.emit(ils.Metrics())
 	mb.metricMongodbStorageSize.emit(ils.Metrics())
 	for _, op := range rmo {
 		op(rm)
@@ -981,9 +1868,24 @@ func (mb *MetricsBuilder) RecordMongodbCollectionCountDataPoint(ts pcommon.Times
 	mb.metricMongodbCollectionCount.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
 }
 
+// RecordMongodbConnectionAvailableDataPoint adds a data point to mongodb.connection.available metric.
+func (mb *MetricsBuilder) RecordMongodbConnectionAvailableDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	mb.metricMongodbConnectionAvailable.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
+}
+
 // RecordMongodbConnectionCountDataPoint adds a data point to mongodb.connection.count metric.
 func (mb *MetricsBuilder) RecordMongodbConnectionCountDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string, connectionTypeAttributeValue AttributeConnectionType) {
 	mb.metricMongodbConnectionCount.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue, connectionTypeAttributeValue.String())
+}
+
+// RecordMongodbCursorCountDataPoint adds a data point to mongodb.cursor.count metric.
+func (mb *MetricsBuilder) RecordMongodbCursorCountDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbCursorCount.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbCursorTimeoutCountDataPoint adds a data point to mongodb.cursor.timeout.count metric.
+func (mb *MetricsBuilder) RecordMongodbCursorTimeoutCountDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbCursorTimeoutCount.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordMongodbDataSizeDataPoint adds a data point to mongodb.data.size metric.
@@ -991,14 +1893,49 @@ func (mb *MetricsBuilder) RecordMongodbDataSizeDataPoint(ts pcommon.Timestamp, v
 	mb.metricMongodbDataSize.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
 }
 
+// RecordMongodbDatabaseCountDataPoint adds a data point to mongodb.database.count metric.
+func (mb *MetricsBuilder) RecordMongodbDatabaseCountDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbDatabaseCount.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbDocumentDeleteCountDataPoint adds a data point to mongodb.document.delete.count metric.
+func (mb *MetricsBuilder) RecordMongodbDocumentDeleteCountDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	mb.metricMongodbDocumentDeleteCount.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
+}
+
+// RecordMongodbDocumentInsertCountDataPoint adds a data point to mongodb.document.insert.count metric.
+func (mb *MetricsBuilder) RecordMongodbDocumentInsertCountDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	mb.metricMongodbDocumentInsertCount.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
+}
+
+// RecordMongodbDocumentUpdateCountDataPoint adds a data point to mongodb.document.update.count metric.
+func (mb *MetricsBuilder) RecordMongodbDocumentUpdateCountDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	mb.metricMongodbDocumentUpdateCount.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
+}
+
 // RecordMongodbExtentCountDataPoint adds a data point to mongodb.extent.count metric.
 func (mb *MetricsBuilder) RecordMongodbExtentCountDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
 	mb.metricMongodbExtentCount.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
 }
 
+// RecordMongodbFlushCountDataPoint adds a data point to mongodb.flush.count metric.
+func (mb *MetricsBuilder) RecordMongodbFlushCountDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	mb.metricMongodbFlushCount.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
+}
+
+// RecordMongodbFlushTimeDataPoint adds a data point to mongodb.flush.time metric.
+func (mb *MetricsBuilder) RecordMongodbFlushTimeDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
+	mb.metricMongodbFlushTime.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
+}
+
 // RecordMongodbGlobalLockTimeDataPoint adds a data point to mongodb.global_lock.time metric.
 func (mb *MetricsBuilder) RecordMongodbGlobalLockTimeDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricMongodbGlobalLockTime.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbIndexAccessCountDataPoint adds a data point to mongodb.index.access.count metric.
+func (mb *MetricsBuilder) RecordMongodbIndexAccessCountDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string, typeAttributeValue AttributeType) {
+	mb.metricMongodbIndexAccessCount.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue, typeAttributeValue.String())
 }
 
 // RecordMongodbIndexCountDataPoint adds a data point to mongodb.index.count metric.
@@ -1016,6 +1953,21 @@ func (mb *MetricsBuilder) RecordMongodbMemoryUsageDataPoint(ts pcommon.Timestamp
 	mb.metricMongodbMemoryUsage.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue, memoryTypeAttributeValue.String())
 }
 
+// RecordMongodbNetworkIoReceiveDataPoint adds a data point to mongodb.network.io.receive metric.
+func (mb *MetricsBuilder) RecordMongodbNetworkIoReceiveDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbNetworkIoReceive.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbNetworkIoTransmitDataPoint adds a data point to mongodb.network.io.transmit metric.
+func (mb *MetricsBuilder) RecordMongodbNetworkIoTransmitDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbNetworkIoTransmit.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbNetworkRequestCountDataPoint adds a data point to mongodb.network.request.count metric.
+func (mb *MetricsBuilder) RecordMongodbNetworkRequestCountDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbNetworkRequestCount.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordMongodbObjectCountDataPoint adds a data point to mongodb.object.count metric.
 func (mb *MetricsBuilder) RecordMongodbObjectCountDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
 	mb.metricMongodbObjectCount.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
@@ -1024,6 +1976,16 @@ func (mb *MetricsBuilder) RecordMongodbObjectCountDataPoint(ts pcommon.Timestamp
 // RecordMongodbOperationCountDataPoint adds a data point to mongodb.operation.count metric.
 func (mb *MetricsBuilder) RecordMongodbOperationCountDataPoint(ts pcommon.Timestamp, val int64, operationAttributeValue AttributeOperation) {
 	mb.metricMongodbOperationCount.recordDataPoint(mb.startTime, ts, val, operationAttributeValue.String())
+}
+
+// RecordMongodbOperationTimeDataPoint adds a data point to mongodb.operation.time metric.
+func (mb *MetricsBuilder) RecordMongodbOperationTimeDataPoint(ts pcommon.Timestamp, val int64, operationAttributeValue AttributeOperation) {
+	mb.metricMongodbOperationTime.recordDataPoint(mb.startTime, ts, val, operationAttributeValue.String())
+}
+
+// RecordMongodbSessionCountDataPoint adds a data point to mongodb.session.count metric.
+func (mb *MetricsBuilder) RecordMongodbSessionCountDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbSessionCount.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordMongodbStorageSizeDataPoint adds a data point to mongodb.storage.size metric.

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
@@ -611,7 +611,7 @@ type metricMongodbDocumentOperationCount struct {
 // init fills mongodb.document.operation.count metric with initial data.
 func (m *metricMongodbDocumentOperationCount) init() {
 	m.data.SetName("mongodb.document.operation.count")
-	m.data.SetDescription("The number of documents operations executed.")
+	m.data.SetDescription("The number of document operations executed.")
 	m.data.SetUnit("{documents}")
 	m.data.SetDataType(pmetric.MetricDataTypeSum)
 	m.data.Sum().SetIsMonotonic(false)

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -166,33 +166,15 @@ metrics:
       aggregation: cumulative
       monotonic: false
     attributes: [database, collection]
-  mongodb.document.insert.count:
-    description: The number of documents inserted.
+  mongodb.document.operation.count:
+    description: The number of documents operations executed.
     unit: "{documents}"
     enabled: true
     sum:
       value_type: int
       aggregation: cumulative
       monotonic: false
-    attributes: [database]
-  mongodb.document.delete.count:
-    description: The number of documents deleted.
-    unit: "{documents}"
-    enabled: true
-    sum:
-      value_type: int
-      aggregation: cumulative
-      monotonic: false
-    attributes: [database]
-  mongodb.document.update.count:
-    description: The number of documents updated.
-    unit: "{documents}"
-    enabled: true
-    sum:
-      value_type: int
-      aggregation: cumulative
-      monotonic: false
-    attributes: [database]
+    attributes: [database, operation]
   mongodb.network.io.receive:
     description: The number of bytes received.
     unit: By

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -146,3 +146,138 @@ metrics:
       value_type: int
       monotonic: true
     attributes: [database]
+  mongodb.connection.available:
+    description: The number of unused connections.
+    unit: "{connections}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: [database]
+  mongodb.database.count:
+    description: The number of existing databases.
+    unit: "{databases}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.index.access.count:
+    description: The number of times an index has been accessed. 
+    unit: "{accesses}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: [database, type]
+  mongodb.document.insert.count:
+    description: The number of documents inserted.
+    unit: "{documents}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: [database]
+  mongodb.document.delete.count:
+    description: The number of documents deleted.
+    unit: "{documents}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: [database]
+  mongodb.document.update.count:
+    description: The number of documents updated.
+    unit: "{documents}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: [database]
+  mongodb.network.io.receive:
+    description: The number of bytes received.
+    unit: By
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.network.io.transmit:
+    description: The number of by transmitted.
+    unit: By
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.network.request.count:
+    description: The number of requests received by the server.
+    unit: "{requests}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.operation.time:
+    description: The total time spent performing operations.
+    unit: ms
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: true
+    attributes: [operation]
+  mongodb.session.count:
+    description: The total number of active sessions.
+    unit: "{sessions}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.flush.count:
+    description: The number of times the database has flushed writes to disk.
+    unit: "{flushes}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: [database]
+  mongodb.flush.time:
+    description: The total amount of time spent flushing writes to disk.
+    unit: ms
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: true
+    attributes: [database]
+  mongodb.cursor.count:
+    description: The number of open cursors maintained for clients.
+    unit: "{cursors}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.cursor.timeout.count:
+    description: The number of cursors that have timed out.
+    unit: "{cursors}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: []

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -167,7 +167,7 @@ metrics:
       monotonic: false
     attributes: [database, collection]
   mongodb.document.operation.count:
-    description: The number of documents operations executed.
+    description: The number of document operations executed.
     unit: "{documents}"
     enabled: true
     sum:

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -8,6 +8,8 @@ resource_attributes:
 attributes:
   database:
     description: The name of a database.
+  collection:
+    description: The name of a collection.
   memory_type:
     value: type
     description: The type of memory used.
@@ -146,15 +148,6 @@ metrics:
       value_type: int
       monotonic: true
     attributes: [database]
-  mongodb.connection.available:
-    description: The number of unused connections.
-    unit: "{connections}"
-    enabled: true
-    sum:
-      value_type: int
-      aggregation: cumulative
-      monotonic: false
-    attributes: [database]
   mongodb.database.count:
     description: The number of existing databases.
     unit: "{databases}"
@@ -172,7 +165,7 @@ metrics:
       value_type: int
       aggregation: cumulative
       monotonic: false
-    attributes: [database, type]
+    attributes: [database, collection]
   mongodb.document.insert.count:
     description: The number of documents inserted.
     unit: "{documents}"
@@ -245,24 +238,6 @@ metrics:
       aggregation: cumulative
       monotonic: false
     attributes: []
-  mongodb.flush.count:
-    description: The number of times the database has flushed writes to disk.
-    unit: "{flushes}"
-    enabled: true
-    sum:
-      value_type: int
-      aggregation: cumulative
-      monotonic: false
-    attributes: [database]
-  mongodb.flush.time:
-    description: The total amount of time spent flushing writes to disk.
-    unit: ms
-    enabled: true
-    sum:
-      value_type: int
-      aggregation: cumulative
-      monotonic: true
-    attributes: [database]
   mongodb.cursor.count:
     description: The number of open cursors maintained for clients.
     unit: "{cursors}"

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -415,7 +415,7 @@ func (s *mongodbScraper) recordOperationTime(now pcommon.Timestamp, doc bson.M, 
 func aggregateOperationTimeValues(document bson.M, collectionPathNames []string, operationMap map[string]metadata.AttributeOperation) (map[string]int64, error) {
 	operationTotals := map[string]int64{}
 	for _, collectionPathName := range collectionPathNames {
-		for operationName, _ := range operationMap {
+		for operationName := range operationMap {
 			value, err := getOperationTimeValues(document, collectionPathName, operationName)
 			if err != nil {
 				return nil, err

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -373,9 +373,8 @@ func (s *mongodbScraper) recordIndexAccess(now pcommon.Timestamp, documents []bs
 		if err != nil {
 			scraperErrors.AddPartial(1, err)
 			return
-		} else {
-			indexAccessTotal += indexAccessValue
 		}
+		indexAccessTotal += indexAccessValue
 	}
 	s.mb.RecordMongodbIndexAccessCountDataPoint(now, indexAccessTotal, dbName, collectionName)
 }

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -94,18 +94,18 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errors scrapererror
 	s.collectAdminDatabase(ctx, now, errors)
 	s.collectTopStats(ctx, now, errors)
 
-	// Mongo version 4.0+ is required to have authorized access to list collection names
-	// reference: https://www.mongodb.com/docs/manual/reference/method/db.getCollectionNames/
-	mongo40, _ := version.NewVersion("4.0")
-	if s.mongoVersion.GreaterThanOrEqual(mongo40) {
-		for _, dbName := range dbNames {
-			s.collectDatabase(ctx, now, dbName, errors)
-			collectionNames, err := s.client.ListCollectionNames(ctx, dbName)
-			if err != nil {
-				s.logger.Error("Failed to fetch collection names", zap.Error(err))
-				return
-			}
+	for _, dbName := range dbNames {
+		s.collectDatabase(ctx, now, dbName, errors)
+		collectionNames, err := s.client.ListCollectionNames(ctx, dbName)
+		if err != nil {
+			s.logger.Error("Failed to fetch collection names", zap.Error(err))
+			return
+		}
 
+		// Mongo version 4.0+ is required to have authorized access to list collection names
+		// reference: https://www.mongodb.com/docs/manual/reference/method/db.getCollectionNames/
+		mongo40, _ := version.NewVersion("4.0")
+		if s.mongoVersion.GreaterThanOrEqual(mongo40) {
 			for _, collectionName := range collectionNames {
 				s.collectIndexStats(ctx, now, dbName, collectionName, errors)
 			}

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -96,7 +96,6 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errors scrapererror
 
 	// Mongo version 4.0+ is required to have authorized access to list collection names
 	// reference: https://www.mongodb.com/docs/manual/reference/method/db.getCollectionNames/
-	// TODO:
 	mongo40, _ := version.NewVersion("4.0")
 	if s.mongoVersion.GreaterThanOrEqual(mongo40) {
 		for _, dbName := range dbNames {

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -93,16 +93,23 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errors scrapererror
 	s.mb.RecordMongodbDatabaseCountDataPoint(now, int64(len(dbNames)))
 	s.collectAdminDatabase(ctx, now, errors)
 	s.collectTopStats(ctx, now, errors)
-	for _, dbName := range dbNames {
-		s.collectDatabase(ctx, now, dbName, errors)
-		collectionNames, err := s.client.ListCollectionNames(ctx, dbName)
-		if err != nil {
-			s.logger.Error("Failed to fetch collection names", zap.Error(err))
-			return
-		}
 
-		for _, collectionName := range collectionNames {
-			s.collectIndexStats(ctx, now, dbName, collectionName, errors)
+	// Mongo version 4.0+ is required to have authorized access to list collection names
+	// reference: https://www.mongodb.com/docs/manual/reference/method/db.getCollectionNames/
+	// TODO:
+	mongo40, _ := version.NewVersion("4.0")
+	if s.mongoVersion.GreaterThanOrEqual(mongo40) {
+		for _, dbName := range dbNames {
+			s.collectDatabase(ctx, now, dbName, errors)
+			collectionNames, err := s.client.ListCollectionNames(ctx, dbName)
+			if err != nil {
+				s.logger.Error("Failed to fetch collection names", zap.Error(err))
+				return
+			}
+
+			for _, collectionName := range collectionNames {
+				s.collectIndexStats(ctx, now, dbName, collectionName, errors)
+			}
 		}
 	}
 }

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -90,9 +90,20 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errors scrapererror
 
 	now := pcommon.NewTimestampFromTime(time.Now())
 
+	s.mb.RecordMongodbDatabaseCountDataPoint(now, int64(len(dbNames)))
 	s.collectAdminDatabase(ctx, now, errors)
+	s.collectTopStats(ctx, now, errors)
 	for _, dbName := range dbNames {
 		s.collectDatabase(ctx, now, dbName, errors)
+		collectionNames, err := s.client.ListCollectionNames(ctx, dbName)
+		if err != nil {
+			s.logger.Error("Failed to fetch collection names", zap.Error(err))
+			return
+		}
+
+		for _, collectionName := range collectionNames {
+			s.collectIndexStats(ctx, now, dbName, collectionName, errors)
+		}
 	}
 }
 
@@ -124,6 +135,26 @@ func (s *mongodbScraper) collectAdminDatabase(ctx context.Context, now pcommon.T
 	s.mb.EmitForResource()
 }
 
+func (s *mongodbScraper) collectTopStats(ctx context.Context, now pcommon.Timestamp, errors scrapererror.ScrapeErrors) {
+	topStats, err := s.client.TopStats(ctx)
+	if err != nil {
+		errors.AddPartial(1, err)
+		return
+	}
+	s.recordOperationTime(now, topStats, errors)
+	s.mb.EmitForResource()
+}
+
+func (s *mongodbScraper) collectIndexStats(ctx context.Context, now pcommon.Timestamp, databaseName string, collectionName string, errors scrapererror.ScrapeErrors) {
+	indexStats, err := s.client.IndexStats(ctx, databaseName, collectionName)
+	if err != nil {
+		errors.AddPartial(1, err)
+		return
+	}
+	s.recordIndexStats(ctx, now, indexStats, databaseName, collectionName, errors)
+	s.mb.EmitForResource()
+}
+
 func (s *mongodbScraper) recordDBStats(now pcommon.Timestamp, doc bson.M, dbName string, errors scrapererror.ScrapeErrors) {
 	s.recordCollections(now, doc, dbName, errors)
 	s.recordDataSize(now, doc, dbName, errors)
@@ -136,11 +167,20 @@ func (s *mongodbScraper) recordDBStats(now pcommon.Timestamp, doc bson.M, dbName
 
 func (s *mongodbScraper) recordNormalServerStats(now pcommon.Timestamp, doc bson.M, dbName string, errors scrapererror.ScrapeErrors) {
 	s.recordConnections(now, doc, dbName, errors)
+	s.recordDocumentOperations(now, doc, dbName, errors)
 	s.recordMemoryUsage(now, doc, dbName, errors)
 }
 
 func (s *mongodbScraper) recordAdminStats(now pcommon.Timestamp, document bson.M, errors scrapererror.ScrapeErrors) {
-	s.recordGlobalLockTime(now, document, errors)
 	s.recordCacheOperations(now, document, errors)
+	s.recordCursorCount(now, document, errors)
+	s.recordCursorTimeoutCount(now, document, errors)
+	s.recordGlobalLockTime(now, document, errors)
+	s.recordNetworkCount(now, document, errors)
 	s.recordOperations(now, document, errors)
+	s.recordSessionCount(now, document, errors)
+}
+
+func (s *mongodbScraper) recordIndexStats(ctx context.Context, now pcommon.Timestamp, indexStats []bson.M, databaseName string, collectionName string, errors scrapererror.ScrapeErrors) {
+	s.recordIndexAccess(now, indexStats, databaseName, collectionName, errors)
 }

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -151,7 +151,7 @@ func (s *mongodbScraper) collectIndexStats(ctx context.Context, now pcommon.Time
 		errors.AddPartial(1, err)
 		return
 	}
-	s.recordIndexStats(ctx, now, indexStats, databaseName, collectionName, errors)
+	s.recordIndexStats(now, indexStats, databaseName, collectionName, errors)
 	s.mb.EmitForResource()
 }
 
@@ -181,6 +181,6 @@ func (s *mongodbScraper) recordAdminStats(now pcommon.Timestamp, document bson.M
 	s.recordSessionCount(now, document, errors)
 }
 
-func (s *mongodbScraper) recordIndexStats(ctx context.Context, now pcommon.Timestamp, indexStats []bson.M, databaseName string, collectionName string, errors scrapererror.ScrapeErrors) {
+func (s *mongodbScraper) recordIndexStats(now pcommon.Timestamp, indexStats []bson.M, databaseName string, collectionName string, errors scrapererror.ScrapeErrors) {
 	s.recordIndexAccess(now, indexStats, databaseName, collectionName, errors)
 }

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -1,16 +1,16 @@
-// Copyright The OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// // Copyright The OpenTelemetry Authors
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //      http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
 
 package mongodbreceiver
 
@@ -23,7 +23,9 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
@@ -64,6 +66,12 @@ func TestScrape(t *testing.T) {
 	require.NoError(t, err)
 	dbStats, err := loadDBStatsAsMap()
 	require.NoError(t, err)
+	topStats, err := loadTopAsMap()
+	require.NoError(t, err)
+	productsIndexStats, err := loadIndexStatsAsMap("products")
+	require.NoError(t, err)
+	ordersIndexStats, err := loadIndexStatsAsMap("orders")
+	require.NoError(t, err)
 	mongo40, err := version.NewVersion("4.0")
 	require.NoError(t, err)
 
@@ -73,6 +81,10 @@ func TestScrape(t *testing.T) {
 	fc.On("ServerStatus", mock.Anything, fakeDatabaseName).Return(ss, nil)
 	fc.On("ServerStatus", mock.Anything, "admin").Return(adminStatus, nil)
 	fc.On("DBStats", mock.Anything, fakeDatabaseName).Return(dbStats, nil)
+	fc.On("TopStats", mock.Anything).Return(topStats, nil)
+	fc.On("ListCollectionNames", mock.Anything, fakeDatabaseName).Return([]string{"products", "orders"}, nil)
+	fc.On("IndexStats", mock.Anything, fakeDatabaseName, "products").Return(productsIndexStats, nil)
+	fc.On("IndexStats", mock.Anything, fakeDatabaseName, "orders").Return(ordersIndexStats, nil)
 
 	scraper := mongodbScraper{
 		client:       fc,
@@ -135,4 +147,58 @@ func TestGlobalLockTimeOldFormat(t *testing.T) {
 	metrics := scraper.mb.Emit().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	collectedValue := metrics.At(0).Sum().DataPoints().At(0).IntVal()
 	require.Equal(t, expectedValue, collectedValue)
+}
+
+func TestTopMetricsAggregation(t *testing.T) {
+	mont := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	defer mont.Close()
+
+	loadedTop, err := loadTop()
+	require.NoError(t, err)
+
+	mont.Run("test top stats are aggregated correctly", func(mt *mtest.T) {
+		mt.AddMockResponses(loadedTop)
+		driver := mt.Client
+		client := mongodbClient{
+			Client: driver,
+			logger: zap.NewNop(),
+		}
+		var doc bson.M
+		doc, err = client.TopStats(context.Background())
+		require.NoError(t, err)
+
+		collectionPathNames, err := digForCollectionPathNames(doc)
+		require.NoError(t, err)
+		require.ElementsMatch(t, collectionPathNames,
+			[]string{
+				"config.transactions",
+				"test.admin",
+				"test.orders",
+				"admin.system.roles",
+				"local.system.replset",
+				"test.products",
+				"admin.system.users",
+				"admin.system.version",
+				"config.system.sessions",
+				"local.oplog.rs",
+				"local.startup_log",
+			})
+
+		actualOperationTimeValues, err := aggregateOperationTimeValues(doc, collectionPathNames)
+		require.NoError(t, err)
+
+		// values are taken from testdata/top.json
+		expectedInsertValues := 0 + 0 + 0 + 0 + 0 + 11302 + 0 + 1163 + 0 + 0 + 0
+		expectedQueryValues := 0 + 0 + 6072 + 0 + 0 + 0 + 44 + 0 + 0 + 0 + 2791
+		expectedUpdateValues := 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 155 + 9962 + 0
+		expectedRemoveValues := 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 3750 + 0
+		expectedGetmoreValues := 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
+		expectedCommandValues := 540 + 397 + 4009 + 0 + 0 + 23285 + 0 + 10993 + 0 + 10116 + 0
+		require.EqualValues(t, expectedInsertValues, actualOperationTimeValues["insert"])
+		require.EqualValues(t, expectedQueryValues, actualOperationTimeValues["queries"])
+		require.EqualValues(t, expectedUpdateValues, actualOperationTimeValues["update"])
+		require.EqualValues(t, expectedRemoveValues, actualOperationTimeValues["remove"])
+		require.EqualValues(t, expectedGetmoreValues, actualOperationTimeValues["getmore"])
+		require.EqualValues(t, expectedCommandValues, actualOperationTimeValues["commands"])
+	})
 }

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -1,16 +1,16 @@
-// // Copyright The OpenTelemetry Authors
-// //
-// // Licensed under the Apache License, Version 2.0 (the "License");
-// // you may not use this file except in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// //      http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing, software
-// // distributed under the License is distributed on an "AS IS" BASIS,
-// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// // See the License for the specific language governing permissions and
-// // limitations under the License.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package mongodbreceiver
 
@@ -184,7 +184,7 @@ func TestTopMetricsAggregation(t *testing.T) {
 				"local.startup_log",
 			})
 
-		actualOperationTimeValues, err := aggregateOperationTimeValues(doc, collectionPathNames)
+		actualOperationTimeValues, err := aggregateOperationTimeValues(doc, collectionPathNames, operationsMap)
 		require.NoError(t, err)
 
 		// values are taken from testdata/top.json

--- a/receiver/mongodbreceiver/testdata/admin.json
+++ b/receiver/mongodbreceiver/testdata/admin.json
@@ -327,6 +327,14 @@
             }
         }
 	},
+	"process": "mongod",
+	"storageEngine": {
+		"name": "wiredTiger",
+		"persistent": true,
+		"readOnly": false,
+		"supportsCommittedReads": true,
+		"supportsSnapshotReadConcern": true
+	},
 	"wiredTiger": {
 		"cache": {
 			"pages read into cache": 14,

--- a/receiver/mongodbreceiver/testdata/admin.json
+++ b/receiver/mongodbreceiver/testdata/admin.json
@@ -1,4 +1,15 @@
 {
+	"network": {
+        "bytesIn": {
+            "$numberLong": "3056"
+        },
+        "bytesOut": {
+            "$numberLong": "5393"
+        },
+        "numRequests": {
+            "$numberLong": "20"
+        }
+    },
 	"asserts": {
 		"msg": {
 			"$numberInt": "0"
@@ -298,10 +309,33 @@
 			"$numberInt": "0"
 		}
 	},
+	"metrics": {
+		"cursor": {
+            "timedOut": {
+                "$numberLong": "0"
+            },
+            "open": {
+                "pinned": {
+                    "$numberLong": "0"
+                },
+                "total": {
+                    "$numberLong": "0"
+                },
+                "noTimeout": {
+                    "$numberLong": "0"
+                }
+            }
+        }
+	},
 	"wiredTiger": {
 		"cache": {
 			"pages read into cache": 14,
 			"pages requested from the cache": 215
+		},
+		"session": {
+			"open session count": {
+				"$numberInt": "19"
+			}
 		}
 	},
 	"version": "4.0.25"

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.2_6
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.2_6
@@ -1,0 +1,6 @@
+FROM mongo:2.6
+
+COPY scripts/setup.sh /setup.sh
+RUN chmod +x /setup.sh
+
+EXPOSE 27017

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.3_0
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.3_0
@@ -4,4 +4,3 @@ COPY scripts/setup.sh /setup.sh
 RUN chmod +x /setup.sh
 
 EXPOSE 27017
-

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.3_0
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.3_0
@@ -1,0 +1,7 @@
+FROM mongo:3.0
+
+COPY scripts/setup.sh /setup.sh
+RUN chmod +x /setup.sh
+
+EXPOSE 27017
+

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0
@@ -4,4 +4,3 @@ COPY scripts/setup.sh /setup.sh
 RUN chmod +x /setup.sh
 
 EXPOSE 27017
-ENV MONGO_INITDB_DATABASE=testdb

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0
@@ -1,3 +1,7 @@
 FROM mongo:4.0
 
+COPY scripts/setup.sh /setup.sh
+RUN chmod +x /setup.sh
+
 EXPOSE 27017
+ENV MONGO_INITDB_DATABASE=testdb

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0.lpu
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0.lpu
@@ -1,0 +1,11 @@
+FROM mongo:4.0.25-xenial
+
+COPY scripts/setup.sh /setup.sh
+RUN chmod +x /setup.sh
+
+COPY scripts/lpu.sh /lpu.sh
+RUN chmod +x /lpu.sh
+
+EXPOSE 27017
+ENV MONGO_INITDB_ROOT_USERNAME=otel
+ENV MONGO_INITDB_ROOT_PASSWORD=otel

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0.lpu
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0.lpu
@@ -1,4 +1,4 @@
-FROM mongo:4.0.25-xenial
+FROM mongo:4.0
 
 COPY scripts/setup.sh /setup.sh
 RUN chmod +x /setup.sh

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.5_0
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.5_0
@@ -1,3 +1,7 @@
 FROM mongo:5.0
 
+COPY scripts/setup.sh /setup.sh
+RUN chmod +x /setup.sh
+
 EXPOSE 27017
+ENV MONGO_INITDB_DATABASE=testdb

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.5_0
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.5_0
@@ -4,4 +4,3 @@ COPY scripts/setup.sh /setup.sh
 RUN chmod +x /setup.sh
 
 EXPOSE 27017
-ENV MONGO_INITDB_DATABASE=testdb

--- a/receiver/mongodbreceiver/testdata/integration/expected.2_6.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.2_6.json
@@ -1,0 +1,314 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {},
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of open cursors maintained for clients.",
+                     "name": "mongodb.cursor.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of cursors that have timed out.",
+                     "name": "mongodb.cursor.timeout.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of existing databases.",
+                     "name": "mongodb.database.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           }
+                        ]
+                     },
+                     "unit": "{databases}"
+                  },
+                  {
+                     "description": "The time the global lock has been held.",
+                     "name": "mongodb.global_lock.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "The number of bytes received.",
+                     "name": "mongodb.network.io.receive",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2252",
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of by transmitted.",
+                     "name": "mongodb.network.io.transmit",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4926",
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of requests received by the server.",
+                     "name": "mongodb.network.request.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "25",
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           }
+                        ]
+                     },
+                     "unit": "{requests}"
+                  },
+                  {
+                     "description": "The number of operations executed.",
+                     "name": "mongodb.operation.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "27",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {},
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The total time spent performing operations.",
+                     "name": "mongodb.operation.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "247",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "69572",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           },
+                           {
+                              "asInt": "20",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013561302791000",
+                              "timeUnixNano": "1659013621342408000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/receiver/mongodbreceiver/testdata/integration/expected.2_6.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.2_6.json
@@ -13,8 +13,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            }
                         ]
                      },
@@ -28,8 +28,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            }
                         ]
                      },
@@ -43,8 +43,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3",
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            }
                         ]
                      },
@@ -57,9 +57,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "asInt": "438",
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            }
                         ],
                         "isMonotonic": true
@@ -74,8 +74,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2105",
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            }
                         ]
                      },
@@ -89,8 +89,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4679",
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            }
                         ]
                      },
@@ -104,8 +104,8 @@
                         "dataPoints": [
                            {
                               "asInt": "23",
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            }
                         ]
                      },
@@ -118,19 +118,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "25",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
-                           },
-                           {
                               "asInt": "1",
                               "attributes": [
                                  {
@@ -140,8 +127,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            },
                            {
                               "asInt": "4",
@@ -153,8 +140,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            },
                            {
                               "asInt": "0",
@@ -166,8 +153,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            },
                            {
                               "asInt": "0",
@@ -179,8 +166,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            },
                            {
                               "asInt": "0",
@@ -192,8 +179,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "25",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            }
                         ],
                         "isMonotonic": true
@@ -220,7 +220,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "138",
+                              "asInt": "140",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -229,11 +229,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            },
                            {
-                              "asInt": "3235",
+                              "asInt": "748",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -242,8 +242,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            },
                            {
                               "asInt": "0",
@@ -255,8 +255,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            },
                            {
                               "asInt": "0",
@@ -268,8 +268,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            },
                            {
                               "asInt": "0",
@@ -281,11 +281,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            },
                            {
-                              "asInt": "107337",
+                              "asInt": "632046",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -294,13 +294,1054 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320855922000",
-                              "timeUnixNano": "1659041380928213000"
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "ms"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "database",
+                  "value": {
+                     "stringValue": "testdb"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of collections.",
+                     "name": "mongodb.collection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{collections}"
+                  },
+                  {
+                     "description": "The number of connections.",
+                     "name": "mongodb.connection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "The size of the collection. Data compression does not affect this value.",
+                     "name": "mongodb.data.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "256",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of document operations executed.",
+                     "name": "mongodb.document.operation.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of extents.",
+                     "name": "mongodb.extent.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{extents}"
+                  },
+                  {
+                     "description": "The number of indexes.",
+                     "name": "mongodb.index.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{indexes}"
+                  },
+                  {
+                     "description": "Sum of the space allocated to all indexes in the database, including free index space.",
+                     "name": "mongodb.index.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "8176",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of memory used.",
+                     "name": "mongodb.memory.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "62914560",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "528482304",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of objects.",
+                     "name": "mongodb.object.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{objects}"
+                  },
+                  {
+                     "description": "The total amount of storage allocated to this collection.",
+                     "name": "mongodb.storage.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "24576",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "database",
+                  "value": {
+                     "stringValue": "local"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of collections.",
+                     "name": "mongodb.collection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{collections}"
+                  },
+                  {
+                     "description": "The number of connections.",
+                     "name": "mongodb.connection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "The size of the collection. Data compression does not affect this value.",
+                     "name": "mongodb.data.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1160",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of document operations executed.",
+                     "name": "mongodb.document.operation.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of extents.",
+                     "name": "mongodb.extent.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{extents}"
+                  },
+                  {
+                     "description": "The number of indexes.",
+                     "name": "mongodb.index.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{indexes}"
+                  },
+                  {
+                     "description": "Sum of the space allocated to all indexes in the database, including free index space.",
+                     "name": "mongodb.index.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "8176",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of memory used.",
+                     "name": "mongodb.memory.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "79691776",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "528482304",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of objects.",
+                     "name": "mongodb.object.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "5",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{objects}"
+                  },
+                  {
+                     "description": "The total amount of storage allocated to this collection.",
+                     "name": "mongodb.storage.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "10502144",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "database",
+                  "value": {
+                     "stringValue": "admin"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of collections.",
+                     "name": "mongodb.collection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{collections}"
+                  },
+                  {
+                     "description": "The number of connections.",
+                     "name": "mongodb.connection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "The size of the collection. Data compression does not affect this value.",
+                     "name": "mongodb.data.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of document operations executed.",
+                     "name": "mongodb.document.operation.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of extents.",
+                     "name": "mongodb.extent.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{extents}"
+                  },
+                  {
+                     "description": "The number of indexes.",
+                     "name": "mongodb.index.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{indexes}"
+                  },
+                  {
+                     "description": "Sum of the space allocated to all indexes in the database, including free index space.",
+                     "name": "mongodb.index.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of memory used.",
+                     "name": "mongodb.memory.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "79691776",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           },
+                           {
+                              "asInt": "528482304",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of objects.",
+                     "name": "mongodb.object.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ]
+                     },
+                     "unit": "{objects}"
+                  },
+                  {
+                     "description": "The total amount of storage allocated to this collection.",
+                     "name": "mongodb.storage.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430617000",
+                              "timeUnixNano": "1659372771440302000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "By"
                   }
                ],
                "scope": {

--- a/receiver/mongodbreceiver/testdata/integration/expected.2_6.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.2_6.json
@@ -13,8 +13,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            }
                         ]
                      },
@@ -28,8 +28,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            }
                         ]
                      },
@@ -43,8 +43,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3",
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            }
                         ]
                      },
@@ -58,8 +58,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            }
                         ],
                         "isMonotonic": true
@@ -73,9 +73,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2252",
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "asInt": "2105",
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            }
                         ]
                      },
@@ -88,9 +88,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "4926",
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "asInt": "4679",
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            }
                         ]
                      },
@@ -103,9 +103,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "25",
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "asInt": "23",
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            }
                         ]
                      },
@@ -118,6 +118,19 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "25",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
+                           },
+                           {
                               "asInt": "1",
                               "attributes": [
                                  {
@@ -127,8 +140,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            },
                            {
                               "asInt": "4",
@@ -140,8 +153,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            },
                            {
                               "asInt": "0",
@@ -153,8 +166,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            },
                            {
                               "asInt": "0",
@@ -166,8 +179,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            },
                            {
                               "asInt": "0",
@@ -179,21 +192,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
-                           },
-                           {
-                              "asInt": "27",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            }
                         ],
                         "isMonotonic": true
@@ -220,7 +220,20 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "247",
+                              "asInt": "138",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
+                           },
+                           {
+                              "asInt": "3235",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -229,8 +242,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            },
                            {
                               "asInt": "0",
@@ -242,8 +255,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            },
                            {
                               "asInt": "0",
@@ -255,8 +268,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            },
                            {
                               "asInt": "0",
@@ -268,11 +281,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            },
                            {
-                              "asInt": "69572",
+                              "asInt": "107337",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -281,21 +294,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
-                           },
-                           {
-                              "asInt": "20",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013561302791000",
-                              "timeUnixNano": "1659013621342408000"
+                              "startTimeUnixNano": "1659041320855922000",
+                              "timeUnixNano": "1659041380928213000"
                            }
                         ],
                         "isMonotonic": true

--- a/receiver/mongodbreceiver/testdata/integration/expected.3_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.3_0.json
@@ -13,8 +13,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            }
                         ]
                      },
@@ -28,8 +28,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            }
                         ]
                      },
@@ -43,8 +43,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            }
                         ]
                      },
@@ -57,9 +57,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2184",
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "asInt": "2105",
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            }
                         ]
                      },
@@ -72,9 +72,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "4769",
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "asInt": "4716",
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            }
                         ]
                      },
@@ -87,9 +87,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "24",
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "asInt": "23",
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            }
                         ]
                      },
@@ -102,19 +102,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
-                           },
-                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -124,8 +111,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            },
                            {
                               "asInt": "0",
@@ -137,8 +124,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            },
                            {
                               "asInt": "0",
@@ -150,11 +137,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            },
                            {
-                              "asInt": "25",
+                              "asInt": "24",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -163,8 +150,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            },
                            {
                               "asInt": "0",
@@ -176,8 +163,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            }
                         ],
                         "isMonotonic": true
@@ -209,41 +209,15 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "getmore"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
-                           },
-                           {
-                              "asInt": "40827",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
                                        "stringValue": "insert"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            },
                            {
-                              "asInt": "24",
+                              "asInt": "43",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -252,8 +226,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            },
                            {
                               "asInt": "0",
@@ -265,8 +239,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            },
                            {
                               "asInt": "0",
@@ -278,8 +252,34 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659015643616781000",
-                              "timeUnixNano": "1659015703623668000"
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
+                           },
+                           {
+                              "asInt": "40877",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041320718830000",
+                              "timeUnixNano": "1659041380793233000"
                            }
                         ],
                         "isMonotonic": true

--- a/receiver/mongodbreceiver/testdata/integration/expected.3_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.3_0.json
@@ -1,0 +1,298 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {},
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of open cursors maintained for clients.",
+                     "name": "mongodb.cursor.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of cursors that have timed out.",
+                     "name": "mongodb.cursor.timeout.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of existing databases.",
+                     "name": "mongodb.database.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           }
+                        ]
+                     },
+                     "unit": "{databases}"
+                  },
+                  {
+                     "description": "The number of bytes received.",
+                     "name": "mongodb.network.io.receive",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2184",
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of by transmitted.",
+                     "name": "mongodb.network.io.transmit",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4769",
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of requests received by the server.",
+                     "name": "mongodb.network.request.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "24",
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           }
+                        ]
+                     },
+                     "unit": "{requests}"
+                  },
+                  {
+                     "description": "The number of operations executed.",
+                     "name": "mongodb.operation.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "25",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {},
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The total time spent performing operations.",
+                     "name": "mongodb.operation.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "40827",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "24",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659015643616781000",
+                              "timeUnixNano": "1659015703623668000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/receiver/mongodbreceiver/testdata/integration/expected.3_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.3_0.json
@@ -13,8 +13,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            }
                         ]
                      },
@@ -28,8 +28,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            }
                         ]
                      },
@@ -43,8 +43,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            }
                         ]
                      },
@@ -58,8 +58,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2105",
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            }
                         ]
                      },
@@ -73,8 +73,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4716",
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            }
                         ]
                      },
@@ -88,8 +88,8 @@
                         "dataPoints": [
                            {
                               "asInt": "23",
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            }
                         ]
                      },
@@ -111,8 +111,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            },
                            {
                               "asInt": "0",
@@ -124,8 +124,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            },
                            {
                               "asInt": "0",
@@ -137,8 +137,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            },
                            {
                               "asInt": "24",
@@ -150,8 +150,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            },
                            {
                               "asInt": "0",
@@ -163,8 +163,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            },
                            {
                               "asInt": "1",
@@ -176,8 +176,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            }
                         ],
                         "isMonotonic": true
@@ -204,6 +204,19 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "295177",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           },
+                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -213,11 +226,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            },
                            {
-                              "asInt": "43",
+                              "asInt": "29",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -226,8 +239,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            },
                            {
                               "asInt": "0",
@@ -239,8 +252,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            },
                            {
                               "asInt": "0",
@@ -252,8 +265,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            },
                            {
                               "asInt": "0",
@@ -265,26 +278,707 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
-                           },
-                           {
-                              "asInt": "40877",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659041320718830000",
-                              "timeUnixNano": "1659041380793233000"
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "ms"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "database",
+                  "value": {
+                     "stringValue": "testdb"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of collections.",
+                     "name": "mongodb.collection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{collections}"
+                  },
+                  {
+                     "description": "The number of connections.",
+                     "name": "mongodb.connection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "The size of the collection. Data compression does not affect this value.",
+                     "name": "mongodb.data.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "256",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of document operations executed.",
+                     "name": "mongodb.document.operation.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of extents.",
+                     "name": "mongodb.extent.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{extents}"
+                  },
+                  {
+                     "description": "The number of indexes.",
+                     "name": "mongodb.index.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{indexes}"
+                  },
+                  {
+                     "description": "Sum of the space allocated to all indexes in the database, including free index space.",
+                     "name": "mongodb.index.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "8176",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of memory used.",
+                     "name": "mongodb.memory.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "81788928",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           },
+                           {
+                              "asInt": "543162368",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of objects.",
+                     "name": "mongodb.object.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{objects}"
+                  },
+                  {
+                     "description": "The total amount of storage allocated to this collection.",
+                     "name": "mongodb.storage.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "20480",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "database",
+                  "value": {
+                     "stringValue": "local"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of collections.",
+                     "name": "mongodb.collection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{collections}"
+                  },
+                  {
+                     "description": "The number of connections.",
+                     "name": "mongodb.connection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "The size of the collection. Data compression does not affect this value.",
+                     "name": "mongodb.data.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1240",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of document operations executed.",
+                     "name": "mongodb.document.operation.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of extents.",
+                     "name": "mongodb.extent.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{extents}"
+                  },
+                  {
+                     "description": "The number of indexes.",
+                     "name": "mongodb.index.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{indexes}"
+                  },
+                  {
+                     "description": "Sum of the space allocated to all indexes in the database, including free index space.",
+                     "name": "mongodb.index.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "8176",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of memory used.",
+                     "name": "mongodb.memory.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "543162368",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           },
+                           {
+                              "asInt": "81788928",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of objects.",
+                     "name": "mongodb.object.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "5",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ]
+                     },
+                     "unit": "{objects}"
+                  },
+                  {
+                     "description": "The total amount of storage allocated to this collection.",
+                     "name": "mongodb.storage.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "10498048",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372711430846000",
+                              "timeUnixNano": "1659372771440281000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "By"
                   }
                ],
                "scope": {

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.json
@@ -21,11 +21,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
-                              "asInt": "288",
+                              "asInt": "495",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -34,13 +34,58 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "{operations}"
+                  },
+                  {
+                     "description": "The number of open cursors maintained for clients.",
+                     "name": "mongodb.cursor.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of cursors that have timed out.",
+                     "name": "mongodb.cursor.timeout.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of existing databases.",
+                     "name": "mongodb.database.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{databases}"
                   },
                   {
                      "description": "The time the global lock has been held.",
@@ -49,14 +94,59 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "60365",
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "asInt": "63141",
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "ms"
+                  },
+                  {
+                     "description": "The number of bytes received.",
+                     "name": "mongodb.network.io.receive",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4427",
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of by transmitted.",
+                     "name": "mongodb.network.io.transmit",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "11121",
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of requests received by the server.",
+                     "name": "mongodb.network.request.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "43",
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{requests}"
                   },
                   {
                      "description": "The number of operations executed.",
@@ -65,7 +155,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -74,11 +164,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
-                              "asInt": "1",
+                              "asInt": "3",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -87,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
                               "asInt": "0",
@@ -100,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
                               "asInt": "0",
@@ -113,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
                               "asInt": "0",
@@ -126,11 +216,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
-                              "asInt": "21",
+                              "asInt": "43",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -139,13 +229,130 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "{operations}"
+                  },
+                  {
+                     "description": "The total number of active sessions.",
+                     "name": "mongodb.session.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "19",
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{sessions}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {},
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The total time spent performing operations.",
+                     "name": "mongodb.operation.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "292059",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
+                           {
+                              "asInt": "101",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
+                           {
+                              "asInt": "1702",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
                   }
                ],
                "scope": {
@@ -185,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -214,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
                               "asInt": "838857",
@@ -233,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
                               "asInt": "3",
@@ -252,8 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -275,12 +482,81 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents deleted.",
+                     "name": "mongodb.document.delete.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents inserted.",
+                     "name": "mongodb.document.insert.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents updated.",
+                     "name": "mongodb.document.update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
                   },
                   {
                      "description": "The number of extents.",
@@ -298,8 +574,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -321,8 +597,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -344,8 +620,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -357,6 +633,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "1142947840",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
                            {
                               "asInt": "84934656",
                               "attributes": [
@@ -373,27 +668,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
-                           },
-                           {
-                              "asInt": "1053818880",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "virtual"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -415,8 +691,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -438,13 +714,57 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "system.version"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
                   }
                ],
                "scope": {
@@ -484,8 +804,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -513,8 +833,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
                               "asInt": "838857",
@@ -532,8 +852,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
                               "asInt": "3",
@@ -551,8 +871,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -574,12 +894,81 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents deleted.",
+                     "name": "mongodb.document.delete.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents inserted.",
+                     "name": "mongodb.document.insert.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents updated.",
+                     "name": "mongodb.document.update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
                   },
                   {
                      "description": "The number of extents.",
@@ -597,8 +986,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -620,8 +1009,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -643,8 +1032,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -672,11 +1061,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
-                              "asInt": "1053818880",
+                              "asInt": "1142947840",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -691,8 +1080,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -714,8 +1103,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -737,13 +1126,57 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "system.sessions"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
                   }
                ],
                "scope": {
@@ -783,8 +1216,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -796,6 +1229,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
                            {
                               "asInt": "1",
                               "attributes": [
@@ -812,8 +1264,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
                               "asInt": "838857",
@@ -831,27 +1283,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
-                           },
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "current"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -864,7 +1297,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1467",
+                              "asInt": "1445",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -873,12 +1306,81 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents deleted.",
+                     "name": "mongodb.document.delete.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents inserted.",
+                     "name": "mongodb.document.insert.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents updated.",
+                     "name": "mongodb.document.update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
                   },
                   {
                      "description": "The number of extents.",
@@ -896,8 +1398,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -919,8 +1421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -942,8 +1444,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -971,11 +1473,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            },
                            {
-                              "asInt": "1053818880",
+                              "asInt": "1142947840",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -990,8 +1492,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -1013,8 +1515,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ]
                      },
@@ -1036,13 +1538,513 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655218029063505000",
-                              "timeUnixNano": "1655218089081590000"
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "startup_log"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "database",
+                  "value": {
+                     "stringValue": "testdb"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of collections.",
+                     "name": "mongodb.collection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{collections}"
+                  },
+                  {
+                     "description": "The number of connections.",
+                     "name": "mongodb.connection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "The size of the collection. Data compression does not affect this value.",
+                     "name": "mongodb.data.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "71",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents deleted.",
+                     "name": "mongodb.document.delete.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents inserted.",
+                     "name": "mongodb.document.insert.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents updated.",
+                     "name": "mongodb.document.update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of extents.",
+                     "name": "mongodb.extent.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{extents}"
+                  },
+                  {
+                     "description": "The number of indexes.",
+                     "name": "mongodb.index.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{indexes}"
+                  },
+                  {
+                     "description": "Sum of the space allocated to all indexes in the database, including free index space.",
+                     "name": "mongodb.index.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "28672",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of memory used.",
+                     "name": "mongodb.memory.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "84934656",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           },
+                           {
+                              "asInt": "1142947840",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of objects.",
+                     "name": "mongodb.object.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{objects}"
+                  },
+                  {
+                     "description": "The total amount of storage allocated to this collection.",
+                     "name": "mongodb.storage.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "20480",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "orders"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "products"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205864329000",
+                              "timeUnixNano": "1658762265872462000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
                   }
                ],
                "scope": {

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.json
@@ -21,11 +21,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
-                              "asInt": "434",
+                              "asInt": "410",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "63270",
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "asInt": "61009",
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ],
                         "isMonotonic": true
@@ -110,9 +110,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "3932",
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "asInt": "2902",
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -125,9 +125,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "10590",
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "asInt": "8852",
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -140,9 +140,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "39",
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "asInt": "30",
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -164,11 +164,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
-                              "asInt": "4",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -177,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "0",
@@ -190,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "0",
@@ -203,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "0",
@@ -216,11 +216,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
-                              "asInt": "40",
+                              "asInt": "33",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -229,8 +229,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "19",
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -272,19 +272,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "314198",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           },
-                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -294,11 +281,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
-                              "asInt": "2021",
+                              "asInt": "67",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -307,8 +294,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "0",
@@ -320,8 +307,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "0",
@@ -333,8 +320,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "0",
@@ -346,8 +333,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
+                           {
+                              "asInt": "18212",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -421,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "838857",
@@ -440,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "3",
@@ -459,8 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -482,16 +482,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents deleted.",
-                     "name": "mongodb.document.delete.count",
+                     "description": "The number of documents operations executed.",
+                     "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -503,21 +503,17 @@
                                     "value": {
                                        "stringValue": "admin"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents inserted.",
-                     "name": "mongodb.document.insert.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -526,21 +522,17 @@
                                     "value": {
                                        "stringValue": "admin"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents updated.",
-                     "name": "mongodb.document.update.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -549,10 +541,16 @@
                                     "value": {
                                        "stringValue": "admin"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -574,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -597,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -620,8 +618,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -634,7 +632,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "83886080",
+                              "asInt": "85983232",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -649,8 +647,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "1142947840",
@@ -668,8 +666,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -691,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -714,8 +712,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ],
                         "isMonotonic": true
@@ -759,8 +757,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -804,8 +802,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -833,8 +831,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "838857",
@@ -852,8 +850,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "3",
@@ -871,8 +869,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -894,16 +892,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents deleted.",
-                     "name": "mongodb.document.delete.count",
+                     "description": "The number of documents operations executed.",
+                     "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -915,21 +913,17 @@
                                     "value": {
                                        "stringValue": "config"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents inserted.",
-                     "name": "mongodb.document.insert.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -938,21 +932,17 @@
                                     "value": {
                                        "stringValue": "config"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents updated.",
-                     "name": "mongodb.document.update.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -961,10 +951,16 @@
                                     "value": {
                                        "stringValue": "config"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -986,8 +982,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1009,8 +1005,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1032,8 +1028,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1046,7 +1042,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "83886080",
+                              "asInt": "85983232",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1061,8 +1057,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "1142947840",
@@ -1080,8 +1076,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1103,8 +1099,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1126,8 +1122,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ],
                         "isMonotonic": true
@@ -1171,8 +1167,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1216,8 +1212,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1245,8 +1241,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "838857",
@@ -1264,8 +1260,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "3",
@@ -1283,8 +1279,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1306,16 +1302,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents deleted.",
-                     "name": "mongodb.document.delete.count",
+                     "description": "The number of documents operations executed.",
+                     "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -1327,21 +1323,17 @@
                                     "value": {
                                        "stringValue": "local"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents inserted.",
-                     "name": "mongodb.document.insert.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -1350,21 +1342,17 @@
                                     "value": {
                                        "stringValue": "local"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents updated.",
-                     "name": "mongodb.document.update.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -1373,10 +1361,16 @@
                                     "value": {
                                        "stringValue": "local"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1398,8 +1392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1421,8 +1415,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1444,8 +1438,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1458,7 +1452,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "83886080",
+                              "asInt": "85983232",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1473,8 +1467,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "1142947840",
@@ -1492,8 +1486,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1515,8 +1509,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1538,8 +1532,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ],
                         "isMonotonic": true
@@ -1583,8 +1577,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1619,7 +1613,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "2",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1628,8 +1622,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1641,25 +1635,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           },
                            {
                               "asInt": "838857",
                               "attributes": [
@@ -1676,8 +1651,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            },
                            {
                               "asInt": "3",
@@ -1695,8 +1670,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1718,16 +1712,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents deleted.",
-                     "name": "mongodb.document.delete.count",
+                     "description": "The number of documents operations executed.",
+                     "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -1739,21 +1733,17 @@
                                     "value": {
                                        "stringValue": "testdb"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents inserted.",
-                     "name": "mongodb.document.insert.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -1762,21 +1752,17 @@
                                     "value": {
                                        "stringValue": "testdb"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents updated.",
-                     "name": "mongodb.document.update.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -1785,10 +1771,16 @@
                                     "value": {
                                        "stringValue": "testdb"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1810,8 +1802,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1824,7 +1816,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "3",
+                              "asInt": "2",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1833,8 +1825,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1847,7 +1839,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "12288",
+                              "asInt": "8192",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1856,8 +1848,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1869,6 +1861,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "85983232",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           },
                            {
                               "asInt": "1142947840",
                               "attributes": [
@@ -1885,27 +1896,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
-                           },
-                           {
-                              "asInt": "83886080",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1927,8 +1919,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },
@@ -1941,7 +1933,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "4096",
+                              "asInt": "8192",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1950,8 +1942,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ],
                         "isMonotonic": true
@@ -1980,7 +1972,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1995,8 +1987,52 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021373117000",
-                              "timeUnixNano": "1658764081381964000"
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "products"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013541055721000",
+                              "timeUnixNano": "1659013601067067000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.json
@@ -21,11 +21,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
-                              "asInt": "495",
+                              "asInt": "434",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "63141",
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "asInt": "63270",
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ],
                         "isMonotonic": true
@@ -110,9 +110,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "4427",
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "asInt": "3932",
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -125,9 +125,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "11121",
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "asInt": "10590",
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -140,9 +140,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "43",
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "asInt": "39",
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -155,7 +155,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -164,11 +164,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
-                              "asInt": "3",
+                              "asInt": "4",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -177,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "0",
@@ -190,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "0",
@@ -203,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "0",
@@ -216,11 +216,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
-                              "asInt": "43",
+                              "asInt": "40",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -229,8 +229,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "19",
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -272,7 +272,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "292059",
+                              "asInt": "314198",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -281,11 +281,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
-                              "asInt": "101",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -294,11 +294,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
-                              "asInt": "1702",
+                              "asInt": "2021",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -307,8 +307,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "0",
@@ -320,8 +320,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "0",
@@ -333,8 +333,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "0",
@@ -346,8 +346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -421,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "838857",
@@ -440,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "3",
@@ -459,8 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -482,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -505,8 +505,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -519,7 +519,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -528,8 +528,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -551,8 +551,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -574,8 +574,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -597,8 +597,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -620,8 +620,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -633,6 +633,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "83886080",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
+                           },
                            {
                               "asInt": "1142947840",
                               "attributes": [
@@ -649,27 +668,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
-                           },
-                           {
-                              "asInt": "84934656",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -691,8 +691,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -714,8 +714,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ],
                         "isMonotonic": true
@@ -759,8 +759,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -804,8 +804,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -833,8 +833,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "838857",
@@ -852,8 +852,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "3",
@@ -871,8 +871,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -894,8 +894,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -917,8 +917,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -931,7 +931,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -940,8 +940,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -963,8 +963,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -986,8 +986,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1009,8 +1009,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1032,8 +1032,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1046,7 +1046,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "84934656",
+                              "asInt": "83886080",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1061,8 +1061,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "1142947840",
@@ -1080,8 +1080,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1103,8 +1103,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1126,8 +1126,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ],
                         "isMonotonic": true
@@ -1171,8 +1171,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1216,8 +1216,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1229,25 +1229,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "current"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
-                           },
                            {
                               "asInt": "1",
                               "attributes": [
@@ -1264,8 +1245,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "838857",
@@ -1283,8 +1264,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1306,8 +1306,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1329,8 +1329,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1343,7 +1343,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1352,8 +1352,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1375,8 +1375,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1398,8 +1398,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1421,8 +1421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1444,8 +1444,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1458,7 +1458,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "84934656",
+                              "asInt": "83886080",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1473,8 +1473,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "1142947840",
@@ -1492,8 +1492,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1515,8 +1515,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1538,8 +1538,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ],
                         "isMonotonic": true
@@ -1583,8 +1583,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1619,7 +1619,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1628,8 +1628,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1641,6 +1641,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
+                           },
                            {
                               "asInt": "838857",
                               "attributes": [
@@ -1657,8 +1676,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            },
                            {
                               "asInt": "3",
@@ -1676,27 +1695,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1709,7 +1709,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "71",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1718,8 +1718,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1741,8 +1741,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1755,7 +1755,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1764,8 +1764,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1787,8 +1787,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1810,8 +1810,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1824,7 +1824,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "4",
+                              "asInt": "3",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1833,8 +1833,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1847,7 +1847,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "28672",
+                              "asInt": "12288",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1856,8 +1856,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1869,25 +1869,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "84934656",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
-                           },
                            {
                               "asInt": "1142947840",
                               "attributes": [
@@ -1904,8 +1885,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
+                           },
+                           {
+                              "asInt": "83886080",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1918,7 +1918,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1927,8 +1927,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },
@@ -1941,7 +1941,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "20480",
+                              "asInt": "4096",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1950,8 +1950,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ],
                         "isMonotonic": true
@@ -1995,52 +1995,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
-                           }
-                        ]
-                     },
-                     "unit": "{accesses}"
-                  }
-               ],
-               "scope": {
-                  "name": "otelcol/mongodbreceiver",
-                  "version": "latest"
-               }
-            }
-         ]
-      },
-      {
-         "resource": {
-            "attributes": []
-         },
-         "scopeMetrics": [
-            {
-               "metrics": [
-                  {
-                     "description": "The number of times an index has been accessed.",
-                     "name": "mongodb.index.access.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "collection",
-                                    "value": {
-                                       "stringValue": "products"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205864329000",
-                              "timeUnixNano": "1658762265872462000"
+                              "startTimeUnixNano": "1658764021373117000",
+                              "timeUnixNano": "1658764081381964000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.json
@@ -21,11 +21,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
-                              "asInt": "410",
+                              "asInt": "349",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "61009",
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "asInt": "61216",
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ],
                         "isMonotonic": true
@@ -110,9 +110,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2902",
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "asInt": "2725",
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -125,9 +125,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "8852",
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "asInt": "8590",
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -140,9 +140,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "30",
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "asInt": "28",
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -164,8 +164,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "1",
@@ -177,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -190,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -203,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -216,11 +216,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
-                              "asInt": "33",
+                              "asInt": "31",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -229,8 +229,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "19",
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -281,11 +281,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
-                              "asInt": "67",
+                              "asInt": "128",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -294,8 +294,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -307,8 +307,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -320,8 +320,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -333,11 +333,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
-                              "asInt": "18212",
+                              "asInt": "8778",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -346,8 +346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -405,25 +405,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
-                           },
                            {
                               "asInt": "838857",
                               "attributes": [
@@ -440,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "3",
@@ -459,8 +440,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -482,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -511,8 +511,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -530,8 +530,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -549,8 +549,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -572,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -595,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -618,8 +618,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -632,7 +632,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "85983232",
+                              "asInt": "83886080",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -647,8 +647,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "1142947840",
@@ -666,8 +666,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -689,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -712,8 +712,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ],
                         "isMonotonic": true
@@ -757,8 +757,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -802,8 +802,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -831,8 +831,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "838857",
@@ -850,8 +850,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "3",
@@ -869,8 +869,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -892,8 +892,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -921,8 +921,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -940,8 +940,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -959,8 +959,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -982,8 +982,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1005,8 +1005,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1028,8 +1028,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1042,7 +1042,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "85983232",
+                              "asInt": "83886080",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1057,8 +1057,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "1142947840",
@@ -1076,8 +1076,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1099,8 +1099,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1122,8 +1122,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ],
                         "isMonotonic": true
@@ -1167,8 +1167,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1212,8 +1212,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1241,8 +1241,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "838857",
@@ -1260,8 +1260,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "3",
@@ -1279,8 +1279,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1302,8 +1302,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1327,12 +1327,31 @@
                                  {
                                     "key": "operation",
                                     "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
                                        "stringValue": "insert"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -1350,27 +1369,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1392,8 +1392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1415,8 +1415,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1438,8 +1438,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1451,25 +1451,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "85983232",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
-                           },
                            {
                               "asInt": "1142947840",
                               "attributes": [
@@ -1486,8 +1467,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
+                           },
+                           {
+                              "asInt": "83886080",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1509,8 +1509,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1532,8 +1532,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ],
                         "isMonotonic": true
@@ -1577,8 +1577,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1613,7 +1613,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1622,8 +1622,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1635,25 +1635,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "838857",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "available"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
-                           },
                            {
                               "asInt": "3",
                               "attributes": [
@@ -1670,8 +1651,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "1",
@@ -1689,8 +1670,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
+                           },
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1712,8 +1712,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1741,8 +1741,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -1760,8 +1760,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "0",
@@ -1779,8 +1779,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1802,8 +1802,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1816,7 +1816,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1825,8 +1825,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1839,7 +1839,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "8192",
+                              "asInt": "4096",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1848,8 +1848,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1862,7 +1862,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "85983232",
+                              "asInt": "83886080",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1877,8 +1877,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            },
                            {
                               "asInt": "1142947840",
@@ -1896,8 +1896,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1919,8 +1919,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },
@@ -1933,7 +1933,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "8192",
+                              "asInt": "4096",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1942,8 +1942,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ],
                         "isMonotonic": true
@@ -1987,52 +1987,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
-                           }
-                        ]
-                     },
-                     "unit": "{accesses}"
-                  }
-               ],
-               "scope": {
-                  "name": "otelcol/mongodbreceiver",
-                  "version": "latest"
-               }
-            }
-         ]
-      },
-      {
-         "resource": {
-            "attributes": []
-         },
-         "scopeMetrics": [
-            {
-               "metrics": [
-                  {
-                     "description": "The number of times an index has been accessed.",
-                     "name": "mongodb.index.access.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "collection",
-                                    "value": {
-                                       "stringValue": "products"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541055721000",
-                              "timeUnixNano": "1659013601067067000"
+                              "startTimeUnixNano": "1659041321356490000",
+                              "timeUnixNano": "1659041381430031000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.lpu.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.lpu.json
@@ -21,8 +21,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "327",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "78703",
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "asInt": "77742",
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ],
                         "isMonotonic": true
@@ -111,8 +111,8 @@
                         "dataPoints": [
                            {
                               "asInt": "5486",
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -126,8 +126,8 @@
                         "dataPoints": [
                            {
                               "asInt": "13731",
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -141,8 +141,8 @@
                         "dataPoints": [
                            {
                               "asInt": "47",
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -155,32 +155,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "getmore"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
-                           },
-                           {
                               "asInt": "49",
                               "attributes": [
                                  {
@@ -190,8 +164,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "1",
@@ -203,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "2",
@@ -216,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "1",
@@ -229,8 +203,34 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "19",
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -272,6 +272,45 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "897",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
+                           },
+                           {
+                              "asInt": "143",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
+                           },
+                           {
+                              "asInt": "170",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
+                           },
+                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -281,8 +320,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "0",
@@ -294,11 +333,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
-                              "asInt": "13297066",
+                              "asInt": "7291597",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -307,47 +346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
-                           },
-                           {
-                              "asInt": "967",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
-                           },
-                           {
-                              "asInt": "164",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
-                           },
-                           {
-                              "asInt": "192",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "update"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -405,6 +405,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
+                           },
                            {
                               "asInt": "1",
                               "attributes": [
@@ -421,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "838857",
@@ -440,27 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
-                           },
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "current"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -482,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -511,8 +511,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "1",
@@ -530,8 +530,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "0",
@@ -549,8 +549,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -572,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -595,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -618,8 +618,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -632,7 +632,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "83886080",
+                              "asInt": "84934656",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -647,8 +647,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "1141899264",
@@ -666,8 +666,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -689,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -712,8 +712,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ],
                         "isMonotonic": true
@@ -758,8 +758,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -787,8 +787,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "838857",
@@ -806,8 +806,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "3",
@@ -825,8 +825,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -848,8 +848,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -877,8 +877,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "1",
@@ -896,8 +896,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "0",
@@ -915,8 +915,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -938,8 +938,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -961,8 +961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -984,8 +984,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -998,7 +998,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "83886080",
+                              "asInt": "84934656",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1013,8 +1013,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "1141899264",
@@ -1032,8 +1032,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1055,8 +1055,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1078,8 +1078,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ],
                         "isMonotonic": true
@@ -1124,8 +1124,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1153,8 +1153,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "838857",
@@ -1172,8 +1172,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "3",
@@ -1191,8 +1191,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1214,8 +1214,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1239,31 +1239,12 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
                                        "stringValue": "update"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "0",
@@ -1281,8 +1262,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1304,8 +1304,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1327,8 +1327,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1350,8 +1350,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1364,7 +1364,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "83886080",
+                              "asInt": "84934656",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1379,8 +1379,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "1141899264",
@@ -1398,8 +1398,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1421,8 +1421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1444,8 +1444,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ],
                         "isMonotonic": true
@@ -1489,8 +1489,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1534,8 +1534,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1563,8 +1563,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "838857",
@@ -1582,8 +1582,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "3",
@@ -1601,8 +1601,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1624,8 +1624,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1653,8 +1653,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "1",
@@ -1672,8 +1672,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "0",
@@ -1691,8 +1691,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1714,8 +1714,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1737,8 +1737,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1760,8 +1760,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1774,7 +1774,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "83886080",
+                              "asInt": "84934656",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1789,8 +1789,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            },
                            {
                               "asInt": "1141899264",
@@ -1808,8 +1808,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1831,8 +1831,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },
@@ -1854,8 +1854,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ],
                         "isMonotonic": true
@@ -1899,8 +1899,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372677632975000",
-                              "timeUnixNano": "1659372737672982000"
+                              "startTimeUnixNano": "1659375653524886000",
+                              "timeUnixNano": "1659375713570345000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.lpu.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.lpu.json
@@ -21,8 +21,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "327",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "77742",
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "asInt": "78162",
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ],
                         "isMonotonic": true
@@ -110,9 +110,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "5486",
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "asInt": "5461",
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -126,8 +126,8 @@
                         "dataPoints": [
                            {
                               "asInt": "13731",
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -141,8 +141,8 @@
                         "dataPoints": [
                            {
                               "asInt": "47",
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -155,19 +155,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "49",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
-                           },
-                           {
                               "asInt": "1",
                               "attributes": [
                                  {
@@ -177,8 +164,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "2",
@@ -190,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "1",
@@ -203,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "0",
@@ -216,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "0",
@@ -229,8 +216,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
+                           },
+                           {
+                              "asInt": "49",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "19",
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -272,7 +272,33 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "897",
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
+                           },
+                           {
+                              "asInt": "13939349",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
+                           },
+                           {
+                              "asInt": "792",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -281,11 +307,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
-                              "asInt": "143",
+                              "asInt": "54",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -294,11 +320,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
-                              "asInt": "170",
+                              "asInt": "127",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -307,8 +333,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "0",
@@ -320,34 +346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "getmore"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
-                           },
-                           {
-                              "asInt": "7291597",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -421,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "1",
@@ -440,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "838857",
@@ -459,8 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -482,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -511,8 +511,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "1",
@@ -530,8 +530,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "0",
@@ -549,8 +549,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -572,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -595,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -618,8 +618,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -631,25 +631,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "84934656",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
-                           },
                            {
                               "asInt": "1141899264",
                               "attributes": [
@@ -666,8 +647,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
+                           },
+                           {
+                              "asInt": "83886080",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -689,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -712,8 +712,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ],
                         "isMonotonic": true
@@ -758,8 +758,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -771,25 +771,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
-                           },
                            {
                               "asInt": "838857",
                               "attributes": [
@@ -806,8 +787,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "3",
@@ -825,8 +806,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -848,8 +848,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -861,6 +861,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
+                           },
                            {
                               "asInt": "1",
                               "attributes": [
@@ -877,8 +896,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "1",
@@ -896,27 +915,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -938,8 +938,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -961,8 +961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -984,8 +984,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -998,7 +998,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "84934656",
+                              "asInt": "83886080",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1013,8 +1013,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "1141899264",
@@ -1032,8 +1032,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1055,8 +1055,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1078,8 +1078,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ],
                         "isMonotonic": true
@@ -1124,8 +1124,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1137,6 +1137,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
+                           },
                            {
                               "asInt": "1",
                               "attributes": [
@@ -1153,8 +1172,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "838857",
@@ -1172,27 +1191,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
-                           },
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "current"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1214,8 +1214,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1239,12 +1239,31 @@
                                  {
                                     "key": "operation",
                                     "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
                                        "stringValue": "update"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "0",
@@ -1262,27 +1281,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1304,8 +1304,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1327,8 +1327,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1350,8 +1350,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1364,7 +1364,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "84934656",
+                              "asInt": "83886080",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1379,8 +1379,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "1141899264",
@@ -1398,8 +1398,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1421,8 +1421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1444,8 +1444,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ],
                         "isMonotonic": true
@@ -1489,8 +1489,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1534,8 +1534,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1563,8 +1563,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "838857",
@@ -1582,8 +1582,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "3",
@@ -1601,8 +1601,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1624,8 +1624,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1653,8 +1653,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "1",
@@ -1672,8 +1672,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            },
                            {
                               "asInt": "0",
@@ -1691,8 +1691,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1714,8 +1714,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1737,8 +1737,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1760,8 +1760,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1773,25 +1773,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "84934656",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
-                           },
                            {
                               "asInt": "1141899264",
                               "attributes": [
@@ -1808,8 +1789,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
+                           },
+                           {
+                              "asInt": "83886080",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1831,8 +1831,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },
@@ -1854,8 +1854,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ],
                         "isMonotonic": true
@@ -1899,8 +1899,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659375653524886000",
-                              "timeUnixNano": "1659375713570345000"
+                              "startTimeUnixNano": "1659382988957643000",
+                              "timeUnixNano": "1659383048978781000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.lpu.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.lpu.json
@@ -12,7 +12,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "22",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -21,11 +21,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "349",
+                              "asInt": "327",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "64661",
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "asInt": "78703",
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ],
                         "isMonotonic": true
@@ -110,9 +110,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2660",
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "asInt": "5486",
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -125,9 +125,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "8366",
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "asInt": "13731",
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -140,9 +140,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "27",
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "asInt": "47",
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -160,15 +160,28 @@
                                  {
                                     "key": "operation",
                                     "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
                                        "stringValue": "getmore"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "30",
+                              "asInt": "49",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -177,11 +190,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -190,11 +203,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "1",
+                              "asInt": "2",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -203,11 +216,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -216,21 +229,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "19",
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -277,15 +277,28 @@
                                  {
                                     "key": "operation",
                                     "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
                                        "stringValue": "getmore"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "368984",
+                              "asInt": "13297066",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -294,11 +307,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "967",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -307,11 +320,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "57",
+                              "asInt": "164",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -320,11 +333,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "192",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -333,21 +346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ],
                         "isMonotonic": true
@@ -383,7 +383,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "2",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -421,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "838857",
@@ -440,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "3",
@@ -459,8 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -473,7 +473,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "59",
+                              "asInt": "1160",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -482,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -496,7 +496,26 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
+                           },
+                           {
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -511,8 +530,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "0",
@@ -530,27 +549,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -572,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -586,7 +586,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "3",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -595,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -609,7 +609,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "16384",
+                              "asInt": "81920",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -618,8 +618,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -647,8 +647,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "1141899264",
@@ -666,8 +666,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -680,7 +680,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "4",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -689,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -703,7 +703,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "16384",
+                              "asInt": "49152",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -712,57 +712,13 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
-                  }
-               ],
-               "scope": {
-                  "name": "otelcol/mongodbreceiver",
-                  "version": "latest"
-               }
-            }
-         ]
-      },
-      {
-         "resource": {
-            "attributes": []
-         },
-         "scopeMetrics": [
-            {
-               "metrics": [
-                  {
-                     "description": "The number of times an index has been accessed.",
-                     "name": "mongodb.index.access.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "collection",
-                                    "value": {
-                                       "stringValue": "system.version"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
-                           }
-                        ]
-                     },
-                     "unit": "{accesses}"
                   }
                ],
                "scope": {
@@ -802,8 +758,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -831,8 +787,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "838857",
@@ -850,8 +806,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "3",
@@ -869,8 +825,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -883,7 +839,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "99",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -892,8 +848,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -906,7 +862,26 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
+                           },
+                           {
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -921,8 +896,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "0",
@@ -940,27 +915,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -982,8 +938,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1005,8 +961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1019,7 +975,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "8192",
+                              "asInt": "32768",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1028,8 +984,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1057,8 +1013,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "1141899264",
@@ -1076,8 +1032,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1090,7 +1046,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1099,8 +1055,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1113,7 +1069,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "4096",
+                              "asInt": "16384",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1122,57 +1078,13 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
-                  }
-               ],
-               "scope": {
-                  "name": "otelcol/mongodbreceiver",
-                  "version": "latest"
-               }
-            }
-         ]
-      },
-      {
-         "resource": {
-            "attributes": []
-         },
-         "scopeMetrics": [
-            {
-               "metrics": [
-                  {
-                     "description": "The number of times an index has been accessed.",
-                     "name": "mongodb.index.access.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "collection",
-                                    "value": {
-                                       "stringValue": "system.sessions"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
-                           }
-                        ]
-                     },
-                     "unit": "{accesses}"
                   }
                ],
                "scope": {
@@ -1212,8 +1124,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1241,8 +1153,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "838857",
@@ -1260,8 +1172,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "3",
@@ -1279,8 +1191,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1293,7 +1205,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1445",
+                              "asInt": "3141",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1302,8 +1214,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1316,7 +1228,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1331,11 +1243,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1350,8 +1262,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "0",
@@ -1369,8 +1281,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1392,8 +1304,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1415,8 +1327,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1429,7 +1341,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "16384",
+                              "asInt": "32768",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1438,8 +1350,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1467,8 +1379,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "1141899264",
@@ -1486,8 +1398,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1500,7 +1412,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "2",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1509,8 +1421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1523,7 +1435,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "16384",
+                              "asInt": "32768",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1532,8 +1444,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ],
                         "isMonotonic": true
@@ -1577,8 +1489,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1622,8 +1534,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1651,8 +1563,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "838857",
@@ -1670,8 +1582,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "3",
@@ -1689,8 +1601,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1712,8 +1624,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1726,7 +1638,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1741,11 +1653,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1760,8 +1672,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "0",
@@ -1779,8 +1691,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1802,8 +1714,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1825,8 +1737,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1848,8 +1760,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1877,8 +1789,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            },
                            {
                               "asInt": "1141899264",
@@ -1896,8 +1808,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1919,8 +1831,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },
@@ -1942,8 +1854,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ],
                         "isMonotonic": true
@@ -1987,8 +1899,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372653220006000",
-                              "timeUnixNano": "1659372713228518000"
+                              "startTimeUnixNano": "1659372677632975000",
+                              "timeUnixNano": "1659372737672982000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
@@ -21,11 +21,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
-                              "asInt": "362",
+                              "asInt": "349",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "63548",
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "asInt": "61151",
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ],
                         "isMonotonic": true
@@ -110,9 +110,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "4491",
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "asInt": "3425",
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -125,9 +125,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "14578",
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "asInt": "12324",
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -140,9 +140,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "39",
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "asInt": "30",
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -160,41 +160,15 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "getmore"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           },
-                           {
-                              "asInt": "40",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
                                        "stringValue": "insert"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
-                              "asInt": "2",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -203,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "0",
@@ -216,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "0",
@@ -229,8 +203,34 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
+                           {
+                              "asInt": "33",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "15",
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -272,6 +272,19 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "37487",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
+                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -281,11 +294,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
-                              "asInt": "371",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -294,8 +307,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "0",
@@ -307,8 +320,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "0",
@@ -320,8 +333,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "0",
@@ -333,21 +346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           },
-                           {
-                              "asInt": "602496",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -421,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "838857",
@@ -440,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "3",
@@ -459,8 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -482,16 +482,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents deleted.",
-                     "name": "mongodb.document.delete.count",
+                     "description": "The number of documents operations executed.",
+                     "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -503,21 +503,17 @@
                                     "value": {
                                        "stringValue": "admin"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents inserted.",
-                     "name": "mongodb.document.insert.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -526,21 +522,17 @@
                                     "value": {
                                        "stringValue": "admin"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents updated.",
-                     "name": "mongodb.document.update.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -549,10 +541,16 @@
                                     "value": {
                                        "stringValue": "admin"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -574,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -597,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -611,7 +609,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "115343360",
+                              "asInt": "116391936",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -626,11 +624,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
-                              "asInt": "1577058304",
+                              "asInt": "1578106880",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -645,8 +643,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -668,8 +666,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -691,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ],
                         "isMonotonic": true
@@ -736,8 +734,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -781,8 +779,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -810,8 +808,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "838857",
@@ -829,8 +827,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "3",
@@ -848,8 +846,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -871,16 +869,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents deleted.",
-                     "name": "mongodb.document.delete.count",
+                     "description": "The number of documents operations executed.",
+                     "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -892,21 +890,17 @@
                                     "value": {
                                        "stringValue": "config"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents inserted.",
-                     "name": "mongodb.document.insert.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -915,21 +909,17 @@
                                     "value": {
                                        "stringValue": "config"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents updated.",
-                     "name": "mongodb.document.update.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -938,10 +928,16 @@
                                     "value": {
                                        "stringValue": "config"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -963,8 +959,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -986,8 +982,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1000,7 +996,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "115343360",
+                              "asInt": "116391936",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1015,11 +1011,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
-                              "asInt": "1577058304",
+                              "asInt": "1578106880",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1034,8 +1030,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1057,8 +1053,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1080,8 +1076,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ],
                         "isMonotonic": true
@@ -1125,8 +1121,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1170,8 +1166,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1183,6 +1179,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
                            {
                               "asInt": "838857",
                               "attributes": [
@@ -1199,8 +1214,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "3",
@@ -1218,27 +1233,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           },
-                           {
-                              "asInt": "2",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1260,16 +1256,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents deleted.",
-                     "name": "mongodb.document.delete.count",
+                     "description": "The number of documents operations executed.",
+                     "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -1281,21 +1277,17 @@
                                     "value": {
                                        "stringValue": "local"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents inserted.",
-                     "name": "mongodb.document.insert.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -1304,21 +1296,17 @@
                                     "value": {
                                        "stringValue": "local"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents updated.",
-                     "name": "mongodb.document.update.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -1327,10 +1315,16 @@
                                     "value": {
                                        "stringValue": "local"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1352,8 +1346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1375,8 +1369,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1389,7 +1383,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "115343360",
+                              "asInt": "116391936",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1404,11 +1398,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
-                              "asInt": "1577058304",
+                              "asInt": "1578106880",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1423,8 +1417,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1446,8 +1440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1469,8 +1463,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ],
                         "isMonotonic": true
@@ -1514,8 +1508,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1550,7 +1544,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "2",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1559,8 +1553,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1588,8 +1582,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "838857",
@@ -1607,8 +1601,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
                               "asInt": "3",
@@ -1626,8 +1620,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1649,16 +1643,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents deleted.",
-                     "name": "mongodb.document.delete.count",
+                     "description": "The number of documents operations executed.",
+                     "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -1670,21 +1664,17 @@
                                     "value": {
                                        "stringValue": "testdb"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents inserted.",
-                     "name": "mongodb.document.insert.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -1693,21 +1683,17 @@
                                     "value": {
                                        "stringValue": "testdb"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents updated.",
-                     "name": "mongodb.document.update.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -1716,10 +1702,16 @@
                                     "value": {
                                        "stringValue": "testdb"
                                     }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1732,7 +1724,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "3",
+                              "asInt": "2",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1741,8 +1733,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1755,7 +1747,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "12288",
+                              "asInt": "8192",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1764,8 +1756,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1778,7 +1770,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "115343360",
+                              "asInt": "116391936",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1793,11 +1785,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            },
                            {
-                              "asInt": "1577058304",
+                              "asInt": "1578106880",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1812,8 +1804,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1835,8 +1827,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },
@@ -1849,7 +1841,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "4096",
+                              "asInt": "8192",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1858,8 +1850,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ],
                         "isMonotonic": true
@@ -1888,7 +1880,51 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2",
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "products"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1903,8 +1939,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658764021718948000",
-                              "timeUnixNano": "1658764081728143000"
+                              "startTimeUnixNano": "1659013541131416000",
+                              "timeUnixNano": "1659013601140916000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
@@ -21,8 +21,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "302",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "61370",
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "asInt": "64354",
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ],
                         "isMonotonic": true
@@ -111,8 +111,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3240",
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -126,8 +126,8 @@
                         "dataPoints": [
                            {
                               "asInt": "11974",
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -141,8 +141,8 @@
                         "dataPoints": [
                            {
                               "asInt": "28",
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -160,25 +160,12 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
                                        "stringValue": "query"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -190,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -203,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -216,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "31",
@@ -229,8 +216,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "15",
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -272,20 +272,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "getmore"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
-                           },
-                           {
-                              "asInt": "26768",
+                              "asInt": "648801",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -294,8 +281,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -307,8 +294,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -320,8 +307,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -333,8 +320,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -346,8 +333,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -421,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "2",
@@ -440,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "838857",
@@ -459,8 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -482,15 +482,15 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents operations executed.",
+                     "description": "The number of document operations executed.",
                      "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -511,8 +511,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -530,8 +530,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -549,8 +549,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -572,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -595,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -609,7 +609,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "115343360",
+                              "asInt": "117440512",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -624,11 +624,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
-                              "asInt": "1577058304",
+                              "asInt": "1582301184",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -643,8 +643,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -666,8 +666,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -689,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ],
                         "isMonotonic": true
@@ -734,8 +734,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -779,8 +779,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -792,25 +792,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "current"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
-                           },
                            {
                               "asInt": "2",
                               "attributes": [
@@ -827,8 +808,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "838857",
@@ -846,8 +827,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -869,15 +869,15 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents operations executed.",
+                     "description": "The number of document operations executed.",
                      "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -898,8 +898,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -917,8 +917,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -936,8 +936,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -959,8 +959,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -982,8 +982,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -996,7 +996,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "115343360",
+                              "asInt": "117440512",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1011,11 +1011,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
-                              "asInt": "1577058304",
+                              "asInt": "1582301184",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1030,8 +1030,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1053,8 +1053,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1076,8 +1076,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ],
                         "isMonotonic": true
@@ -1121,8 +1121,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1166,8 +1166,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1195,8 +1195,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "838857",
@@ -1214,8 +1214,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "3",
@@ -1233,8 +1233,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1256,15 +1256,15 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents operations executed.",
+                     "description": "The number of document operations executed.",
                      "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -1281,12 +1281,31 @@
                                  {
                                     "key": "operation",
                                     "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
                                        "stringValue": "insert"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -1304,27 +1323,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1346,8 +1346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1369,8 +1369,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1383,7 +1383,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "115343360",
+                              "asInt": "117440512",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1398,11 +1398,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
-                              "asInt": "1577058304",
+                              "asInt": "1582301184",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1417,8 +1417,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1440,8 +1440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1463,8 +1463,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ],
                         "isMonotonic": true
@@ -1508,8 +1508,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1553,8 +1553,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1582,8 +1582,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "838857",
@@ -1601,8 +1601,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "3",
@@ -1620,8 +1620,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1643,15 +1643,15 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents operations executed.",
+                     "description": "The number of document operations executed.",
                      "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -1672,8 +1672,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -1691,8 +1691,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            },
                            {
                               "asInt": "0",
@@ -1710,8 +1710,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1733,8 +1733,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1756,8 +1756,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1770,26 +1770,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "115343360",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
-                           },
-                           {
-                              "asInt": "1577058304",
+                              "asInt": "1582301184",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1804,8 +1785,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
+                           },
+                           {
+                              "asInt": "117440512",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1827,8 +1827,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },
@@ -1850,8 +1850,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ],
                         "isMonotonic": true
@@ -1895,8 +1895,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659041321486317000",
-                              "timeUnixNano": "1659041381557011000"
+                              "startTimeUnixNano": "1659372652703455000",
+                              "timeUnixNano": "1659372712711585000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
@@ -21,11 +21,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
-                              "asInt": "414",
+                              "asInt": "362",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "63029",
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "asInt": "63548",
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ],
                         "isMonotonic": true
@@ -110,9 +110,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "5002",
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "asInt": "4491",
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -125,9 +125,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "15285",
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "asInt": "14578",
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -140,9 +140,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "43",
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "asInt": "39",
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -155,7 +155,33 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
+                           },
+                           {
+                              "asInt": "40",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
+                           },
+                           {
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -164,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "2",
@@ -177,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "0",
@@ -190,8 +216,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "0",
@@ -203,34 +229,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "getmore"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
-                           },
-                           {
-                              "asInt": "43",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "15",
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -272,7 +272,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "165",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -281,11 +281,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
-                              "asInt": "359",
+                              "asInt": "371",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -294,8 +294,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "0",
@@ -307,8 +307,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "0",
@@ -320,8 +320,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "0",
@@ -333,11 +333,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
-                              "asInt": "771551",
+                              "asInt": "602496",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -346,8 +346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -405,25 +405,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "current"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
-                           },
                            {
                               "asInt": "2",
                               "attributes": [
@@ -440,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "838857",
@@ -459,8 +440,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -482,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -505,8 +505,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -519,7 +519,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -528,8 +528,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -551,8 +551,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -574,8 +574,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -597,8 +597,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -611,7 +611,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "116391936",
+                              "asInt": "115343360",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -626,8 +626,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "1577058304",
@@ -645,8 +645,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -668,8 +668,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -691,8 +691,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ],
                         "isMonotonic": true
@@ -736,8 +736,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -781,8 +781,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -810,8 +810,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "838857",
@@ -829,8 +829,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "3",
@@ -848,8 +848,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -871,8 +871,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -894,8 +894,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -908,7 +908,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -917,8 +917,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -940,8 +940,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -963,8 +963,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -986,8 +986,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -999,6 +999,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "115343360",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
+                           },
                            {
                               "asInt": "1577058304",
                               "attributes": [
@@ -1015,27 +1034,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
-                           },
-                           {
-                              "asInt": "116391936",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1057,8 +1057,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1080,8 +1080,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ],
                         "isMonotonic": true
@@ -1125,8 +1125,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1170,8 +1170,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1183,25 +1183,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "2",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
-                           },
                            {
                               "asInt": "838857",
                               "attributes": [
@@ -1218,8 +1199,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "3",
@@ -1237,8 +1218,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1260,8 +1260,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1283,8 +1283,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1297,7 +1297,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1306,8 +1306,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1329,8 +1329,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1352,8 +1352,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1375,8 +1375,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1389,7 +1389,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "116391936",
+                              "asInt": "115343360",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1404,8 +1404,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "1577058304",
@@ -1423,8 +1423,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1446,8 +1446,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1469,8 +1469,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ],
                         "isMonotonic": true
@@ -1514,8 +1514,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1550,7 +1550,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1559,8 +1559,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1588,8 +1588,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "838857",
@@ -1607,8 +1607,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "3",
@@ -1626,8 +1626,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1640,7 +1640,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "71",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1649,8 +1649,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1672,8 +1672,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1686,7 +1686,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1695,8 +1695,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1718,8 +1718,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1732,7 +1732,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "4",
+                              "asInt": "3",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1741,8 +1741,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1755,7 +1755,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "32768",
+                              "asInt": "12288",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1764,8 +1764,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1778,7 +1778,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "116391936",
+                              "asInt": "115343360",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1793,8 +1793,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            },
                            {
                               "asInt": "1577058304",
@@ -1812,8 +1812,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1826,7 +1826,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1835,8 +1835,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },
@@ -1849,7 +1849,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "24576",
+                              "asInt": "4096",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1858,8 +1858,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ],
                         "isMonotonic": true
@@ -1903,52 +1903,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
-                           }
-                        ]
-                     },
-                     "unit": "{accesses}"
-                  }
-               ],
-               "scope": {
-                  "name": "otelcol/mongodbreceiver",
-                  "version": "latest"
-               }
-            }
-         ]
-      },
-      {
-         "resource": {
-            "attributes": []
-         },
-         "scopeMetrics": [
-            {
-               "metrics": [
-                  {
-                     "description": "The number of times an index has been accessed.",
-                     "name": "mongodb.index.access.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "collection",
-                                    "value": {
-                                       "stringValue": "products"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658762205486230000",
-                              "timeUnixNano": "1658762265498112000"
+                              "startTimeUnixNano": "1658764021718948000",
+                              "timeUnixNano": "1658764081728143000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
@@ -21,11 +21,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
-                              "asInt": "255",
+                              "asInt": "414",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -34,13 +34,58 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "{operations}"
+                  },
+                  {
+                     "description": "The number of open cursors maintained for clients.",
+                     "name": "mongodb.cursor.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of cursors that have timed out.",
+                     "name": "mongodb.cursor.timeout.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of existing databases.",
+                     "name": "mongodb.database.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{databases}"
                   },
                   {
                      "description": "The time the global lock has been held.",
@@ -49,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "60891",
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "asInt": "63029",
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ],
                         "isMonotonic": true
@@ -59,11 +104,82 @@
                      "unit": "ms"
                   },
                   {
+                     "description": "The number of bytes received.",
+                     "name": "mongodb.network.io.receive",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "5002",
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of by transmitted.",
+                     "name": "mongodb.network.io.transmit",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "15285",
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of requests received by the server.",
+                     "name": "mongodb.network.request.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "43",
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{requests}"
+                  },
+                  {
                      "description": "The number of operations executed.",
                      "name": "mongodb.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -74,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
                               "asInt": "0",
@@ -87,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
                               "asInt": "0",
@@ -100,11 +216,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
-                              "asInt": "21",
+                              "asInt": "43",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -113,11 +229,50 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
-                           },
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "The total number of active sessions.",
+                     "name": "mongodb.session.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "15",
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{sessions}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {},
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The total time spent performing operations.",
+                     "name": "mongodb.operation.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "165",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -126,11 +281,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "359",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -139,13 +294,65 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "771551",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "unit": "{operations}"
+                     "unit": "ms"
                   }
                ],
                "scope": {
@@ -185,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -198,25 +405,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "838857",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "available"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
-                           },
                            {
                               "asInt": "3",
                               "attributes": [
@@ -233,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
                               "asInt": "2",
@@ -252,8 +440,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -275,12 +482,81 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents deleted.",
+                     "name": "mongodb.document.delete.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents inserted.",
+                     "name": "mongodb.document.insert.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents updated.",
+                     "name": "mongodb.document.update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
                   },
                   {
                      "description": "The number of indexes.",
@@ -298,8 +574,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -321,8 +597,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -335,7 +611,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "110100480",
+                              "asInt": "116391936",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -350,11 +626,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
-                              "asInt": "1570766848",
+                              "asInt": "1577058304",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -369,8 +645,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -392,8 +668,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -415,13 +691,57 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "system.version"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
                   }
                ],
                "scope": {
@@ -461,8 +781,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -474,6 +794,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
                            {
                               "asInt": "838857",
                               "attributes": [
@@ -490,8 +829,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
                               "asInt": "3",
@@ -509,27 +848,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
-                           },
-                           {
-                              "asInt": "2",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -551,12 +871,81 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents deleted.",
+                     "name": "mongodb.document.delete.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents inserted.",
+                     "name": "mongodb.document.insert.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents updated.",
+                     "name": "mongodb.document.update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
                   },
                   {
                      "description": "The number of indexes.",
@@ -574,8 +963,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -597,8 +986,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -611,26 +1000,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "110100480",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
-                           },
-                           {
-                              "asInt": "1570766848",
+                              "asInt": "1577058304",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -645,8 +1015,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "116391936",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -668,8 +1057,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -691,13 +1080,57 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "system.sessions"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
                   }
                ],
                "scope": {
@@ -737,8 +1170,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -766,8 +1199,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
                               "asInt": "838857",
@@ -785,8 +1218,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
                               "asInt": "3",
@@ -804,8 +1237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -818,7 +1251,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2050",
+                              "asInt": "2078",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -827,12 +1260,81 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents deleted.",
+                     "name": "mongodb.document.delete.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents inserted.",
+                     "name": "mongodb.document.insert.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents updated.",
+                     "name": "mongodb.document.update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
                   },
                   {
                      "description": "The number of indexes.",
@@ -850,8 +1352,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -873,8 +1375,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -887,7 +1389,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "110100480",
+                              "asInt": "116391936",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -902,11 +1404,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            },
                            {
-                              "asInt": "1570766848",
+                              "asInt": "1577058304",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -921,8 +1423,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -944,8 +1446,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ]
                      },
@@ -967,13 +1469,490 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1655220107119723000",
-                              "timeUnixNano": "1655220167129638000"
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "startup_log"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "database",
+                  "value": {
+                     "stringValue": "testdb"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of collections.",
+                     "name": "mongodb.collection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{collections}"
+                  },
+                  {
+                     "description": "The number of connections.",
+                     "name": "mongodb.connection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "The size of the collection. Data compression does not affect this value.",
+                     "name": "mongodb.data.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "71",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents deleted.",
+                     "name": "mongodb.document.delete.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents inserted.",
+                     "name": "mongodb.document.insert.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents updated.",
+                     "name": "mongodb.document.update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of indexes.",
+                     "name": "mongodb.index.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{indexes}"
+                  },
+                  {
+                     "description": "Sum of the space allocated to all indexes in the database, including free index space.",
+                     "name": "mongodb.index.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "32768",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of memory used.",
+                     "name": "mongodb.memory.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "116391936",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           },
+                           {
+                              "asInt": "1577058304",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of objects.",
+                     "name": "mongodb.object.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{objects}"
+                  },
+                  {
+                     "description": "The total amount of storage allocated to this collection.",
+                     "name": "mongodb.storage.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "24576",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "orders"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "products"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658762205486230000",
+                              "timeUnixNano": "1658762265498112000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
                   }
                ],
                "scope": {

--- a/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.5_0.json
@@ -21,11 +21,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
-                              "asInt": "349",
+                              "asInt": "302",
                               "attributes": [
                                  {
                                     "key": "type",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -94,9 +94,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "61151",
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "asInt": "61370",
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ],
                         "isMonotonic": true
@@ -110,9 +110,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "3425",
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "asInt": "3240",
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -125,9 +125,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "12324",
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "asInt": "11974",
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -140,9 +140,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "30",
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "asInt": "28",
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -164,8 +164,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -177,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -190,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -203,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -216,11 +216,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
-                              "asInt": "33",
+                              "asInt": "31",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -229,8 +229,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "15",
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -272,7 +272,20 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "37487",
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
+                           },
+                           {
+                              "asInt": "26768",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -281,8 +294,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -294,8 +307,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -307,8 +320,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -320,8 +333,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -333,21 +346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "getmore"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -405,6 +405,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "admin"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
+                           },
                            {
                               "asInt": "2",
                               "attributes": [
@@ -421,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "838857",
@@ -440,27 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
-                           },
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "admin"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "current"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -482,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -511,8 +511,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -530,8 +530,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -549,8 +549,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -572,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -595,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -609,7 +609,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "116391936",
+                              "asInt": "115343360",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -624,11 +624,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
-                              "asInt": "1578106880",
+                              "asInt": "1577058304",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -643,8 +643,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -666,8 +666,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -689,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ],
                         "isMonotonic": true
@@ -734,8 +734,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -779,8 +779,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -792,6 +792,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
+                           },
                            {
                               "asInt": "2",
                               "attributes": [
@@ -808,8 +827,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "838857",
@@ -827,27 +846,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
-                           },
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "current"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -869,8 +869,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -894,12 +894,31 @@
                                  {
                                     "key": "operation",
                                     "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "config"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
                                        "stringValue": "update"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -917,27 +936,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "config"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -959,8 +959,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -982,8 +982,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -996,7 +996,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "116391936",
+                              "asInt": "115343360",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1011,11 +1011,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
-                              "asInt": "1578106880",
+                              "asInt": "1577058304",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1030,8 +1030,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1053,8 +1053,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1076,8 +1076,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ],
                         "isMonotonic": true
@@ -1121,8 +1121,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1166,8 +1166,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1195,8 +1195,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "838857",
@@ -1214,8 +1214,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "3",
@@ -1233,8 +1233,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1256,8 +1256,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1285,8 +1285,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -1304,8 +1304,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -1323,8 +1323,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1346,8 +1346,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1369,8 +1369,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1383,7 +1383,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "116391936",
+                              "asInt": "115343360",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1398,11 +1398,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
-                              "asInt": "1578106880",
+                              "asInt": "1577058304",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1417,8 +1417,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1440,8 +1440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1463,8 +1463,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ],
                         "isMonotonic": true
@@ -1508,8 +1508,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1544,7 +1544,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1553,8 +1553,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1582,8 +1582,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "838857",
@@ -1601,8 +1601,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "3",
@@ -1620,8 +1620,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1643,8 +1643,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1668,31 +1668,12 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
                                        "stringValue": "insert"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
                               "asInt": "0",
@@ -1710,8 +1691,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1724,7 +1724,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1733,8 +1733,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1747,7 +1747,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "8192",
+                              "asInt": "4096",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1756,8 +1756,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1770,7 +1770,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "116391936",
+                              "asInt": "115343360",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1785,11 +1785,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            },
                            {
-                              "asInt": "1578106880",
+                              "asInt": "1577058304",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1804,8 +1804,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1827,8 +1827,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },
@@ -1841,7 +1841,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "8192",
+                              "asInt": "4096",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -1850,8 +1850,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ],
                         "isMonotonic": true
@@ -1891,56 +1891,12 @@
                                  {
                                     "key": "collection",
                                     "value": {
-                                       "stringValue": "products"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
-                           }
-                        ]
-                     },
-                     "unit": "{accesses}"
-                  }
-               ],
-               "scope": {
-                  "name": "otelcol/mongodbreceiver",
-                  "version": "latest"
-               }
-            }
-         ]
-      },
-      {
-         "resource": {
-            "attributes": []
-         },
-         "scopeMetrics": [
-            {
-               "metrics": [
-                  {
-                     "description": "The number of times an index has been accessed.",
-                     "name": "mongodb.index.access.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "collection",
-                                    "value": {
                                        "stringValue": "orders"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659013541131416000",
-                              "timeUnixNano": "1659013601140916000"
+                              "startTimeUnixNano": "1659041321486317000",
+                              "timeUnixNano": "1659041381557011000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/integration/scripts/lpu.sh
+++ b/receiver/mongodbreceiver/testdata/integration/scripts/lpu.sh
@@ -13,12 +13,7 @@ setup_permissions() {
           {
               user: "${USER}",
               pwd: "${PASS}",
-              roles: [
-                  {
-                      role: "clusterMonitor",
-                      db: "admin"
-                  }
-              ]
+              roles: [ "clusterMonitor"]
           }
   );
 EOF

--- a/receiver/mongodbreceiver/testdata/integration/scripts/lpu.sh
+++ b/receiver/mongodbreceiver/testdata/integration/scripts/lpu.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+USER="otelu"
+PASS="otelp"
+MONGO_INITDB_ROOT_USERNAME="otel"
+MONGO_INITDB_ROOT_PASSWORD="otel"
+
+setup_permissions() {
+  mongo -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD<<EOF
+  use admin
+  db.createUser(
+          {
+              user: "${USER}",
+              pwd: "${PASS}",
+              roles: [
+                  {
+                      role: "clusterMonitor",
+                      db: "admin"
+                  }
+              ]
+          }
+  );
+EOF
+}
+
+echo "Configuring ${USER} permissions. . ."
+end=$((SECONDS+20))
+while [ $SECONDS -lt $end ]; do
+    if setup_permissions; then
+        echo "Permissions configured!"
+        break
+    fi
+    echo "Trying again in 5 seconds. . ."
+    sleep 5
+done
+
+
+add_collections() {
+    mongo -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD<<EOF
+    use testdb
+    db.createCollection("orders")
+EOF
+}
+
+echo "Adding collections. . ."
+end=$((SECONDS+20))
+while [ $SECONDS -lt $end ]; do
+    if add_collections; then
+        echo "collections added!"
+        exit 0
+    fi
+    echo "Trying again in 5 seconds. . ."
+    sleep 5
+done
+
+echo "Failed to add collections"

--- a/receiver/mongodbreceiver/testdata/integration/scripts/setup.sh
+++ b/receiver/mongodbreceiver/testdata/integration/scripts/setup.sh
@@ -5,13 +5,7 @@ add_collections() {
     mongo <<EOF
     use testdb
     db.createCollection("orders")
-    db.orders.createIndex( { item: 1, quantity: 1 } )
-    db.orders.createIndex( { type: 1, item: 1 } )
-    { "_id" : 1, "item" : "abc", "price" : 12, "quantity" : 2, "type": "apparel" }
-    { "_id" : 2, "item" : "jkl", "price" : 20, "quantity" : 1, "type": "electronics" }
-    { "_id" : 3, "item" : "abc", "price" : 10, "quantity" : 5, "type": "apparel" }
-    db.orders.find( { type: "apparel"} )
-    db.orders.find( { item: "abc" } ).sort( { quantity: 1 } )
+    db.createCollection("products")
 EOF
 }
 

--- a/receiver/mongodbreceiver/testdata/integration/scripts/setup.sh
+++ b/receiver/mongodbreceiver/testdata/integration/scripts/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+add_collections() {
+    mongo <<EOF
+    use testdb
+    db.createCollection("orders")
+    db.createCollection("products")
+    db.products.insert( { item: "envelopes", qty : 100, type: "Clasp" }, { writeConcern: { w: 1, wtimeout: 5000 } } )
+    db.orders.createIndex( { item: 1, quantity: 1 } )
+    db.orders.createIndex( { type: 1, item: 1 } )
+    { "_id" : 1, "item" : "abc", "price" : 12, "quantity" : 2, "type": "apparel" }
+    { "_id" : 2, "item" : "jkl", "price" : 20, "quantity" : 1, "type": "electronics" }
+    { "_id" : 3, "item" : "abc", "price" : 10, "quantity" : 5, "type": "apparel" }
+    db.orders.find( { type: "apparel"} )
+    db.orders.find( { item: "abc" } ).sort( { quantity: 1 } )
+EOF
+}
+
+echo "Adding collections. . ."
+end=$((SECONDS+20))
+while [ $SECONDS -lt $end ]; do
+    if add_collections; then
+        echo "collections added!"
+        exit 0
+    fi
+    echo "Trying again in 5 seconds. . ."
+    sleep 5
+done
+
+echo "Failed to add collections"

--- a/receiver/mongodbreceiver/testdata/integration/scripts/setup.sh
+++ b/receiver/mongodbreceiver/testdata/integration/scripts/setup.sh
@@ -5,8 +5,6 @@ add_collections() {
     mongo <<EOF
     use testdb
     db.createCollection("orders")
-    db.createCollection("products")
-    db.products.insert( { item: "envelopes", qty : 100, type: "Clasp" }, { writeConcern: { w: 1, wtimeout: 5000 } } )
     db.orders.createIndex( { item: 1, quantity: 1 } )
     db.orders.createIndex( { type: 1, item: 1 } )
     { "_id" : 1, "item" : "abc", "price" : 12, "quantity" : 2, "type": "apparel" }

--- a/receiver/mongodbreceiver/testdata/integration/scripts/setup.sh
+++ b/receiver/mongodbreceiver/testdata/integration/scripts/setup.sh
@@ -5,7 +5,6 @@ add_collections() {
     mongo <<EOF
     use testdb
     db.createCollection("orders")
-    db.createCollection("products")
 EOF
 }
 

--- a/receiver/mongodbreceiver/testdata/ordersIndexStats0.json
+++ b/receiver/mongodbreceiver/testdata/ordersIndexStats0.json
@@ -1,1 +1,22 @@
-{"name":"item_1_quantity_1","key":{"item":{"$numberDouble":"1.0"},"quantity":{"$numberDouble":"1.0"}},"host":"7ed0d71b9d8c:27017","accesses":{"since":{"$date":{"$numberLong":"1658658173354"}},"ops":{"$numberLong":"1"}}}
+{
+    "name": "item_1_quantity_1",
+    "key": {
+        "item": {
+            "$numberDouble": "1.0"
+        },
+        "quantity": {
+            "$numberDouble": "1.0"
+        }
+    },
+    "host": "7ed0d71b9d8c:27017",
+    "accesses": {
+        "since": {
+            "$date": {
+                "$numberLong": "1658658173354"
+            }
+        },
+        "ops": {
+            "$numberLong": "1"
+        }
+    }
+}

--- a/receiver/mongodbreceiver/testdata/ordersIndexStats0.json
+++ b/receiver/mongodbreceiver/testdata/ordersIndexStats0.json
@@ -1,0 +1,1 @@
+{"name":"item_1_quantity_1","key":{"item":{"$numberDouble":"1.0"},"quantity":{"$numberDouble":"1.0"}},"host":"7ed0d71b9d8c:27017","accesses":{"since":{"$date":{"$numberLong":"1658658173354"}},"ops":{"$numberLong":"1"}}}

--- a/receiver/mongodbreceiver/testdata/ordersIndexStats1.json
+++ b/receiver/mongodbreceiver/testdata/ordersIndexStats1.json
@@ -1,0 +1,1 @@
+{"host":"7ed0d71b9d8c:27017","accesses":{"ops":{"$numberLong":"0"},"since":{"$date":{"$numberLong":"1658658173350"}}},"name":"_id_","key":{"_id":{"$numberInt":"1"}}}

--- a/receiver/mongodbreceiver/testdata/ordersIndexStats1.json
+++ b/receiver/mongodbreceiver/testdata/ordersIndexStats1.json
@@ -1,1 +1,19 @@
-{"host":"7ed0d71b9d8c:27017","accesses":{"ops":{"$numberLong":"0"},"since":{"$date":{"$numberLong":"1658658173350"}}},"name":"_id_","key":{"_id":{"$numberInt":"1"}}}
+{
+    "host": "7ed0d71b9d8c:27017",
+    "accesses": {
+        "ops": {
+            "$numberLong": "0"
+        },
+        "since": {
+            "$date": {
+                "$numberLong": "1658658173350"
+            }
+        }
+    },
+    "name": "_id_",
+    "key": {
+        "_id": {
+            "$numberInt": "1"
+        }
+    }
+}

--- a/receiver/mongodbreceiver/testdata/ordersIndexStats2.json
+++ b/receiver/mongodbreceiver/testdata/ordersIndexStats2.json
@@ -1,0 +1,1 @@
+{"name":"type_1_item_1","key":{"item":{"$numberDouble":"1.0"},"type":{"$numberDouble":"1.0"}},"host":"7ed0d71b9d8c:27017","accesses":{"ops":{"$numberLong":"1"},"since":{"$date":{"$numberLong":"1658658173912"}}}}

--- a/receiver/mongodbreceiver/testdata/ordersIndexStats2.json
+++ b/receiver/mongodbreceiver/testdata/ordersIndexStats2.json
@@ -1,1 +1,22 @@
-{"name":"type_1_item_1","key":{"item":{"$numberDouble":"1.0"},"type":{"$numberDouble":"1.0"}},"host":"7ed0d71b9d8c:27017","accesses":{"ops":{"$numberLong":"1"},"since":{"$date":{"$numberLong":"1658658173912"}}}}
+{
+    "name": "type_1_item_1",
+    "key": {
+        "item": {
+            "$numberDouble": "1.0"
+        },
+        "type": {
+            "$numberDouble": "1.0"
+        }
+    },
+    "host": "7ed0d71b9d8c:27017",
+    "accesses": {
+        "ops": {
+            "$numberLong": "1"
+        },
+        "since": {
+            "$date": {
+                "$numberLong": "1658658173912"
+            }
+        }
+    }
+}

--- a/receiver/mongodbreceiver/testdata/productsIndexStats0.json
+++ b/receiver/mongodbreceiver/testdata/productsIndexStats0.json
@@ -1,1 +1,19 @@
-{"host":"7ed0d71b9d8c:27017","accesses":{"ops":{"$numberLong":"0"},"since":{"$date":{"$numberLong":"1658658169155"}}},"name":"_id_","key":{"_id":{"$numberInt":"1"}}}
+{
+    "host": "18b74be36b02:27017",
+    "accesses": {
+        "since": {
+            "$date": {
+                "$numberLong": "1658840946592"
+            }
+        },
+        "ops": {
+            "$numberLong": "0"
+        }
+    },
+    "name": "_id_",
+    "key": {
+        "_id": {
+            "$numberInt": "1"
+        }
+    }
+}

--- a/receiver/mongodbreceiver/testdata/productsIndexStats0.json
+++ b/receiver/mongodbreceiver/testdata/productsIndexStats0.json
@@ -1,0 +1,1 @@
+{"host":"7ed0d71b9d8c:27017","accesses":{"ops":{"$numberLong":"0"},"since":{"$date":{"$numberLong":"1658658169155"}}},"name":"_id_","key":{"_id":{"$numberInt":"1"}}}

--- a/receiver/mongodbreceiver/testdata/scraper/expected.json
+++ b/receiver/mongodbreceiver/testdata/scraper/expected.json
@@ -21,8 +21,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            },
                            {
                               "asInt": "201",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -95,8 +95,8 @@
                         "dataPoints": [
                            {
                               "asInt": "58964",
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ],
                         "isMonotonic": true
@@ -111,8 +111,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3056",
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -126,8 +126,8 @@
                         "dataPoints": [
                            {
                               "asInt": "5393",
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -141,8 +141,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20",
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -155,6 +155,19 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
+                           },
+                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -164,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            },
                            {
                               "asInt": "0",
@@ -177,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            },
                            {
                               "asInt": "0",
@@ -190,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            },
                            {
                               "asInt": "20",
@@ -203,8 +216,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            },
                            {
                               "asInt": "0",
@@ -216,21 +229,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
-                           },
-                           {
-                              "asInt": "2",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "19",
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -272,58 +272,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "12465",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
-                           },
-                           {
-                              "asInt": "8907",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
-                           },
-                           {
-                              "asInt": "10117",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "update"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
-                           },
-                           {
-                              "asInt": "3750",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
-                           },
-                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -333,8 +281,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            },
                            {
                               "asInt": "49340",
@@ -346,8 +294,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
+                           },
+                           {
+                              "asInt": "12465",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
+                           },
+                           {
+                              "asInt": "8907",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
+                           },
+                           {
+                              "asInt": "10117",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
+                           },
+                           {
+                              "asInt": "3750",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -405,6 +405,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
+                           },
                            {
                               "asInt": "1",
                               "attributes": [
@@ -421,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            },
                            {
                               "asInt": "838857",
@@ -440,27 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
-                           },
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "fakedatabase"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "current"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -482,15 +482,15 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents operations executed.",
+                     "description": "The number of document operations executed.",
                      "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -507,31 +507,12 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "fakedatabase"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
                                        "stringValue": "update"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            },
                            {
                               "asInt": "0",
@@ -549,8 +530,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -572,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -595,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -618,8 +618,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -631,25 +631,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "1141899264",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "fakedatabase"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "virtual"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
-                           },
                            {
                               "asInt": "82837504",
                               "attributes": [
@@ -666,8 +647,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
+                           },
+                           {
+                              "asInt": "1141899264",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -689,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -712,8 +712,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ],
                         "isMonotonic": true
@@ -757,8 +757,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },
@@ -801,8 +801,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659010604528867000",
-                              "timeUnixNano": "1659010604528937000"
+                              "startTimeUnixNano": "1659372940162070000",
+                              "timeUnixNano": "1659372940162165000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/scraper/expected.json
+++ b/receiver/mongodbreceiver/testdata/scraper/expected.json
@@ -1,458 +1,822 @@
 {
-    "resourceMetrics": [
-        {
-            "resource": {},
-            "scopeMetrics": [
-                {
-                    "scope": {
-                        "name": "otelcol/mongodbreceiver",
-                        "version": "latest"
-                    },
-                    "metrics": [
-                        {
-                            "name": "mongodb.global_lock.time",
-                            "description": "The time the global lock has been held.",
-                            "unit": "ms",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "58964"
+   "resourceMetrics": [
+      {
+         "resource": {},
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of cache operations of the instance.",
+                     "name": "mongodb.cache.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "14",
+                              "attributes": [
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "miss"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                                "isMonotonic": true
-                            }
-                        },
-                        {
-                            "name": "mongodb.operation.count",
-                            "description": "The number of operations executed.",
-                            "unit": "{operations}",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "insert"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "query"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "2"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "update"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "delete"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "getmore"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "command"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "20"
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "201",
+                              "attributes": [
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "hit"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                                "isMonotonic": true
-                            }
-                        },
-                        {
-                            "name": "mongodb.cache.operations",
-                            "description": "The number of cache operations of the instance.",
-                            "unit": "{operations}",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "type",
-                                                "value": {
-                                                    "stringValue": "miss"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "14"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "type",
-                                                "value": {
-                                                    "stringValue": "hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "201"
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "The number of open cursors maintained for clients.",
+                     "name": "mongodb.cursor.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of cursors that have timed out.",
+                     "name": "mongodb.cursor.timeout.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{cursors}"
+                  },
+                  {
+                     "description": "The number of existing databases.",
+                     "name": "mongodb.database.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{databases}"
+                  },
+                  {
+                     "description": "The time the global lock has been held.",
+                     "name": "mongodb.global_lock.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "58964",
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "The number of bytes received.",
+                     "name": "mongodb.network.io.receive",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3056",
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of by transmitted.",
+                     "name": "mongodb.network.io.transmit",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "5393",
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of requests received by the server.",
+                     "name": "mongodb.network.request.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "20",
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{requests}"
+                  },
+                  {
+                     "description": "The number of operations executed.",
+                     "name": "mongodb.operation.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                                "isMonotonic": true
-                            }
-                        }
-                    ]
-                }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "20",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "The total number of active sessions.",
+                     "name": "mongodb.session.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "19",
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{sessions}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {},
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The total time spent performing operations.",
+                     "name": "mongodb.operation.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "10117",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "3750",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "49340",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "12465",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "8907",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "database",
+                  "value": {
+                     "stringValue": "fakedatabase"
+                  }
+               }
             ]
-        },
-        {
-            "resource": {
-                "attributes": [
-                    {
-                        "key": "database",
-                        "value": {
-                            "stringValue": "fakedatabase"
-                        }
-                    }
-                ]
-            },
-            "scopeMetrics": [
-                {
-                    "scope": {
-                        "name": "otelcol/mongodbreceiver",
-                        "version": "latest"
-                    },
-                    "metrics": [
-                        {
-                            "name": "mongodb.collection.count",
-                            "description": "The number of collections.",
-                            "unit": "{collections}",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "1"
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of collections.",
+                     "name": "mongodb.collection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
-                            }
-                        },
-                        {
-                            "name": "mongodb.connection.count",
-                            "description": "The number of connections.",
-                            "unit": "{connections}",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            },
-                                            {
-                                                "key": "type",
-                                                "value": {
-                                                    "stringValue": "active"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "1"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            },
-                                            {
-                                                "key": "type",
-                                                "value": {
-                                                    "stringValue": "available"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "838857"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            },
-                                            {
-                                                "key": "type",
-                                                "value": {
-                                                    "stringValue": "current"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "3"
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{collections}"
+                  },
+                  {
+                     "description": "The number of connections.",
+                     "name": "mongodb.connection.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
-                            }
-                        },
-                        {
-                            "name": "mongodb.data.size",
-                            "description": "The size of the collection. Data compression does not affect this value.",
-                            "unit": "By",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "3141"
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "active"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
-                            }
-                        },
-                        {
-                            "name": "mongodb.extent.count",
-                            "description": "The number of extents.",
-                            "unit": "{extents}",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "0"
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "838857",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
-                            }
-                        },
-                        {
-                            "name": "mongodb.index.count",
-                            "description": "The number of indexes.",
-                            "unit": "{indexes}",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "1"
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "available"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
-                            }
-                        },
-                        {
-                            "name": "mongodb.index.size",
-                            "description": "Sum of the space allocated to all indexes in the database, including free index space.",
-                            "unit": "By",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "16384"
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
-                            }
-                        },
-                        {
-                            "name": "mongodb.memory.usage",
-                            "description": "The amount of memory used.",
-                            "unit": "By",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            },
-                                            {
-                                                "key": "type",
-                                                "value": {
-                                                    "stringValue": "resident"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "82837504"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            },
-                                            {
-                                                "key": "type",
-                                                "value": {
-                                                    "stringValue": "virtual"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "1141899264"
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "current"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
-                            }
-                        },
-                        {
-                            "name": "mongodb.object.count",
-                            "description": "The number of objects.",
-                            "unit": "{objects}",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "2"
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "The size of the collection. Data compression does not affect this value.",
+                     "name": "mongodb.data.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "3141",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
-                            }
-                        },
-                        {
-                            "name": "mongodb.storage.size",
-                            "description": "The total amount of storage allocated to this collection.",
-                            "unit": "By",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "database",
-                                                "value": {
-                                                    "stringValue": "fakedatabase"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1642713579528563000",
-                                        "timeUnixNano": "1642713579528689000",
-                                        "asInt": "16384"
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents deleted.",
+                     "name": "mongodb.document.delete.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
                                     }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                                "isMonotonic": true
-                            }
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents inserted.",
+                     "name": "mongodb.document.insert.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of documents updated.",
+                     "name": "mongodb.document.update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The number of extents.",
+                     "name": "mongodb.extent.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{extents}"
+                  },
+                  {
+                     "description": "The number of indexes.",
+                     "name": "mongodb.index.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{indexes}"
+                  },
+                  {
+                     "description": "Sum of the space allocated to all indexes in the database, including free index space.",
+                     "name": "mongodb.index.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "16384",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of memory used.",
+                     "name": "mongodb.memory.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "82837504",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           },
+                           {
+                              "asInt": "1141899264",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "virtual"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of objects.",
+                     "name": "mongodb.object.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{objects}"
+                  },
+                  {
+                     "description": "The total amount of storage allocated to this collection.",
+                     "name": "mongodb.storage.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "16384",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "By"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "products"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": []
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of times an index has been accessed.",
+                     "name": "mongodb.index.access.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "collection",
+                                    "value": {
+                                       "stringValue": "orders"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1658761350152323000",
+                              "timeUnixNano": "1658761350152405000"
+                           }
+                        ]
+                     },
+                     "unit": "{accesses}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mongodbreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      }
+   ]
 }

--- a/receiver/mongodbreceiver/testdata/scraper/expected.json
+++ b/receiver/mongodbreceiver/testdata/scraper/expected.json
@@ -21,8 +21,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            },
                            {
                               "asInt": "201",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ],
                         "isMonotonic": true
@@ -50,8 +50,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -65,8 +65,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -80,8 +80,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -95,8 +95,8 @@
                         "dataPoints": [
                            {
                               "asInt": "58964",
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ],
                         "isMonotonic": true
@@ -111,8 +111,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3056",
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -126,8 +126,8 @@
                         "dataPoints": [
                            {
                               "asInt": "5393",
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -141,8 +141,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20",
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -155,19 +155,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "2",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
-                           },
-                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -177,8 +164,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            },
                            {
                               "asInt": "0",
@@ -190,8 +177,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            },
                            {
                               "asInt": "0",
@@ -203,8 +190,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            },
                            {
                               "asInt": "20",
@@ -216,8 +203,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            },
                            {
                               "asInt": "0",
@@ -229,8 +216,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ],
                         "isMonotonic": true
@@ -245,8 +245,8 @@
                         "dataPoints": [
                            {
                               "asInt": "19",
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -272,58 +272,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "10117",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "update"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
-                           },
-                           {
-                              "asInt": "3750",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "getmore"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
-                           },
-                           {
-                              "asInt": "49340",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
-                           },
-                           {
                               "asInt": "12465",
                               "attributes": [
                                  {
@@ -333,8 +281,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            },
                            {
                               "asInt": "8907",
@@ -346,8 +294,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
+                           },
+                           {
+                              "asInt": "10117",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
+                           },
+                           {
+                              "asInt": "3750",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
+                           },
+                           {
+                              "asInt": "49340",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ],
                         "isMonotonic": true
@@ -392,8 +392,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -421,8 +421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            },
                            {
                               "asInt": "838857",
@@ -440,8 +440,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            },
                            {
                               "asInt": "3",
@@ -459,8 +459,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -482,19 +482,57 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "The number of documents deleted.",
-                     "name": "mongodb.document.delete.count",
+                     "description": "The number of documents operations executed.",
+                     "name": "mongodb.document.operation.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
+                           },
                            {
                               "asInt": "0",
                               "attributes": [
@@ -503,56 +541,16 @@
                                     "value": {
                                        "stringValue": "fakedatabase"
                                     }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents inserted.",
-                     "name": "mongodb.document.insert.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "attributes": [
+                                 },
                                  {
-                                    "key": "database",
+                                    "key": "operation",
                                     "value": {
-                                       "stringValue": "fakedatabase"
+                                       "stringValue": "delete"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
-                           }
-                        ]
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "The number of documents updated.",
-                     "name": "mongodb.document.update.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "fakedatabase"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -574,8 +572,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -597,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -620,8 +618,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -633,25 +631,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "82837504",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "fakedatabase"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
-                           },
                            {
                               "asInt": "1141899264",
                               "attributes": [
@@ -668,8 +647,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
+                           },
+                           {
+                              "asInt": "82837504",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "fakedatabase"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -691,8 +689,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -714,8 +712,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ],
                         "isMonotonic": true
@@ -759,8 +757,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },
@@ -803,8 +801,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1658761350152323000",
-                              "timeUnixNano": "1658761350152405000"
+                              "startTimeUnixNano": "1659010604528867000",
+                              "timeUnixNano": "1659010604528937000"
                            }
                         ]
                      },

--- a/receiver/mongodbreceiver/testdata/serverStatus.json
+++ b/receiver/mongodbreceiver/testdata/serverStatus.json
@@ -134,6 +134,22 @@
 			"$numberInt": "1089"
 		}
 	},
+	"metrics": {
+        "document": {
+            "updated": {
+                "$numberLong": "1"
+            },
+            "deleted": {
+                "$numberLong": "0"
+            },
+            "inserted": {
+                "$numberLong": "1"
+            },
+            "returned": {
+                "$numberLong": "0"
+            }
+        }
+	},
 	"network": {
 		"bytesIn": {
 			"$numberLong": "2683"

--- a/receiver/mongodbreceiver/testdata/top.json
+++ b/receiver/mongodbreceiver/testdata/top.json
@@ -1,0 +1,822 @@
+{
+    "totals": {
+        "note": "all times in microseconds",
+        "local.oplog.rs": {
+            "commands": {
+                "time": {
+                    "$numberInt": "540"
+                },
+                "count": {
+                    "$numberInt": "8"
+                }
+            },
+            "total": {
+                "time": {
+                    "$numberInt": "24986"
+                },
+                "count": {
+                    "$numberInt": "17010"
+                }
+            },
+            "readLock": {
+                "time": {
+                    "$numberInt": "24986"
+                },
+                "count": {
+                    "$numberInt": "17010"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "writeLock": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "queries": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "remove": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            }
+        },
+        "test.admin": {
+            "readLock": {
+                "count": {
+                    "$numberInt": "4"
+                },
+                "time": {
+                    "$numberInt": "397"
+                }
+            },
+            "writeLock": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "queries": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "commands": {
+                "time": {
+                    "$numberInt": "397"
+                },
+                "count": {
+                    "$numberInt": "4"
+                }
+            },
+            "total": {
+                "time": {
+                    "$numberInt": "397"
+                },
+                "count": {
+                    "$numberInt": "4"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "remove": {
+                "count": {
+                    "$numberInt": "0"
+                },
+                "time": {
+                    "$numberInt": "0"
+                }
+            }
+        },
+        "test.orders": {
+            "writeLock": {
+                "count": {
+                    "$numberInt": "0"
+                },
+                "time": {
+                    "$numberInt": "0"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "queries": {
+                "time": {
+                    "$numberInt": "6072"
+                },
+                "count": {
+                    "$numberInt": "2"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "remove": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "commands": {
+                "time": {
+                    "$numberInt": "4009"
+                },
+                "count": {
+                    "$numberInt": "9"
+                }
+            },
+            "total": {
+                "time": {
+                    "$numberInt": "10081"
+                },
+                "count": {
+                    "$numberInt": "11"
+                }
+            },
+            "readLock": {
+                "time": {
+                    "$numberInt": "10081"
+                },
+                "count": {
+                    "$numberInt": "11"
+                }
+            }
+        },
+        "local.startup_log": {
+            "total": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "1"
+                }
+            },
+            "writeLock": {
+                "count": {
+                    "$numberInt": "1"
+                },
+                "time": {
+                    "$numberInt": "0"
+                }
+            },
+            "queries": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "readLock": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "remove": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "commands": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            }
+        },
+        "local.system.replset": {
+            "writeLock": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "total": {
+                "time": {
+                    "$numberInt": "368"
+                },
+                "count": {
+                    "$numberInt": "2"
+                }
+            },
+            "readLock": {
+                "time": {
+                    "$numberInt": "368"
+                },
+                "count": {
+                    "$numberInt": "2"
+                }
+            },
+            "queries": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "remove": {
+                "count": {
+                    "$numberInt": "0"
+                },
+                "time": {
+                    "$numberInt": "0"
+                }
+            },
+            "commands": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            }
+        },
+        "test.products": {
+            "queries": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "11302"
+                },
+                "count": {
+                    "$numberInt": "1"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "commands": {
+                "count": {
+                    "$numberInt": "31"
+                },
+                "time": {
+                    "$numberInt": "23285"
+                }
+            },
+            "total": {
+                "time": {
+                    "$numberInt": "34587"
+                },
+                "count": {
+                    "$numberInt": "32"
+                }
+            },
+            "readLock": {
+                "time": {
+                    "$numberInt": "23285"
+                },
+                "count": {
+                    "$numberInt": "31"
+                }
+            },
+            "remove": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "writeLock": {
+                "time": {
+                    "$numberInt": "11302"
+                },
+                "count": {
+                    "$numberInt": "1"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            }
+        },
+        "admin.system.roles": {
+            "remove": {
+                "count": {
+                    "$numberInt": "0"
+                },
+                "time": {
+                    "$numberInt": "0"
+                }
+            },
+            "total": {
+                "time": {
+                    "$numberInt": "44"
+                },
+                "count": {
+                    "$numberInt": "1"
+                }
+            },
+            "writeLock": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "commands": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "readLock": {
+                "time": {
+                    "$numberInt": "44"
+                },
+                "count": {
+                    "$numberInt": "1"
+                }
+            },
+            "queries": {
+                "time": {
+                    "$numberInt": "44"
+                },
+                "count": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        "admin.system.users": {
+            "readLock": {
+                "time": {
+                    "$numberInt": "11817"
+                },
+                "count": {
+                    "$numberInt": "55"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "1163"
+                },
+                "count": {
+                    "$numberInt": "1"
+                }
+            },
+            "queries": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "remove": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "commands": {
+                "time": {
+                    "$numberInt": "10993"
+                },
+                "count": {
+                    "$numberInt": "54"
+                }
+            },
+            "total": {
+                "time": {
+                    "$numberInt": "13026"
+                },
+                "count": {
+                    "$numberInt": "57"
+                }
+            },
+            "writeLock": {
+                "count": {
+                    "$numberInt": "2"
+                },
+                "time": {
+                    "$numberInt": "1209"
+                }
+            }
+        },
+        "admin.system.version": {
+            "queries": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "155"
+                },
+                "count": {
+                    "$numberInt": "1"
+                }
+            },
+            "remove": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "commands": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "total": {
+                "time": {
+                    "$numberInt": "339"
+                },
+                "count": {
+                    "$numberInt": "3"
+                }
+            },
+            "readLock": {
+                "count": {
+                    "$numberInt": "1"
+                },
+                "time": {
+                    "$numberInt": "184"
+                }
+            },
+            "writeLock": {
+                "time": {
+                    "$numberInt": "155"
+                },
+                "count": {
+                    "$numberInt": "2"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            }
+        },
+        "config.system.sessions": {
+            "getmore": {
+                "count": {
+                    "$numberInt": "0"
+                },
+                "time": {
+                    "$numberInt": "0"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "remove": {
+                "count": {
+                    "$numberInt": "47"
+                },
+                "time": {
+                    "$numberInt": "3750"
+                }
+            },
+            "commands": {
+                "count": {
+                    "$numberInt": "114"
+                },
+                "time": {
+                    "$numberInt": "10116"
+                }
+            },
+            "total": {
+                "time": {
+                    "$numberInt": "23836"
+                },
+                "count": {
+                    "$numberInt": "168"
+                }
+            },
+            "readLock": {
+                "time": {
+                    "$numberInt": "10116"
+                },
+                "count": {
+                    "$numberInt": "114"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "9962"
+                },
+                "count": {
+                    "$numberInt": "6"
+                }
+            },
+            "writeLock": {
+                "time": {
+                    "$numberInt": "13720"
+                },
+                "count": {
+                    "$numberInt": "54"
+                }
+            },
+            "queries": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            }
+        },
+        "config.transactions": {
+            "total": {
+                "time": {
+                    "$numberInt": "2791"
+                },
+                "count": {
+                    "$numberInt": "57"
+                }
+            },
+            "readLock": {
+                "time": {
+                    "$numberInt": "2791"
+                },
+                "count": {
+                    "$numberInt": "57"
+                }
+            },
+            "insert": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "update": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "commands": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "writeLock": {
+                "count": {
+                    "$numberInt": "0"
+                },
+                "time": {
+                    "$numberInt": "0"
+                }
+            },
+            "queries": {
+                "time": {
+                    "$numberInt": "2791"
+                },
+                "count": {
+                    "$numberInt": "57"
+                }
+            },
+            "getmore": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            },
+            "remove": {
+                "time": {
+                    "$numberInt": "0"
+                },
+                "count": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    },
+    "ok": {
+        "$numberDouble": "1.0"
+    }
+}

--- a/unreleased/mongodbreceiver-enhancements.yaml
+++ b/unreleased/mongodbreceiver-enhancements.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enhance mongodbreceiver by adding new metrics
+
+# One or more tracking issues related to the change
+issues: [12672]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
This pr enhances the mongodb receiver by adding new useful metrics such as:
```
mongodb.database.count
mongodb.index.access.count
mongodb.document.insert.count
mongodb.document.delete.count
mongodb.document.update.count
mongodb.network.io.receive
mongodb.network.io.transmit
mongodb.network.request.count
mongodb.operation.time
mongodb.session.count
mongodb.cursor.count
mongodb.cursor.timeout.count
```
**Link to tracking Issue:**
#12672 

**Testing:** <Describe what testing was performed and which tests were added.>
Added script for the integration test to create categories to simulate gathering index.access.count metrics over different collections.
Added json responses for scraper testing

**Documentation:**
Metadata documentation has been updated