### PR TITLE
Change awsutil to use host instead of empty extensions map

### DIFF
--- a/internal/aws/ecsutil/client_test.go
+++ b/internal/aws/ecsutil/client_test.go
@@ -47,7 +47,7 @@ func TestClient(t *testing.T) {
 
 func TestNewClientProvider(t *testing.T) {
 	baseURL, _ := url.Parse("http://localhost:8080")
-	provider := NewClientProvider(*baseURL, confighttp.HTTPClientSettings{}, componenttest.NewNopTelemetrySettings())
+	provider := NewClientProvider(*baseURL, confighttp.HTTPClientSettings{}, componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	require.NotNil(t, provider)
 	_, ok := provider.(*defaultClientProvider)
 	require.True(t, ok)
@@ -59,7 +59,7 @@ func TestNewClientProvider(t *testing.T) {
 
 func TestDefaultClient(t *testing.T) {
 	endpoint, _ := url.Parse("http://localhost:8080")
-	client, err := defaultClient(*endpoint, confighttp.HTTPClientSettings{}, componenttest.NewNopTelemetrySettings())
+	client, err := defaultClient(*endpoint, confighttp.HTTPClientSettings{}, componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.NotNil(t, client.httpClient.Transport)
 	require.Equal(t, "http://localhost:8080", client.baseURL.String())
@@ -69,6 +69,7 @@ func TestBuildReq(t *testing.T) {
 	endpoint, _ := url.Parse("http://localhost:8080")
 	p := &defaultClientProvider{
 		baseURL:  *endpoint,
+		host:     componenttest.NewNopHost(),
 		settings: componenttest.NewNopTelemetrySettings(),
 	}
 	cl, err := p.BuildClient()
@@ -84,6 +85,7 @@ func TestBuildBadReq(t *testing.T) {
 	endpoint, _ := url.Parse("http://localhost:8080")
 	p := &defaultClientProvider{
 		baseURL:  *endpoint,
+		host:     componenttest.NewNopHost(),
 		settings: componenttest.NewNopTelemetrySettings(),
 	}
 	cl, err := p.BuildClient()
@@ -96,6 +98,7 @@ func TestGetBad(t *testing.T) {
 	endpoint, _ := url.Parse("http://localhost:8080")
 	p := &defaultClientProvider{
 		baseURL:  *endpoint,
+		host:     componenttest.NewNopHost(),
 		settings: componenttest.NewNopTelemetrySettings(),
 	}
 	cl, err := p.BuildClient()

--- a/internal/aws/ecsutil/rest_client.go
+++ b/internal/aws/ecsutil/rest_client.go
@@ -18,17 +18,27 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
 )
 
 func NewRestClient(baseEndpoint url.URL, clientSettings confighttp.HTTPClientSettings, settings component.TelemetrySettings) (RestClient, error) {
-	clientProvider := NewClientProvider(baseEndpoint, clientSettings, settings)
+	clientProvider := NewClientProvider(baseEndpoint, clientSettings, &nopHost{}, settings)
 
 	client, err := clientProvider.BuildClient()
 	if err != nil {
 		return nil, err
 	}
 	return NewRestClientFromClient(client), nil
+}
+
+// TODO: Instead of using this, expose it as a argument to NewRestClient.
+type nopHost struct {
+	component.Host
+}
+
+func (nh *nopHost) GetExtensions() map[config.ComponentID]component.Extension {
+	return map[config.ComponentID]component.Extension{}
 }
 
 // RestClient is swappable for testing.


### PR DESCRIPTION
In the RestClient did not change since it is created during component creation (not during start) and access to Host is not available.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
