### PR TITLE
[chore] bump GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.4 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.4 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.4 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.32.4 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -170,8 +170,8 @@ github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 h1:KeNholpO2xKjgaa
 github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962/go.mod h1:kC29dT1vFpj7py2OvG1khBdQpo3kInWP+6QipLbdngo=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.4 h1:UyZMaiNzZpplk4mH8+NMVeHk6g/xmhx4RSziYWbw9WI=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.4/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4 h1:cuBjW4kDHYj01QZXfEpHB2OFJ2mDorD8u2H1DECRjZc=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4/go.mod h1:b+Y8gQ58Qg8QzCZERRU2yxs4f9QSXNG242ECOqEw82I=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43 h1:wFvJmrXVfsglLwcVkNBXjzhI5u43frt0g4FPExIo1L0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43/go.mod h1:w8YgARcD4aNj6gMm2RZD2nErSOAQSUktsOXdFV6P6Hk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.4 h1:xAqSQ5sZeqy521z9m6mvD8jVK+y7HNn98lFG2JEF8i0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.4/go.mod h1:TYQvIf3npgGuaYiCVl2IPEsRt8q9/Lv9xzcvcuul7gg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.4 h1:UlCxYSeY3a8FYR2Ni8SC8vxcb2MCTwBN8yDoy0AVGGU=

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.13
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.57.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.57.2

--- a/exporter/googlecloudexporter/go.sum
+++ b/exporter/googlecloudexporter/go.sum
@@ -66,8 +66,8 @@ contrib.go.opencensus.io/exporter/stackdriver v0.13.13/go.mod h1:5pSSGY0Bhuk7waT
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4 h1:cuBjW4kDHYj01QZXfEpHB2OFJ2mDorD8u2H1DECRjZc=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4/go.mod h1:b+Y8gQ58Qg8QzCZERRU2yxs4f9QSXNG242ECOqEw82I=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43 h1:wFvJmrXVfsglLwcVkNBXjzhI5u43frt0g4FPExIo1L0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43/go.mod h1:w8YgARcD4aNj6gMm2RZD2nErSOAQSUktsOXdFV6P6Hk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.4 h1:UlCxYSeY3a8FYR2Ni8SC8vxcb2MCTwBN8yDoy0AVGGU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.4/go.mod h1:d4ODYSOkLoLTyUyic8etLjC7Kzy13ZO2R+kdVi9ImQg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.32.4 h1:ZuSnzmTHyLCDJxeq5h785t8VcbRDX40+e5iVTSE4Y3Q=

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/google
 go 1.17
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.4
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.57.2

--- a/exporter/googlemanagedprometheusexporter/go.sum
+++ b/exporter/googlemanagedprometheusexporter/go.sum
@@ -64,8 +64,8 @@ cloud.google.com/go/trace v1.2.0/go.mod h1:Wc8y/uYyOhPy12KEnXG9XGrvfMz5F5SrYecQl
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4 h1:cuBjW4kDHYj01QZXfEpHB2OFJ2mDorD8u2H1DECRjZc=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4/go.mod h1:b+Y8gQ58Qg8QzCZERRU2yxs4f9QSXNG242ECOqEw82I=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43 h1:wFvJmrXVfsglLwcVkNBXjzhI5u43frt0g4FPExIo1L0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43/go.mod h1:w8YgARcD4aNj6gMm2RZD2nErSOAQSUktsOXdFV6P6Hk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.4 h1:xAqSQ5sZeqy521z9m6mvD8jVK+y7HNn98lFG2JEF8i0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.4/go.mod h1:TYQvIf3npgGuaYiCVl2IPEsRt8q9/Lv9xzcvcuul7gg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.4 h1:UlCxYSeY3a8FYR2Ni8SC8vxcb2MCTwBN8yDoy0AVGGU=

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.4 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.4 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.4 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.32.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 h1:KeNholpO2xKjgaa
 github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962/go.mod h1:kC29dT1vFpj7py2OvG1khBdQpo3kInWP+6QipLbdngo=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.4 h1:UyZMaiNzZpplk4mH8+NMVeHk6g/xmhx4RSziYWbw9WI=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.4/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4 h1:cuBjW4kDHYj01QZXfEpHB2OFJ2mDorD8u2H1DECRjZc=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4/go.mod h1:b+Y8gQ58Qg8QzCZERRU2yxs4f9QSXNG242ECOqEw82I=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43 h1:wFvJmrXVfsglLwcVkNBXjzhI5u43frt0g4FPExIo1L0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.5-0.20220804200517-c595ccfb4c43/go.mod h1:w8YgARcD4aNj6gMm2RZD2nErSOAQSUktsOXdFV6P6Hk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.4 h1:xAqSQ5sZeqy521z9m6mvD8jVK+y7HNn98lFG2JEF8i0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.4/go.mod h1:TYQvIf3npgGuaYiCVl2IPEsRt8q9/Lv9xzcvcuul7gg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.4 h1:UlCxYSeY3a8FYR2Ni8SC8vxcb2MCTwBN8yDoy0AVGGU=


### PR DESCRIPTION
**Description:** 
Bumps github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector to a version that doesn't use Flags API.

@dashpole @bogdandrutu let me know if we can't actually take a version like this and we have to wait for an official release.

**Link to tracking Issue:** 
Works towards unblocking https://github.com/open-telemetry/opentelemetry-collector/pull/5814

**Testing:**
Unit tests