### PR TITLE
[processor/k8sattributesprocessor] add statefulset attribute

### DIFF
--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -73,7 +73,7 @@ type ExtractConfig struct {
 	// The field accepts a list of strings.
 	//
 	// Metadata fields supported right now are,
-	//   k8s.pod.name, k8s.pod.uid, k8s.deployment.name,
+	//   k8s.pod.name, k8s.pod.uid, k8s.deployment.name, k8s.statefulset.name,
 	//   k8s.node.name, k8s.namespace.name and k8s.pod.start_time
 	//
 	// Specifying anything other than these values will result in an error.

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -182,6 +182,7 @@ type FieldFilter struct {
 // ExtractionRules is used to specify the information that needs to be extracted
 // from pods and added to the spans as tags.
 type ExtractionRules struct {
+	StatefulSet        bool
 	Deployment         bool
 	Namespace          bool
 	PodName            bool

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -81,6 +81,7 @@ func withExtractMetadata(fields ...string) option {
 				conventions.AttributeContainerID,
 				conventions.AttributeContainerImageName,
 				conventions.AttributeContainerImageTag,
+				conventions.AttributeK8SStatefulSetName,
 			}
 		}
 		for _, field := range fields {
@@ -108,6 +109,8 @@ func withExtractMetadata(fields ...string) option {
 				p.rules.ContainerImageTag = true
 			case deprecatedMetadataCluster, conventions.AttributeK8SClusterName:
 				// This one is deprecated, ignore it
+			case conventions.AttributeK8SStatefulSetName:
+				p.rules.StatefulSet = true
 			default:
 				return fmt.Errorf("\"%s\" is not a supported metadata field", field)
 			}

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -316,6 +316,7 @@ func TestWithExtractMetadata(t *testing.T) {
 	assert.True(t, p.rules.StartTime)
 	assert.True(t, p.rules.Deployment)
 	assert.True(t, p.rules.Node)
+	assert.True(t, p.rules.StatefulSet)
 
 	p = &kubernetesprocessor{}
 	err := withExtractMetadata("randomfield")(p)
@@ -330,6 +331,7 @@ func TestWithExtractMetadata(t *testing.T) {
 	assert.False(t, p.rules.StartTime)
 	assert.False(t, p.rules.Deployment)
 	assert.False(t, p.rules.Node)
+	assert.False(t, p.rules.StatefulSet)
 }
 
 func TestWithFilterLabels(t *testing.T) {

--- a/unreleased/add-sts-attribute.yaml
+++ b/unreleased/add-sts-attribute.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Adds support for discovering Kubernetes StatefulSet name"
+
+# One or more tracking issues related to the change
+issues: [141]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adding support for discovering K8s statefulsets using https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/k8s/#statefulset

Example configuration:
```
    k8sattributes:
      passthrough: false
      extract:
        metadata: 
          - "k8s.namespace.name"
          - "k8s.deployment.name"
          - "k8s.statefulset.name"
        labels:
          - key_regex: '(.*)'

```

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
- Unit tests
- Manually tested collecting metrics from statefulset

**Documentation:** <Describe the documentation added.>
- Updated docs