### PR TITLE
[extension/sigv4authextension] Added separate region for STS for cross region auth

### DIFF
--- a/extension/sigv4authextension/README.md
+++ b/extension/sigv4authextension/README.md
@@ -14,9 +14,10 @@ The configuration fields are as follows:
 * `assume_role`: Specifies the configuration needed to assume a role
   * `arn`: **Optional**. The Amazon Resource Name (ARN) of a role to assume
   * `session_name`: **Optional**. The name of a role session
-* `region`: **Optional**. The AWS region for AWS Sigv4
+  * `sts_region`: **Optional**. The AWS region where STS is used to assumed the configured role
     * Note that this is **required** when a role to assume is also provided
-    * Also note that an attempt will be made to obtain a valid region from the endpoint of the service you are exporting to
+* `region`: **Optional**. The AWS region for the service you are exporting to for AWS Sigv4. This is differentiated from `sts_region` to handle cross region authentication
+    * Note that an attempt will be made to obtain a valid region from the endpoint of the service you are exporting to
     * [List of AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)
 * `service`: **Optional**. The AWS service for AWS Sigv4
     * Note that an attempt will be made to obtain a valid service from the endpoint of the service you are exporting to
@@ -27,6 +28,7 @@ extensions:
   sigv4auth:
     assume_role:
       arn: "arn:aws:iam::123456789012:role/aws-service-role/access"
+      sts_region: "us-east-1"
 
 receivers:
   hostmetrics:

--- a/extension/sigv4authextension/README.md
+++ b/extension/sigv4authextension/README.md
@@ -11,11 +11,10 @@ This extension provides Sigv4 authentication for making requests to AWS services
 
 The configuration fields are as follows:
 
-* `assume_role`: Specifies the configuration needed to assume a role
-  * `arn`: **Optional**. The Amazon Resource Name (ARN) of a role to assume
+* `assume_role`: **Optional**. Specifies the configuration needed to assume a role
+  * `arn`: The Amazon Resource Name (ARN) of a role to assume
   * `session_name`: **Optional**. The name of a role session
-  * `sts_region`: **Optional**. The AWS region where STS is used to assumed the configured role
-    * Note that this is **required** when a role to assume is also provided
+  * `sts_region`: The AWS region where STS is used to assumed the configured role
 * `region`: **Optional**. The AWS region for the service you are exporting to for AWS Sigv4. This is differentiated from `sts_region` to handle cross region authentication
     * Note that an attempt will be made to obtain a valid region from the endpoint of the service you are exporting to
     * [List of AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -38,6 +38,7 @@ type Config struct {
 type AssumeRole struct {
 	ARN         string `mapstructure:"arn,omitempty"`
 	SessionName string `mapstructure:"session_name,omitempty"`
+	STSRegion   string `mapstructure:"sts_region,omitempty"`
 }
 
 // compile time check that the Config struct satisfies the config.Extension interface

--- a/extension/sigv4authextension/extension.go
+++ b/extension/sigv4authextension/extension.go
@@ -83,7 +83,7 @@ func newSigv4Extension(cfg *Config, awsSDKInfo string, logger *zap.Logger) *sigv
 // from the Config.
 func getCredsProviderFromConfig(cfg *Config) (*aws.CredentialsProvider, error) {
 	awscfg, err := awsconfig.LoadDefaultConfig(context.Background(),
-		awsconfig.WithRegion(cfg.Region),
+		awsconfig.WithRegion(cfg.AssumeRole.STSRegion),
 	)
 	if err != nil {
 		return nil, err

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestNewSigv4Extension(t *testing.T) {
-	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn"}}
+	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}}
 
 	sa := newSigv4Extension(cfg, "awsSDKInfo", zap.NewNop())
 	assert.Equal(t, cfg.Region, sa.cfg.Region)
@@ -41,7 +41,7 @@ func TestRoundTripper(t *testing.T) {
 
 	base := (http.RoundTripper)(http.DefaultTransport.(*http.Transport).Clone())
 	awsSDKInfo := "awsSDKInfo"
-	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn"}, credsProvider: awsCredsProvider}
+	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}, credsProvider: awsCredsProvider}
 
 	sa := newSigv4Extension(cfg, awsSDKInfo, zap.NewNop())
 	assert.NotNil(t, sa)
@@ -59,7 +59,7 @@ func TestRoundTripper(t *testing.T) {
 }
 
 func TestPerRPCCredentials(t *testing.T) {
-	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn"}}
+	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}}
 	sa := newSigv4Extension(cfg, "", zap.NewNop())
 
 	rpc, err := sa.PerRPCCredentials()
@@ -77,14 +77,14 @@ func TestGetCredsProviderFromConfig(t *testing.T) {
 	}{
 		{
 			"success_case_without_role",
-			&Config{Region: "region", Service: "service"},
+			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{STSRegion: "region"}},
 			"AccessKeyID",
 			"SecretAccessKey",
 			false,
 		},
 		{
 			"failure_case_without_role",
-			&Config{Region: "region", Service: "service"},
+			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{STSRegion: "region"}},
 			"",
 			"",
 			true,

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -57,7 +57,7 @@ func TestRoundTrip(t *testing.T) {
 			"error_round_tripper",
 			errorRoundTripper,
 			true,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn"}},
+			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
 		},
 	}
 
@@ -148,14 +148,14 @@ func TestInferServiceAndRegion(t *testing.T) {
 		{
 			"no_match_with_config",
 			req4,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn"}},
+			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
 			"service",
 			"region",
 		},
 		{
 			"match_with_config",
 			req5,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn"}},
+			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
 			"service",
 			"region",
 		},

--- a/unreleased/sigv4-add-sts-region.yaml
+++ b/unreleased/sigv4-add-sts-region.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sigv4authextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added separate region for STS for cross region auth
+
+# One or more tracking issues related to the change
+issues: [12736]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This PR adds a new field for the config in `assume_role`, `sts_region`. This was added to address an issue with cross region authentication, where STS is used in one region to assume a configured role, but the service being exported to is in another region. The `region` field remains as the service region.

**Link to tracking Issue:**
#12736 

**Testing:** <Describe what testing was performed and which tests were added.>
* Modified tests based on changes

**Documentation:** <Describe the documentation added.>
* Updated README based on changes