### PR TITLE
[receiver/prometheus] Fix handling of datapoint timestamps

### DIFF
--- a/receiver/prometheusreceiver/internal/metricsutil_test.go
+++ b/receiver/prometheusreceiver/internal/metricsutil_test.go
@@ -23,11 +23,34 @@ type kv struct {
 	Key, Value string
 }
 
-func distPoint(ts pcommon.Timestamp, bounds []float64, counts []uint64) *pmetric.HistogramDataPoint {
+func metricSlice(metrics ...*pmetric.Metric) *pmetric.MetricSlice {
+	ms := pmetric.NewMetricSlice()
+	for _, metric := range metrics {
+		destMetric := ms.AppendEmpty()
+		metric.CopyTo(destMetric)
+	}
+
+	return &ms
+}
+
+func histogramPointRaw(attributes []*kv, startTimestamp, timestamp pcommon.Timestamp) pmetric.HistogramDataPoint {
 	hdp := pmetric.NewHistogramDataPoint()
+	hdp.SetStartTimestamp(startTimestamp)
+	hdp.SetTimestamp(timestamp)
+
+	attrs := hdp.Attributes()
+	for _, kv := range attributes {
+		attrs.InsertString(kv.Key, kv.Value)
+	}
+
+	return hdp
+}
+
+func histogramPoint(attributes []*kv, startTimestamp, timestamp pcommon.Timestamp, bounds []float64, counts []uint64) *pmetric.HistogramDataPoint {
+	hdp := histogramPointRaw(attributes, startTimestamp, timestamp)
 	hdp.SetExplicitBounds(pcommon.NewImmutableFloat64Slice(bounds))
 	hdp.SetBucketCounts(pcommon.NewImmutableUInt64Slice(counts))
-	hdp.SetTimestamp(ts)
+
 	var sum float64
 	var count uint64
 	for i, bcount := range counts {
@@ -42,7 +65,14 @@ func distPoint(ts pcommon.Timestamp, bounds []float64, counts []uint64) *pmetric
 	return &hdp
 }
 
-func cumulativeDistMetric(name string, kvp []*kv, startTs pcommon.Timestamp, points ...*pmetric.HistogramDataPoint) *pmetric.Metric {
+func histogramPointNoValue(attributes []*kv, startTimestamp, timestamp pcommon.Timestamp) *pmetric.HistogramDataPoint {
+	hdp := histogramPointRaw(attributes, startTimestamp, timestamp)
+	hdp.SetFlags(1)
+
+	return &hdp
+}
+
+func histogramMetric(name string, points ...*pmetric.HistogramDataPoint) *pmetric.Metric {
 	metric := pmetric.NewMetric()
 	metric.SetName(name)
 	metric.SetDataType(pmetric.MetricDataTypeHistogram)
@@ -54,24 +84,38 @@ func cumulativeDistMetric(name string, kvp []*kv, startTs pcommon.Timestamp, poi
 	for _, point := range points {
 		destPoint := destPointL.AppendEmpty()
 		point.CopyTo(destPoint)
-		point.SetStartTimestamp(startTs)
-		attrs := destPoint.Attributes()
-		for _, kv := range kvp {
-			attrs.InsertString(kv.Key, kv.Value)
-		}
 	}
+
 	return &metric
 }
 
-func doublePoint(ts pcommon.Timestamp, value float64) *pmetric.NumberDataPoint {
+func doublePointRaw(attributes []*kv, startTimestamp, timestamp pcommon.Timestamp) pmetric.NumberDataPoint {
 	ndp := pmetric.NewNumberDataPoint()
-	ndp.SetTimestamp(ts)
+	ndp.SetStartTimestamp(startTimestamp)
+	ndp.SetTimestamp(timestamp)
+
+	for _, kv := range attributes {
+		ndp.Attributes().InsertString(kv.Key, kv.Value)
+	}
+
+	return ndp
+}
+
+func doublePoint(attributes []*kv, startTimestamp, timestamp pcommon.Timestamp, value float64) *pmetric.NumberDataPoint {
+	ndp := doublePointRaw(attributes, startTimestamp, timestamp)
 	ndp.SetDoubleVal(value)
 
 	return &ndp
 }
 
-func gaugeMetric(name string, kvp []*kv, startTs pcommon.Timestamp, points ...*pmetric.NumberDataPoint) *pmetric.Metric {
+func doublePointNoValue(attributes []*kv, startTimestamp, timestamp pcommon.Timestamp) *pmetric.NumberDataPoint {
+	ndp := doublePointRaw(attributes, startTimestamp, timestamp)
+	ndp.SetFlags(1)
+
+	return &ndp
+}
+
+func gaugeMetric(name string, points ...*pmetric.NumberDataPoint) *pmetric.Metric {
 	metric := pmetric.NewMetric()
 	metric.SetName(name)
 	metric.SetDataType(pmetric.MetricDataTypeGauge)
@@ -80,48 +124,12 @@ func gaugeMetric(name string, kvp []*kv, startTs pcommon.Timestamp, points ...*p
 	for _, point := range points {
 		destPoint := destPointL.AppendEmpty()
 		point.CopyTo(destPoint)
-		point.SetStartTimestamp(startTs)
-		attrs := destPoint.Attributes()
-		for _, kv := range kvp {
-			attrs.InsertString(kv.Key, kv.Value)
-		}
 	}
+
 	return &metric
 }
 
-func summaryPoint(ts pcommon.Timestamp, count uint64, sum float64, quantiles, values []float64) *pmetric.SummaryDataPoint {
-	sdp := pmetric.NewSummaryDataPoint()
-	sdp.SetTimestamp(ts)
-	sdp.SetCount(count)
-	sdp.SetSum(sum)
-	qvL := sdp.QuantileValues()
-	for i := 0; i < len(quantiles); i++ {
-		qvi := qvL.AppendEmpty()
-		qvi.SetQuantile(quantiles[i])
-		qvi.SetValue(values[i])
-	}
-	return &sdp
-}
-
-func summaryMetric(name string, kvp []*kv, startTs pcommon.Timestamp, points ...*pmetric.SummaryDataPoint) *pmetric.Metric {
-	metric := pmetric.NewMetric()
-	metric.SetName(name)
-	metric.SetDataType(pmetric.MetricDataTypeSummary)
-
-	destPointL := metric.Summary().DataPoints()
-	for _, point := range points {
-		destPoint := destPointL.AppendEmpty()
-		point.CopyTo(destPoint)
-		point.SetStartTimestamp(startTs)
-		attrs := destPoint.Attributes()
-		for _, kv := range kvp {
-			attrs.InsertString(kv.Key, kv.Value)
-		}
-	}
-	return &metric
-}
-
-func sumMetric(name string, kvp []*kv, startTs pcommon.Timestamp, points ...*pmetric.NumberDataPoint) *pmetric.Metric {
+func sumMetric(name string, points ...*pmetric.NumberDataPoint) *pmetric.Metric {
 	metric := pmetric.NewMetric()
 	metric.SetName(name)
 	metric.SetDataType(pmetric.MetricDataTypeSum)
@@ -133,11 +141,55 @@ func sumMetric(name string, kvp []*kv, startTs pcommon.Timestamp, points ...*pme
 	for _, point := range points {
 		destPoint := destPointL.AppendEmpty()
 		point.CopyTo(destPoint)
-		point.SetStartTimestamp(startTs)
-		attrs := destPoint.Attributes()
-		for _, kv := range kvp {
-			attrs.InsertString(kv.Key, kv.Value)
-		}
 	}
+
+	return &metric
+}
+
+func summaryPointRaw(attributes []*kv, startTimestamp, timestamp pcommon.Timestamp) pmetric.SummaryDataPoint {
+	sdp := pmetric.NewSummaryDataPoint()
+	sdp.SetStartTimestamp(startTimestamp)
+	sdp.SetTimestamp(timestamp)
+
+	for _, kv := range attributes {
+		sdp.Attributes().InsertString(kv.Key, kv.Value)
+	}
+
+	return sdp
+}
+
+func summaryPoint(attributes []*kv, startTimestamp, timestamp pcommon.Timestamp, count uint64, sum float64, quantiles, values []float64) *pmetric.SummaryDataPoint {
+	sdp := summaryPointRaw(attributes, startTimestamp, timestamp)
+	sdp.SetCount(count)
+	sdp.SetSum(sum)
+
+	qvL := sdp.QuantileValues()
+	for i := 0; i < len(quantiles); i++ {
+		qvi := qvL.AppendEmpty()
+		qvi.SetQuantile(quantiles[i])
+		qvi.SetValue(values[i])
+	}
+
+	return &sdp
+}
+
+func summaryPointNoValue(attributes []*kv, startTimestamp, timestamp pcommon.Timestamp) *pmetric.SummaryDataPoint {
+	sdp := summaryPointRaw(attributes, startTimestamp, timestamp)
+	sdp.SetFlags(1)
+
+	return &sdp
+}
+
+func summaryMetric(name string, points ...*pmetric.SummaryDataPoint) *pmetric.Metric {
+	metric := pmetric.NewMetric()
+	metric.SetName(name)
+	metric.SetDataType(pmetric.MetricDataTypeSummary)
+
+	destPointL := metric.Summary().DataPoints()
+	for _, point := range points {
+		destPoint := destPointL.AppendEmpty()
+		point.CopyTo(destPoint)
+	}
+
 	return &metric
 }

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -321,10 +321,30 @@ var target2Page1 = `
 # TYPE go_threads gauge
 go_threads 18
 
+# HELP http_request_duration_seconds A histogram of the request duration.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{method="post",code="200",le="1"} 8
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 2
+http_request_duration_seconds_sum{method="post",code="200"} 7
+http_request_duration_seconds_count{method="post",code="200"} 10
+http_request_duration_seconds_bucket{method="post",code="400",le="1"} 30
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 20
+http_request_duration_seconds_sum{method="post",code="400"} 25
+http_request_duration_seconds_count{method="post",code="400"} 50
+
 # HELP http_requests_total The total number of HTTP requests.
 # TYPE http_requests_total counter
 http_requests_total{method="post",code="200"} 10
 http_requests_total{method="post",code="400"} 50
+
+# HELP rpc_duration_seconds A summary of the RPC duration in seconds.
+# TYPE rpc_duration_seconds summary
+rpc_duration_seconds{code="0" quantile="0.5"} 47
+rpc_duration_seconds_sum{code="0"} 100
+rpc_duration_seconds_count{code="0"} 50
+rpc_duration_seconds{code="5" quantile="0.5"} 35
+rpc_duration_seconds_sum{code="5"} 180
+rpc_duration_seconds_count{code="5"} 400
 `
 
 var target2Page2 = `
@@ -332,11 +352,38 @@ var target2Page2 = `
 # TYPE go_threads gauge
 go_threads 16
 
+# HELP http_request_duration_seconds A histogram of the request duration.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{method="post",code="200",le="1"} 40
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 10
+http_request_duration_seconds_sum{method="post",code="200"} 43
+http_request_duration_seconds_count{method="post",code="200"} 50
+http_request_duration_seconds_bucket{method="post",code="300",le="1"} 3
+http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 0
+http_request_duration_seconds_sum{method="post",code="300"} 2
+http_request_duration_seconds_count{method="post",code="300"} 3
+http_request_duration_seconds_bucket{method="post",code="400",le="1"} 35
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 25
+http_request_duration_seconds_sum{method="post",code="400"} 30
+http_request_duration_seconds_count{method="post",code="400"} 60
+
 # HELP http_requests_total The total number of HTTP requests.
 # TYPE http_requests_total counter
 http_requests_total{method="post",code="200"} 50
+http_requests_total{method="post",code="300"} 3
 http_requests_total{method="post",code="400"} 60
-http_requests_total{method="post",code="500"} 3
+
+# HELP rpc_duration_seconds A summary of the RPC duration in seconds.
+# TYPE rpc_duration_seconds summary
+rpc_duration_seconds{code="0" quantile="0.5"} 57
+rpc_duration_seconds_sum{code="0"} 110
+rpc_duration_seconds_count{code="0"} 60
+rpc_duration_seconds{code="3" quantile="0.5"} 42
+rpc_duration_seconds_sum{code="3"} 50
+rpc_duration_seconds_count{code="3"} 30
+rpc_duration_seconds{code="5" quantile="0.5"} 45
+rpc_duration_seconds_sum{code="5"} 190
+rpc_duration_seconds_count{code="5"} 410
 `
 
 var target2Page3 = `
@@ -344,11 +391,38 @@ var target2Page3 = `
 # TYPE go_threads gauge
 go_threads 16
 
+# HELP http_request_duration_seconds A histogram of the request duration.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{method="post",code="200",le="1"} 40
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 10
+http_request_duration_seconds_sum{method="post",code="200"} 43
+http_request_duration_seconds_count{method="post",code="200"} 50
+http_request_duration_seconds_bucket{method="post",code="300",le="1"} 3
+http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 2
+http_request_duration_seconds_sum{method="post",code="300"} 7
+http_request_duration_seconds_count{method="post",code="300"} 5
+http_request_duration_seconds_bucket{method="post",code="400",le="1"} 35
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 25
+http_request_duration_seconds_sum{method="post",code="400"} 30
+http_request_duration_seconds_count{method="post",code="400"} 60
+
 # HELP http_requests_total The total number of HTTP requests.
 # TYPE http_requests_total counter
 http_requests_total{method="post",code="200"} 50
+http_requests_total{method="post",code="300"} 5
 http_requests_total{method="post",code="400"} 60
-http_requests_total{method="post",code="500"} 5
+
+# HELP rpc_duration_seconds A summary of the RPC duration in seconds.
+# TYPE rpc_duration_seconds summary
+rpc_duration_seconds{code="0" quantile="0.5"} 67
+rpc_duration_seconds_sum{code="0"} 120
+rpc_duration_seconds_count{code="0"} 70
+rpc_duration_seconds{code="3" quantile="0.5"} 52
+rpc_duration_seconds_sum{code="3"} 60
+rpc_duration_seconds_count{code="3"} 40
+rpc_duration_seconds{code="5" quantile="0.5"} 55
+rpc_duration_seconds_sum{code="5"} 200
+rpc_duration_seconds_count{code="5"} 420
 `
 
 var target2Page4 = `
@@ -356,11 +430,38 @@ var target2Page4 = `
 # TYPE go_threads gauge
 go_threads 16
 
+# HELP http_request_duration_seconds A histogram of the request duration.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{method="post",code="200",le="1"} 40
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 9
+http_request_duration_seconds_sum{method="post",code="200"} 42
+http_request_duration_seconds_count{method="post",code="200"} 49
+http_request_duration_seconds_bucket{method="post",code="300",le="1"} 2
+http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 1
+http_request_duration_seconds_sum{method="post",code="300"} 4
+http_request_duration_seconds_count{method="post",code="300"} 3
+http_request_duration_seconds_bucket{method="post",code="400",le="1"} 34
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 25
+http_request_duration_seconds_sum{method="post",code="400"} 29
+http_request_duration_seconds_count{method="post",code="400"} 59
+
 # HELP http_requests_total The total number of HTTP requests.
 # TYPE http_requests_total counter
 http_requests_total{method="post",code="200"} 49
+http_requests_total{method="post",code="300"} 3
 http_requests_total{method="post",code="400"} 59
-http_requests_total{method="post",code="500"} 3
+
+# HELP rpc_duration_seconds A summary of the RPC duration in seconds.
+# TYPE rpc_duration_seconds summary
+rpc_duration_seconds{code="0" quantile="0.5"} 66
+rpc_duration_seconds_sum{code="0"} 119
+rpc_duration_seconds_count{code="0"} 69
+rpc_duration_seconds{code="3" quantile="0.5"} 51
+rpc_duration_seconds_sum{code="3"} 59
+rpc_duration_seconds_count{code="3"} 39
+rpc_duration_seconds{code="5" quantile="0.5"} 54
+rpc_duration_seconds_sum{code="5"} 199
+rpc_duration_seconds_count{code="5"} 419
 `
 
 var target2Page5 = `
@@ -368,18 +469,45 @@ var target2Page5 = `
 # TYPE go_threads gauge
 go_threads 16
 
+# HELP http_request_duration_seconds A histogram of the request duration.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{method="post",code="200",le="1"} 41
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 9
+http_request_duration_seconds_sum{method="post",code="200"} 43
+http_request_duration_seconds_count{method="post",code="200"} 50
+http_request_duration_seconds_bucket{method="post",code="300",le="1"} 4
+http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 1
+http_request_duration_seconds_sum{method="post",code="300"} 4
+http_request_duration_seconds_count{method="post",code="300"} 5
+http_request_duration_seconds_bucket{method="post",code="400",le="1"} 34
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 25
+http_request_duration_seconds_sum{method="post",code="400"} 29
+http_request_duration_seconds_count{method="post",code="400"} 59
+
 # HELP http_requests_total The total number of HTTP requests.
 # TYPE http_requests_total counter
 http_requests_total{method="post",code="200"} 50
+http_requests_total{method="post",code="300"} 5
 http_requests_total{method="post",code="400"} 59
-http_requests_total{method="post",code="500"} 5
+
+# HELP rpc_duration_seconds A summary of the RPC duration in seconds.
+# TYPE rpc_duration_seconds summary
+rpc_duration_seconds{code="0" quantile="0.5"} 76
+rpc_duration_seconds_sum{code="0"} 129
+rpc_duration_seconds_count{code="0"} 79
+rpc_duration_seconds{code="3" quantile="0.5"} 61
+rpc_duration_seconds_sum{code="3"} 69
+rpc_duration_seconds_count{code="3"} 49
+rpc_duration_seconds{code="5" quantile="0.5"} 64
+rpc_duration_seconds_sum{code="5"} 209
+rpc_duration_seconds_count{code="5"} 429
 `
 
 func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.ResourceMetrics) {
 	verifyNumValidScrapeResults(t, td, resourceMetrics)
 	m1 := resourceMetrics[0]
-	// m1 has 2 metrics + 5 internal scraper metrics
-	assert.Equal(t, 7, metricsCount(m1))
+	// m1 has 4 metrics + 5 internal scraper metrics
+	assert.Equal(t, 9, metricsCount(m1))
 
 	wantAttributes := td.attributes
 
@@ -393,6 +521,26 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(18),
+					},
+				},
+			}),
+		assertMetricPresent("http_request_duration_seconds_bucket",
+			compareMetricType(pmetric.MetricDataTypeHistogram),
+			[]dataPointExpectation{
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts1),
+						compareHistogramTimestamp(ts1),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "200"}),
+						compareHistogram(10, 7, []uint64{8, 2}),
+					},
+				},
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts1),
+						compareHistogramTimestamp(ts1),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "400"}),
+						compareHistogram(50, 25, []uint64{30, 20}),
 					},
 				},
 			}),
