### PR TITLE
Revert "re-enable UDP ListenAndServer tests "

### DIFF
--- a/receiver/carbonreceiver/transport/server_test.go
+++ b/receiver/carbonreceiver/transport/server_test.go
@@ -55,8 +55,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr := testutil.GetAvailableLocalNetworkAddress(t, tt.name)
-
+			addr := testutil.GetAvailableLocalAddress(t)
 			svr, err := tt.buildServerFn(addr)
 			require.NoError(t, err)
 			require.NotNil(t, svr)

--- a/receiver/statsdreceiver/transport/server_test.go
+++ b/receiver/statsdreceiver/transport/server_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func Test_Server_ListenAndServe(t *testing.T) {
+	t.Skip("Test is unstable, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1426")
 
 	tests := []struct {
 		name          string
@@ -47,21 +48,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr := testutil.GetAvailableLocalNetworkAddress(t, "udp")
-
-			// Endpoint should be free.
-			ln0, err := net.ListenPacket("udp", addr)
-			require.NoError(t, err)
-			require.NotNil(t, ln0)
-
-			// Ensure that the endpoint wasn't something like ":0" by checking that a second listener will fail.
-			ln1, err := net.ListenPacket("udp", addr)
-			require.Error(t, err)
-			require.Nil(t, ln1)
-
-			// Unbind the local address so the mock UDP service can use it
-			ln0.Close()
-
+			addr := testutil.GetAvailableLocalAddress(t)
 			srv, err := tt.buildServerFn(addr)
 			require.NoError(t, err)
 			require.NotNil(t, srv)


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#12901

This causes lots of issues (and the list is longer):
* https://github.com/open-telemetry/opentelemetry-collector-contrib/runs/7642125554?check_suite_focus=true
* https://github.com/open-telemetry/opentelemetry-collector-contrib/runs/7641424767?check_suite_focus=true

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10916