### PR TITLE
[processor/resourcedetection] save "name" from Azure metadata in azure.vm.name attr

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -245,6 +245,7 @@ Queries the [Azure Instance Metadata Service](https://aka.ms/azureimds) to retri
     * cloud.account.id (subscription ID)
     * host.id (virtual machine ID)
     * host.name
+    * azure.vm.name (same as host.name)
     * azure.vm.size (virtual machine size)
     * azure.vm.scaleset.name (name of the scale set if any)
     * azure.resourcegroup.name (resource group name)

--- a/processor/resourcedetectionprocessor/internal/azure/azure.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azure.go
@@ -65,6 +65,9 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 	attrs.InsertString(conventions.AttributeCloudRegion, compute.Location)
 	attrs.InsertString(conventions.AttributeHostID, compute.VMID)
 	attrs.InsertString(conventions.AttributeCloudAccountID, compute.SubscriptionID)
+	// Also save compute.Name in "azure.vm.name" as host.id (AttributeHostName) is
+	// used by system detector.
+	attrs.InsertString("azure.vm.name", compute.Name)
 	attrs.InsertString("azure.vm.size", compute.VMSize)
 	attrs.InsertString("azure.vm.scaleset.name", compute.VMScaleSetName)
 	attrs.InsertString("azure.resourcegroup.name", compute.ResourceGroupName)

--- a/processor/resourcedetectionprocessor/internal/azure/azure_test.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azure_test.go
@@ -61,6 +61,7 @@ func TestDetectAzureAvailable(t *testing.T) {
 		conventions.AttributeCloudRegion:    "location",
 		conventions.AttributeHostID:         "vmID",
 		conventions.AttributeCloudAccountID: "subscriptionID",
+		"azure.vm.name":                     "name",
 		"azure.vm.size":                     "vmSize",
 		"azure.resourcegroup.name":          "resourceGroup",
 		"azure.vm.scaleset.name":            "myScaleset",

--- a/unreleased/fqdn-fix.yaml
+++ b/unreleased/fqdn-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: update Azure resource detector to save "name" from Azure metadata API in azure.vm.name attribute
+
+# One or more tracking issues related to the change
+issues: [12779]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** Save the "name" value from the Azure metadata API in resource attribute `azure.vm.name`. This value was already being saved in the `host.name` attribute, but that attribute is also used by the system detector.

**Link to tracking Issue:** #12779 

**Testing:** Unit tests updated. Manual testing performed on Azure.

**Documentation:** Field name and explanation added to readme