### PR TITLE
[processor/k8sattributes] add replicaset attributes

### DIFF
--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -74,7 +74,8 @@ type ExtractConfig struct {
 	//
 	// Metadata fields supported right now are,
 	//   k8s.pod.name, k8s.pod.uid, k8s.deployment.name,
-	//   k8s.node.name, k8s.namespace.name and k8s.pod.start_time
+	//   k8s.node.name, k8s.namespace.name, k8s.pod.start_time,
+	//   k8s.replicaset.name, and k8s.replicaset.uid
 	//
 	// Specifying anything other than these values will result in an error.
 	// By default all of the fields are extracted and added to spans and metrics.

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -448,6 +448,14 @@ func TestExtractionRules(t *testing.T) {
 			Annotations: map[string]string{
 				"annotation1": "av1",
 			},
+			OwnerReferences: []meta_v1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       "auth-service-66f5996c7c",
+					UID:        "207ea729-c779-401d-8347-008ecbc137e3",
+				},
+			},
 		},
 		Spec: api_v1.PodSpec{
 			NodeName: "node1",
@@ -472,6 +480,22 @@ func TestExtractionRules(t *testing.T) {
 		},
 		attributes: map[string]string{
 			"k8s.deployment.name": "auth-service",
+		},
+	}, {
+		name: "replicasetId",
+		rules: ExtractionRules{
+			ReplicaSetID: true,
+		},
+		attributes: map[string]string{
+			"k8s.replicaset.uid": "207ea729-c779-401d-8347-008ecbc137e3",
+		},
+	}, {
+		name: "replicasetName",
+		rules: ExtractionRules{
+			ReplicaSetName: true,
+		},
+		attributes: map[string]string{
+			"k8s.replicaset.name": "auth-service-66f5996c7c",
 		},
 	}, {
 		name: "metadata",

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -186,6 +186,8 @@ type ExtractionRules struct {
 	Namespace          bool
 	PodName            bool
 	PodUID             bool
+	ReplicaSetID       bool
+	ReplicaSetName     bool
 	Node               bool
 	StartTime          bool
 	ContainerID        bool

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -98,6 +98,10 @@ func withExtractMetadata(fields ...string) option {
 				p.rules.StartTime = true
 			case metadataDeployment, conventions.AttributeK8SDeploymentName:
 				p.rules.Deployment = true
+			case conventions.AttributeK8SReplicaSetName:
+				p.rules.ReplicaSetName = true
+			case conventions.AttributeK8SReplicaSetUID:
+				p.rules.ReplicaSetID = true
 			case metadataNode, conventions.AttributeK8SNodeName:
 				p.rules.Node = true
 			case conventions.AttributeContainerID:

--- a/unreleased/k8sattributes-replicaset.yaml
+++ b/unreleased/k8sattributes-replicaset.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: k8sattributesprocessor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Adds support for discovering Kubernetes ReplicaSet name"
+note: "Add support for discovering Kubernetes ReplicaSet name and ReplicaSet UID"
 
 # One or more tracking issues related to the change
 issues: [141]

--- a/unreleased/k8sattributes-replicaset.yaml
+++ b/unreleased/k8sattributes-replicaset.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Adds support for discovering Kubernetes ReplicaSet name"
+
+# One or more tracking issues related to the change
+issues: [141]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Adding support for discovering K8S ReplicaSet using 

https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/k8s/#replicaset

Example configuration:
```
    k8sattributes:
      passthrough: false
      extract:
        metadata: 
          - "k8s.namespace.name"
          - "k8s.deployment.name"
          - "k8s.replicaset.name"
          - "k8s.replicaset.uid"
        labels:
          - key_regex: '(.*)'

```
**Link to tracking Issue:* 141

Ref #141
**Testing:** 
- unit test
- local testing

**Documentation:** 

added docs