### PR TITLE
[extension/observer] add ID to Endpoint.Env()

### DIFF
--- a/extension/observer/endpoints.go
+++ b/extension/observer/endpoints.go
@@ -74,6 +74,7 @@ func (e *Endpoint) Env() (EndpointEnv, error) {
 	env := e.Details.Env()
 	env["endpoint"] = e.Target
 	env["type"] = string(e.Details.Type())
+	env["id"] = string(e.ID)
 
 	return env, nil
 }

--- a/extension/observer/endpoints_test.go
+++ b/extension/observer/endpoints_test.go
@@ -46,6 +46,7 @@ func TestEndpointEnv(t *testing.T) {
 			want: EndpointEnv{
 				"type":     "pod",
 				"endpoint": "192.68.73.2",
+				"id":       "pod_id",
 				"name":     "pod_name",
 				"labels": map[string]string{
 					"label_key": "label_val",
@@ -83,6 +84,7 @@ func TestEndpointEnv(t *testing.T) {
 			want: EndpointEnv{
 				"type":     "port",
 				"endpoint": "192.68.73.2",
+				"id":       "port_id",
 				"name":     "port_name",
 				"port":     uint16(2379),
 				"pod": EndpointEnv{
@@ -116,6 +118,7 @@ func TestEndpointEnv(t *testing.T) {
 			want: EndpointEnv{
 				"type":         "hostport",
 				"endpoint":     "127.0.0.1",
+				"id":           "port_id",
 				"process_name": "process_name",
 				"command":      "./cmd --config config.yaml",
 				"is_ipv6":      true,
@@ -146,6 +149,7 @@ func TestEndpointEnv(t *testing.T) {
 			},
 			want: EndpointEnv{
 				"type":           "container",
+				"id":             "container_endpoint_id",
 				"name":           "otel-collector",
 				"image":          "otel-collector-image",
 				"tag":            "1.0.0",
@@ -186,6 +190,7 @@ func TestEndpointEnv(t *testing.T) {
 			},
 			want: EndpointEnv{
 				"type":                  "k8s.node",
+				"id":                    "k8s_node_endpoint_id",
 				"name":                  "a-k8s-node",
 				"uid":                   "a-k8s-node-uid",
 				"hostname":              "a-k8s-node-hostname",

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -109,6 +109,7 @@ targeting it will have different variables available.
 | Variable    | Description                       |
 |-------------|-----------------------------------|
 | type        | `"pod"`                           |
+| id          | ID of source endpoint             |
 | name        | name of the pod                   |
 | namespace   | namespace of the pod              |
 | uid         | unique id of the pod              |
@@ -120,6 +121,7 @@ targeting it will have different variables available.
 | Variable        | Description                             |
 |-----------------|-----------------------------------------|
 | type            | `"port"`                                |
+| id              | ID of source endpoint                   |
 | name            | container port name                     |
 | port            | port number                             |
 | protocol        | The transport protocol ("TCP" or "UDP") |
@@ -134,6 +136,7 @@ targeting it will have different variables available.
 | Variable      | Description                                      |
 |---------------|--------------------------------------------------|
 | type          | `"hostport"`                                     |
+| id            | ID of source endpoint                            |
 | process_name  | Name of the process                              |
 | command       | Command line with the used to invoke the process |
 | is_ipv6       | true if endpoint is IPv6, otherwise false        |
@@ -145,6 +148,7 @@ targeting it will have different variables available.
 | Variable       | Description                                                       |
 |----------------|-------------------------------------------------------------------|
 | type           | `"container"`                                                     |
+| id             | ID of source endpoint                                             |
 | name           | Primary name of the container                                     |
 | image          | Name of the container image                                       |
 | port           | Exposed port of the container                                     |
@@ -160,6 +164,7 @@ targeting it will have different variables available.
 | Variable       | Description                                                       |
 |----------------|-------------------------------------------------------------------|
 | type                  | `"k8s.node"`                                                                                                           |
+| id                    | ID of source endpoint                                                                                                  |
 | name                  | The name of the Kubernetes node                                                                                        |
 | uid                   | The unique ID for the node                                                                                             |
 | hostname              | The node's hostname as reported by its Status object                                                                   |

--- a/unreleased/addendpointidtoenv.yaml
+++ b/unreleased/addendpointidtoenv.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: observer
+note: Add observer.Endpoint.ID to Env()
+issues: [12751]


### PR DESCRIPTION
**Description:**
Adding a feature - Currently the `observer.Endpoint.ID` isn't included in the `Endpoint.Env()` made available to Notify subscribers like the Receiver Creator, which can make associating dynamically created receivers with a specific Endpoint difficult, especially as endpoints change over time and as similar targets exist with much of the same details. These changes add an `"id"` field to the env to be able to definitively determine which endpoint is being sourced.

**Testing:**
Updated existing unit tests

**Documentation:**
Updated receiver creator readme with Env details.