### PR TITLE
[receiver/hostmetrics] Add new process metrics

### DIFF
--- a/.chloggen/hostmetricsreceiver-new-metrics.yaml
+++ b/.chloggen/hostmetricsreceiver-new-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new process metrics
+
+# One or more tracking issues related to the change
+issues: [12482]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Add `process.context_switches` and `process.open_file_descriptors` as process metrics. They are disabled by default.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
@@ -8,11 +8,13 @@ These are the metrics available for this scraper.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
+| process.context_switches | Number of times the process has been context switched. | {count} | Sum(Int) | <ul> <li>context_switch_type</li> </ul> |
 | **process.cpu.time** | Total CPU seconds broken down by different states. | s | Sum(Double) | <ul> <li>state</li> </ul> |
 | **process.disk.io** | Disk bytes transferred. | By | Sum(Int) | <ul> <li>direction</li> </ul> |
-| **process.memory.physical_usage** | The amount of physical memory in use. | By | Sum(Int) | <ul> </ul> |
+| **process.memory.physical_usage** | The amount of physical memory in use | By | Sum(Int) | <ul> </ul> |
 | **process.memory.virtual_usage** | Virtual memory size. | By | Sum(Int) | <ul> </ul> |
-| process.paging.faults | Number of page faults the process has made. This metric is only available on Linux. | {faults} | Sum(Int) | <ul> <li>type</li> </ul> |
+| process.open_file_descriptors | Number of file descriptors in use by the process. | {count} | Sum(Int) | <ul> </ul> |
+| process.paging.faults | Number of page faults the process has made. This metric is only available on Linux. | {faults} | Sum(Int) | <ul> <li>paging_fault_type</li> </ul> |
 | process.threads | Process threads count. | {threads} | Sum(Int) | <ul> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
@@ -40,6 +42,7 @@ metrics:
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
+| context_switch_type (type) | Type of context switched. | involuntary, voluntary |
 | direction | Direction of flow of bytes (read or write). | read, write |
+| paging_fault_type (type) | Type of memory paging fault. | major, minor |
 | state | Breakdown of CPU usage by type. | system, user, wait |
-| type | Type of memory paging fault. | major, minor |

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -47,9 +47,15 @@ attributes:
     description: Breakdown of CPU usage by type.
     enum: [system, user, wait]
 
-  type:
+  paging_fault_type:
+    value: type
     description: Type of memory paging fault.
     enum: [major, minor]
+
+  context_switch_type:
+    value: type
+    description: Type of context switched.
+    enum: [involuntary, voluntary]
 
 metrics:
   process.cpu.time:
@@ -64,7 +70,7 @@ metrics:
 
   process.memory.physical_usage:
     enabled: true
-    description: The amount of physical memory in use.
+    description: The amount of physical memory in use
     unit: By
     sum:
       value_type: int
@@ -98,7 +104,7 @@ metrics:
       value_type: int
       aggregation: cumulative
       monotonic: true
-    attributes: [type]
+    attributes: [paging_fault_type]
 
   process.threads:
     enabled: false
@@ -108,3 +114,22 @@ metrics:
       value_type: int
       aggregation: cumulative
       monotonic: false
+
+  process.open_file_descriptors:
+    enabled: false
+    description: Number of file descriptors in use by the process.
+    unit: '{count}'
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+  
+  process.context_switches:
+    enabled: false
+    description: Number of times the process has been context switched.
+    unit: '{count}'
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: true
+    attributes: [context_switch_type]

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -94,6 +94,8 @@ type processHandle interface {
 	CreateTime() (int64, error)
 	Parent() (*process.Process, error)
 	PageFaults() (*process.PageFaultsStat, error)
+	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
+	NumFDs() (int32, error)
 }
 
 type gopsProcessHandles struct {


### PR DESCRIPTION
**Description:**

Add the following process metrics:
- `process.context_switches`
- `process.open_file_descriptors`

**Link to tracking Issue:**#12482

Spec PR to add semantic conventions for the added metrics: https://github.com/open-telemetry/opentelemetry-specification/pull/2706

**Testing:**

Unit tests and manual testing of the metrics.