### PR TITLE
[tqlotel] Add priority keys parameter to the limit function.

### DIFF
--- a/pkg/telemetryquerylanguage/functions/tqlotel/README.md
+++ b/pkg/telemetryquerylanguage/functions/tqlotel/README.md
@@ -101,18 +101,22 @@ Examples:
 
 ## limit
 
-`limit(target, limit)`
+`limit(target, limit, priority_keys)`
 
 The `limit` function reduces the number of elements in a `pdata.Map` to be no greater than the limit.
 
-`target` is a path expression to a `pdata.Map` type field. `limit` is a non-negative integer. 
+`target` is a path expression to a `pdata.Map` type field. `limit` is a non-negative integer.
+`priority_keys` is a list of strings of attribute keys that won't be dropped during limiting.
 
-The map will be mutated such that the number of items does not exceed the limit. Which items are dropped is random.
+The number of priority keys must be less than the supplied `limit`.
+
+The map will be mutated such that the number of items does not exceed the limit.
+Which items are dropped is random, provide `priority_keys` to preserve required keys.
 
 Examples:
 
 - `limit(attributes, 100)`
-- `limit(resource.attributes, 50)`
+- `limit(resource.attributes, 50, "http.host", "http.method")`
 
 ## replace_all_matches
 

--- a/pkg/telemetryquerylanguage/functions/tqlotel/README.md
+++ b/pkg/telemetryquerylanguage/functions/tqlotel/README.md
@@ -111,6 +111,8 @@ The `limit` function reduces the number of elements in a `pdata.Map` to be no gr
 The number of priority keys must be less than the supplied `limit`.
 
 The map will be mutated such that the number of items does not exceed the limit.
+The map is not copied or reallocated.
+
 Which items are dropped is random, provide `priority_keys` to preserve required keys.
 
 Examples:

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -43,7 +43,7 @@ transform:
     queries:
       - set(metric.description, "Sum") where metric.type == "Sum"
       - keep_keys(resource.attributes, "host.name")
-      - limit(attributes, 100)
+      - limit(attributes, 100, "host.name")
       - truncate_all(attributes, 4096)
       - truncate_all(resource.attributes, 4096)
       - convert_sum_to_gauge() where metric.name == "system.processes.count"
@@ -163,7 +163,7 @@ The transform processor's implementation of the [Telemetry Query Language](https
   - Although the TQL allows the `set` function to be used with `metric.data_type`, its implementation in the transform processor is NOOP.  To modify a data type you must use a function specific to that purpose.
 - [Identity Conflict](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/standard-warnings.md#identity-conflict): Transformation of metrics have the potential to affect the identity of a metric leading to an Identity Crisis. Be especially cautious when transforming metric name and when reducing/changing existing attributes.  Adding new attributes is safe.
 - [Orphaned Telemetry](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/standard-warnings.md#orphaned-telemetry): The processor allows you to modify `span_id`, `trace_id`, and `parent_span_id` for traces and `span_id`, and `trace_id` logs.  Modifying these fields could lead to orphaned spans or logs. 
-- The `limit` function drops attributes at random.  If there are attributes that should never be dropped then this function should not be used.  [#9734](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9734)
+- The `limit` function drops attributes at random. If there are attributes that should never be dropped please provide them as function arguments, e.g. `limit(attibutes, 10, "http.host", "http.method")`
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/unreleased/tql-limit-func-priority-keys.yaml
+++ b/unreleased/tql-limit-func-priority-keys.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/telemetryquerylanguage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add ability to specify attribute keys in the `limit` function that aren't allowed to be dropped"
+
+# One or more tracking issues related to the change
+issues: [9734]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This breaking change affects the transform processor since we don't have a way to default values in a function call.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Add ability to specify attributes that aren't allowed to be dropped during limiting. Resolves #9734.

**Link to tracking Issue:** <Issue number if applicable>
#9734

**Testing:** <Describe what testing was performed and which tests were added.>
- Unit tests
- Running Otel collector locally with following configurations:
```yaml
receivers:
  otlp:
    protocols:
      grpc:

exporters:
  logging:

processors:
  transform:
    traces:
      queries:
        - limit(attributes, 1, "http.url")
service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [transform]
      exporters: [logging]
```
and testing with 

```python
trace.set_tracer_provider(TracerProvider())
tracer = trace.get_tracer(__name__)
otlp_exporter = OTLPSpanExporter()
span_processor = BatchSpanProcessor(otlp_exporter)
trace.get_tracer_provider().add_span_processor(span_processor)

with tracer.start_as_current_span("foo") as span:
    span.set_attributes({
        SpanAttributes.HTTP_HOST: "",
        SpanAttributes.HTTP_METHOD: "",
        SpanAttributes.HTTP_STATUS_CODE: "",
        SpanAttributes.HTTP_TARGET: "",
        SpanAttributes.HTTP_CLIENT_IP: "",
        SpanAttributes.HTTP_URL: ""
    })

```
**Documentation:** <Describe the documentation added.>
Updated:
- `pkg/telemetryquerylanguage/functions/tqlotel/README.md`
- `processor/transformprocessor/README.md`