### PR TITLE
[receiver/aerospikereceiver] Fix crash when auth is used with no pass or user in single node mode.

### DIFF
--- a/receiver/aerospikereceiver/client.go
+++ b/receiver/aerospikereceiver/client.go
@@ -170,7 +170,12 @@ func (c *defaultASClient) NamespaceInfo() namespaceInfo {
 		res[node] = map[string]map[string]string{}
 		for ns, stats := range namespaces {
 			// ns == "namespace/<namespaceName>"
-			nsName := strings.SplitN(ns, "/", 2)[1]
+			nsData := strings.SplitN(ns, "/", 2)
+			if len(nsData) < 2 {
+				c.logger.Warn("NamespaceInfo nsData len < 2")
+				continue
+			}
+			nsName := nsData[1]
 			res[node][nsName] = parseStats(ns, stats, ";")
 		}
 	}
@@ -207,7 +212,7 @@ func mapNodeInfoFunc(nodes []cluster.Node, nodeF nodeFunc, policy *as.InfoPolicy
 			name := nd.GetName()
 			metrics, err := nodeF(nd, policy)
 			if err != nil {
-				logger.Errorf("mapNodeInfoFunc err: %s", err)
+				logger.Errorf("mapNodeInfoFunc err: %w", err)
 			}
 
 			ns := nodeStats{

--- a/receiver/aerospikereceiver/cluster/node.go
+++ b/receiver/aerospikereceiver/cluster/node.go
@@ -15,6 +15,7 @@ package cluster // import "github.com/open-telemetry/opentelemetry-collector-con
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v5"
@@ -74,6 +75,13 @@ func _newConnNode(policy *as.ClientPolicy, host *as.Host, authEnabled bool, conn
 	if err != nil {
 		return nil, err
 	}
+
+	for k := range m {
+		if strings.HasPrefix(strings.ToUpper(k), "ERROR:") {
+			return nil, as.ErrNotAuthenticated
+		}
+	}
+
 	name := m["node"]
 
 	res := connNode{
@@ -96,6 +104,12 @@ func (n *connNode) RequestInfo(_ *as.InfoPolicy, commands ...string) (map[string
 
 	if err != nil {
 		return nil, err
+	}
+
+	for k := range res {
+		if strings.HasPrefix(strings.ToUpper(k), "ERROR:") {
+			return nil, as.ErrNotAuthenticated
+		}
 	}
 
 	return res, nil

--- a/unreleased/aerospikereceiver-auth-fix.yaml
+++ b/unreleased/aerospikereceiver-auth-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: aerospikereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix crash when connecting to an Aerospike server with authentication using a config with collect_cluster_metrics == false and no username or password.
+
+# One or more tracking issues related to the change
+issues: [12979]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION


**Description:** <Describe what has changed.>
When running a pipeline with the Aerospike receiver with collect_cluster_metrics set to false and username and password empty, the receiver will crash if auth fails with Aerospike error NOT_AUTHENTICATED. This is fixed by checking the response from RequestInfo for the "ERROR:" suffix and returning an error if it is found.

**Link to tracking Issue:** [12979](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12979)

**Testing:** Added unit tests that trigger the crash and now pass. Tested locally on Aerospike cluster with auth enabled.

**Documentation:** No documentation changes needed. Nothing user facing changed.