### PR TITLE
[exporter/splunkhecexporter] fix content length config use

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -81,7 +81,7 @@ func (c *client) pushMetricsData(
 	gzipWriter := c.zippers.Get().(*gzip.Writer)
 	defer c.zippers.Put(gzipWriter)
 
-	gzipBuffer := bytes.NewBuffer(make([]byte, 0, c.config.MaxContentLengthLogs))
+	gzipBuffer := bytes.NewBuffer(make([]byte, 0, c.config.MaxContentLengthMetrics))
 	gzipWriter.Reset(gzipBuffer)
 
 	// Callback when each batch is to be sent.
@@ -127,7 +127,7 @@ func (c *client) pushTraceData(
 	gzipWriter := c.zippers.Get().(*gzip.Writer)
 	defer c.zippers.Put(gzipWriter)
 
-	gzipBuffer := bytes.NewBuffer(make([]byte, 0, c.config.MaxContentLengthLogs))
+	gzipBuffer := bytes.NewBuffer(make([]byte, 0, c.config.MaxContentLengthTraces))
 	gzipWriter.Reset(gzipBuffer)
 
 	// Callback when each batch is to be sent.

--- a/unreleased/splunkhecexporter_content_length_config.yaml
+++ b/unreleased/splunkhecexporter_content_length_config.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: use proper config flags to configure content length of gzip buffers for metrics and traces
+
+# One or more tracking issues related to the change
+issues: [12906]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION

**Description:**
The content length config for logs was used for traces and metrics.

**Link to tracking Issue:** 
#12906 
**Testing:**
N/A

**Documentation:**
None.