### PR TITLE
[receiver/mysql] Pass pointer to ScrapeErrors instead of by value 

### DIFF
--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -82,12 +82,12 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 		m.logger.Error("Failed to fetch InnoDB stats", zap.Error(innoErr))
 	}
 
-	var errors scrapererror.ScrapeErrors
+	errs := &scrapererror.ScrapeErrors{}
 	for k, v := range innodbStats {
 		if k != "buffer_pool_size" {
 			continue
 		}
-		addPartialIfError(errors, m.mb.RecordMysqlBufferPoolLimitDataPoint(now, v))
+		addPartialIfError(errs, m.mb.RecordMysqlBufferPoolLimitDataPoint(now, v))
 	}
 
 	// collect global status metrics.
@@ -97,190 +97,190 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 		return pmetric.Metrics{}, err
 	}
 
-	m.recordDataPages(now, globalStats, errors)
-	m.recordDataUsage(now, globalStats, errors)
+	m.recordDataPages(now, globalStats, errs)
+	m.recordDataUsage(now, globalStats, errs)
 
 	for k, v := range globalStats {
 		switch k {
 
 		// buffer_pool.pages
 		case "Innodb_buffer_pool_pages_data":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolPagesDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolPagesDataPoint(now, v,
 				metadata.AttributeBufferPoolPagesData))
 		case "Innodb_buffer_pool_pages_free":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolPagesDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolPagesDataPoint(now, v,
 				metadata.AttributeBufferPoolPagesFree))
 		case "Innodb_buffer_pool_pages_misc":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolPagesDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolPagesDataPoint(now, v,
 				metadata.AttributeBufferPoolPagesMisc))
 
 		// buffer_pool.page_flushes
 		case "Innodb_buffer_pool_pages_flushed":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolPageFlushesDataPoint(now, v))
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolPageFlushesDataPoint(now, v))
 
 		// buffer_pool.operations
 		case "Innodb_buffer_pool_read_ahead_rnd":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
 				metadata.AttributeBufferPoolOperationsReadAheadRnd))
 		case "Innodb_buffer_pool_read_ahead":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
 				metadata.AttributeBufferPoolOperationsReadAhead))
 		case "Innodb_buffer_pool_read_ahead_evicted":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
 				metadata.AttributeBufferPoolOperationsReadAheadEvicted))
 		case "Innodb_buffer_pool_read_requests":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
 				metadata.AttributeBufferPoolOperationsReadRequests))
 		case "Innodb_buffer_pool_reads":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
 				metadata.AttributeBufferPoolOperationsReads))
 		case "Innodb_buffer_pool_wait_free":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
 				metadata.AttributeBufferPoolOperationsWaitFree))
 		case "Innodb_buffer_pool_write_requests":
-			addPartialIfError(errors, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolOperationsDataPoint(now, v,
 				metadata.AttributeBufferPoolOperationsWriteRequests))
 
 		// commands
 		case "Com_stmt_execute":
-			addPartialIfError(errors, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandExecute))
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandExecute))
 		case "Com_stmt_close":
-			addPartialIfError(errors, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandClose))
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandClose))
 		case "Com_stmt_fetch":
-			addPartialIfError(errors, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandFetch))
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandFetch))
 		case "Com_stmt_prepare":
-			addPartialIfError(errors, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandPrepare))
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandPrepare))
 		case "Com_stmt_reset":
-			addPartialIfError(errors, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandReset))
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandReset))
 		case "Com_stmt_send_long_data":
