### PR TITLE
Use azure.vm.name attribute in both Azure detector and SFx hostid logic

### DIFF
--- a/internal/splunk/hostid.go
+++ b/internal/splunk/hostid.go
@@ -123,7 +123,15 @@ func azureID(attrs pcommon.Map, cloudAccount string) string {
 	}
 
 	var hostname string
-	if attr, ok := attrs.Get(conventions.AttributeHostName); ok {
+
+	// Since the sfx backend expects a resource ID that was built using the VM name
+	// value returned by the Azure metadata API, and not the hostname (which may
+	// have been set by a system detector, be fully qualified, and may also differ
+	// from the hostname) we attempt to use the azure.vm.name attribute as the
+	// hostname.
+	if attr, ok := attrs.Get("azure.vm.name"); ok {
+		hostname = attr.StringVal()
+	} else if attr, ok := attrs.Get(conventions.AttributeHostName); ok {
 		hostname = attr.StringVal()
 	}
 	if hostname == "" {

--- a/internal/splunk/hostid_test.go
+++ b/internal/splunk/hostid_test.go
@@ -266,3 +266,20 @@ func TestAzureID(t *testing.T) {
 	expected := "mycloudaccount/myresourcegroup/microsoft.compute/virtualmachinescalesets/myscalesetname/virtualmachines/1"
 	assert.Equal(t, expected, id)
 }
+
+func TestAzureID_VMName(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.Insert("azure.resourcegroup.name", pcommon.NewValueString("my-resource-group"))
+	attrs.Insert("azure.vm.name", pcommon.NewValueString("my-vm-name"))
+	attrs.Insert(conventions.AttributeHostName, pcommon.NewValueString("my.fq.host.name"))
+	id := azureID(attrs, "my-cloud-account")
+	assert.Equal(t, "my-cloud-account/my-resource-group/microsoft.compute/virtualmachines/my-vm-name", id)
+}
+
+func TestAzureID_HostName(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.Insert("azure.resourcegroup.name", pcommon.NewValueString("my-resource-group"))
+	attrs.Insert(conventions.AttributeHostName, pcommon.NewValueString("my.fq.host.name"))
+	id := azureID(attrs, "my-cloud-account")
+	assert.Equal(t, "my-cloud-account/my-resource-group/microsoft.compute/virtualmachines/my.fq.host.name", id)
+}

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -245,6 +245,7 @@ Queries the [Azure Instance Metadata Service](https://aka.ms/azureimds) to retri
     * cloud.account.id (subscription ID)
     * host.id (virtual machine ID)
     * host.name
+    * azure.vm.name (same as host.name, but preserved in the presence of a system detector with precedence)
     * azure.vm.size (virtual machine size)
     * azure.vm.scaleset.name (name of the scale set if any)
     * azure.resourcegroup.name (resource group name)

--- a/unreleased/fqdn-fix.yaml
+++ b/unreleased/fqdn-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: use azure.vm.name attribute in both Azure detector and SFx hostid logic
+
+# One or more tracking issues related to the change
+issues: [12779]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** The Azure resource detector writes the "name" value from the Azure metadata API to the `host.name` attribute of the current resource. The problem with this is that the the `host.name` attribute is also written to by the system detector, and the Azure detector may not have precedence, in which case the Azure metadata name value won't be available downstream. The signalfx exporter requires the name from the Azure metadata API to operate (and other components may as require it as well at some point) so this change both saves this value to a new resource attribute key, `azure.vm.name`, (in addition to continuing to write it to the `host.name` attribute) and reads from this new attribute in the signalfx exporter.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12779

**Testing:** Unit tests added. Manual testing was performed on Azure.

**Documentation:** Field added to readme