### PR TITLE
[receiver/prometheusreceiver] Add exemplars to prometheus receiver

### DIFF
--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -51,6 +51,7 @@ type metricGroup struct {
 	hasSum       bool
 	value        float64
 	complexValue []*dataPoint
+	exemplars    map[float64]pmetric.Exemplar
 }
 
 func newMetricFamily(metricName string, mc MetadataCache, logger *zap.Logger) *metricFamily {
@@ -140,6 +141,14 @@ func (mg *metricGroup) toDistributionPoint(dest pmetric.HistogramDataPointSlice)
 	point.SetStartTimestamp(tsNanos) // metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 	point.SetTimestamp(tsNanos)
 	populateAttributes(pmetric.MetricDataTypeHistogram, mg.ls, point.Attributes())
+	mg.setExemplars(point.Exemplars())
+}
+
+func (mg *metricGroup) setExemplars(exemplars pmetric.ExemplarSlice) {
+	for _, e := range mg.exemplars {
+		exemplar := exemplars.AppendEmpty()
+		e.MoveTo(exemplar)
+	}
 }
 
 func pdataTimestampFromMs(timeAtMs int64) pcommon.Timestamp {
@@ -203,6 +212,7 @@ func (mg *metricGroup) toNumberDataPoint(dest pmetric.NumberDataPointSlice) {
 		point.SetDoubleVal(mg.value)
 	}
 	populateAttributes(pmetric.MetricDataTypeGauge, mg.ls, point.Attributes())
+	mg.setExemplars(point.Exemplars())
 }
 
 func populateAttributes(mType pmetric.MetricDataType, ls labels.Labels, dest pcommon.Map) {
@@ -228,9 +238,10 @@ func (mf *metricFamily) loadMetricGroupOrCreate(groupKey uint64, ls labels.Label
 	mg, ok := mf.groups[groupKey]
 	if !ok {
 		mg = &metricGroup{
-			family: mf,
-			ts:     ts,
-			ls:     ls,
+			family:    mf,
+			ts:        ts,
+			ls:        ls,
+			exemplars: make(map[float64]pmetric.Exemplar),
 		}
 		mf.groups[groupKey] = mg
 		// maintaining data insertion order is helpful to generate stable/reproducible metric output

--- a/receiver/prometheusreceiver/internal/metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/metricfamily_test.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"encoding/hex"
 	"math"
 	"testing"
 	"time"
@@ -91,12 +92,35 @@ var mc = byLookupMetadataCache{
 	},
 }
 
+func createNewExemplar(value float64, timestamp int64, traceid string) map[float64]pmetric.Exemplar {
+	var (
+		tid   [16]byte
+		sid   [8]byte
+		exMap = make(map[float64]pmetric.Exemplar)
+	)
+	ex := pmetric.NewExemplar()
+	ex.SetDoubleVal(value)
+	ex.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(timestamp)))
+
+	t, _ := hex.DecodeString(traceid)
+	copyToLowerBytes(tid[:], t)
+	ex.SetTraceID(pcommon.NewTraceID(tid))
+
+	s, _ := hex.DecodeString(traceid)
+	copyToLowerBytes(sid[:], s)
+	ex.SetSpanID(pcommon.NewSpanID(sid))
+
+	exMap[value] = ex
+
+	return exMap
+}
 func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 	type scrape struct {
 		at         int64
 		value      float64
 		metric     string
 		extraLabel labels.Label
+		exemplars  map[float64]pmetric.Exemplar
 	}
 	tests := []struct {
 		name                string
@@ -115,11 +139,15 @@ func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 			scrapes: []*scrape{
 				{at: 11, value: 66, metric: "histogram_count"},
 				{at: 11, value: 1004.78, metric: "histogram_sum"},
-				{at: 11, value: 33, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "0.75"}},
-				{at: 11, value: 55, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "2.75"}},
+				{at: 11, value: 33, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "0.75"}, exemplars: createNewExemplar(33, 11, "0000c5bd3caea93d")},
+				{at: 11, value: 55, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "2.75"}, exemplars: createNewExemplar(55, 11, "0006f0ea595fa831")},
 				{at: 11, value: 66, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "+Inf"}},
 			},
 			want: func() pmetric.HistogramDataPoint {
+				var (
+					tid1, tid2 [16]byte
+					sid1, sid2 [8]byte
+				)
 				point := pmetric.NewHistogramDataPoint()
 				point.SetCount(66)
 				point.SetSum(1004.78)
@@ -130,6 +158,29 @@ func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 				attributes := point.Attributes()
 				attributes.UpsertString("a", "A")
 				attributes.UpsertString("b", "B")
+
+				// add exemplars
+				exemplars := pmetric.NewExemplarSlice()
+
+				e1 := exemplars.AppendEmpty()
+				e1.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(11)))
+				e1.SetDoubleVal(33)
+				tr, _ := hex.DecodeString("0000c5bd3caea93d")
+				copyToLowerBytes(tid1[:], tr)
+				sp, _ := hex.DecodeString("0000c5bd3caea93d")
+				copyToLowerBytes(sid1[:], sp)
+				e1.SetTraceID(pcommon.NewTraceID(tid1))
+				e1.SetSpanID(pcommon.NewSpanID(sid1))
+
+				e2 := exemplars.AppendEmpty()
+				e2.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(11)))
+				e2.SetDoubleVal(55)
+				tr1, _ := hex.DecodeString("0006f0ea595fa831")
+				copyToLowerBytes(tid2[:], tr1)
+				sp1, _ := hex.DecodeString("0006f0ea595fa831")
+				copyToLowerBytes(sid2[:], sp1)
+				e2.SetTraceID(pcommon.NewTraceID(tid2))
+				e2.SetSpanID(pcommon.NewSpanID(sid2))
 				return point
 			},
 		},

--- a/unreleased/append-exemplars-to-prometheus-receiver.yaml
+++ b/unreleased/append-exemplars-to-prometheus-receiver.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: receiver/prometheusreceiver
+
+note: Append exemplars to the metrics received by prometheus receiver
+
+issues: [8353]
+
+subtext: Acknowledge exemplars coming from prometheus receiver and append it to otel format


### PR DESCRIPTION
**Description:** 
Added a support to acknowledge exemplars from prometheus receiver and attach the exemplars to otel metric object.

Adding a feature 
Currently, there is no support for exemplars in prometheus receiver. Added functionality to address this

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8353

**Testing:** 
Used **prometheusremotewrite** to send data with exemplars and verified if we are able to visualize exemplars data.
