### PR TITLE
[receiver/zookeeperreceiver] emit metrics without direction attribute

### DIFF
--- a/receiver/zookeeperreceiver/README.md
+++ b/receiver/zookeeperreceiver/README.md
@@ -23,5 +23,48 @@ receivers:
     collection_interval: 20s
 ```
 
+## Metrics
+
+Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml) with further documentation in [documentation.md](./documentation.md)
+
+### Feature gate configurations
+
+#### Transition from metrics with "direction" attribute
+
+Some zookeeper metrics reported are transitioning from being reported with
+ a `direction` attribute to being reported with the
+direction included in the metric name to adhere to the OpenTelemetry specification
+(https://github.com/open-telemetry/opentelemetry-specification/pull/2617):
+
+- `zookeeper.packet.count` will become:
+  - `zookeeper.packet.received.count`
+  - `zookeeper.packet.sent.count`
+
+The following feature gates control the transition process:
+
+- **receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without `direction` attribute are emitted by the receiver.
+- **receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with `direction` attribute are emitted by the receiver.
+
+##### Transition schedule:
+
+1. v0.57.0, July 2022:
+
+- The new metrics are available for all scrapers, but disabled by default, they can be enabled with the feature gates.
+- The old metrics with `direction` attribute are deprecated with a warning.
+- `receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute` is enabled by default.
+- `receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute` is disabled by default.
+
+2. v0.58.0, August 2022:
+
+- The new metrics are enabled by default, deprecated metrics disabled, they can be enabled with the feature gates.
+- `receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute` is disabled by default.
+- `receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute` is enabled by default.
+
+3. v0.60.0, September 2022:
+
+- The feature gates are removed.
+- The new metrics without `direction` attribute are always emitted.
+- The deprecated metrics with `direction` attribute are no longer available.
+
 [in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/zookeeperreceiver/documentation.md
+++ b/receiver/zookeeperreceiver/documentation.md
@@ -19,6 +19,8 @@ These are the metrics available for this scraper.
 | **zookeeper.latency.max** | Maximum time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
 | **zookeeper.latency.min** | Minimum time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
 | **zookeeper.packet.count** | The number of ZooKeeper packets received or sent by a server. | {packets} | Sum(Int) | <ul> <li>direction</li> </ul> |
+| **zookeeper.packet.received.count** | The number of ZooKeeper packets received by a server. | {packets} | Sum(Int) | <ul> </ul> |
+| **zookeeper.packet.sent.count** | The number of ZooKeeper packets sent by a server. | {packets} | Sum(Int) | <ul> </ul> |
 | **zookeeper.request.active** | Number of currently executing requests. | {requests} | Sum(Int) | <ul> </ul> |
 | **zookeeper.sync.pending** | The number of pending syncs from the followers. Only exposed by the leader. | {syncs} | Sum(Int) | <ul> </ul> |
 | **zookeeper.watch.count** | Number of watches placed on Z-Nodes on a ZooKeeper server. | {watches} | Sum(Int) | <ul> </ul> |

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -118,11 +118,30 @@ metrics:
     unit: "{file_descriptors}"
     gauge:
       value_type: int
+  # produced when receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   zookeeper.packet.count:
     enabled: true
     description: The number of ZooKeeper packets received or sent by a server.
     unit: "{packets}"
     attributes: [direction]
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative
+  # produced when receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
+  zookeeper.packet.sent.count:
+    enabled: true
+    description: The number of ZooKeeper packets sent by a server.
+    unit: "{packets}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative
+  # produced when receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
+  zookeeper.packet.received.count:
+    enabled: true
+    description: The number of ZooKeeper packets received by a server.
+    unit: "{packets}"
     sum:
       value_type: int
       monotonic: true

--- a/receiver/zookeeperreceiver/scraper.go
+++ b/receiver/zookeeperreceiver/scraper.go
@@ -36,7 +36,7 @@ import (
 var zookeeperFormatRE = regexp.MustCompile(`(^zk_\w+)\s+([\w\.\-]+)`)
 
 const (
-	mntrCommand = "mntr"
+	mntrCommand                                       = "mntr"
 	emitMetricsWithDirectionAttributeFeatureGateID    = "receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute"
 	emitMetricsWithoutDirectionAttributeFeatureGateID = "receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute"
 )
@@ -99,12 +99,12 @@ func newZookeeperMetricsScraper(settings component.ReceiverCreateSettings, confi
 	}
 
 	return &zookeeperMetricsScraper{
-		logger:                settings.Logger,
-		config:                config,
-		mb:                    metadata.NewMetricsBuilder(config.Metrics, settings.BuildInfo),
-		closeConnection:       closeConnection,
-		setConnectionDeadline: setConnectionDeadline,
-		sendCmd:               sendCmd,
+		logger:                               settings.Logger,
+		config:                               config,
+		mb:                                   metadata.NewMetricsBuilder(config.Metrics, settings.BuildInfo),
+		closeConnection:                      closeConnection,
+		setConnectionDeadline:                setConnectionDeadline,
+		sendCmd:                              sendCmd,
 		emitMetricsWithDirectionAttribute:    featuregate.GetRegistry().IsEnabled(emitMetricsWithDirectionAttributeFeatureGateID),
 		emitMetricsWithoutDirectionAttribute: featuregate.GetRegistry().IsEnabled(emitMetricsWithoutDirectionAttributeFeatureGateID),
 	}, nil
@@ -156,7 +156,7 @@ func (z *zookeeperMetricsScraper) getResourceMetrics(conn net.Conn) (pmetric.Met
 		return pmetric.NewMetrics(), err
 	}
 
-	creator := newMetricCreator(z.mb)
+	creator := newMetricCreator(z.mb, z.emitMetricsWithDirectionAttribute, z.emitMetricsWithoutDirectionAttribute)
 	now := pcommon.NewTimestampFromTime(time.Now())
 	resourceOpts := make([]metadata.ResourceMetricsOption, 0, 2)
 	for scanner.Scan() {

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14-without-direction.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14-without-direction.json
@@ -1,0 +1,242 @@
+{
+   "resourceMetrics": [
+      {
+         "scopeMetrics": [
+            {
+               "scope": {
+                  "name": "otelcol/zookeeperreceiver",
+                  "version": "latest"
+               },
+               "metrics": [
+                  {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "name": "zookeeper.connection.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.ephemeral_node.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "unit": "{nodes}"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "27",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.file_descriptor.limit",
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "name": "zookeeper.file_descriptor.open",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "26",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of times fsync duration has exceeded warning threshold.",
+                     "name": "zookeeper.fsync.exceeded_threshold.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{events}"
+                  },
+                  {
+                     "description": "Average time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.avg",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Maximum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.max",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Minimum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.min",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "The number of ZooKeeper packets received by a server.",
+                     "name": "zookeeper.packet.received.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{packets}"
+                  },
+                  {
+                     "description": "The number of ZooKeeper packets sent by a server.",
+                     "name": "zookeeper.packet.sent.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{packets}"
+                  },
+                  {
+                     "description": "Number of currently executing requests.",
+                     "name": "zookeeper.request.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "unit": "{requests}"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "name": "zookeeper.watch.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "unit": "{watches}"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.znode.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
+                           }
+                        ]
+                     },
+                     "unit": "{znodes}"
+                  }
+               ]
+            }
+         ],
+         "resource": {
+            "attributes": [
+               {
+                  "key": "zk.version",
+                  "value": {
+                     "stringValue": "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf"
+                  }
+               },
+               {
+                  "key": "server.state",
+                  "value": {
+                     "stringValue": "standalone"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5-without-direction.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5-without-direction.json
@@ -1,0 +1,276 @@
+{
+   "resourceMetrics": [
+      {
+         "scopeMetrics": [
+            {
+               "scope": {
+                  "name": "otelcol/zookeeperreceiver",
+                  "version": "latest"
+               },
+               "metrics": [
+                  {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "name": "zookeeper.connection.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.ephemeral_node.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "unit": "{nodes}"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "107",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.file_descriptor.limit",
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "name": "zookeeper.file_descriptor.open",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "54",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "The number of followers. Only exposed by the leader.",
+                     "name": "zookeeper.follower.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "synced"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unsynced"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "unit": "{followers}"
+                  },
+                  {
+                     "description": "Average time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.avg",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Maximum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.max",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Minimum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.min",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "The number of ZooKeeper packets received by a server.",
+                     "name": "zookeeper.packet.received.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{packets}"
+                  },
+                  {
+                     "description": "The number of ZooKeeper packets sent by a server.",
+                     "name": "zookeeper.packet.sent.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{packets}"
+                  },
+                  {
+                     "description": "Number of currently executing requests.",
+                     "name": "zookeeper.request.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "unit": "{requests}"
+                  },
+                  {
+                     "description": "The number of pending syncs from the followers. Only exposed by the leader.",
+                     "name": "zookeeper.sync.pending",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "unit": "{syncs}"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "name": "zookeeper.watch.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "unit": "{watches}"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.znode.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "5",
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
+                           }
+                        ]
+                     },
+                     "unit": "{znodes}"
+                  }
+               ]
+            }
+         ],
+         "resource": {
+            "attributes": [
+               {
+                  "key": "zk.version",
+                  "value": {
+                     "stringValue": "3.5.5-390fe37ea45dee01bf87dc1c042b5e3dcce88653"
+                  }
+               },
+               {
+                  "key": "server.state",
+                  "value": {
+                     "stringValue": "leader"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/unreleased/zk_direction.yaml
+++ b/unreleased/zk_direction.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: zookeeperreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove direction for metrics. The feature gate: receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute can be set to apply the following (#12772)"
+
+# One or more tracking issues related to the change
+issues: [12184]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |-
+  - `zookeeper` metrics:
+    - `zookeeper.packet.count` will become:
+      - `zookeeper.packet.received.count`
+      - `zookeeper.packet.sent.count`


### PR DESCRIPTION
**Description:**
This PR updates the Zookeeper Receiver so that it can emit metrics without a direction attribute. The behavior of the direction attribute is currently controlled by the feature gates `receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute` and `receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute`. The feature gates will be available for a grace period to help users transition to metrics without a direction attribute, which will eventually become the default.

**Link to tracking Issue:**
#12184

**Testing:**
Unit testing

**Documentation:**
 The readme has been updated to document the feature gates and transition plan.