-			addPartialIfError(errors, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandSendLongData))
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandSendLongData))
 
 		// handlers
 		case "Handler_commit":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerCommit))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerCommit))
 		case "Handler_delete":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerDelete))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerDelete))
 		case "Handler_discover":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerDiscover))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerDiscover))
 		case "Handler_external_lock":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerExternalLock))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerExternalLock))
 		case "Handler_mrr_init":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerMrrInit))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerMrrInit))
 		case "Handler_prepare":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerPrepare))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerPrepare))
 		case "Handler_read_first":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadFirst))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadFirst))
 		case "Handler_read_key":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadKey))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadKey))
 		case "Handler_read_last":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadLast))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadLast))
 		case "Handler_read_next":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadNext))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadNext))
 		case "Handler_read_prev":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadPrev))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadPrev))
 		case "Handler_read_rnd":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadRnd))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadRnd))
 		case "Handler_read_rnd_next":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadRndNext))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerReadRndNext))
 		case "Handler_rollback":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerRollback))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerRollback))
 		case "Handler_savepoint":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerSavepoint))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerSavepoint))
 		case "Handler_savepoint_rollback":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerSavepointRollback))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerSavepointRollback))
 		case "Handler_update":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerUpdate))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerUpdate))
 		case "Handler_write":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerWrite))
+			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerWrite))
 
 		// double_writes
 		case "Innodb_dblwr_pages_written":
-			addPartialIfError(errors, m.mb.RecordMysqlDoubleWritesDataPoint(now, v, metadata.AttributeDoubleWritesPagesWritten))
+			addPartialIfError(errs, m.mb.RecordMysqlDoubleWritesDataPoint(now, v, metadata.AttributeDoubleWritesPagesWritten))
 		case "Innodb_dblwr_writes":
-			addPartialIfError(errors, m.mb.RecordMysqlDoubleWritesDataPoint(now, v, metadata.AttributeDoubleWritesWrites))
+			addPartialIfError(errs, m.mb.RecordMysqlDoubleWritesDataPoint(now, v, metadata.AttributeDoubleWritesWrites))
 
 		// log_operations
 		case "Innodb_log_waits":
-			addPartialIfError(errors, m.mb.RecordMysqlLogOperationsDataPoint(now, v, metadata.AttributeLogOperationsWaits))
+			addPartialIfError(errs, m.mb.RecordMysqlLogOperationsDataPoint(now, v, metadata.AttributeLogOperationsWaits))
 		case "Innodb_log_write_requests":
-			addPartialIfError(errors, m.mb.RecordMysqlLogOperationsDataPoint(now, v, metadata.AttributeLogOperationsWriteRequests))
+			addPartialIfError(errs, m.mb.RecordMysqlLogOperationsDataPoint(now, v, metadata.AttributeLogOperationsWriteRequests))
 		case "Innodb_log_writes":
-			addPartialIfError(errors, m.mb.RecordMysqlLogOperationsDataPoint(now, v, metadata.AttributeLogOperationsWrites))
+			addPartialIfError(errs, m.mb.RecordMysqlLogOperationsDataPoint(now, v, metadata.AttributeLogOperationsWrites))
 
 		// operations
 		case "Innodb_data_fsyncs":
-			addPartialIfError(errors, m.mb.RecordMysqlOperationsDataPoint(now, v, metadata.AttributeOperationsFsyncs))
+			addPartialIfError(errs, m.mb.RecordMysqlOperationsDataPoint(now, v, metadata.AttributeOperationsFsyncs))
 		case "Innodb_data_reads":
-			addPartialIfError(errors, m.mb.RecordMysqlOperationsDataPoint(now, v, metadata.AttributeOperationsReads))
+			addPartialIfError(errs, m.mb.RecordMysqlOperationsDataPoint(now, v, metadata.AttributeOperationsReads))
 		case "Innodb_data_writes":
-			addPartialIfError(errors, m.mb.RecordMysqlOperationsDataPoint(now, v, metadata.AttributeOperationsWrites))
+			addPartialIfError(errs, m.mb.RecordMysqlOperationsDataPoint(now, v, metadata.AttributeOperationsWrites))
 
 		// page_operations
 		case "Innodb_pages_created":
-			addPartialIfError(errors, m.mb.RecordMysqlPageOperationsDataPoint(now, v, metadata.AttributePageOperationsCreated))
+			addPartialIfError(errs, m.mb.RecordMysqlPageOperationsDataPoint(now, v, metadata.AttributePageOperationsCreated))
 		case "Innodb_pages_read":