@@ -416,12 +564,32 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 					},
 				},
 			}),
+		assertMetricPresent("rpc_duration_seconds",
+			compareMetricType(pmetric.MetricDataTypeSummary),
+			[]dataPointExpectation{
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts1),
+						compareSummaryTimestamp(ts1),
+						compareSummaryAttributes(map[string]string{"code": "0"}),
+						compareSummary(50, 100, [][]float64{{0.5, 47}}),
+					},
+				},
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts1),
+						compareSummaryTimestamp(ts1),
+						compareSummaryAttributes(map[string]string{"code": "5"}),
+						compareSummary(400, 180, [][]float64{{0.5, 35}}),
+					},
+				},
+			}),
 	}
 	doCompare(t, "scrape1", wantAttributes, m1, e1)
 
 	m2 := resourceMetrics[1]
-	// m2 has 2 metrics + 5 internal scraper metrics
-	assert.Equal(t, 7, metricsCount(m2))
+	// m2 has 4 metrics + 5 internal scraper metrics
+	assert.Equal(t, 9, metricsCount(m2))
 
 	metricsScrape2 := m2.ScopeMetrics().At(0).Metrics()
 	ts2 := getTS(metricsScrape2)
@@ -436,6 +604,34 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 					},
 				},
 			}),
