### PR TITLE
[pkg/stanza] Unexport and organize fields on manager struct

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -117,16 +117,8 @@ func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Input, error) 
 	}
 
 	return &Input{
-		SugaredLogger:      logger.With("component", "fileconsumer"),
-		finder:             c.Finder,
-		PollInterval:       c.PollInterval.Raw(),
-		queuedMatches:      make([]string, 0),
-		firstCheck:         true,
-		cancel:             func() {},
-		knownFiles:         make([]*Reader, 0, 10),
-		roller:             newRoller(),
-		MaxConcurrentFiles: c.MaxConcurrentFiles,
-		SeenPaths:          make(map[string]struct{}, 100),
+		SugaredLogger: logger.With("component", "fileconsumer"),
+		cancel:        func() {},
 		readerFactory: readerFactory{
 			SugaredLogger: logger.With("component", "fileconsumer"),
 			readerConfig: &readerConfig{
@@ -137,5 +129,13 @@ func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Input, error) 
 			fromBeginning:  startAtBeginning,
 			splitterConfig: c.Splitter,
 		},
+		finder:             c.Finder,
+		roller:             newRoller(),
+		pollInterval:       c.PollInterval.Raw(),
+		maxConcurrentFiles: c.MaxConcurrentFiles,
+		knownFiles:         make([]*Reader, 0, 10),
+		seenPaths:          make(map[string]struct{}, 100),
+		firstCheck:         true,
+		queuedMatches:      make([]string, 0),
 	}, nil
 }

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -415,7 +415,7 @@ func TestBuild(t *testing.T) {
 			require.NoError,
 			func(t *testing.T, f *Input) {
 				require.Equal(t, f.finder.Include, []string{"/var/log/testpath.*"})
-				require.Equal(t, f.PollInterval, 10*time.Millisecond)
+				require.Equal(t, f.pollInterval, 10*time.Millisecond)
 			},
 		},
 		{

--- a/pkg/stanza/operator/input/file/file_test.go
+++ b/pkg/stanza/operator/input/file/file_test.go
@@ -407,8 +407,11 @@ func TestReadExistingAndNewLogs(t *testing.T) {
 // we don't read any entries that were in the file before startup
 func TestStartAtEnd(t *testing.T) {
 	t.Parallel()
+
+	var pollInterval time.Duration
 	operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
 		cfg.StartAt = "end"
+		pollInterval = cfg.PollInterval.Raw()
 	}, nil)
 
 	temp := openTemp(t, tempDir)
@@ -419,7 +422,7 @@ func TestStartAtEnd(t *testing.T) {
 		require.NoError(t, operator.Stop())
 	}()
 
-	time.Sleep(2 * operator.fileConsumer.PollInterval)
+	time.Sleep(2 * pollInterval)
 
 	expectNoMessages(t, logReceived)
 
@@ -433,8 +436,11 @@ func TestStartAtEnd(t *testing.T) {
 // beginning
 func TestStartAtEndNewFile(t *testing.T) {
 	t.Parallel()
+
+	var pollInterval time.Duration
 	operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
 		cfg.StartAt = "end"
+		pollInterval = cfg.PollInterval.Raw()
 	}, nil)
 
 	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
@@ -442,7 +448,7 @@ func TestStartAtEndNewFile(t *testing.T) {
 		require.NoError(t, operator.Stop())
 	}()
 
-	time.Sleep(2 * operator.fileConsumer.PollInterval)
+	time.Sleep(2 * pollInterval)
 
 	temp := openTemp(t, tempDir)
 	writeString(t, temp, "testlog1\ntestlog2\n")

--- a/unreleased/pkg-stanza-fileconsumer-cleanup-names.yaml
+++ b/unreleased/pkg-stanza-fileconsumer-cleanup-names.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza/fileconsumer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unexport several fields that are meant for internal usage only
+
+# One or more tracking issues related to the change
+issues: [12793]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
These fields are currently meant only for internal use.

Additionally, this reorganizes the fields within the `Input` struct, 
to follow some roughly logical grouping around concern/usage.