### PR TITLE
[receiver/couchdb] Pass pointer to ScrapeErrors instead of by value

### DIFF
--- a/receiver/couchdbreceiver/metrics.go
+++ b/receiver/couchdbreceiver/metrics.go
@@ -23,139 +23,139 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver/internal/metadata"
 )
 
-func (c *couchdbScraper) recordCouchdbAverageRequestTimeDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errors scrapererror.ScrapeErrors) {
+func (c *couchdbScraper) recordCouchdbAverageRequestTimeDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errs *scrapererror.ScrapeErrors) {
 	averageRequestTimeMetricKey := []string{"request_time", "value", "arithmetic_mean"}
 	averageRequestTimeValue, err := getValueFromBody(averageRequestTimeMetricKey, stats)
 	if err != nil {
-		errors.AddPartial(1, err)
+		errs.AddPartial(1, err)
 		return
 	}
 
 	parsedValue, err := c.parseFloat(averageRequestTimeValue)
 	if err != nil {
-		errors.AddPartial(1, err)
+		errs.AddPartial(1, err)
 		return
 	}
 	c.mb.RecordCouchdbAverageRequestTimeDataPoint(now, parsedValue)
 }
 
-func (c *couchdbScraper) recordCouchdbHttpdBulkRequestsDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errors scrapererror.ScrapeErrors) {
+func (c *couchdbScraper) recordCouchdbHttpdBulkRequestsDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errs *scrapererror.ScrapeErrors) {
 	httpdBulkRequestsMetricKey := []string{"httpd", "bulk_requests", "value"}
 	httpdBulkRequestsMetricValue, err := getValueFromBody(httpdBulkRequestsMetricKey, stats)
 	if err != nil {
-		errors.AddPartial(1, err)
+		errs.AddPartial(1, err)
 		return
 	}
 
 	parsedValue, err := c.parseInt(httpdBulkRequestsMetricValue)
 	if err != nil {
-		errors.AddPartial(1, err)
+		errs.AddPartial(1, err)
 		return
 	}
 	c.mb.RecordCouchdbHttpdBulkRequestsDataPoint(now, parsedValue)
 }
 
-func (c *couchdbScraper) recordCouchdbHttpdRequestsDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errors scrapererror.ScrapeErrors) {
+func (c *couchdbScraper) recordCouchdbHttpdRequestsDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errs *scrapererror.ScrapeErrors) {
 	for methodVal, method := range metadata.MapAttributeHTTPMethod {
 		httpdRequestMethodKey := []string{"httpd_request_methods", methodVal, "value"}
 		httpdRequestMethodValue, err := getValueFromBody(httpdRequestMethodKey, stats)
 		if err != nil {
-			errors.AddPartial(1, err)
+			errs.AddPartial(1, err)
 			continue
 		}
 
 		parsedValue, err := c.parseInt(httpdRequestMethodValue)
 		if err != nil {
-			errors.AddPartial(1, err)
+			errs.AddPartial(1, err)
 			continue
 		}
 		c.mb.RecordCouchdbHttpdRequestsDataPoint(now, parsedValue, method)
 	}
 }
 
-func (c *couchdbScraper) recordCouchdbHttpdResponsesDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errors scrapererror.ScrapeErrors) {
+func (c *couchdbScraper) recordCouchdbHttpdResponsesDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errs *scrapererror.ScrapeErrors) {
 	codes := []string{"200", "201", "202", "204", "206", "301", "302", "304", "400", "401", "403", "404", "405", "406", "409", "412", "413", "414", "415", "416", "417", "500", "501", "503"}
 	for _, code := range codes {
 		httpdResponsetCodeKey := []string{"httpd_status_codes", code, "value"}
 		httpdResponsetCodeValue, err := getValueFromBody(httpdResponsetCodeKey, stats)
 		if err != nil {
-			errors.AddPartial(1, err)
+			errs.AddPartial(1, err)
 			continue
 		}
 
 		parsedValue, err := c.parseInt(httpdResponsetCodeValue)
 		if err != nil {
-			errors.AddPartial(1, err)
+			errs.AddPartial(1, err)
 			continue
 		}
 		c.mb.RecordCouchdbHttpdResponsesDataPoint(now, parsedValue, code)
 	}
 }
 
