### PR TITLE
[tqlotel] Fix assertion in the limit function tests.

### DIFF
--- a/pkg/telemetryquerylanguage/functions/tqlotel/func_limit_test.go
+++ b/pkg/telemetryquerylanguage/functions/tqlotel/func_limit_test.go
@@ -97,11 +97,12 @@ func Test_limit(t *testing.T) {
 
 			exprFunc, _ := Limit(tt.target, tt.limit)
 			exprFunc(ctx)
+			actual := ctx.GetItem()
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
 
-			assert.Equal(t, expected, expected)
+			assert.Equal(t, expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`Test_limit` was asserting expected value against expected. This
change fixes the assertion.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Modifying expected test values and see whether tests fail.

**Documentation:** <Describe the documentation added.>