+		assertMetricPresent("http_request_duration_seconds_bucket",
+			compareMetricType(pmetric.MetricDataTypeHistogram),
+			[]dataPointExpectation{
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts1),
+						compareHistogramTimestamp(ts2),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "200"}),
+						compareHistogram(50, 43, []uint64{40, 10}),
+					},
+				},
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts2),
+						compareHistogramTimestamp(ts2),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "300"}),
+						compareHistogram(3, 2, []uint64{3, 0}),
+					},
+				},
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts1),
+						compareHistogramTimestamp(ts2),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "400"}),
+						compareHistogram(60, 30, []uint64{35, 25}),
+					},
+				},
+			}),
 		assertMetricPresent("http_requests_total",
 			compareMetricType(pmetric.MetricDataTypeSum),
 			[]dataPointExpectation{
@@ -449,18 +645,46 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 				},
 				{
 					numberPointComparator: []numberPointComparator{
+						compareStartTimestamp(ts2),
+						compareTimestamp(ts2),
+						compareDoubleValue(3),
+						compareAttributes(map[string]string{"method": "post", "code": "300"}),
+					},
+				},
+				{
+					numberPointComparator: []numberPointComparator{
 						compareStartTimestamp(ts1),
 						compareTimestamp(ts2),
 						compareDoubleValue(60),
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
+			}),
+		assertMetricPresent("rpc_duration_seconds",
+			compareMetricType(pmetric.MetricDataTypeSummary),
+			[]dataPointExpectation{
 				{
-					numberPointComparator: []numberPointComparator{
-						compareStartTimestamp(ts2),
-						compareTimestamp(ts2),
-						compareDoubleValue(3),
-						compareAttributes(map[string]string{"method": "post", "code": "500"}),
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts1),
+						compareSummaryTimestamp(ts2),
+						compareSummaryAttributes(map[string]string{"code": "0"}),
+						compareSummary(60, 110, [][]float64{{0.5, 57}}),
+					},
+				},
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts2),
+						compareSummaryTimestamp(ts2),
+						compareSummaryAttributes(map[string]string{"code": "3"}),
+						compareSummary(30, 50, [][]float64{{0.5, 42}}),
+					},
+				},
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts1),
+						compareSummaryTimestamp(ts2),
+						compareSummaryAttributes(map[string]string{"code": "5"}),
+						compareSummary(410, 190, [][]float64{{0.5, 45}}),
 					},
 				},
 			}),
