### PR TITLE
[chore] update sponsors order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,9 +114,6 @@ and the rest of contributors.
 
 The following GitHub users are the currently available sponsors, either by being an approver or a maintainer of the contrib repository. The list is ordered based on a random sort of the list of sponsors done live at the Collector SIG meeting on 27-Apr-2022 and serves as the seed for the round-robin selection of sponsors, as described in the section above.
 
-* [@Aneurysm9](https://github.com/Aneurysm9)
-* [@mx-psi](https://github.com/mx-psi)
-* [@pmm-sumo](https://github.com/pmm-sumo)
 * [@jpkrohling](https://github.com/jpkrohling)
 * [@dmitryax](https://github.com/dmitryax)
 * [@bogdandrutu](https://github.com/bogdandrutu)
@@ -124,6 +121,8 @@ The following GitHub users are the currently available sponsors, either by being
 * [@TylerHelmuth](https://github.com/TylerHelmuth)
 * [@djaglowski](https://github.com/djaglowski)
 * [@codeboten](https://github.com/codeboten)
+* [@Aneurysm9](https://github.com/Aneurysm9)
+* [@mx-psi](https://github.com/mx-psi)
 
 Whenever a sponsor is picked from the top of this list, please move them to the bottom.
 


### PR DESCRIPTION
Removing pmm-sumo, moving @Aneurysm9 and @mx-psi to the bottom of the rotation after sponsoring: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/11872 https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/11871
