### PR TITLE
[tqlotel] Avoid copying when filtering keys in KeepKeys.

### DIFF
--- a/pkg/telemetryquerylanguage/functions/tqlotel/func_keep_keys.go
+++ b/pkg/telemetryquerylanguage/functions/tqlotel/func_keep_keys.go
@@ -33,16 +33,13 @@ func KeepKeys(target tql.GetSetter, keys []string) (tql.ExprFunc, error) {
 		}
 
 		if attrs, ok := val.(pcommon.Map); ok {
-			// TODO(anuraaga): Avoid copying when filtering keys https://github.com/open-telemetry/opentelemetry-collector/issues/4756
-			filtered := pcommon.NewMap()
-			filtered.EnsureCapacity(attrs.Len())
-			attrs.Range(func(key string, val pcommon.Value) bool {
-				if _, ok := keySet[key]; ok {
-					filtered.Insert(key, val)
-				}
-				return true
+			attrs.RemoveIf(func(key string, value pcommon.Value) bool {
+				_, ok := keySet[key]
+				return !ok
 			})
-			target.Set(ctx, filtered)
+			if attrs.Len() == 0 {
+				attrs.Clear()
+			}
 		}
 		return nil
 	}, nil

--- a/unreleased/tql-keep-keys-perfomanace.yaml
+++ b/unreleased/tql-keep-keys-perfomanace.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: telemetryquerylanguage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Avoid copying attributes when filtering on keys in the `keep_keys` TQL function"
+
+# One or more tracking issues related to the change
+issues: [4756]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Uses `AttributeMap#RemoveIf` introduced in [#4914](https://github.com/open-telemetry/opentelemetry-collector/pull/4914), also see [#4756](https://github.com/open-telemetry/opentelemetry-collector/issues/4756).

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector/issues/4756

**Testing:** <Describe what testing was performed and which tests were added.>
Existing unit tests.

**Documentation:** <Describe the documentation added.>