### PR TITLE
Fix indentation in README of resourcedetectionprocessor

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -161,12 +161,12 @@ EC2 custom configuration example:
 processors:
   resourcedetection/ec2:
     detectors: ["ec2"]
-      ec2:
-        # A list of regex's to match tag keys to add as resource attributes can be specified
-        tags:
-          - ^tag1$
-          - ^tag2$
-          - ^label.*$
+    ec2:
+      # A list of regex's to match tag keys to add as resource attributes can be specified
+      tags:
+        - ^tag1$
+        - ^tag2$
+        - ^label.*$
 ```
 
 If you are using a proxy server on your EC2 instance, it's important that you exempt requests for instance metadata as [described in the AWS cli user guide](https://github.com/awsdocs/aws-cli-user-guide/blob/a2393582590b64bd2a1d9978af15b350e1f9eb8e/doc_source/cli-configure-proxy.md#using-a-proxy-on-amazon-ec2-instances). Failing to do so can result in proxied or missing instance data.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
I was using otelcol-contrib 0.56.0, 0.57.2 and tries using the example from the README:
```yaml
processors:
  resourcedetection/ec2:
    detectors: ["ec2"]
      ec2:
        # A list of regex's to match tag keys to add as resource attributes can be specified
        tags:
          - ^tag1$
          - ^tag2$
          - ^label.*$
```

But got the following error:
```
Error: failed to get config: cannot resolve the configuration: yaml: line 27: did not find expected key
2022/08/08 14:41:49 collector server run finished with error: failed to get config: cannot resolve the configuration: yaml: line 27: did not find expected key
```
The line it was referring to was `resourcedetection/ec2:`.
To fix this issue I had to change the config to this (indentation):

```yaml
processors:
  resourcedetection/ec2:
    detectors: ["ec2"]
    ec2:
      # A list of regex's to match tag keys to add as resource attributes can be specified
      tags:
        - ^tag1$
        - ^tag2$
        - ^label.*$
```
So I think the README should be changed in order to avoid further confusion.