### PR TITLE
[internal/common/testutil] Add support for testing listening udp ports

### DIFF
--- a/internal/common/testutil/testutil.go
+++ b/internal/common/testutil/testutil.go
@@ -15,6 +15,7 @@
 package testutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 
 import (
+	"fmt"
 	"net"
 	"os/exec"
 	"runtime"
@@ -31,17 +32,26 @@ type portpair struct {
 	last  string
 }
 
-// GetAvailableLocalAddress finds an available local port and returns an endpoint
+// GetAvailableLocalAddress finds an available local port on tcp network and returns an endpoint
 // describing it. The port is available for opening when this function returns
 // provided that there is no race by some other code to grab the same port
 // immediately.
 func GetAvailableLocalAddress(t testing.TB) string {
+	return GetAvailableLocalNetworkAddress(t, "tcp")
+}
+
+// GetAvailableLocalNetworkAddress finds an available local port on specified network and returns an endpoint
+// describing it. The port is available for opening when this function returns
+// provided that there is no race by some other code to grab the same port
+// immediately.
+func GetAvailableLocalNetworkAddress(t testing.TB, network string) string {
 	// Retry has been added for windows as net.Listen can return a port that is not actually available. Details can be
 	// found in https://github.com/docker/for-win/issues/3171 but to summarize Hyper-V will reserve ranges of ports
 	// which do not show up under the "netstat -ano" but can only be found by
 	// "netsh interface ipv4 show excludedportrange protocol=tcp".  We'll use []exclusions to hold those ranges and
 	// retry if the port returned by GetAvailableLocalAddress falls in one of those them.
 	var exclusions []portpair
+
 	portFound := false
 	if runtime.GOOS == "windows" {
 		exclusions = getExclusionsList(t)
@@ -49,7 +59,7 @@ func GetAvailableLocalAddress(t testing.TB) string {
 
 	var endpoint string
 	for !portFound {
-		endpoint = findAvailableAddress(t)
+		endpoint = findAvailableAddress(t, network)
 		_, port, err := net.SplitHostPort(endpoint)
 		require.NoError(t, err)
 		portFound = true
@@ -66,15 +76,32 @@ func GetAvailableLocalAddress(t testing.TB) string {
 	return endpoint
 }
 
-func findAvailableAddress(t testing.TB) string {
-	ln, err := net.Listen("tcp", "localhost:0")
-	require.NoError(t, err, "Failed to get a free local port")
-	// There is a possible race if something else takes this same port before
-	// the test uses it, however, that is unlikely in practice.
-	defer func() {
-		assert.NoError(t, ln.Close())
-	}()
-	return ln.Addr().String()
+func findAvailableAddress(t testing.TB, network string) string {
+	switch network {
+	// net.Listen supported network strings
+	case "tcp", "tcp4", "tcp6", "unix", "unixpacket":
+		ln, err := net.Listen(network, "localhost:0")
+		require.NoError(t, err, "Failed to get a free local port")
+		// There is a possible race if something else takes this same port before
+		// the test uses it, however, that is unlikely in practice.
+		defer func() {
+			assert.NoError(t, ln.Close())
+		}()
+		fmt.Printf("Network: %s Address: %s\n", network, ln.Addr().String())
+		return ln.Addr().String()
+	// net.ListenPacket supported network strings
+	case "udp", "udp4", "udp6", "unixgram":
+		ln, err := net.ListenPacket(network, "localhost:0")
+		require.NoError(t, err, "Failed to get a free local port")
+		// There is a possible race if something else takes this same port before
+		// the test uses it, however, that is unlikely in practice.
+		defer func() {
+			assert.NoError(t, ln.Close())
+		}()
+		fmt.Printf("Network: %s Address: %s\n", network, ln.LocalAddr().String())
+		return ln.LocalAddr().String()
+	}
+	return ""
 }
 
 // Get excluded ports on Windows from the command: netsh interface ipv4 show excludedportrange protocol=tcp

--- a/internal/common/testutil/testutil.go
+++ b/internal/common/testutil/testutil.go
@@ -15,7 +15,6 @@
 package testutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 
 import (
-	"fmt"
 	"net"
 	"os/exec"
 	"runtime"
@@ -87,7 +86,6 @@ func findAvailableAddress(t testing.TB, network string) string {
 		defer func() {
 			assert.NoError(t, ln.Close())
 		}()
-		fmt.Printf("Network: %s Address: %s\n", network, ln.Addr().String())
 		return ln.Addr().String()
 	// net.ListenPacket supported network strings
 	case "udp", "udp4", "udp6", "unixgram":
@@ -98,7 +96,6 @@ func findAvailableAddress(t testing.TB, network string) string {
 		defer func() {
 			assert.NoError(t, ln.Close())
 		}()
-		fmt.Printf("Network: %s Address: %s\n", network, ln.LocalAddr().String())
 		return ln.LocalAddr().String()
 	}
 	return ""

--- a/internal/common/testutil/testutil_test.go
+++ b/internal/common/testutil/testutil_test.go
@@ -15,7 +15,6 @@
 package testutil
 
 import (
-	"fmt"
 	"net"
 	"testing"
 
@@ -40,7 +39,6 @@ func TestGetAvailableLocalAddress(t *testing.T) {
 }
 func TestGetAvailableLocalUDPAddress(t *testing.T) {
 	addr := GetAvailableLocalNetworkAddress(t, "udp")
-	fmt.Println(addr)
 	// Endpoint should be free.
 	ln0, err := net.ListenPacket("udp", addr)
 	require.NoError(t, err)

--- a/internal/common/testutil/testutil_test.go
+++ b/internal/common/testutil/testutil_test.go
@@ -15,6 +15,7 @@
 package testutil
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -34,6 +35,22 @@ func TestGetAvailableLocalAddress(t *testing.T) {
 
 	// Ensure that the endpoint wasn't something like ":0" by checking that a second listener will fail.
 	ln1, err := net.Listen("tcp", addr)
+	require.Error(t, err)
+	require.Nil(t, ln1)
+}
+func TestGetAvailableLocalUDPAddress(t *testing.T) {
+	addr := GetAvailableLocalNetworkAddress(t, "udp")
+	fmt.Println(addr)
+	// Endpoint should be free.
+	ln0, err := net.ListenPacket("udp", addr)
+	require.NoError(t, err)
+	require.NotNil(t, ln0)
+	t.Cleanup(func() {
+		require.NoError(t, ln0.Close())
+	})
+
+	// Ensure that the endpoint wasn't something like ":0" by checking that a second listener will fail.
+	ln1, err := net.ListenPacket("udp", addr)
 	require.Error(t, err)
 	require.Nil(t, ln1)
 }


### PR DESCRIPTION
**Description:** 
Refactored the internal testutil functions for available port discovery used in component service mocking to be able to support `udp` ports similarly to existing `tcp` port functionality. Once this is merged, this should provide a path forward to fixing racy tests for all UDP listening components (ex: statsd and carbon receivers), where the tests are currently marked to be skipped.

Summary of changes:
* Extended the internal testutil functions to make it possible to mock listening UDP ports for components that make use of udp listening servers (ex: statsd receiver).

* The existing `findAvailableAddress` function was refactored to support both `net.Listen` and `net.ListenPacket` supported network types. `net.ListenPacket` is needed for `udp` available port discovery. 

* A new testutil function `GetAvailableLocalNetworkAddress` was added that exposes the network string argument needed for `net.Listen` and `net.ListenPacket` used in `findAvailableAddress`.

* The existing `GetAvailableLocalAddress` function is refactored as a wrapper around `GetAvailableLocalNetworkAddress` to provide backwards compatible behavior for all existing functional mock tcp listening test.


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Ref Issue:
#10916

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Added new test for finding free UDP listening port.

**Documentation:** 
No additional documentation added.