### PR TITLE
[receiver/hostmetrics] Do not fetch conntrack stats if metrics disabled

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
@@ -40,6 +40,10 @@ var allTCPStates = []string{
 }
 
 func (s *scraper) recordNetworkConntrackMetrics() error {
+	if !s.config.Metrics.SystemNetworkConntrackCount.Enabled && !s.config.Metrics.SystemNetworkConntrackMax.Enabled {
+		return nil
+	}
+
 	now := pcommon.NewTimestampFromTime(time.Now())
 	conntrack, err := s.conntrack()
 	if err != nil {

--- a/unreleased/fix-conntrack-metric-warnings.yaml
+++ b/unreleased/fix-conntrack-metric-warnings.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: receiver/hostmetrics
+note: Do not throw scraping errors if conntrack metrics collection is disabled
+issues: [12799]


### PR DESCRIPTION
To avoid errors in the logs when conntrack stats are unavailable on the host and the metrics are disabled

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12799