### PR TITLE
[pkg/stanza/fileconsumer] Fix issue where offsets could be ignored when start_at=end

### DIFF
--- a/pkg/stanza/docs/operators/file_input.md
+++ b/pkg/stanza/docs/operators/file_input.md
@@ -18,7 +18,7 @@ The `file_input` operator reads logs from files. It will place the lines read in
 | `include_file_path`             | `false`          | Whether to add the file path as the attribute `log.file.path`. |
 | `include_file_name_resolved`    | `false`          | Whether to add the file name after symlinks resolution as the attribute `log.file.name_resolved`. |
 | `include_file_path_resolved`    | `false`          | Whether to add the file path after symlinks resolution as the attribute `log.file.path_resolved`. |
-| `start_at`                      | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`. |
+| `start_at`                      | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`. This setting will be ignored if previously read file offsets are retrieved from a persistence mechanism. |
 | `fingerprint_size`              | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time). |
 | `max_log_size`                  | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |.
 | `max_concurrent_files`          | 1024             | The maximum number of log files from which logs will be read concurrently (minimum = 2). If the number of files matched in the `include` pattern exceeds half of this number, then files will be processed in batches. One batch will be processed per `poll_interval`. |

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -320,6 +320,11 @@ func (f *Input) loadLastPollFiles(ctx context.Context) error {
 		return fmt.Errorf("decoding file count: %w", err)
 	}
 
+	if knownFileCount > 0 {
+		f.Infow("Resuming from previously known offset(s). 'start_at' setting is not applicable.")
+		f.readerFactory.fromBeginning = true
+	}
+
 	// Decode each of the known files
 	f.knownFiles = make([]*Reader, 0, knownFileCount)
 	for i := 0; i < knownFileCount; i++ {

--- a/unreleased/pkg-stanza-refactor-unsafe-reader.yaml
+++ b/unreleased/pkg-stanza-refactor-unsafe-reader.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix issue where checkpoints could be ignored if `start_at`` was set to `end``"
+
+# One or more tracking issues related to the change
+issues: [12769]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
The 'start_at' setting is meant to be applicable only during a the first poll 
cycle of the collector. Once the collector has had a chance to start watching 
for files, it should consume any new files from scratch. When restarted, the 
collector should check for the existence of offsets that were previously saved. 
If found, the collector should act the same as it would _after_ the first poll 
cycle. (ie. For known files, start from offsets. For newly found files, start 
from the beginning.) 
 
This PR also standardizes and hardens the related unit tests, which should now 
comprehensively cover all cases w/r/t starting and restarting with offsets. 

The PR also cleans up the mechanism by which we detect whether or not to 
initialize an offset to the end during "restartup". (see [comment here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12767/files#r932277408))

Depends on #12771 

Resolves #12769 