### PR TITLE
[chore] update base docker image to go 1.18

### DIFF
--- a/cmd/telemetrygen/Dockerfile
+++ b/cmd/telemetrygen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS build
+FROM golang:1.18 AS build
 
 WORKDIR /src
 ADD . /src

--- a/cmd/tracegen/Dockerfile
+++ b/cmd/tracegen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS build
+FROM golang:1.18 AS build
 
 WORKDIR /src
 ADD . /src

--- a/examples/demo/client/Dockerfile
+++ b/examples/demo/client/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17
+FROM golang:1.18
 COPY . /usr/src/client/
 WORKDIR /usr/src/client/
 RUN go env -w GOPROXY=direct

--- a/examples/demo/server/Dockerfile
+++ b/examples/demo/server/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17
+FROM golang:1.18
 COPY . /usr/src/server/
 WORKDIR /usr/src/server/
 RUN go env -w GOPROXY=direct

--- a/examples/tracing/Dockerfile
+++ b/examples/tracing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS build
+FROM golang:1.18 AS build
 
 WORKDIR /src
 ADD . /src

--- a/exporter/loadbalancingexporter/example/Dockerfile
+++ b/exporter/loadbalancingexporter/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS build
+FROM golang:1.18 AS build
 
 WORKDIR /src
 ADD . /src

--- a/exporter/lokiexporter/example/Dockerfile
+++ b/exporter/lokiexporter/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS build
+FROM golang:1.18 AS build
 
 WORKDIR /src
 ADD . /src

--- a/exporter/splunkhecexporter/example/Dockerfile
+++ b/exporter/splunkhecexporter/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS build
+FROM golang:1.18 AS build
 
 WORKDIR /src
 ADD . /src

--- a/receiver/simpleprometheusreceiver/examples/federation/prom-counter/Dockerfile
+++ b/receiver/simpleprometheusreceiver/examples/federation/prom-counter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-stretch
+FROM golang:1.18-stretch
 
 WORKDIR /go/src/app
 


### PR DESCRIPTION
This change ensures that the version of go used in the containers can use go workspaces.

Pulled this change out of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/10904