### PR TITLE
[pkg/stanza] Add custom time formatter

### DIFF
--- a/pkg/stanza/docs/operators/time_parser.md
+++ b/pkg/stanza/docs/operators/time_parser.md
@@ -4,15 +4,18 @@ The `time_parser` operator sets the timestamp on an entry by parsing a value fro
 
 ### Configuration Fields
 
-| Field         | Default          | Description |
-| ---           | ---              | ---         |
-| `id`          | `time_parser`    | A unique identifier for the operator. |
-| `output`      | Next in pipeline | The connected operator(s) that will receive all outbound entries. |
-| `parse_from`  | required         | The [field](../types/field.md) from which the value will be parsed. |
-| `layout_type` | `strptime`       | The type of timestamp. Valid values are `strptime`, `gotime`, and `epoch`. |
-| `layout`      | required         | The exact layout of the timestamp to be parsed. |
-| `if`          |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
-| `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
+| Field              | Default          | Description |
+| ---                | ---              | ---         |
+| `id`               | `time_parser`    | A unique identifier for the operator. |
+| `output`           | Next in pipeline | The connected operator(s) that will receive all outbound entries. |
+| `parse_from`       | required         | The [field](../types/field.md) from which the value will be parsed. |
+| `layout_type`      | `strptime`       | The type of timestamp. Valid values are `strptime`, `gotime`, and `epoch`. |
+| `layout`           | required         | The exact layout of the timestamp to be parsed. |
+| `save_to`          | optional         | Optional [field](../types/field.md) to save formatted value. |
+| `save_layout`      | optional         | The exact layout of the timestamp to be formatted. |
+| `save_layout_type` | `strptime`       | The type of timestamp. Valid values are `strptime`, `gotime`, and `epoch`. |
+| `if`               |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
+| `on_error`         | `send`           | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
 
 
 ### Example Configurations

--- a/pkg/stanza/docs/types/timestamp.md
+++ b/pkg/stanza/docs/types/timestamp.md
@@ -6,12 +6,15 @@ To configure timestamp parsing, add a `timestamp` block in the parser's configur
 
 If a timestamp block is specified, the parser operator will perform the timestamp parsing _after_ performing its other parsing actions, but _before_ passing the entry to the specified output operator.
 
-| Field         | Default    | Description |
-| ---           | ---        | ---         |
-| `parse_from`  | required   | The [field](../types/field.md) from which the value will be parsed. |
-| `layout_type` | `strptime` | The type of timestamp. Valid values are `strptime`, `gotime`, and `epoch`. |
-| `layout`      | required   | The exact layout of the timestamp to be parsed. |
-| `location`    | `Local`    | The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database. [This page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) contains many examples, such as `America/New_York`. |
+| Field              | Default    | Description |
+| ---                | ---        | ---         |
+| `parse_from`       | required   | The [field](../types/field.md) from which the value will be parsed. |
+| `layout_type`      | `strptime` | The type of timestamp. Valid values are `strptime`, `gotime`, and `epoch`. |
+| `layout`           | required   | The exact layout of the timestamp to be parsed. |
+| `save_to`          | optional   | Optional [field](../types/field.md) to save custom formatted timestamp. |
+| `save_layout`      | optional   | The exact layout of the timestamp to be formatted. |
+| `save_layout_type` | `strptime` | The type of timestamp. Valid values are `strptime`, `gotime`, and `epoch`. |
+| `location`         | `Local`    | The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database. [This page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) contains many examples, such as `America/New_York`. |
 
 ### How to specify timestamp parsing parameters
 


### PR DESCRIPTION
**Description:** Opentelemetry stores time in [timestamps with nanoseconds](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/internal/data/protogen/logs/v1/logs.pb.go#L351).
But different storages or later processing may expect time in some specific format.
This PR adds time formatter to stanza package. So time in desired format could be added to desired Body field or Attribute.

This is configured via stanza `time_parser` options:
* `save_to` - field where to store time in desired format
* `save_layout` - desired layout/format
* `save_layout_type` - type layout type (strptime, gotime, epoch)

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12974

**Testing:** tested locally

**Documentation:** Updated related markdown files