@@ -468,8 +692,8 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 	doCompare(t, "scrape2", wantAttributes, m2, e2)
 
 	m3 := resourceMetrics[2]
-	// m3 has 2 metrics + 5 internal scraper metrics
-	assert.Equal(t, 7, metricsCount(m3))
+	// m3 has 4 metrics + 5 internal scraper metrics
+	assert.Equal(t, 9, metricsCount(m3))
 
 	metricsScrape3 := m3.ScopeMetrics().At(0).Metrics()
 	ts3 := getTS(metricsScrape3)
@@ -484,6 +708,34 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 					},
 				},
 			}),
+		assertMetricPresent("http_request_duration_seconds_bucket",
+			compareMetricType(pmetric.MetricDataTypeHistogram),
+			[]dataPointExpectation{
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts1),
+						compareHistogramTimestamp(ts3),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "200"}),
+						compareHistogram(50, 43, []uint64{40, 10}),
+					},
+				},
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts2),
+						compareHistogramTimestamp(ts3),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "300"}),
+						compareHistogram(5, 7, []uint64{3, 2}),
+					},
+				},
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts1),
+						compareHistogramTimestamp(ts3),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "400"}),
+						compareHistogram(60, 30, []uint64{35, 25}),
+					},
+				},
+			}),
 		assertMetricPresent("http_requests_total",
 			compareMetricType(pmetric.MetricDataTypeSum),
 			[]dataPointExpectation{
@@ -497,18 +749,46 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 				},
 				{
 					numberPointComparator: []numberPointComparator{
+						compareStartTimestamp(ts2),
+						compareTimestamp(ts3),
+						compareDoubleValue(5),
+						compareAttributes(map[string]string{"method": "post", "code": "300"}),
+					},
+				},
+				{
+					numberPointComparator: []numberPointComparator{
 						compareStartTimestamp(ts1),
 						compareTimestamp(ts3),
 						compareDoubleValue(60),
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
+			}),
+		assertMetricPresent("rpc_duration_seconds",
+			compareMetricType(pmetric.MetricDataTypeSummary),
+			[]dataPointExpectation{
 				{
-					numberPointComparator: []numberPointComparator{
-						compareStartTimestamp(ts2),
-						compareTimestamp(ts3),
-						compareDoubleValue(5),
-						compareAttributes(map[string]string{"method": "post", "code": "500"}),
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts1),
+						compareSummaryTimestamp(ts3),
+						compareSummaryAttributes(map[string]string{"code": "0"}),
+						compareSummary(70, 120, [][]float64{{0.5, 67}}),
+					},
+				},
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts2),
+						compareSummaryTimestamp(ts3),
+						compareSummaryAttributes(map[string]string{"code": "3"}),
+						compareSummary(40, 60, [][]float64{{0.5, 52}}),
+					},
+				},
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts1),
+						compareSummaryTimestamp(ts3),
+						compareSummaryAttributes(map[string]string{"code": "5"}),
+						compareSummary(420, 200, [][]float64{{0.5, 55}}),
 					},
 				},
 			}),
