### PR TITLE
[exporter/signalfx] use azure.vm.name to build azure resource id

### DIFF
--- a/internal/splunk/hostid.go
+++ b/internal/splunk/hostid.go
@@ -123,7 +123,7 @@ func azureID(attrs pcommon.Map, cloudAccount string) string {
 	}
 
 	var hostname string
-	if attr, ok := attrs.Get(conventions.AttributeHostName); ok {
+	if attr, ok := attrs.Get("azure.vm.name"); ok {
 		hostname = attr.StringVal()
 	}
 	if hostname == "" {

--- a/internal/splunk/hostid_test.go
+++ b/internal/splunk/hostid_test.go
@@ -73,6 +73,7 @@ var (
 		attrs.InsertString(conventions.AttributeCloudRegion, "myCloudRegion")
 		attrs.InsertString(conventions.AttributeHostID, "myHostID")
 		attrs.InsertString(conventions.AttributeCloudAccountID, "myCloudAccount")
+		attrs.InsertString("azure.vm.name", "myVMName")
 		attrs.InsertString("azure.vm.size", "42")
 		attrs.InsertString("azure.resourcegroup.name", "myResourcegroupName")
 		return res
@@ -82,10 +83,11 @@ var (
 		attrs := res.Attributes()
 		attrs.InsertString(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAzure)
 		attrs.InsertString(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAzureVM)
-		attrs.InsertString(conventions.AttributeHostName, "myVMScalesetName_1")
+		attrs.InsertString(conventions.AttributeHostName, "my.fq.host.name")
 		attrs.InsertString(conventions.AttributeCloudRegion, "myCloudRegion")
 		attrs.InsertString(conventions.AttributeHostID, "myHostID")
 		attrs.InsertString(conventions.AttributeCloudAccountID, "myCloudAccount")
+		attrs.InsertString("azure.vm.name", "myVMScalesetName_1")
 		attrs.InsertString("azure.vm.size", "42")
 		attrs.InsertString("azure.vm.scaleset.name", "myVMScalesetName")
 		attrs.InsertString("azure.resourcegroup.name", "myResourcegroupName")
@@ -189,7 +191,7 @@ func TestResourceToHostID(t *testing.T) {
 			args: args{azureResource},
 			want: HostID{
 				Key: "azure_resource_id",
-				ID:  "mycloudaccount/myresourcegroupname/microsoft.compute/virtualmachines/myhostname",
+				ID:  "mycloudaccount/myresourcegroupname/microsoft.compute/virtualmachines/myvmname",
 			},
 			ok: true,
 		},
@@ -255,14 +257,4 @@ func TestResourceToHostID(t *testing.T) {
 			assert.Equal(t, tt.want, hostID)
 		})
 	}
-}
-
-func TestAzureID(t *testing.T) {
-	attrs := pcommon.NewMap()
-	attrs.Insert("azure.resourcegroup.name", pcommon.NewValueString("myResourceGroup"))
-	attrs.Insert("azure.vm.scaleset.name", pcommon.NewValueString("myScalesetName"))
-	attrs.Insert(conventions.AttributeHostName, pcommon.NewValueString("myScalesetName_1"))
-	id := azureID(attrs, "myCloudAccount")
-	expected := "mycloudaccount/myresourcegroup/microsoft.compute/virtualmachinescalesets/myscalesetname/virtualmachines/1"
-	assert.Equal(t, expected, id)
 }

--- a/unreleased/azure-resource-id.yaml
+++ b/unreleased/azure-resource-id.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: use azure.vm.name instead of host.name to build azure resource id
+
+# One or more tracking issues related to the change
+issues: [12779]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** Use the resource attribute `azure.vm.name` instead of `host.name` to build `azure_resource_id` because `host.name` is also used by the system detector.

**Link to tracking Issue:** #12779 

**Testing:** Tested manually against Azure/linux. Unit tests updated.