-func (c *couchdbScraper) recordCouchdbHttpdViewsDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errors scrapererror.ScrapeErrors) {
+func (c *couchdbScraper) recordCouchdbHttpdViewsDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errs *scrapererror.ScrapeErrors) {
 	for viewVal, view := range metadata.MapAttributeView {
 		viewKey := []string{"httpd", viewVal, "value"}
 		viewValue, err := getValueFromBody(viewKey, stats)
 		if err != nil {
-			errors.AddPartial(1, err)
+			errs.AddPartial(1, err)
 			continue
 		}
 
 		parsedValue, err := c.parseInt(viewValue)
 		if err != nil {
-			errors.AddPartial(1, err)
+			errs.AddPartial(1, err)
 			continue
 		}
 		c.mb.RecordCouchdbHttpdViewsDataPoint(now, parsedValue, view)
 	}
 }
 
-func (c *couchdbScraper) recordCouchdbDatabaseOpenDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errors scrapererror.ScrapeErrors) {
+func (c *couchdbScraper) recordCouchdbDatabaseOpenDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errs *scrapererror.ScrapeErrors) {
 	openDatabaseKey := []string{"open_databases", "value"}
 	openDatabaseMetricValue, err := getValueFromBody(openDatabaseKey, stats)
 	if err != nil {
-		errors.AddPartial(1, err)
+		errs.AddPartial(1, err)
 		return
 	}
 
 	parsedValue, err := c.parseInt(openDatabaseMetricValue)
 	if err != nil {
-		errors.AddPartial(1, err)
+		errs.AddPartial(1, err)
 		return
 	}
 	c.mb.RecordCouchdbDatabaseOpenDataPoint(now, parsedValue)
 }
 
-func (c *couchdbScraper) recordCouchdbFileDescriptorOpenDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errors scrapererror.ScrapeErrors) {
+func (c *couchdbScraper) recordCouchdbFileDescriptorOpenDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errs *scrapererror.ScrapeErrors) {
 	fileDescriptorKey := []string{"open_os_files", "value"}
 	fileDescriptorMetricValue, err := getValueFromBody(fileDescriptorKey, stats)
 	if err != nil {
-		errors.AddPartial(1, err)
+		errs.AddPartial(1, err)
 		return
 	}
 
 	parsedValue, err := c.parseInt(fileDescriptorMetricValue)
 	if err != nil {
-		errors.AddPartial(1, err)
+		errs.AddPartial(1, err)
 		return
 	}
 	c.mb.RecordCouchdbFileDescriptorOpenDataPoint(now, parsedValue)
 }
 