-			addPartialIfError(errors, m.mb.RecordMysqlPageOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlPageOperationsDataPoint(now, v,
 				metadata.AttributePageOperationsRead))
 		case "Innodb_pages_written":
-			addPartialIfError(errors, m.mb.RecordMysqlPageOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlPageOperationsDataPoint(now, v,
 				metadata.AttributePageOperationsWritten))
 
 		// row_locks
 		case "Innodb_row_lock_waits":
-			addPartialIfError(errors, m.mb.RecordMysqlRowLocksDataPoint(now, v, metadata.AttributeRowLocksWaits))
+			addPartialIfError(errs, m.mb.RecordMysqlRowLocksDataPoint(now, v, metadata.AttributeRowLocksWaits))
 		case "Innodb_row_lock_time":
-			addPartialIfError(errors, m.mb.RecordMysqlRowLocksDataPoint(now, v, metadata.AttributeRowLocksTime))
+			addPartialIfError(errs, m.mb.RecordMysqlRowLocksDataPoint(now, v, metadata.AttributeRowLocksTime))
 
 		// row_operations
 		case "Innodb_rows_deleted":
-			addPartialIfError(errors, m.mb.RecordMysqlRowOperationsDataPoint(now, v, metadata.AttributeRowOperationsDeleted))
+			addPartialIfError(errs, m.mb.RecordMysqlRowOperationsDataPoint(now, v, metadata.AttributeRowOperationsDeleted))
 		case "Innodb_rows_inserted":
-			addPartialIfError(errors, m.mb.RecordMysqlRowOperationsDataPoint(now, v, metadata.AttributeRowOperationsInserted))
+			addPartialIfError(errs, m.mb.RecordMysqlRowOperationsDataPoint(now, v, metadata.AttributeRowOperationsInserted))
 		case "Innodb_rows_read":
-			addPartialIfError(errors, m.mb.RecordMysqlRowOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlRowOperationsDataPoint(now, v,
 				metadata.AttributeRowOperationsRead))
 		case "Innodb_rows_updated":
-			addPartialIfError(errors, m.mb.RecordMysqlRowOperationsDataPoint(now, v,
+			addPartialIfError(errs, m.mb.RecordMysqlRowOperationsDataPoint(now, v,
 				metadata.AttributeRowOperationsUpdated))
 
 		// locks
 		case "Table_locks_immediate":
-			addPartialIfError(errors, m.mb.RecordMysqlLocksDataPoint(now, v, metadata.AttributeLocksImmediate))
+			addPartialIfError(errs, m.mb.RecordMysqlLocksDataPoint(now, v, metadata.AttributeLocksImmediate))
 		case "Table_locks_waited":
-			addPartialIfError(errors, m.mb.RecordMysqlLocksDataPoint(now, v, metadata.AttributeLocksWaited))
+			addPartialIfError(errs, m.mb.RecordMysqlLocksDataPoint(now, v, metadata.AttributeLocksWaited))
 
 		// sorts
 		case "Sort_merge_passes":
-			addPartialIfError(errors, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsMergePasses))
+			addPartialIfError(errs, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsMergePasses))
 		case "Sort_range":
-			addPartialIfError(errors, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsRange))
+			addPartialIfError(errs, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsRange))
 		case "Sort_rows":
-			addPartialIfError(errors, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsRows))
+			addPartialIfError(errs, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsRows))
 		case "Sort_scan":
-			addPartialIfError(errors, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsScan))
+			addPartialIfError(errs, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsScan))
 
 		// threads
 		case "Threads_cached":
-			addPartialIfError(errors, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsCached))
+			addPartialIfError(errs, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsCached))
 		case "Threads_connected":
-			addPartialIfError(errors, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsConnected))
+			addPartialIfError(errs, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsConnected))
 		case "Threads_created":
-			addPartialIfError(errors, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsCreated))
+			addPartialIfError(errs, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsCreated))
 		case "Threads_running":
