### PR TITLE
[receiver/prometheus] Use custom wait strategy to solve flaky tests

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -161,7 +161,7 @@ func setupMockPrometheus(tds ...*testData) (*mockPrometheus, *promcfg.Config, er
 	return mp, pCfg, err
 }
 
-func waitForScrapeResults(t *testing.T, targets []*testData, mp *mockPrometheus, cms *consumertest.MetricsSink) {
+func waitForScrapeResults(t *testing.T, targets []*testData, cms *consumertest.MetricsSink) {
 	assert.Eventually(t, func() bool {
 		// This is the receiver's pov as to what should have been collected from the server
 		metrics := cms.AllMetrics()
@@ -616,7 +616,7 @@ func testComponent(t *testing.T, targets []*testData, useStartTimeMetric bool, s
 	//      and when the receiver actually processes the http request response.
 	//      this is a eventually timeout,tick that just waits for some condition.
 	//      however the condition to wait for may be suboptimal and may need to be adjusted.
-	waitForScrapeResults(t, targets, mp, cms)
+	waitForScrapeResults(t, targets, cms)
 
 	// waitgroup Wait() is strictly from a server POV indicating the sufficient number and type of requests have been seen
 	mp.wg.Wait()

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -166,7 +166,7 @@ func setupMockPrometheus(tds ...*testData) (*mockPrometheus, *promcfg.Config, er
 
 func waitForScrapeResults(t *testing.T, targets []*testData, mp *mockPrometheus, cms *consumertest.MetricsSink) {
 	assert.Eventually(t, func() bool {
-		// This is the Server's pov as to what has been served to the reciever
+		// This is the Server's pov as to what has been served to the receiver
 		if len(mp.served) < len(targets) {
 			// If we don't have enough scrapes yet lets return false and wait for another tick
 			return false
@@ -621,7 +621,7 @@ func testComponent(t *testing.T, targets []*testData, useStartTimeMetric bool, s
 	})
 
 	// Note:waitForScrapeResult is an attempt to address a possible race between waitgroup Done() being called in the ServerHTTP function
-	//      and when the reciever actually processes the http request response.
+	//      and when the receiver actually processes the http request response.
 	//      this is a eventually timeout,tick that just waits for some condition.
 	//      however the condition to wait for may be suboptimal and may need to be adjusted.
 	waitForScrapeResults(t, targets, mp, cms)

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -612,14 +612,14 @@ func testComponent(t *testing.T, targets []*testData, useStartTimeMetric bool, s
 		assert.Len(t, flattenTargets(receiver.scrapeManager.TargetsAll()), 0, "expected scrape manager to have no targets")
 	})
 
+	// waitgroup Wait() is strictly from a server POV indicating the sufficient number and type of requests have been seen
+	mp.wg.Wait()
+
 	// Note:waitForScrapeResult is an attempt to address a possible race between waitgroup Done() being called in the ServerHTTP function
-	//      and when the receiver actually processes the http request response.
+	//      and when the receiver actually processes the http request responses into metrics.
 	//      this is a eventually timeout,tick that just waits for some condition.
 	//      however the condition to wait for may be suboptimal and may need to be adjusted.
 	waitForScrapeResults(t, targets, cms)
-
-	// waitgroup Wait() is strictly from a server POV indicating the sufficient number and type of requests have been seen
-	mp.wg.Wait()
 
 	// This begins the processing of the scrapes collected by the receiver
 	metrics := cms.AllMetrics()

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -160,7 +160,8 @@ func setupMockPrometheus(tds ...*testData) (*mockPrometheus, *promcfg.Config, er
 		job := make(map[string]interface{})
 		job["job_name"] = tds[i].name
 		job["metrics_path"] = metricPaths[i]
-		job["scrape_interval"] = "100ms"
+		job["scrape_interval"] = "2s"
+		job["scrape_timeout"] = "1s"
 		job["static_configs"] = []map[string]interface{}{{"targets": []string{u.Host}}}
 		jobs = append(jobs, job)
 	}

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -195,7 +195,7 @@ func waitForScrapeResults(t *testing.T, targets []*testData, mp *mockPrometheus,
 			}
 		}
 		return true
-	}, 10*time.Second, 500*time.Millisecond)
+	}, 30*time.Second, 500*time.Millisecond)
 }
 
 func verifyNumValidScrapeResults(t *testing.T, td *testData, resourceMetrics []*pmetric.ResourceMetrics) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
* Addressed scrape timing configuration that was too tight for production test environment, causing test to fail sometimes due to borderline slowness of the http response loop.
* Added additional race condition protection to account for potential race between http server request processing and reciever response processing.

**Link to tracking Issue:** 
#11753

This also impacts several other prom receiver bugs, but we'll start with this one and then do a separate PR to unskip the rest once this appears to be working.

**Testing:** 
Local testing with synthetically slowed down ServeHTTP function using 500ms delay as environment target.

