### PR TITLE
[chloggen] Update template to request 'PR and/or issue numbers', rather than just issues

### DIFF
--- a/cmd/chloggen/entry.go
+++ b/cmd/chloggen/entry.go
@@ -23,7 +23,8 @@ type Entry struct {
 	ChangeType string `yaml:"change_type"`
 	Component  string `yaml:"component"`
 	Note       string `yaml:"note"`
-	Issues     []int  `yaml:"issues"`
+	GithubNums []int  `yaml:"github_nums"`
+	Issues     []int  `yaml:"issues"` // Deprecated, but still usable
 	SubText    string `yaml:"subtext"`
 }
 
@@ -55,26 +56,31 @@ func (e Entry) Validate() error {
 		return fmt.Errorf("specify a 'note'")
 	}
 
-	if len(e.Issues) == 0 {
-		return fmt.Errorf("specify one or more issues #'s")
+	if len(e.GithubNums)+len(e.Issues) == 0 {
+		return fmt.Errorf("specify one or more 'github_nums'")
 	}
 
 	return nil
 }
 
 func (e Entry) String() string {
-	issueStrs := make([]string, 0, len(e.Issues))
-	for _, issue := range e.Issues {
-		issueStrs = append(issueStrs, fmt.Sprintf("#%d", issue))
-	}
-	issueStr := strings.Join(issueStrs, ", ")
-
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("- `%s`: %s (%s)", e.Component, e.Note, issueStr))
+	sb.WriteString(fmt.Sprintf("- `%s`: %s (%s)", e.Component, e.Note, e.numString()))
 	if e.SubText != "" {
 		sb.WriteString("\n  ")
 		lines := strings.Split(strings.ReplaceAll(e.SubText, "\r\n", "\n"), "\n")
 		sb.WriteString(strings.Join(lines, "\n  "))
 	}
 	return sb.String()
+}
+
+func (e Entry) numString() string {
+	numStrs := make([]string, 0, len(e.GithubNums)+len(e.Issues))
+	for _, num := range e.GithubNums {
+		numStrs = append(numStrs, fmt.Sprintf("#%d", num))
+	}
+	for _, issue := range e.Issues {
+		numStrs = append(numStrs, fmt.Sprintf("#%d", issue))
+	}
+	return strings.Join(numStrs, ", ")
 }

--- a/cmd/chloggen/main_test.go
+++ b/cmd/chloggen/main_test.go
@@ -116,7 +116,29 @@ func TestValidateE2E(t *testing.T) {
 			wantErr: "specify a 'note'",
 		},
 		{
-			name: "missing_issue",
+			name: "pr_without_issue",
+			entries: func() []*Entry {
+				return append(getSampleEntries(), &Entry{
+					ChangeType: bugFix,
+					Component:  "receiver/foo",
+					Note:       "Add some bar",
+					GithubNums: []int{123},
+				})
+			}(),
+		},
+		{
+			name: "issue_without_pr",
+			entries: func() []*Entry {
+				return append(getSampleEntries(), &Entry{
+					ChangeType: bugFix,
+					Component:  "receiver/foo",
+					Note:       "Add some bar",
+					Issues:     []int{123},
+				})
+			}(),
+		},
+		{
+			name: "no_pr_or_issue",
 			entries: func() []*Entry {
 				return append(getSampleEntries(), &Entry{
 					ChangeType: bugFix,
@@ -125,7 +147,7 @@ func TestValidateE2E(t *testing.T) {
 					Issues:     []int{},
 				})
 			}(),
-			wantErr: "specify one or more issues #'s",
+			wantErr: "specify one or more 'github_nums'",
 		},
 		{
 			name: "all_invalid",
@@ -272,7 +294,7 @@ func deprecationEntry() *Entry {
 		ChangeType: deprecation,
 		Component:  "exporter/old",
 		Note:       "Deprecate old",
-		Issues:     []int{12348},
+		GithubNums: []int{12348},
 	}
 }
 
@@ -281,6 +303,7 @@ func newComponentEntry() *Entry {
 		ChangeType: newComponent,
 		Component:  "exporter/new",
 		Note:       "Add new exporter ...",
+		GithubNums: []int{12333},
 		Issues:     []int{12349},
 	}
 }

--- a/cmd/chloggen/testdata/all_change_types.md
+++ b/cmd/chloggen/testdata/all_change_types.md
@@ -16,7 +16,7 @@
 - `exporter/old`: Deprecate old (#12348)
 
 ### 🚀 New components 🚀
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12333, #12349)
 
 ### 💡 Enhancements 💡
 - `receiver/foo`: Add some bar (#12345)

--- a/cmd/chloggen/testdata/all_change_types_multiple.md
+++ b/cmd/chloggen/testdata/all_change_types_multiple.md
@@ -23,8 +23,8 @@
 - `exporter/old`: Deprecate old (#12348)
 
 ### 🚀 New components 🚀
-- `exporter/new`: Add new exporter ... (#12349)
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12333, #12349)
+- `exporter/new`: Add new exporter ... (#12333, #12349)
 
 ### 💡 Enhancements 💡
 - `receiver/foo`: Add some bar (#12345)

--- a/cmd/chloggen/testdata/new_component_only.md
+++ b/cmd/chloggen/testdata/new_component_only.md
@@ -5,7 +5,7 @@
 # v0.45.0
 
 ### 🚀 New components 🚀
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12333, #12349)
 
 
 ## v0.44.0

--- a/unreleased/chloggen-issue-or-pr.yaml
+++ b/unreleased/chloggen-issue-or-pr.yaml
@@ -1,14 +1,14 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component:
+component: chloggen
 
-# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update template to request 'PR and/or issue numbers', rather than just issues
 
 # The PR and/or issue numbers related to the change
-github_nums: []
+github_nums: [13121, 12417]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.


### PR DESCRIPTION
- Add a new `github_nums` field to the changelog yaml. The field allows PR authors
  to specify the PR number and/or one or more issues numbers.
- "Deprecate" the `issues` field.
  - The field is still valid and will be concatenated onto the `github_nums` field.
  - It is removed from the template, replaced by the `github_nums` field.
  - Support for the field can be removed altogether at a later time. However, in order
    to minimize disruption to developers, both can be supported for a time. New PRs
    will typically use the new template, so the old field will fall out of use over time.

This is a proposal to resolve #12417 