-			addPartialIfError(errors, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsRunning))
+			addPartialIfError(errs, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsRunning))
 		}
 	}
 
-	return m.mb.Emit(), errors.Combine()
+	return m.mb.Emit(), errs.Combine()
 }
 
-func addPartialIfError(errors scrapererror.ScrapeErrors, err error) {
+func addPartialIfError(errors *scrapererror.ScrapeErrors, err error) {
 	if err != nil {
 		errors.AddPartial(1, err)
 	}
 }
 
-func (m *mySQLScraper) recordDataPages(now pcommon.Timestamp, globalStats map[string]string, errors scrapererror.ScrapeErrors) {
+func (m *mySQLScraper) recordDataPages(now pcommon.Timestamp, globalStats map[string]string, errors *scrapererror.ScrapeErrors) {
 	dirty, err := parseInt(globalStats["Innodb_buffer_pool_pages_dirty"])
 	if err != nil {
 		errors.AddPartial(2, err) // we need dirty to calculate free, so 2 data points lost here
@@ -296,7 +296,7 @@ func (m *mySQLScraper) recordDataPages(now pcommon.Timestamp, globalStats map[st
 	m.mb.RecordMysqlBufferPoolDataPagesDataPoint(now, data-dirty, metadata.AttributeBufferPoolDataClean)
 }
 
-func (m *mySQLScraper) recordDataUsage(now pcommon.Timestamp, globalStats map[string]string, errors scrapererror.ScrapeErrors) {
+func (m *mySQLScraper) recordDataUsage(now pcommon.Timestamp, globalStats map[string]string, errors *scrapererror.ScrapeErrors) {
 	dirty, err := parseInt(globalStats["Innodb_buffer_pool_bytes_dirty"])
 	if err != nil {
 		errors.AddPartial(2, err) // we need dirty to calculate free, so 2 data points lost here

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -65,7 +65,7 @@ func TestScrape(t *testing.T) {
 		scraper := newMySQLScraper(componenttest.NewNopReceiverCreateSettings(), cfg)
 		scraper.sqlclient = &mockClient{
 			globalStatsFile: "global_stats_partial",
-			innodbStatsFile: "empty",
+			innodbStatsFile: "innodb_stats_empty",
 		}
 
 		actualMetrics, scrapeErr := scraper.scrape(context.Background())

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -17,41 +17,80 @@ package mysqlreceiver
 import (
 	"bufio"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/receiver/scrapererror"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest/golden"
 )
 
 func TestScrape(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.Username = "otel"
-	cfg.Password = "otel"
-	cfg.NetAddr = confignet.NetAddr{Endpoint: "localhost:3306"}
+	t.Run("successful scrape", func(t *testing.T) {
+		cfg := createDefaultConfig().(*Config)
+		cfg.Username = "otel"
+		cfg.Password = "otel"
+		cfg.NetAddr = confignet.NetAddr{Endpoint: "localhost:3306"}
 
-	scraper := newMySQLScraper(componenttest.NewNopReceiverCreateSettings(), cfg)
-	scraper.sqlclient = &mockClient{}
+		scraper := newMySQLScraper(componenttest.NewNopReceiverCreateSettings(), cfg)
+		scraper.sqlclient = &mockClient{
+			globalStatsFile: "global_stats",
+			innodbStatsFile: "innodb_stats",
+		}
 
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
+		actualMetrics, err := scraper.scrape(context.Background())
+		require.NoError(t, err)
 
-	expectedFile := filepath.Join("testdata", "scraper", "expected.json")
-	expectedMetrics, err := golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
+		expectedFile := filepath.Join("testdata", "scraper", "expected.json")
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
 
-	require.NoError(t, scrapertest.CompareMetrics(actualMetrics, expectedMetrics))
+		require.NoError(t, scrapertest.CompareMetrics(actualMetrics, expectedMetrics))
+	})
+
+	t.Run("Scrape has partial failure", func(t *testing.T) {
+		cfg := createDefaultConfig().(*Config)
+		cfg.Username = "otel"
+		cfg.Password = "otel"
+		cfg.NetAddr = confignet.NetAddr{Endpoint: "localhost:3306"}
+
+		scraper := newMySQLScraper(componenttest.NewNopReceiverCreateSettings(), cfg)
+		scraper.sqlclient = &mockClient{
+			globalStatsFile: "global_stats_partial",
+			innodbStatsFile: "empty",
+		}
+
+		actualMetrics, scrapeErr := scraper.scrape(context.Background())
+		require.Error(t, scrapeErr)
+
+		expectedFile := filepath.Join("testdata", "scraper", "expected_partial.json")
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
+		assert.NoError(t, scrapertest.CompareMetrics(actualMetrics, expectedMetrics))
+
+		var partialError scrapererror.PartialScrapeError
+		require.True(t, errors.As(scrapeErr, &partialError), "returned error was not PartialScrapeError")
+		// 5 comes from 4 failed "must-have" metrics that aren't present,
+		// and the other failure comes from a row that fails to parse as a number
+		require.Equal(t, partialError.Failed, 5, "Expected partial error count to be 5")
+	})
+
 }
 
 var _ client = (*mockClient)(nil)
 
-type mockClient struct{}
+type mockClient struct {
+	globalStatsFile string
+	innodbStatsFile string
+}
 
 func readFile(fname string) (map[string]string, error) {
 	var stats = map[string]string{}
@@ -74,11 +113,11 @@ func (c *mockClient) Connect() error {
 }
 
 func (c *mockClient) getGlobalStats() (map[string]string, error) {
-	return readFile("global_stats")
+	return readFile(c.globalStatsFile)
 }
 
 func (c *mockClient) getInnodbStats() (map[string]string, error) {
-	return readFile("innodb_stats")
+	return readFile(c.innodbStatsFile)
 }
 
 func (c *mockClient) Close() error {

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -56,7 +56,7 @@ func TestScrape(t *testing.T) {
 		require.NoError(t, scrapertest.CompareMetrics(actualMetrics, expectedMetrics))
 	})
 
-	t.Run("Scrape has partial failure", func(t *testing.T) {
+	t.Run("scrape has partial failure", func(t *testing.T) {
 		cfg := createDefaultConfig().(*Config)
 		cfg.Username = "otel"
 		cfg.Password = "otel"

--- a/receiver/mysqlreceiver/testdata/scraper/expected_partial.json
+++ b/receiver/mysqlreceiver/testdata/scraper/expected_partial.json
@@ -1,0 +1,40 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {},
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of pages in the InnoDB buffer pool.",
+                     "name": "mysql.buffer_pool.pages",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "233",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "free"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1659981155092597000",
+                              "timeUnixNano": "1659981155092604000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/mysqlreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/receiver/mysqlreceiver/testdata/scraper/global_stats_partial.txt
+++ b/receiver/mysqlreceiver/testdata/scraper/global_stats_partial.txt
@@ -1,0 +1,3 @@
+name	count
+Innodb_buffer_pool_pages_data	NotANumber
+Innodb_buffer_pool_pages_free	233

--- a/receiver/mysqlreceiver/testdata/scraper/innodb_stats_empty.txt
+++ b/receiver/mysqlreceiver/testdata/scraper/innodb_stats_empty.txt
@@ -1,0 +1,1 @@
+name	count

--- a/unreleased/mysql-receiver_fix-scrape-errors.yaml
+++ b/unreleased/mysql-receiver_fix-scrape-errors.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix some partial errors not being correctly reported
+
+# One or more tracking issues related to the change
+issues: [13009]
+


### PR DESCRIPTION
**Description:** <Describe what has changed.>
* fixes issue where partial errors are not recorded due to passing the ScrapeErrors struct by value
* rename errors -> errs to avoid possible shadowing of the errors package

**Link to tracking Issue:** #13009

**Testing:**
* Added a test with a partial scrape error to test that partial errors are being recorded

**Documentation:** N/A