### PR TITLE
[storagetest] Move mock client from pkg/stanza/adapter and export

### DIFF
--- a/extension/storage/storagetest/client.go
+++ b/extension/storage/storagetest/client.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagetest // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/storagetest"
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"go.opentelemetry.io/collector/extension/experimental/storage"
+)
+
+type MemoryClient struct {
+	cache    map[string][]byte
+	cacheMux sync.Mutex
+}
+
+func NewMemoryClient() *MemoryClient {
+	return &MemoryClient{
+		cache: make(map[string][]byte),
+	}
+}
+
+func (p *MemoryClient) Get(_ context.Context, key string) ([]byte, error) {
+	p.cacheMux.Lock()
+	defer p.cacheMux.Unlock()
+	return p.cache[key], nil
+}
+
+func (p *MemoryClient) Set(_ context.Context, key string, value []byte) error {
+	p.cacheMux.Lock()
+	defer p.cacheMux.Unlock()
+	p.cache[key] = value
+	return nil
+}
+
+func (p *MemoryClient) Delete(_ context.Context, key string) error {
+	p.cacheMux.Lock()
+	defer p.cacheMux.Unlock()
+	delete(p.cache, key)
+	return nil
+}
+
+func (p *MemoryClient) Batch(_ context.Context, ops ...storage.Operation) error {
+	p.cacheMux.Lock()
+	defer p.cacheMux.Unlock()
+
+	for _, op := range ops {
+		switch op.Type {
+		case storage.Get:
+			op.Value = p.cache[op.Key]
+		case storage.Set:
+			p.cache[op.Key] = op.Value
+		case storage.Delete:
+			delete(p.cache, op.Key)
+		default:
+			return errors.New("wrong operation type")
+		}
+	}
+
+	return nil
+}
+
+func (p *MemoryClient) Close(_ context.Context) error {
+	p.cacheMux.Lock()
+	defer p.cacheMux.Unlock()
+	p.cache = nil
+	return nil
+}

--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -17,15 +17,14 @@ package adapter
 import (
 	"context"
 	"errors"
-	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/storagetest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -132,64 +131,6 @@ func (f TestReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Conf
 
 func newMockPersister() *persister {
 	return &persister{
-		client: newMockClient(),
+		client: storagetest.NewMemoryClient(),
 	}
-}
-
-type mockClient struct {
-	cache    map[string][]byte
-	cacheMux sync.Mutex
-}
-
-func newMockClient() *mockClient {
-	return &mockClient{
-		cache: make(map[string][]byte),
-	}
-}
-
-func (p *mockClient) Get(_ context.Context, key string) ([]byte, error) {
-	p.cacheMux.Lock()
-	defer p.cacheMux.Unlock()
-	return p.cache[key], nil
-}
-
-func (p *mockClient) Set(_ context.Context, key string, value []byte) error {
-	p.cacheMux.Lock()
-	defer p.cacheMux.Unlock()
-	p.cache[key] = value
-	return nil
-}
-
-func (p *mockClient) Delete(_ context.Context, key string) error {
-	p.cacheMux.Lock()
-	defer p.cacheMux.Unlock()
-	delete(p.cache, key)
-	return nil
-}
-
-func (p *mockClient) Batch(_ context.Context, ops ...storage.Operation) error {
-	p.cacheMux.Lock()
-	defer p.cacheMux.Unlock()
-
-	for _, op := range ops {
-		switch op.Type {
-		case storage.Get:
-			op.Value = p.cache[op.Key]
-		case storage.Set:
-			p.cache[op.Key] = op.Value
-		case storage.Delete:
-			delete(p.cache, op.Key)
-		default:
-			return errors.New("wrong operation type")
-		}
-	}
-
-	return nil
-}
-
-func (p *mockClient) Close(_ context.Context) error {
-	p.cacheMux.Lock()
-	defer p.cacheMux.Unlock()
-	p.cache = nil
-	return nil
 }

--- a/unreleased/storagetest-enhancements.yaml
+++ b/unreleased/storagetest-enhancements.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: storagetest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Export a MemoryClient, which is useful for testing storage components
+
+# One or more tracking issues related to the change
+issues: [13001]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
This client is useful in testing. In order to make it useful for other
components as well, this PR moves it to the storagetest package, renames,
and exports the client. It is essentially an implementation of an
in-memory storage.Client, so can be used equivalently to a map.