### PR TITLE
re-enable UDP ListenAndServer tests 

### DIFF
--- a/receiver/carbonreceiver/transport/server_test.go
+++ b/receiver/carbonreceiver/transport/server_test.go
@@ -55,7 +55,8 @@ func Test_Server_ListenAndServe(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr := testutil.GetAvailableLocalAddress(t)
+			addr := testutil.GetAvailableLocalNetworkAddress(t, tt.name)
+
 			svr, err := tt.buildServerFn(addr)
 			require.NoError(t, err)
 			require.NotNil(t, svr)

--- a/receiver/statsdreceiver/transport/server_test.go
+++ b/receiver/statsdreceiver/transport/server_test.go
@@ -59,7 +59,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			require.Error(t, err)
 			require.Nil(t, ln1)
 
-			//Unbind the local address so the mock UDP service can use it
+			// Unbind the local address so the mock UDP service can use it
 			ln0.Close()
 
 			srv, err := tt.buildServerFn(addr)

--- a/receiver/statsdreceiver/transport/server_test.go
+++ b/receiver/statsdreceiver/transport/server_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func Test_Server_ListenAndServe(t *testing.T) {
-	t.Skip("Test is unstable, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1426")
 
 	tests := []struct {
 		name          string
@@ -48,7 +47,21 @@ func Test_Server_ListenAndServe(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr := testutil.GetAvailableLocalAddress(t)
+			addr := testutil.GetAvailableLocalNetworkAddress(t, "udp")
+
+			// Endpoint should be free.
+			ln0, err := net.ListenPacket("udp", addr)
+			require.NoError(t, err)
+			require.NotNil(t, ln0)
+
+			// Ensure that the endpoint wasn't something like ":0" by checking that a second listener will fail.
+			ln1, err := net.ListenPacket("udp", addr)
+			require.Error(t, err)
+			require.Nil(t, ln1)
+
+			//Unbind the local address so the mock UDP service can use it
+			ln0.Close()
+
 			srv, err := tt.buildServerFn(addr)
 			require.NoError(t, err)
 			require.NotNil(t, srv)


### PR DESCRIPTION

**Description:** 
Some UDP listener tests were disabled because of flaky behavior associated with local UDP address availability. Underling cause the the flaky behavior was the internal testutil function used to select an available local address was not UDP aware and was handing back free TCP local addresses.

This PR updates re-enables the skipped tests and updates them to use the network selectable test util function to find local UDP address.

**Link to tracking Issue:** 
Issue: #10916
Previous PR: #12888

**Testing:** 
I've done locally testing with the changes, but because this was originally a flaky test in production (essentially a race) it's unclear that local testing is sufficient.

Worst case these tests are still flaky in production are are disabled again.
Or they could flaky in a different way now. The port race might have hidden other race conditions.

**Note**
There could be other UDP components that need to be updated that have not yet been flagged as flaky tests due to the listening address race. On review of the use of `testutil.GetAvailableLocalAddress` inside the codebase I'm concerned that `jaegerreceiver/jaeger_agent_test.go` has a racy use of `testutil.GetAvailableLocalAddress` for UDP addresses, but since these tests have not been disabled yet I didn't want to disturb them with this change.

**Documentation:**
No documentation Added.