### PR TITLE
[pkg/telemetryquerylanguage] Use correct status code

### DIFF
--- a/pkg/telemetryquerylanguage/contexts/tqltraces/traces.go
+++ b/pkg/telemetryquerylanguage/contexts/tqltraces/traces.go
@@ -69,7 +69,7 @@ var symbolTable = map[tql.EnumSymbol]tql.Enum{
 	"SPAN_KIND_PRODUCER":    tql.Enum(tracesproto.Span_SPAN_KIND_PRODUCER),
 	"SPAN_KIND_CONSUMER":    tql.Enum(tracesproto.Span_SPAN_KIND_CONSUMER),
 	"STATUS_CODE_UNSET":     tql.Enum(tracesproto.Status_STATUS_CODE_UNSET),
-	"STATUS_CODE_OK":        tql.Enum(tracesproto.Status_DEPRECATED_STATUS_CODE_OK),
+	"STATUS_CODE_OK":        tql.Enum(tracesproto.Status_STATUS_CODE_OK),
 	"STATUS_CODE_ERROR":     tql.Enum(tracesproto.Status_STATUS_CODE_ERROR),
 }
 

--- a/pkg/telemetryquerylanguage/contexts/tqltraces/traces_test.go
+++ b/pkg/telemetryquerylanguage/contexts/tqltraces/traces_test.go
@@ -837,7 +837,7 @@ func Test_ParseEnum(t *testing.T) {
 		},
 		{
 			name: "STATUS_CODE_OK",
-			want: tql.Enum(tracesproto.Status_DEPRECATED_STATUS_CODE_OK),
+			want: tql.Enum(tracesproto.Status_STATUS_CODE_OK),
 		},
 		{
 			name: "STATUS_CODE_ERROR",


### PR DESCRIPTION
**Description:**
Updates trace context enum to use the correct value from the protos.

**Link to tracking Issue:** 
Related to #11751 

**Testing:** 
Ran unit tests