-func (c *couchdbScraper) recordCouchdbDatabaseOperationsDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errors scrapererror.ScrapeErrors) {
+func (c *couchdbScraper) recordCouchdbDatabaseOperationsDataPoint(now pcommon.Timestamp, stats map[string]interface{}, errs *scrapererror.ScrapeErrors) {
 	operations := []metadata.AttributeOperation{metadata.AttributeOperationReads, metadata.AttributeOperationWrites}
 	keyPaths := [][]string{{"database_reads", "value"}, {"database_writes", "value"}}
 	for i := 0; i < len(operations); i++ {
 		key := keyPaths[i]
 		value, err := getValueFromBody(key, stats)
 		if err != nil {
-			errors.AddPartial(1, err)
+			errs.AddPartial(1, err)
 			continue
 		}
 
 		parsedValue, err := c.parseInt(value)
 		if err != nil {
-			errors.AddPartial(1, err)
+			errs.AddPartial(1, err)
 			continue
 		}
 		c.mb.RecordCouchdbDatabaseOperationsDataPoint(now, parsedValue, operations[i])

--- a/receiver/couchdbreceiver/scraper.go
+++ b/receiver/couchdbreceiver/scraper.go
@@ -70,15 +70,16 @@ func (c *couchdbScraper) scrape(context.Context) (pmetric.Metrics, error) {
 
 	now := pcommon.NewTimestampFromTime(time.Now())
 
-	var errors scrapererror.ScrapeErrors
-	c.recordCouchdbAverageRequestTimeDataPoint(now, stats, errors)
-	c.recordCouchdbHttpdBulkRequestsDataPoint(now, stats, errors)
-	c.recordCouchdbHttpdRequestsDataPoint(now, stats, errors)
-	c.recordCouchdbHttpdResponsesDataPoint(now, stats, errors)
-	c.recordCouchdbHttpdViewsDataPoint(now, stats, errors)
-	c.recordCouchdbDatabaseOpenDataPoint(now, stats, errors)
-	c.recordCouchdbFileDescriptorOpenDataPoint(now, stats, errors)
-	c.recordCouchdbDatabaseOperationsDataPoint(now, stats, errors)
+	errs := &scrapererror.ScrapeErrors{}
 
-	return c.mb.Emit(metadata.WithCouchdbNodeName(c.config.Endpoint)), errors.Combine()
+	c.recordCouchdbAverageRequestTimeDataPoint(now, stats, errs)
+	c.recordCouchdbHttpdBulkRequestsDataPoint(now, stats, errs)
+	c.recordCouchdbHttpdRequestsDataPoint(now, stats, errs)
+	c.recordCouchdbHttpdResponsesDataPoint(now, stats, errs)
+	c.recordCouchdbHttpdViewsDataPoint(now, stats, errs)
+	c.recordCouchdbDatabaseOpenDataPoint(now, stats, errs)
+	c.recordCouchdbFileDescriptorOpenDataPoint(now, stats, errs)
+	c.recordCouchdbDatabaseOperationsDataPoint(now, stats, errs)
+
+	return c.mb.Emit(metadata.WithCouchdbNodeName(c.config.Endpoint)), errs.Combine()
 }

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -83,8 +84,9 @@ func TestScrape(t *testing.T) {
 		scraper := newCouchdbScraper(componenttest.NewNopReceiverCreateSettings(), cfg)
 		scraper.client = mockClient
 
-		_, err := scraper.scrape(context.Background())
+		metrics, err := scraper.scrape(context.Background())
 		require.Error(t, err)
+		assert.Equal(t, 0, metrics.DataPointCount(), "Expected 0 datapoints to be collected")
 
 		partialScrapeErr := err.(scrapererror.PartialScrapeError)
 		require.True(t, partialScrapeErr.Failed > 0, "Expected scrape failures, but none were recorded!")

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -88,7 +88,8 @@ func TestScrape(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, 0, metrics.DataPointCount(), "Expected 0 datapoints to be collected")
 
-		partialScrapeErr := err.(scrapererror.PartialScrapeError)
+		var partialScrapeErr scrapererror.PartialScrapeError
+		require.True(t, errors.As(err, &partialScrapeErr), "returned error was not PartialScrapeError")
 		require.True(t, partialScrapeErr.Failed > 0, "Expected scrape failures, but none were recorded!")
 	})
 

--- a/unreleased/couchdbreceiver_fix-scrape-errors.yaml
+++ b/unreleased/couchdbreceiver_fix-scrape-errors.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: couchdbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix some partial errors not being correctly reported
+
+# One or more tracking issues related to the change
+issues: [13007]
+


### PR DESCRIPTION
**Description:**
* fixes issue where partial errors are not recorded due to passing the ScrapeErrors struct by value
* rename errors -> errs to avoid possible shadowing of the `errors` package

**Link to tracking Issue:** #13007

**Testing:**
* Added a new test to assert that the returned PartialError increments the number of recorded errors.

**Documentation:** N/A