### PR TITLE
[exporter/pulsar] Add stability level and update creation options

### DIFF
--- a/exporter/pulsarexporter/factory.go
+++ b/exporter/pulsarexporter/factory.go
@@ -63,7 +63,7 @@ func NewFactory(options ...FactoryOption) component.ExporterFactory {
 		typeStr,
 		createDefaultConfig,
 		component.WithTracesExporterAndStabilityLevel(f.createTracesExporter, stability),
-		component.WithMetricsProcessorAndStabilityLevel(f.createMetricsExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(f.createMetricsExporter, stability),
 		component.WithLogsExporterAndStabilityLevel(f.createLogsExporter, stability),
 	)
 }

--- a/exporter/pulsarexporter/factory.go
+++ b/exporter/pulsarexporter/factory.go
@@ -24,7 +24,12 @@ import (
 )
 
 const (
-	typeStr             = "pulsar"
+	// The value of "type" key in configuration.
+	typeStr = "pulsar"
+
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
+
 	defaultTracesTopic  = "otlp_spans"
 	defaultMetricsTopic = "otlp_metrics"
 	defaultLogsTopic    = "otlp_logs"
@@ -57,9 +62,9 @@ func NewFactory(options ...FactoryOption) component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(f.createTracesExporter),
-		component.WithMetricsExporter(f.createMetricsExporter),
-		component.WithLogsExporter(f.createLogsExporter),
+		component.WithTracesExporterAndStabilityLevel(f.createTracesExporter, stability),
+		component.WithMetricsProcessorAndStabilityLevel(f.createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(f.createLogsExporter, stability),
 	)
 }
 

--- a/exporter/pulsarexporter/factory.go
+++ b/exporter/pulsarexporter/factory.go
@@ -28,7 +28,7 @@ const (
 	typeStr = "pulsar"
 
 	// The stability level of the exporter.
-	stability = component.StabilityLevelBeta
+	stability = component.StabilityLevelInDevelopment
 
 	defaultTracesTopic  = "otlp_spans"
 	defaultMetricsTopic = "otlp_metrics"


### PR DESCRIPTION
**Description:** Migrates the pulsar exporter to the new component creation options that include stability level, e.g. `component.WithMetricsExporterAndStabilityLevel()`