### PR TITLE
[pkg/stanza/fileconsumer] Rename primary struct

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -61,7 +61,7 @@ type Config struct {
 }
 
 // Build will build a file input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Input, error) {
+func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Manager, error) {
 	if emit == nil {
 		return nil, fmt.Errorf("must provide emit function")
 	}
@@ -116,7 +116,7 @@ func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Input, error) 
 		return nil, fmt.Errorf("invalid start_at location '%s'", c.StartAt)
 	}
 
-	return &Input{
+	return &Manager{
 		SugaredLogger: logger.With("component", "fileconsumer"),
 		cancel:        func() {},
 		readerFactory: readerFactory{

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -407,13 +407,13 @@ func TestBuild(t *testing.T) {
 		name             string
 		modifyBaseConfig func(*Config)
 		errorRequirement require.ErrorAssertionFunc
-		validate         func(*testing.T, *Input)
+		validate         func(*testing.T, *Manager)
 	}{
 		{
 			"Basic",
 			func(f *Config) {},
 			require.NoError,
-			func(t *testing.T, f *Input) {
+			func(t *testing.T, f *Manager) {
 				require.Equal(t, f.finder.Include, []string{"/var/log/testpath.*"})
 				require.Equal(t, f.pollInterval, 10*time.Millisecond)
 			},
@@ -455,7 +455,7 @@ func TestBuild(t *testing.T) {
 				}
 			},
 			require.NoError,
-			func(t *testing.T, f *Input) {},
+			func(t *testing.T, f *Manager) {},
 		},
 		{
 			"MultilineConfiguredEndPattern",
@@ -466,7 +466,7 @@ func TestBuild(t *testing.T) {
 				}
 			},
 			require.NoError,
-			func(t *testing.T, f *Input) {},
+			func(t *testing.T, f *Manager) {},
 		},
 		{
 			"InvalidEncoding",
@@ -495,7 +495,7 @@ func TestBuild(t *testing.T) {
 				f.Splitter.Multiline = helper.MultilineConfig{}
 			},
 			require.NoError,
-			func(t *testing.T, f *Input) {},
+			func(t *testing.T, f *Manager) {},
 		},
 		{
 			"InvalidLineStartRegex",
@@ -557,10 +557,7 @@ func NewTestConfig() *Config {
 
 func TestMapStructureDecodeConfigWithHook(t *testing.T) {
 	expect := NewTestConfig()
-	input := map[string]interface{}{
-		// Config
-		"id":            "config_test",
-		"type":          "file_input",
+	cfgMap := map[string]interface{}{
 		"attributes":    map[string]interface{}{},
 		"resource":      map[string]interface{}{},
 		"include":       expect.Include,
@@ -584,17 +581,14 @@ func TestMapStructureDecodeConfigWithHook(t *testing.T) {
 	dc := &mapstructure.DecoderConfig{Result: &actual, DecodeHook: helper.JSONUnmarshalerHook()}
 	ms, err := mapstructure.NewDecoder(dc)
 	require.NoError(t, err)
-	err = ms.Decode(input)
+	err = ms.Decode(cfgMap)
 	require.NoError(t, err)
 	require.Equal(t, expect, &actual)
 }
 
 func TestMapStructureDecodeConfig(t *testing.T) {
 	expect := NewTestConfig()
-	input := map[string]interface{}{
-		// Config
-		"id":         "config_test",
-		"type":       "file_input",
+	cfgMap := map[string]interface{}{
 		"attributes": map[string]interface{}{},
 		"resource":   map[string]interface{}{},
 		"include":    expect.Include,
@@ -619,7 +613,7 @@ func TestMapStructureDecodeConfig(t *testing.T) {
 	}
 
 	var actual Config
-	err := mapstructure.Decode(input, &actual)
+	err := mapstructure.Decode(cfgMap, &actual)
 	require.NoError(t, err)
 	require.Equal(t, expect, &actual)
 }

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -40,7 +40,7 @@ See this issue for details: https://github.com/census-instrumentation/opencensus
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, _ := buildTestOperator(t, cfg)
+	operator, _ := buildTestManager(t, cfg)
 
 	_ = openTemp(t, tempDir)
 	err := operator.Start(testutil.NewMockPersister("test"))
@@ -60,7 +60,7 @@ func TestAddFileFields(t *testing.T) {
 	cfg.StartAt = "beginning"
 	cfg.IncludeFileName = true
 	cfg.IncludeFilePath = true
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	// Create a file, then start
 	temp := openTemp(t, tempDir)
@@ -88,7 +88,7 @@ func TestAddFileResolvedFields(t *testing.T) {
 	cfg.IncludeFilePath = true
 	cfg.IncludeFileNameResolved = true
 	cfg.IncludeFilePathResolved = true
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	// Create temp dir with log file
 	dir := t.TempDir()
@@ -140,7 +140,7 @@ func TestAddFileResolvedFieldsWithChangeOfSymlinkTarget(t *testing.T) {
 	cfg.IncludeFilePath = true
 	cfg.IncludeFileNameResolved = true
 	cfg.IncludeFilePathResolved = true
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	// Create temp dir with log file
 	dir := t.TempDir()
@@ -215,7 +215,7 @@ func TestReadExistingLogs(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	// Create a file, then start
 	temp := openTemp(t, tempDir)
@@ -283,7 +283,7 @@ func TestReadUsingNopEncoding(t *testing.T) {
 			cfg.StartAt = "beginning"
 			cfg.MaxLogSize = 8
 			cfg.Splitter.EncodingConfig.Encoding = "nop"
-			operator, emitCalls := buildTestOperator(t, cfg)
+			operator, emitCalls := buildTestManager(t, cfg)
 
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -367,7 +367,7 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 			cfg.StartAt = "beginning"
 			cfg.MaxLogSize = tc.maxLogSize
 			cfg.Splitter.EncodingConfig.Encoding = "nop"
-			operator, emitCalls := buildTestOperator(t, cfg)
+			operator, emitCalls := buildTestManager(t, cfg)
 
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -392,7 +392,7 @@ func TestReadNewLogs(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	// Poll once so we know this isn't a new file
@@ -420,7 +420,7 @@ func TestReadExistingAndNewLogs(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	// Start with a file with an entry in it, and expect that entry
@@ -444,7 +444,7 @@ func TestStartAtEnd(t *testing.T) {
 
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	temp := openTemp(t, tempDir)
@@ -469,7 +469,7 @@ func TestStartAtEndNewFile(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	operator.poll(context.Background())
@@ -491,7 +491,7 @@ func TestNoNewline(t *testing.T) {
 	cfg.StartAt = "beginning"
 	cfg.Splitter = helper.NewSplitterConfig()
 	cfg.Splitter.Flusher.Period.Duration = time.Nanosecond
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	temp := openTemp(t, tempDir)
 	writeString(t, temp, "testlog1\ntestlog2")
@@ -512,7 +512,7 @@ func TestEmptyLine(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	temp := openTemp(t, tempDir)
 	writeString(t, temp, "testlog1\n\ntestlog2\n")
@@ -535,7 +535,7 @@ func TestMultipleEmpty(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	temp := openTemp(t, tempDir)
 	writeString(t, temp, "\n\ntestlog1\n\n\ntestlog2\n")
@@ -562,7 +562,7 @@ func TestLeadingEmpty(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	temp := openTemp(t, tempDir)
 	writeString(t, temp, "\ntestlog1\ntestlog2\n")
@@ -586,7 +586,7 @@ func TestSplitWrite(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	temp := openTemp(t, tempDir)
@@ -606,7 +606,7 @@ func TestIgnoreEmptyFiles(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	temp := openTemp(t, tempDir)
@@ -633,7 +633,7 @@ func TestDecodeBufferIsResized(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
 	defer func() {
@@ -653,7 +653,7 @@ func TestMultiFileSimple(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	temp1 := openTemp(t, tempDir)
 	temp2 := openTemp(t, tempDir)
@@ -677,7 +677,7 @@ func TestMultiFileParallel_PreloadedFiles(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	numFiles := 10
 	numMessages := 100
@@ -718,7 +718,7 @@ func TestMultiFileParallel_LiveFiles(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	numFiles := 10
 	numMessages := 100
@@ -784,7 +784,7 @@ func TestRestartOffsets(t *testing.T) {
 			duringRestart := tokenWithLength(tc.lineLength)
 			during2ndRun := tokenWithLength(tc.lineLength)
 
-			operatorOne, emitCallsOne := buildTestOperator(t, cfg)
+			operatorOne, emitCallsOne := buildTestManager(t, cfg)
 			writeString(t, logFile, string(before1stRun)+"\n")
 			require.NoError(t, operatorOne.Start(persister))
 			if tc.startAt == "beginning" {
@@ -798,7 +798,7 @@ func TestRestartOffsets(t *testing.T) {
 
 			writeString(t, logFile, string(duringRestart)+"\n")
 
-			operatorTwo, emitCallsTwo := buildTestOperator(t, cfg)
+			operatorTwo, emitCallsTwo := buildTestManager(t, cfg)
 			require.NoError(t, operatorTwo.Start(persister))
 			waitForToken(t, emitCallsTwo, duringRestart)
 			writeString(t, logFile, string(during2ndRun)+"\n")
@@ -814,7 +814,7 @@ func TestManyLogsDelivered(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	count := 1000
 	expectedTokens := make([]string, 0, count)
@@ -861,7 +861,7 @@ func TestFileBatching(t *testing.T) {
 	cfg.StartAt = "beginning"
 	cfg.MaxConcurrentFiles = maxConcurrentFiles
 	emitCalls := make(chan *emitParams, expectedLinesPerBatch*2)
-	operator := buildTestOperatorWithEmit(t, cfg, emitCalls)
+	operator := buildTestManagerWithEmit(t, cfg, emitCalls)
 	operator.persister = testutil.NewMockPersister("test")
 
 	temps := make([]*os.File, 0, files)
@@ -912,7 +912,7 @@ func TestFileReader_FingerprintUpdated(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	temp := openTemp(t, tempDir)
 	tempCopy := openFile(t, temp.Name())
@@ -954,7 +954,7 @@ func TestFingerprintGrowsAndStops(t *testing.T) {
 			cfg := NewConfig().includeDir(tempDir)
 			cfg.StartAt = "beginning"
 			cfg.FingerprintSize = helper.ByteSize(maxFP)
-			operator, _ := buildTestOperator(t, cfg)
+			operator, _ := buildTestManager(t, cfg)
 
 			temp := openTemp(t, tempDir)
 			tempCopy := openFile(t, temp.Name())
@@ -1017,7 +1017,7 @@ func TestFingerprintChangeSize(t *testing.T) {
 			cfg := NewConfig().includeDir(tempDir)
 			cfg.StartAt = "beginning"
 			cfg.FingerprintSize = helper.ByteSize(maxFP)
-			operator, _ := buildTestOperator(t, cfg)
+			operator, _ := buildTestManager(t, cfg)
 
 			temp := openTemp(t, tempDir)
 			tempCopy := openFile(t, temp.Name())
@@ -1139,7 +1139,7 @@ func TestEncodings(t *testing.T) {
 			cfg := NewConfig().includeDir(tempDir)
 			cfg.StartAt = "beginning"
 			cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: tc.encoding}
-			operator, emitCalls := buildTestOperator(t, cfg)
+			operator, emitCalls := buildTestManager(t, cfg)
 
 			// Populate the file
 			temp := openTemp(t, tempDir)

--- a/pkg/stanza/fileconsumer/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/fingerprint_test.go
@@ -34,7 +34,7 @@ func TestNewFingerprintDoesNotModifyOffset(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, _ := buildTestOperator(t, cfg)
+	operator, _ := buildTestManager(t, cfg)
 
 	operator.readerFactory.readerConfig.fingerprintSize = len(fingerprint)
 
@@ -130,7 +130,7 @@ func TestNewFingerprint(t *testing.T) {
 			tempDir := t.TempDir()
 			cfg := NewConfig().includeDir(tempDir)
 			cfg.StartAt = "beginning"
-			operator, _ := buildTestOperator(t, cfg)
+			operator, _ := buildTestManager(t, cfg)
 
 			operator.readerFactory.readerConfig.fingerprintSize = tc.fingerprintSize
 
@@ -237,7 +237,7 @@ func TestFingerprintStartsWith_FromFile(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, _ := buildTestOperator(t, cfg)
+	operator, _ := buildTestManager(t, cfg)
 
 	operator.readerFactory.readerConfig.fingerprintSize *= 10
 

--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -46,7 +46,7 @@ func TestMultiFileRotate(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	numFiles := 3
 	numMessages := 3
@@ -104,7 +104,7 @@ func TestMultiFileRotateSlow(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	getMessage := func(f, k, m int) string { return fmt.Sprintf("file %d-%d, message %d", f, k, m) }
 	fileName := func(f, k int) string { return filepath.Join(tempDir, fmt.Sprintf("file%d.rot%d.log", f, k)) }
@@ -155,7 +155,7 @@ func TestMultiCopyTruncateSlow(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 
 	getMessage := func(f, k, m int) string { return fmt.Sprintf("file %d-%d, message %d", f, k, m) }
 	fileName := func(f, k int) string { return filepath.Join(tempDir, fmt.Sprintf("file%d.rot%d.log", f, k)) }
@@ -263,7 +263,7 @@ func (rt rotationTest) run(tc rotationTest, copyTruncate, sequential bool) func(
 		cfg.StartAt = "beginning"
 		cfg.PollInterval = helper.NewDuration(tc.pollInterval)
 		emitCalls := make(chan *emitParams, tc.totalLines)
-		operator := buildTestOperatorWithEmit(t, cfg, emitCalls)
+		operator := buildTestManagerWithEmit(t, cfg, emitCalls)
 
 		logger := getRotatingLogger(t, tempDir, tc.maxLinesPerFile, tc.maxBackupFiles, copyTruncate, sequential)
 
@@ -365,7 +365,7 @@ func TestMoveFile(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	temp1 := openTemp(t, tempDir)
@@ -397,7 +397,7 @@ func TestTrackMovedAwayFiles(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	temp1 := openTemp(t, tempDir)
@@ -438,7 +438,7 @@ func TestTruncateThenWrite(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	temp1 := openTemp(t, tempDir)
@@ -472,7 +472,7 @@ func TestCopyTruncateWriteBoth(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	operator.persister = testutil.NewMockPersister("test")
 
 	temp1 := openTemp(t, tempDir)
@@ -512,7 +512,7 @@ func TestFileMovedWhileOff_BigFiles(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	operator, emitCalls := buildTestOperator(t, cfg)
+	operator, emitCalls := buildTestManager(t, cfg)
 	persister := testutil.NewMockPersister("test")
 
 	log1 := tokenWithLength(1000)

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -48,12 +48,12 @@ type emitParams struct {
 	token []byte
 }
 
-func buildTestOperator(t *testing.T, cfg *Config) (*Input, chan *emitParams) {
+func buildTestManager(t *testing.T, cfg *Config) (*Manager, chan *emitParams) {
 	emitChan := make(chan *emitParams, 100)
-	return buildTestOperatorWithEmit(t, cfg, emitChan), emitChan
+	return buildTestManagerWithEmit(t, cfg, emitChan), emitChan
 }
 
-func buildTestOperatorWithEmit(t *testing.T, cfg *Config, emitChan chan *emitParams) *Input {
+func buildTestManagerWithEmit(t *testing.T, cfg *Config, emitChan chan *emitParams) *Manager {
 	input, err := cfg.Build(testutil.Logger(t), func(_ context.Context, attrs *FileAttributes, token []byte) {
 		emitChan <- &emitParams{attrs, token}
 	})

--- a/pkg/stanza/operator/input/file/file.go
+++ b/pkg/stanza/operator/input/file/file.go
@@ -29,7 +29,7 @@ type toBodyFunc func([]byte) interface{}
 type Input struct {
 	helper.InputOperator
 
-	fileConsumer *fileconsumer.Input
+	fileConsumer *fileconsumer.Manager
 
 	toBody         toBodyFunc
 	preEmitOptions []preEmitOption

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -58,7 +58,7 @@ func createDefaultConfig() config.Receiver {
 }
 
 type receiver struct {
-	input *fileconsumer.Input
+	input *fileconsumer.Manager
 	id    config.ComponentID
 }
 

--- a/unreleased/pkg-stanze-fileconsumer-rename-input.yaml
+++ b/unreleased/pkg-stanze-fileconsumer-rename-input.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza/fileconsumer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename fileconsumer.Input to fileconsumer.Manager
+
+# One or more tracking issues related to the change
+issues: [12876]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
This resolves another minor cleanup task, following from the extraction
of the `fileconsumer` package from the `file_input` operator.

The 'Input' struct is named according to its former context
(being a standalone input operator). This PR changes the name of the
struct to 'Manager', and cleans up references to it.