@@ -516,8 +796,8 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 	doCompare(t, "scrape3", wantAttributes, m3, e3)
 
 	m4 := resourceMetrics[3]
-	// m4 has 2 metrics + 5 internal scraper metrics
-	assert.Equal(t, 7, metricsCount(m4))
+	// m4 has 4 metrics + 5 internal scraper metrics
+	assert.Equal(t, 9, metricsCount(m4))
 
 	metricsScrape4 := m4.ScopeMetrics().At(0).Metrics()
 	ts4 := getTS(metricsScrape4)
@@ -529,6 +809,34 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts4),
 						compareDoubleValue(16),
+					},
+				},
+			}),
+		assertMetricPresent("http_request_duration_seconds_bucket",
+			compareMetricType(pmetric.MetricDataTypeHistogram),
+			[]dataPointExpectation{
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts4),
+						compareHistogramTimestamp(ts4),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "200"}),
+						compareHistogram(49, 42, []uint64{40, 9}),
+					},
+				},
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts4),
+						compareHistogramTimestamp(ts4),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "300"}),
+						compareHistogram(3, 4, []uint64{2, 1}),
+					},
+				},
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts4),
+						compareHistogramTimestamp(ts4),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "400"}),
+						compareHistogram(59, 29, []uint64{34, 25}),
 					},
 				},
 			}),
