### PR TITLE
[pkg/telemetryquerylanguage] Add Join factory

### DIFF
--- a/pkg/telemetryquerylanguage/functions/tqlcommon/README.md
+++ b/pkg/telemetryquerylanguage/functions/tqlcommon/README.md
@@ -3,12 +3,31 @@
 The following functions can be used in any implementation of the Telemetry Query Language.  Although they are tested using [pdata](https://github.com/open-telemetry/opentelemetry-collector/tree/main/pdata) for convenience, the function implementation only interact with native Go types or types defined in the [tql package](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/telemetryquerylanguage/tql).
 
 Factory Functions
+- [Join](#join)
 - [IsMatch](#ismatch)
 
 Functions
 - [set](#set)
 - [replace_match](#replace_match)
 - [replace_pattern](#replace_pattern)
+
+## Join
+
+`Join(delimiter, ...values)`
+
+The `Join` factory function takes a delimiter and a sequence of values and concatenates their string representation. Unsupported values, such as lists or maps that may substantially increase payload size, are not added to the resulting string.
+
+`delimiter` is a string value that is used to join the string. If no delimiter is desired, then simply pass an empty string.
+
+`values` is a series of values passed as arguments. It supports paths, primitive values, and byte slices (such as trace IDs or span IDs).
+
+Examples:
+
+- `Join(": ", attributes["http.method"], attributes["http.path"])`
+
+- `Join(" ", name, 1)`
+
+- `Join("", "HTTP method is: ", attributes["http.method"])`
 
 ## IsMatch
 

--- a/pkg/telemetryquerylanguage/functions/tqlcommon/func_join.go
+++ b/pkg/telemetryquerylanguage/functions/tqlcommon/func_join.go
@@ -1,0 +1,49 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tqlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/functions/tqlcommon"
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql"
+)
+
+func Join(delimiter string, vals []tql.Getter) (tql.ExprFunc, error) {
+	return func(ctx tql.TransformContext) interface{} {
+		builder := strings.Builder{}
+		for i, rv := range vals {
+			switch val := rv.Get(ctx).(type) {
+			case string:
+				builder.WriteString(val)
+			case []byte:
+				builder.WriteString(fmt.Sprintf("%x", val))
+			case int64:
+				builder.WriteString(fmt.Sprint(val))
+			case float64:
+				builder.WriteString(fmt.Sprint(val))
+			case bool:
+				builder.WriteString(fmt.Sprint(val))
+			case nil:
+				builder.WriteString(fmt.Sprint(val))
+			}
+
+			if i != len(vals)-1 {
+				builder.WriteString(delimiter)
+			}
+		}
+		return builder.String()
+	}, nil
+}

--- a/pkg/telemetryquerylanguage/functions/tqlcommon/func_join_test.go
+++ b/pkg/telemetryquerylanguage/functions/tqlcommon/func_join_test.go
@@ -1,0 +1,244 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tqlcommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql/tqltest"
+)
+
+func Test_join(t *testing.T) {
+	tests := []struct {
+		name      string
+		delimiter string
+		vals      []tql.StandardGetSetter
+		expected  string
+	}{
+		{
+			name:      "join strings",
+			delimiter: " ",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "hello"
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "world"
+					},
+				},
+			},
+			expected: "hello world",
+		},
+		{
+			name:      "nil",
+			delimiter: "",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "hello"
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return nil
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "world"
+					},
+				},
+			},
+			expected: "hello<nil>world",
+		},
+		{
+			name:      "integers",
+			delimiter: "",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "hello"
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return int64(1)
+					},
+				},
+			},
+			expected: "hello1",
+		},
+		{
+			name:      "floats",
+			delimiter: "",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "hello"
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return 3.14159
+					},
+				},
+			},
+			expected: "hello3.14159",
+		},
+		{
+			name:      "booleans",
+			delimiter: " ",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "hello"
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return true
+					},
+				},
+			},
+			expected: "hello true",
+		},
+		{
+			name:      "byte slices",
+			delimiter: "",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8}
+					},
+				},
+			},
+			expected: "00000000000000000ed2e63cbe71f5a8",
+		},
+		{
+			name:      "non-byte slices",
+			delimiter: "",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:      "maps",
+			delimiter: "",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return map[string]string{"key": "value"}
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:      "unprintable value in the middle",
+			delimiter: "-",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "hello"
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return map[string]string{"key": "value"}
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "world"
+					},
+				},
+			},
+			expected: "hello--world",
+		},
+		{
+			name:      "empty string values",
+			delimiter: "__",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return ""
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return ""
+					},
+				},
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return ""
+					},
+				},
+			},
+			expected: "____",
+		},
+		{
+			name:      "single argument",
+			delimiter: "-",
+			vals: []tql.StandardGetSetter{
+				{
+					Getter: func(ctx tql.TransformContext) interface{} {
+						return "hello"
+					},
+				},
+			},
+			expected: "hello",
+		},
+		{
+			name:      "no arguments",
+			delimiter: "-",
+			vals:      []tql.StandardGetSetter{},
+			expected:  "",
+		},
+		{
+			name:      "no arguments with an empty delimiter",
+			delimiter: "",
+			vals:      []tql.StandardGetSetter{},
+			expected:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tqltest.TestTransformContext{}
+
+			getters := make([]tql.Getter, len(tt.vals))
+
+			for i, val := range tt.vals {
+				getters[i] = val
+			}
+
+			exprFunc, _ := Join(tt.delimiter, getters)
+			actual := exprFunc(ctx)
+
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/unreleased/add-join-factory.yaml
+++ b/unreleased/add-join-factory.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/telemetryquerylanguage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `Join`, which allows joining an arbitrary number of strings with a delimiter
+
+# One or more tracking issues related to the change
+issues: [12476]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**

This is a follow-up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12706.

Add a `Concat` factory, which allows concatenating an arbitrary number of strings.

This function also converts types to a string representation, if easily applicable. Converting types like numbers or byte slices should relieve the user of having to think about which type something like an attribute is when concatenating it.

The exceptions to stringification are slices and maps, which may have large payloads. `nil` is stringified to allow the user flexibility and to make the resulting string more comprehensible; if they don't want to concatenate anything in these cases, a where-clause is possible.

**Link to tracking Issue:**

Fixes #12476 

**Testing:**

Unit tests were added, manual tests were performed.

**Documentation:**

The `tqlcommon` package's README has been updated with documentation for the factory.