### PR TITLE
KuebeletStats receiver, fetch metadata from initContainers

### DIFF
--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata.go
@@ -133,6 +133,12 @@ func (m *Metadata) getContainerID(podUID string, containerName string) (string, 
 					return stripContainerID(containerStatus.ContainerID), nil
 				}
 			}
+			for _, initContainerStatus := range pod.Status.InitContainerStatuses {
+				if containerName == initContainerStatus.Name {
+					return stripContainerID(initContainerStatus.ContainerID), nil
+				}
+			}
+
 		}
 	}
 

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
@@ -100,6 +100,12 @@ func TestSetExtraLabels(t *testing.T) {
 									ContainerID: "test-container",
 								},
 							},
+							InitContainerStatuses: []v1.ContainerStatus{
+								{
+									Name:        "init-container1",
+									ContainerID: "test-init-container",
+								},
+							},
 						},
 					},
 				},
@@ -107,6 +113,36 @@ func TestSetExtraLabels(t *testing.T) {
 			args: []string{"uid-1234", "container.id", "container1"},
 			want: map[string]interface{}{
 				string(MetadataLabelContainerID): "test-container",
+			},
+		},
+		{
+			name: "set_init_container_id_valid",
+			metadata: NewMetadata([]MetadataLabel{MetadataLabelContainerID}, &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							UID: "uid-1234",
+						},
+						Status: v1.PodStatus{
+							ContainerStatuses: []v1.ContainerStatus{
+								{
+									Name:        "container1",
+									ContainerID: "test-container",
+								},
+							},
+							InitContainerStatuses: []v1.ContainerStatus{
+								{
+									Name:        "init-container1",
+									ContainerID: "test-init-container",
+								},
+							},
+						},
+					},
+				},
+			}, nil),
+			args: []string{"uid-1234", "container.id", "init-container1"},
+			want: map[string]interface{}{
+				string(MetadataLabelContainerID): "test-init-container",
 			},
 		},
 		{

--- a/unreleased/kubeletstats-fetch-metadata-from-initContainers.yaml
+++ b/unreleased/kubeletstats-fetch-metadata-from-initContainers.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: kubeletstatsreceiver
+note: Fetch metadata from initContainers
+issues: [12887]


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

**Description:**
`kubeletstats` is throwing the below error.

```
2022-07-07T15:19:46.365Z warn kubelet/accumulator.go:112 failed to fetch
container metrics {"kind": "receiver", "name": "kubeletstats", "pod":
"init-app-container", "container": "init-example", "error": "failed to
set extra labels from metadata: pod
\"4406a18b-3d22-4b27-bdae-3c89de5f7868\" with container \"init-example\"
not found in the fetched metadata"
```

The current implementation does not handle init containers correctly;
The code is only looking for `ContainerStatuses` but the init containers live under `InitContainerStatuses` instead

**Testing:** 
Unit test was added and manual validation of the fix has been tetsted using the below pod and making sure the error is no longer in the logs.

```
apiVersion: v1
kind: Pod
metadata:
  name: init-app-container
  labels:
    app: initapp
spec:
  containers:
  - name: myapp-container
    image: busybox:1.28
    command: ['sh', '-c', 'sleep 360000']
  initContainers:
  - name: init-example
    image: busybox:1.28
    command: ['sh', '-c', "sleep 20"]
```

**Documentation:** <Describe the documentation added.>