@@ -547,16 +855,44 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 					numberPointComparator: []numberPointComparator{
 						compareStartTimestamp(ts4),
 						compareTimestamp(ts4),
-						compareDoubleValue(59),
-						compareAttributes(map[string]string{"method": "post", "code": "400"}),
+						compareDoubleValue(3),
+						compareAttributes(map[string]string{"method": "post", "code": "300"}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareStartTimestamp(ts4),
 						compareTimestamp(ts4),
-						compareDoubleValue(3),
-						compareAttributes(map[string]string{"method": "post", "code": "500"}),
+						compareDoubleValue(59),
+						compareAttributes(map[string]string{"method": "post", "code": "400"}),
+					},
+				},
+			}),
+		assertMetricPresent("rpc_duration_seconds",
+			compareMetricType(pmetric.MetricDataTypeSummary),
+			[]dataPointExpectation{
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts4),
+						compareSummaryTimestamp(ts4),
+						compareSummaryAttributes(map[string]string{"code": "0"}),
+						compareSummary(69, 119, [][]float64{{0.5, 66}}),
+					},
+				},
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts4),
+						compareSummaryTimestamp(ts4),
+						compareSummaryAttributes(map[string]string{"code": "3"}),
+						compareSummary(39, 59, [][]float64{{0.5, 51}}),
+					},
+				},
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts4),
+						compareSummaryTimestamp(ts4),
+						compareSummaryAttributes(map[string]string{"code": "5"}),
+						compareSummary(419, 199, [][]float64{{0.5, 54}}),
 					},
 				},
 			}),
