### PR TITLE
[pkg/stanza] Stop readerFactory from returning an error when creating an unsafeReader

### DIFF
--- a/unreleased/pkgstanza-remove-overwritting-offset-in-file-reader.yaml
+++ b/unreleased/pkgstanza-remove-overwritting-offset-in-file-reader.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: pkg/stanza
+
+note: Stop readerFactory from returning an error when creating an unsafeReader
+
+issues: [12766]
+
+subtext: This bug caused the filelog receiver to crash when the collector was restarted and the logs were being read from the end of the file


### PR DESCRIPTION
**Description:** 
The method `unsafeReader()` of the `readerBuilder` no longer returns errors when the parameter `isBeginning` is set to `false`. This caused the `filelog` receiver to crash when the collector was restarted and the parameter `start_at` was set to `end` (which was also the default value).

**Link to tracking Issue:** 
Fixes #12766 

**Testing:** 
Manual testing against the test data mentioned in the issue.
