### PR TITLE
[exporter/signalfx] reduce log level of attempts to divide by zero

### DIFF
--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -91,7 +91,14 @@ func newSignalFxExporter(
 
 	headers := buildHeaders(config)
 
-	converter, err := translation.NewMetricsConverter(logger, options.metricTranslator, config.ExcludeMetrics, config.IncludeMetrics, config.NonAlphanumericDimensionChars)
+	sampledLogger := translation.CreateSampledLogger(logger)
+	converter, err := translation.NewMetricsConverter(
+		sampledLogger,
+		options.metricTranslator,
+		config.ExcludeMetrics,
+		config.IncludeMetrics,
+		config.NonAlphanumericDimensionChars,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric converter: %w", err)
 	}

--- a/exporter/signalfxexporter/internal/translation/converter.go
+++ b/exporter/signalfxexporter/internal/translation/converter.go
@@ -187,7 +187,7 @@ type datapointValidator struct {
 }
 
 func newDatapointValidator(logger *zap.Logger, nonAlphanumericDimChars string) *datapointValidator {
-	return &datapointValidator{logger: createSampledLogger(logger), nonAlphanumericDimChars: nonAlphanumericDimChars}
+	return &datapointValidator{logger: CreateSampledLogger(logger), nonAlphanumericDimChars: nonAlphanumericDimChars}
 }
 
 // sanitizeDataPoints sanitizes datapoints prior to dispatching them to the backend.
@@ -269,8 +269,8 @@ func (dpv *datapointValidator) isValidDimensionValue(value, name string) bool {
 	return true
 }
 
-// Copied from https://github.com/open-telemetry/opentelemetry-collector/blob/v0.26.0/exporter/exporterhelper/queued_retry.go#L108
-func createSampledLogger(logger *zap.Logger) *zap.Logger {
+// CreateSampledLogger was copied from https://github.com/open-telemetry/opentelemetry-collector/blob/v0.26.0/exporter/exporterhelper/queued_retry.go#L108
+func CreateSampledLogger(logger *zap.Logger) *zap.Logger {
 	if logger.Core().Enabled(zapcore.DebugLevel) {
 		// Debugging is enabled. Don't do any sampling.
 		return logger

--- a/exporter/signalfxexporter/internal/translation/translator.go
+++ b/exporter/signalfxexporter/internal/translation/translator.go
@@ -622,7 +622,10 @@ func calculateNewMetric(
 	}
 
 	if tr.Operator == MetricOperatorDivision && *v2 == 0 {
-		logger.Warn(
+		// We can get here if, for example, in the denominator we get multiple
+		// datapoints that have the same counter value, which will yield a delta of
+		// zero.
+		logger.Debug(
 			"calculate_new_metric: attempt to divide by zero, skipping",
 			zap.String("tr.Operand2Metric", tr.Operand2Metric),
 			zap.String("tr.MetricName", tr.MetricName),

--- a/unreleased/divide-by-zero.yaml
+++ b/unreleased/divide-by-zero.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: log attempts to divide by zero at the debug level
+
+# One or more tracking issues related to the change
+issues: [12969]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** Attempts to divide by zero when executing sfx translation rules are currently logged as warnings. This has caused some users to report lots of noise in logs. However, encountering a denominator that, as a result of a calculation, computes to zero, doesn't necessarily indicate a problem. As a result, this change decreases the log level to `debug` for this message.

**Link to tracking Issue:** #12969

**Testing:** Testing was performed locally using simulated data.