### PR TITLE
[Makefile] require 'install-tools' in default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ all-groups:
 	@echo "\nother: $(OTHER_MODS)"
 
 .PHONY: all
-all: all-common gotest otelcontribcol otelcontribcol-unstable
+all: install-tools all-common gotest otelcontribcol otelcontribcol-unstable
 
 .PHONY: all-common
 all-common:


### PR DESCRIPTION
Potential fix for #12607. See [comment](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12607#issuecomment-1202685976).