### PR TITLE
[processor/filter] Add SeverityText & Body filtering for logs

### DIFF
--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -80,15 +80,29 @@ processors:
           - Key: host.name
             Value: just_this_one_hostname
     logs/regexp:
+      include:
         match_type: regexp
         resource_attributes:
           - Key: host.name
             Value: prefix.*
     logs/regexp_record:
+      include:
         match_type: regexp
         record_attributes:
           - Key: record_attr
             Value: prefix_.*
+    logs/severity:
+      include:
+        match_type: regexp
+        severity_texts:
+        - INFO[2-4]?
+        - WARN[2-4]?
+        - ERROR[2-4]?
+    logs/bodies:
+      include:
+        match_type: regexp
+        bodies:
+        - ^IMPORTANT RECORD
 ```
 
 Refer to the config files in [testdata](./testdata) for detailed

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -31,6 +31,10 @@ For logs:
 - `record_attributes`: RecordAttributes defines a list of possible record
   attributes to match logs against.
   A match occurs if any record attribute matches all expressions in this given list.
+- `severity_texts`: SeverityTexts defines a list of possible severity texts to match the logs against.
+  A match occurs if the record matches any expression in this given list.
+- `bodies`: Bodies defines a list of possible log bodies to match the logs against.
+  A match occurs if the record matches any expression in this given list.
 
 For metrics:
 

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -98,6 +98,33 @@ type LogMatchProperties struct {
 	// RecordAttributes defines a list of possible record attributes to match logs against.
 	// A match occurs if any record attribute matches at least one expression in this given list.
 	RecordAttributes []filterconfig.Attribute `mapstructure:"record_attributes"`
+
+	// SeverityTexts is a list of strings that the LogRecord's severity text field must match
+	// against.
+	SeverityTexts []string `mapstructure:"severity_texts"`
+
+	// LogBodies is a list of strings that the LogRecord's body field must match
+	// against.
+	LogBodies []string `mapstructure:"bodies"`
+}
+
+// isEmpty returns true if the properties is "empty" (meaning, there are no filters specified)
+// if this is the case, the filter should be ignored.
+func (lmp LogMatchProperties) isEmpty() bool {
+	return len(lmp.ResourceAttributes) == 0 && len(lmp.RecordAttributes) == 0 && len(lmp.SeverityTexts) == 0 && len(lmp.LogBodies) == 0
+}
+
+// matchProperties converts the LogMatchProperties to a corresponding filterconfig.MatchProperties
+func (lmp LogMatchProperties) matchProperties() *filterconfig.MatchProperties {
+	return &filterconfig.MatchProperties{
+		Config: filterset.Config{
+			MatchType: filterset.MatchType(lmp.LogMatchType),
+		},
+		Resources:        lmp.ResourceAttributes,
+		Attributes:       lmp.RecordAttributes,
+		LogSeverityTexts: lmp.SeverityTexts,
+		LogBodies:        lmp.LogBodies,
+	}
 }
 
 var _ config.Processor = (*Config)(nil)

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -190,6 +190,257 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 	}
 }
 
+// TestLoadingConfigSeverityLogsStrict tests loading testdata/config_logs_severity_strict.yaml
+func TestLoadingConfigSeverityLogsStrict(t *testing.T) {
+
+	testDataLogPropertiesInclude := &LogMatchProperties{
+		LogMatchType:  Strict,
+		SeverityTexts: []string{"INFO"},
+	}
+
+	testDataLogPropertiesExclude := &LogMatchProperties{
+		LogMatchType:  Strict,
+		SeverityTexts: []string{"DEBUG", "DEBUG2", "DEBUG3", "DEBUG4"},
+	}
+
+	factories, err := componenttest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Processors[typeStr] = factory
+	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config_logs_severity_strict.yaml"), factories)
+
+	assert.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	tests := []struct {
+		filterID config.ComponentID
+		expCfg   *Config
+	}{
+		{
+			filterID: config.NewComponentIDWithName("filter", "include"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "include")),
+				Logs: LogFilters{
+					Include: testDataLogPropertiesInclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "exclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "exclude")),
+				Logs: LogFilters{
+					Exclude: testDataLogPropertiesExclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "includeexclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "includeexclude")),
+				Logs: LogFilters{
+					Include: testDataLogPropertiesInclude,
+					Exclude: testDataLogPropertiesExclude,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filterID.String(), func(t *testing.T) {
+			cfg := cfg.Processors[test.filterID]
+			assert.Equal(t, test.expCfg, cfg)
+		})
+	}
+}
+
+// TestLoadingConfigSeverityLogsRegexp tests loading testdata/config_logs_severity_regexp.yaml
+func TestLoadingConfigSeverityLogsRegexp(t *testing.T) {
+	testDataLogPropertiesInclude := &LogMatchProperties{
+		LogMatchType:  Regexp,
+		SeverityTexts: []string{"INFO[2-4]?"},
+	}
+
+	testDataLogPropertiesExclude := &LogMatchProperties{
+		LogMatchType:  Regexp,
+		SeverityTexts: []string{"DEBUG[2-4]?"},
+	}
+
+	factories, err := componenttest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Processors[typeStr] = factory
+	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config_logs_severity_regexp.yaml"), factories)
+
+	assert.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	tests := []struct {
+		filterID config.ComponentID
+		expCfg   *Config
+	}{
+		{
+			filterID: config.NewComponentIDWithName("filter", "include"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "include")),
+				Logs: LogFilters{
+					Include: testDataLogPropertiesInclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "exclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "exclude")),
+				Logs: LogFilters{
+					Exclude: testDataLogPropertiesExclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "includeexclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "includeexclude")),
+				Logs: LogFilters{
+					Include: testDataLogPropertiesInclude,
+					Exclude: testDataLogPropertiesExclude,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filterID.String(), func(t *testing.T) {
+			cfg := cfg.Processors[test.filterID]
+			assert.Equal(t, test.expCfg, cfg)
+		})
+	}
+}
+
+// TestLoadingConfigBodyLogsStrict tests loading testdata/config_logs_body_strict.yaml
+func TestLoadingConfigBodyLogsStrict(t *testing.T) {
+
+	testDataLogPropertiesInclude := &LogMatchProperties{
+		LogMatchType: Strict,
+		LogBodies:    []string{"This is an important event"},
+	}
+
+	testDataLogPropertiesExclude := &LogMatchProperties{
+		LogMatchType: Strict,
+		LogBodies:    []string{"This event is not important"},
+	}
+
+	factories, err := componenttest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Processors[typeStr] = factory
+	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config_logs_body_strict.yaml"), factories)
+
+	assert.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	tests := []struct {
+		filterID config.ComponentID
+		expCfg   *Config
+	}{
+		{
+			filterID: config.NewComponentIDWithName("filter", "include"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "include")),
+				Logs: LogFilters{
+					Include: testDataLogPropertiesInclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "exclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "exclude")),
+				Logs: LogFilters{
+					Exclude: testDataLogPropertiesExclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "includeexclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "includeexclude")),
+				Logs: LogFilters{
+					Include: testDataLogPropertiesInclude,
+					Exclude: testDataLogPropertiesExclude,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filterID.String(), func(t *testing.T) {
+			cfg := cfg.Processors[test.filterID]
+			assert.Equal(t, test.expCfg, cfg)
+		})
+	}
+}
+
+// TestLoadingConfigBodyLogsStrict tests loading testdata/config_logs_body_regexp.yaml
+func TestLoadingConfigBodyLogsRegexp(t *testing.T) {
+
+	testDataLogPropertiesInclude := &LogMatchProperties{
+		LogMatchType: Regexp,
+		LogBodies:    []string{"^IMPORTANT:"},
+	}
+
+	testDataLogPropertiesExclude := &LogMatchProperties{
+		LogMatchType: Regexp,
+		LogBodies:    []string{"^MINOR:"},
+	}
+
+	factories, err := componenttest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Processors[typeStr] = factory
+	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config_logs_body_regexp.yaml"), factories)
+
+	assert.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	tests := []struct {
+		filterID config.ComponentID
+		expCfg   *Config
+	}{
+		{
+			filterID: config.NewComponentIDWithName("filter", "include"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "include")),
+				Logs: LogFilters{
+					Include: testDataLogPropertiesInclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "exclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "exclude")),
+				Logs: LogFilters{
+					Exclude: testDataLogPropertiesExclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "includeexclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "includeexclude")),
+				Logs: LogFilters{
+					Include: testDataLogPropertiesInclude,
+					Exclude: testDataLogPropertiesExclude,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filterID.String(), func(t *testing.T) {
+			cfg := cfg.Processors[test.filterID]
+			assert.Equal(t, test.expCfg, cfg)
+		})
+	}
+}
+
 // TestLoadingConfigRegexp tests loading testdata/config_regexp.yaml
 func TestLoadingConfigRegexp(t *testing.T) {
 	// list of filters used repeatedly on testdata/config.yaml

--- a/processor/filterprocessor/testdata/config_logs_body_regexp.yaml
+++ b/processor/filterprocessor/testdata/config_logs_body_regexp.yaml
@@ -36,10 +36,6 @@ exporters:
 
 service:
     pipelines:
-        traces:
-            receivers: [nop]
-            processors: [filter/empty]
-            exporters: [nop]
         logs:
             receivers: [nop]
             processors: [filter/include, filter/exclude, filter/includeexclude]

--- a/processor/filterprocessor/testdata/config_logs_body_regexp.yaml
+++ b/processor/filterprocessor/testdata/config_logs_body_regexp.yaml
@@ -1,0 +1,46 @@
+receivers:
+    nop:
+
+processors:
+    filter/include:
+        logs:
+            # any logs NOT matching filters are excluded from remainder of pipeline
+            include:
+                match_type: regexp
+                bodies:
+                    - "^IMPORTANT:"
+    filter/exclude:
+        logs:
+            # any logs matching filters are excluded from remainder of pipeline
+            exclude:
+                match_type: regexp
+                bodies:
+                    - "^MINOR:"
+
+    filter/includeexclude:
+        logs:
+            # if both include and exclude are specified, include filters are applied first
+            # the following configuration would only allow logs with bodies starting with "IMPORTANT:"
+            include:
+                match_type: regexp
+                bodies:
+                    - "^IMPORTANT:"
+
+            exclude:
+                match_type: regexp
+                bodies:
+                    - "^MINOR:"
+
+exporters:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [filter/empty]
+            exporters: [nop]
+        logs:
+            receivers: [nop]
+            processors: [filter/include, filter/exclude, filter/includeexclude]
+            exporters: [nop]

--- a/processor/filterprocessor/testdata/config_logs_body_strict.yaml
+++ b/processor/filterprocessor/testdata/config_logs_body_strict.yaml
@@ -1,0 +1,46 @@
+receivers:
+    nop:
+
+processors:
+    filter/include:
+        logs:
+            # any logs NOT matching filters are excluded from remainder of pipeline
+            include:
+                match_type: strict
+                bodies:
+                    - "This is an important event"
+    filter/exclude:
+        logs:
+            # any logs matching filters are excluded from remainder of pipeline
+            exclude:
+                match_type: strict
+                bodies:
+                    - "This event is not important"
+
+    filter/includeexclude:
+        logs:
+            # if both include and exclude are specified, include filters are applied first
+            # the following configuration would only allow logs with bodies that exactly match "This is an important event"
+            include:
+                match_type: strict
+                bodies:
+                    - "This is an important event"
+
+            exclude:
+                match_type: strict
+                bodies:
+                    - "This event is not important"
+
+exporters:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [filter/empty]
+            exporters: [nop]
+        logs:
+            receivers: [nop]
+            processors: [filter/include, filter/exclude, filter/includeexclude]
+            exporters: [nop]

--- a/processor/filterprocessor/testdata/config_logs_body_strict.yaml
+++ b/processor/filterprocessor/testdata/config_logs_body_strict.yaml
@@ -36,10 +36,6 @@ exporters:
 
 service:
     pipelines:
-        traces:
-            receivers: [nop]
-            processors: [filter/empty]
-            exporters: [nop]
         logs:
             receivers: [nop]
             processors: [filter/include, filter/exclude, filter/includeexclude]

--- a/processor/filterprocessor/testdata/config_logs_severity_regexp.yaml
+++ b/processor/filterprocessor/testdata/config_logs_severity_regexp.yaml
@@ -1,0 +1,46 @@
+receivers:
+    nop:
+
+processors:
+    filter/include:
+        logs:
+            # any logs NOT matching filters are excluded from remainder of pipeline
+            include:
+                match_type: regexp
+                severity_texts:
+                    - "INFO[2-4]?"
+    filter/exclude:
+        logs:
+            # any logs matching filters are excluded from remainder of pipeline
+            exclude:
+                match_type: regexp
+                severity_texts:
+                    - "DEBUG[2-4]?"
+
+    filter/includeexclude:
+        logs:
+            # if both include and exclude are specified, include filters are applied first
+            # the following configuration would only allow logs with severity INFO, INFO2, INFO3, or INFO4
+            include:
+                match_type: regexp
+                severity_texts:
+                    - "INFO[2-4]?"
+
+            exclude:
+                match_type: regexp
+                severity_texts:
+                    - "DEBUG[2-4]?"
+
+exporters:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [filter/empty]
+            exporters: [nop]
+        logs:
+            receivers: [nop]
+            processors: [filter/include, filter/exclude, filter/includeexclude]
+            exporters: [nop]

--- a/processor/filterprocessor/testdata/config_logs_severity_regexp.yaml
+++ b/processor/filterprocessor/testdata/config_logs_severity_regexp.yaml
@@ -36,10 +36,6 @@ exporters:
 
 service:
     pipelines:
-        traces:
-            receivers: [nop]
-            processors: [filter/empty]
-            exporters: [nop]
         logs:
             receivers: [nop]
             processors: [filter/include, filter/exclude, filter/includeexclude]

--- a/processor/filterprocessor/testdata/config_logs_severity_strict.yaml
+++ b/processor/filterprocessor/testdata/config_logs_severity_strict.yaml
@@ -1,0 +1,52 @@
+receivers:
+    nop:
+
+processors:
+    filter/include:
+        logs:
+            # any logs NOT matching filters are excluded from remainder of pipeline
+            include:
+                match_type: strict
+                severity_texts:
+                    - "INFO"
+    filter/exclude:
+        logs:
+            # any logs matching filters are excluded from remainder of pipeline
+            exclude:
+                match_type: strict
+                severity_texts:
+                    - "DEBUG"
+                    - "DEBUG2"
+                    - "DEBUG3"
+                    - "DEBUG4"
+
+    filter/includeexclude:
+        logs:
+            # if both include and exclude are specified, include filters are applied first
+            # the following configuration would only allow logs with severity "INFO"
+            include:
+                match_type: strict
+                severity_texts:
+                    - "INFO"
+
+            exclude:
+                match_type: strict
+                severity_texts:
+                    - "DEBUG"
+                    - "DEBUG2"
+                    - "DEBUG3"
+                    - "DEBUG4"
+
+exporters:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [filter/empty]
+            exporters: [nop]
+        logs:
+            receivers: [nop]
+            processors: [filter/include, filter/exclude, filter/includeexclude]
+            exporters: [nop]

--- a/processor/filterprocessor/testdata/config_logs_severity_strict.yaml
+++ b/processor/filterprocessor/testdata/config_logs_severity_strict.yaml
@@ -42,10 +42,6 @@ exporters:
 
 service:
     pipelines:
-        traces:
-            receivers: [nop]
-            processors: [filter/empty]
-            exporters: [nop]
         logs:
             receivers: [nop]
             processors: [filter/include, filter/exclude, filter/includeexclude]

--- a/unreleased/add-serverity-filtering-to-filter.yaml
+++ b/unreleased/add-serverity-filtering-to-filter.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filterprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ability to filter based on logs SeverityText and Body.
+
+# One or more tracking issues related to the change
+issues: [ 9235 ]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
* Add `severity_texts` option to log filtering
* Add `bodies` option to log filtering
* Refactor the log filtering to use the `logfilter` package

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9235

**Testing:**
* Added extra unit tests for new functionality

**Documentation:**
* Update docs with new log parameters
* Add extra sample configs in testdata