@@ -564,8 +900,8 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 	doCompare(t, "scrape4", wantAttributes, m4, e4)
 
 	m5 := resourceMetrics[4]
-	// m5 has 2 metrics + 5 internal scraper metrics
-	assert.Equal(t, 7, metricsCount(m5))
+	// m5 has 4 metrics + 5 internal scraper metrics
+	assert.Equal(t, 9, metricsCount(m5))
 
 	metricsScrape5 := m5.ScopeMetrics().At(0).Metrics()
 	ts5 := getTS(metricsScrape5)
@@ -577,6 +913,34 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts5),
 						compareDoubleValue(16),
+					},
+				},
+			}),
+		assertMetricPresent("http_request_duration_seconds_bucket",
+			compareMetricType(pmetric.MetricDataTypeHistogram),
+			[]dataPointExpectation{
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts4),
+						compareHistogramTimestamp(ts5),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "200"}),
+						compareHistogram(50, 43, []uint64{41, 9}),
+					},
+				},
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts4),
+						compareHistogramTimestamp(ts5),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "300"}),
+						compareHistogram(5, 4, []uint64{4, 1}),
+					},
+				},
+				{
+					histogramPointComparator: []histogramPointComparator{
+						compareHistogramStartTimestamp(ts4),
+						compareHistogramTimestamp(ts5),
+						compareHistogramAttributes(map[string]string{"method": "post", "code": "400"}),
+						compareHistogram(59, 29, []uint64{34, 25}),
 					},
 				},
 			}),
