### PR TITLE
[exporter/loki] Don't retry on 4xx responses from loki

### DIFF
--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -152,7 +152,9 @@ func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
 		err = fmt.Errorf("HTTP %d %q: %s", resp.StatusCode, http.StatusText(resp.StatusCode), line)
 
 		// Errors with 4xx status code (excluding 429) should not be retried
-		if resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusTooManyRequests {
+		if resp.StatusCode >= http.StatusBadRequest &&
+			resp.StatusCode < http.StatusInternalServerError &&
+			resp.StatusCode != http.StatusTooManyRequests {
 			return consumererror.NewPermanent(err)
 		}
 

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -150,6 +150,12 @@ func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
 			line = scanner.Text()
 		}
 		err = fmt.Errorf("HTTP %d %q: %s", resp.StatusCode, http.StatusText(resp.StatusCode), line)
+
+		// Errors with 4xx status code (excluding 429) should not be retried
+		if resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusTooManyRequests {
+			return consumererror.NewPermanent(err)
+		}
+
 		return consumererror.NewLogs(err, ld)
 	}
 

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -224,6 +224,17 @@ func TestExporter_pushLogData(t *testing.T) {
 				return outLogs
 			},
 		},
+		{
+			name:             "bad request",
+			reqTestFunc:      genericReqTestFunc,
+			config:           genericConfig,
+			httpResponseCode: http.StatusBadRequest,
+			testServer:       true,
+			genLogsFunc:      genericGenLogsFunc,
+			errFunc: func(err error) {
+				require.True(t, consumererror.IsPermanent(err))
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -235,6 +235,19 @@ func TestExporter_pushLogData(t *testing.T) {
 				require.True(t, consumererror.IsPermanent(err))
 			},
 		},
+		{
+			name:             "too many requests",
+			reqTestFunc:      genericReqTestFunc,
+			config:           genericConfig,
+			httpResponseCode: http.StatusTooManyRequests,
+			testServer:       true,
+			genLogsFunc:      genericGenLogsFunc,
+			errFunc: func(err error) {
+				var e consumererror.Logs
+				require.True(t, errors.As(err, &e))
+				assert.Equal(t, 10, e.GetLogs().LogRecordCount())
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/unreleased/loki_permanent_error.yaml
+++ b/unreleased/loki_permanent_error.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: lokiexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Don't retry on 4xx responses (excluding 429) from loki
+
+# One or more tracking issues related to the change
+issues: [12930]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** Don't retry when receiving a 4xx response (excluding 429) from loki.

**Link to tracking Issue:** #12930