### PR TITLE
[receiver/mongodb] split container test

### DIFF
--- a/receiver/mongodbreceiver/integration_test.go
+++ b/receiver/mongodbreceiver/integration_test.go
@@ -68,7 +68,7 @@ var (
 			Dockerfile: "Dockerfile.mongodb.4_0.lpu",
 		},
 		ExposedPorts: []string{"27317:27017"},
-		WaitingFor:   wait.ForListeningPort("27017").WithStartupTimeout(2 * time.Minute),
+		WaitingFor:   wait.ForListeningPort("27017").WithStartupTimeout(3 * time.Minute),
 	}
 	containerRequest5_0 = testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
@@ -80,7 +80,7 @@ var (
 	}
 )
 
-func TestMongodbIntegration(t *testing.T) {
+func TestMongodbIntegrationBatchA(t *testing.T) {
 	t.Run("Running mongodb 2.6", func(t *testing.T) {
 		t.Parallel()
 		container := getContainer(t, containerRequest2_6, setupScript)
@@ -195,6 +195,9 @@ func TestMongodbIntegration(t *testing.T) {
 		err = scrapertest.CompareMetrics(expectedMetrics, actualMetrics, scrapertest.IgnoreMetricValues())
 		require.NoError(t, err)
 	})
+}
+
+func TestIntegrationBatchB(t *testing.T) {
 	t.Run("Running mongodb 4.0 as LPU", func(t *testing.T) {
 		t.Parallel()
 		container := getContainer(t, containerRequest4_0LPU, LPUSetupScript)
@@ -223,7 +226,7 @@ func TestMongodbIntegration(t *testing.T) {
 		require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
 		require.Eventuallyf(t, func() bool {
 			return len(consumer.AllMetrics()) > 0
-		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
+		}, 3*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
 		require.NoError(t, rcvr.Shutdown(context.Background()))
 
 		actualMetrics := consumer.AllMetrics()[0]

--- a/unreleased/mongodbreceiver-less-flaky-tests.yaml
+++ b/unreleased/mongodbreceiver-less-flaky-tests.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: split integration test to have less flaky tests
+
+# One or more tracking issues related to the change
+issues: [12981]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
The mongodbreceiver integration test runs 5 container tests in parallel which is too much and create flaky results. This pr splits up the container test into 2 batches. 

**Link to tracking Issue:**
#12981 

**Testing:**
Integration test pass and takes almost twice as long since tests are not all ran in parallel.