@@ -595,16 +959,44 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []*pmetric.Resour
 					numberPointComparator: []numberPointComparator{
 						compareStartTimestamp(ts4),
 						compareTimestamp(ts5),
-						compareDoubleValue(59),
-						compareAttributes(map[string]string{"method": "post", "code": "400"}),
+						compareDoubleValue(5),
+						compareAttributes(map[string]string{"method": "post", "code": "300"}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareStartTimestamp(ts4),
 						compareTimestamp(ts5),
-						compareDoubleValue(5),
-						compareAttributes(map[string]string{"method": "post", "code": "500"}),
+						compareDoubleValue(59),
+						compareAttributes(map[string]string{"method": "post", "code": "400"}),
+					},
+				},
+			}),
+		assertMetricPresent("rpc_duration_seconds",
+			compareMetricType(pmetric.MetricDataTypeSummary),
+			[]dataPointExpectation{
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts4),
+						compareSummaryTimestamp(ts5),
+						compareSummaryAttributes(map[string]string{"code": "0"}),
+						compareSummary(79, 129, [][]float64{{0.5, 76}}),
+					},
+				},
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts4),
+						compareSummaryTimestamp(ts5),
+						compareSummaryAttributes(map[string]string{"code": "3"}),
+						compareSummary(49, 69, [][]float64{{0.5, 61}}),
+					},
+				},
+				{
+					summaryPointComparator: []summaryPointComparator{
+						compareSummaryStartTimestamp(ts4),
+						compareSummaryTimestamp(ts5),
+						compareSummaryAttributes(map[string]string{"code": "5"}),
+						compareSummary(429, 209, [][]float64{{0.5, 64}}),
 					},
 				},
 			}),

--- a/unreleased/prom-receiver-bugfix.yaml
+++ b/unreleased/prom-receiver-bugfix.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: prometheusreceiver
+note: Fix handling of timestamps to prevent reset when a new datapoint is recorded
+issues: [12746]


### PR DESCRIPTION
**Description:**
_Changes_

- Fix handling of timestamps to prevent reset when a new datapoint is recorded
  - regression tests added
- Remove unused adjustment logic for gauge metrics
- Clean up tests for metric adjuster

_Details_

The old implementation of the metrics adjuster relied on the number of data points and attribute
values not changing.
When a new datapoint was reported at a lower index in the list, the old datapoints' start timestamps
were not adjusted to their initial timestamp, which effectively caused a "reset" of their respective
time series.
The new implementation considers each time series individually. Instead of storing the whole metric
as `initial` and `previous` reference points and referencing the datapoint inside them by index, it
only stores the actual datapoint that corresponds to the time series.
This removes the need to reset the time series if the number of data points differ from the
`initial` or `previous` values.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12746

**Testing:**
- Unit tests added to prevent regression
- Tested locally in `kind`

**Documentation:** No changes required