### PR TITLE
[chore] update golang for dependabot pr workflow

### DIFF
--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh
         env:


### PR DESCRIPTION
This is using the default on ubuntu/latest which results in go 1.17 being used.
