### PR TITLE
[chore] add timeout to setup-environment

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   setup-environment:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   setup-environment:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   setup-environment:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:


### PR DESCRIPTION
This step in the build pipeline can hang on retrieving the go cache. When this happens, the job will timeout after the default value of 360 minutes. Replacing that default with a more reasonable timeout. I checked the average run time for setup-environment and it seems to be well under this 15 min timeout when it work correctly.
