### PR TITLE
Enable udp server tests

### DIFF
--- a/receiver/carbonreceiver/transport/server_test.go
+++ b/receiver/carbonreceiver/transport/server_test.go
@@ -55,7 +55,8 @@ func Test_Server_ListenAndServe(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr := testutil.GetAvailableLocalAddress(t)
+			addr := testutil.GetAvailableLocalNetworkAddress(t, tt.name)
+
 			svr, err := tt.buildServerFn(addr)
 			require.NoError(t, err)
 			require.NotNil(t, svr)

--- a/receiver/carbonreceiver/transport/server_test.go
+++ b/receiver/carbonreceiver/transport/server_test.go
@@ -93,10 +93,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			// Keep trying until we're timed out or got a result
 			assert.Eventually(t, func() bool {
 				mdd := mc.AllMetrics()
-				if len(mdd) > 0 {
-					return true
-				}
-				return false
+				return len(mdd) > 0
 			}, 10*time.Second, 500*time.Millisecond)
 
 			err = svr.Close()

--- a/receiver/carbonreceiver/transport/server_test.go
+++ b/receiver/carbonreceiver/transport/server_test.go
@@ -90,6 +90,25 @@ func Test_Server_ListenAndServe(t *testing.T) {
 
 			mr.WaitAllOnMetricsProcessedCalls()
 
+			// Keep trying until we're timed out or got a result
+			timeout := time.After(10 * time.Second)
+			ticker := time.Tick(500 * time.Millisecond)
+			for {
+				stop := false
+				select {
+				// Got a timeout!
+				case <-timeout:
+					stop = true
+				// Got a tick
+				case <-ticker:
+					if len(mc.AllMetrics()) > 0 {
+						stop = true
+					}
+				}
+				if stop {
+					break
+				}
+			}
 			err = svr.Close()
 			assert.NoError(t, err)
 

--- a/receiver/carbonreceiver/transport/server_test.go
+++ b/receiver/carbonreceiver/transport/server_test.go
@@ -91,24 +91,14 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			mr.WaitAllOnMetricsProcessedCalls()
 
 			// Keep trying until we're timed out or got a result
-			timeout := time.After(10 * time.Second)
-			ticker := time.Tick(500 * time.Millisecond)
-			for {
-				stop := false
-				select {
-				// Got a timeout!
-				case <-timeout:
-					stop = true
-				// Got a tick
-				case <-ticker:
-					if len(mc.AllMetrics()) > 0 {
-						stop = true
-					}
+			assert.Eventually(t, func() bool {
+				mdd := mc.AllMetrics()
+				if len(mdd) > 0 {
+					return true
 				}
-				if stop {
-					break
-				}
-			}
+				return false
+			}, 10*time.Second, 500*time.Millisecond)
+
 			err = svr.Close()
 			assert.NoError(t, err)
 

--- a/receiver/statsdreceiver/transport/server_test.go
+++ b/receiver/statsdreceiver/transport/server_test.go
@@ -102,7 +102,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 
 			// Keep trying until we're timed out or got a result
 			assert.Eventually(t, func() bool {
-				len(transferChan) > 0
+				return len(transferChan) > 0
 			}, 10*time.Second, 500*time.Millisecond)
 
 			// Close the server connection, this will cause ListenAndServer to error out and the deferred wgListenAndServe.Done will fire

--- a/receiver/statsdreceiver/transport/server_test.go
+++ b/receiver/statsdreceiver/transport/server_test.go
@@ -102,10 +102,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 
 			// Keep trying until we're timed out or got a result
 			assert.Eventually(t, func() bool {
-				if len(transferChan) > 0 {
-					return true
-				}
-				return false
+				len(transferChan) > 0
 			}, 10*time.Second, 500*time.Millisecond)
 
 			// Close the server connection, this will cause ListenAndServer to error out and the deferred wgListenAndServe.Done will fire

--- a/receiver/statsdreceiver/transport/server_test.go
+++ b/receiver/statsdreceiver/transport/server_test.go
@@ -59,7 +59,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			require.Error(t, err)
 			require.Nil(t, ln1)
 
-			//Unbind the local address so the mock UDP service can use it
+			// Unbind the local address so the mock UDP service can use it
 			ln0.Close()
 
 			srv, err := tt.buildServerFn(addr)

--- a/receiver/statsdreceiver/transport/server_test.go
+++ b/receiver/statsdreceiver/transport/server_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func Test_Server_ListenAndServe(t *testing.T) {
-	t.Skip("Test is unstable, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1426")
 
 	tests := []struct {
 		name          string
@@ -48,7 +47,21 @@ func Test_Server_ListenAndServe(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr := testutil.GetAvailableLocalAddress(t)
+			addr := testutil.GetAvailableLocalNetworkAddress(t, "udp")
+
+			// Endpoint should be free.
+			ln0, err := net.ListenPacket("udp", addr)
+			require.NoError(t, err)
+			require.NotNil(t, ln0)
+
+			// Ensure that the endpoint wasn't something like ":0" by checking that a second listener will fail.
+			ln1, err := net.ListenPacket("udp", addr)
+			require.Error(t, err)
+			require.Nil(t, ln1)
+
+			//Unbind the local address so the mock UDP service can use it
+			ln0.Close()
+
 			srv, err := tt.buildServerFn(addr)
 			require.NoError(t, err)
 			require.NotNil(t, srv)


### PR DESCRIPTION
**Description:**
Add additional race condition protections for client/server goroutine interactions in the statsd and carbon receiver ListenAndServer test.

new logic introduces a timeout/tick loop to test for message reception prior to closing the listening server side connection. The new logic addresses the race when the server connection is closed prior to the recv buffer being read in the goroutine reading from the connection buffer, but giving the test enough time to let the server goroutine read from the connection buffer before the main test process request connection close. 

The encoded timeout is generous at 10 seconds, but the tick loop fires every 500 msecs so I expect in production wait loop will break out successfully in a couple of ticks, unless I've misinterpreted the underlying problem.

This is a 2nd effort to fix bug: #10916

**Testing:** 
The production race condition is hard to hit in local testing (races are fun!), but I was able to observe the race locally and was able to re-create it synthetically by introducing long waits in the server goroutine.  


**Documentation:** 
No documentation