### PR TITLE
[prometheusremotewriteexporter] don't add target info when it would only contain job and instance

### DIFF
--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -492,14 +492,6 @@ func addSingleSummaryDataPoint(pt pmetric.SummaryDataPoint, resource pcommon.Res
 
 // addResourceTargetInfo converts the resource to the target info metric
 func addResourceTargetInfo(resource pcommon.Resource, settings Settings, timestamp pcommon.Timestamp, tsMap map[string]*prompb.TimeSeries) {
-	if resource.Attributes().Len() == 0 {
-		return
-	}
-	// create parameters for addSample
-	name := targetMetricName
-	if len(settings.Namespace) > 0 {
-		name = settings.Namespace + "_" + name
-	}
 	// Use resource attributes (other than those used for job+instance) as the
 	// metric labels for the target info metric
 	attributes := pcommon.NewMap()
@@ -513,6 +505,15 @@ func addResourceTargetInfo(resource pcommon.Resource, settings Settings, timesta
 			return false
 		}
 	})
+	if attributes.Len() == 0 {
+		// If we only have job + instance, then target_info isn't useful, so don't add it.
+		return
+	}
+	// create parameters for addSample
+	name := targetMetricName
+	if len(settings.Namespace) > 0 {
+		name = settings.Namespace + "_" + name
+	}
 	labels := createAttributes(resource, attributes, settings.ExternalLabels, nameStr, name)
 	sample := &prompb.Sample{
 		Value: float64(1),

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -457,10 +457,12 @@ func TestAddResourceTargetInfo(t *testing.T) {
 		conventions.AttributeServiceName:       "service-name",
 		conventions.AttributeServiceNamespace:  "service-namespace",
 		conventions.AttributeServiceInstanceID: "service-instance-id",
-		"resource_attr":                        "resource-attr-val-1",
 	}
 	resourceWithServiceAttrs := pcommon.NewResource()
 	pcommon.NewMapFromRaw(resourceAttrMap).CopyTo(resourceWithServiceAttrs.Attributes())
+	resourceWithServiceAttrs.Attributes().UpsertString("resource_attr", "resource-attr-val-1")
+	resourceWithOnlyServiceAttrs := pcommon.NewResource()
+	pcommon.NewMapFromRaw(resourceAttrMap).CopyTo(resourceWithOnlyServiceAttrs.Attributes())
 	for _, tc := range []struct {
 		desc      string
 		resource  pcommon.Resource
@@ -556,6 +558,12 @@ func TestAddResourceTargetInfo(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			desc:      "with resource, with only service attributes",
+			resource:  resourceWithOnlyServiceAttrs,
+			timestamp: testdata.TestMetricStartTimestamp,
+			expected:  map[string]*prompb.TimeSeries{},
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/unreleased/prw-exporter-target_info.yaml
+++ b/unreleased/prw-exporter-target_info.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Don't emit the target_info metric when it would only contain job and instance
+
+# One or more tracking issues related to the change
+issues: [12768]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**

The intention of the check for no resource attributes was to only produce the `target_info` metric when it provides meaningful additional attributes.  However, we currently (without this change) will still emit the metric when target_info only has job and instance labels, which are already present on all other metrics.  This change moves the check to after we filter out those attributes so we don't produce a useless metric.

**Link to tracking Issue:**

Addresses https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12724#issuecomment-1197269139

**Testing:**

Added a unit test

cc @jmacd 