### PR TITLE
[receiver/filelog] Add ability to set log body when parsing

### DIFF
--- a/pkg/stanza/docs/types/parsers.md
+++ b/pkg/stanza/docs/types/parsers.md
@@ -53,3 +53,4 @@ List of embeddable operations:
 - [`severity`](./severity.md)
 - [`trace`](./trace.md)
 - [`scope_name`](./scope_name.md)
+- `body`: A field that should be assigned to a the log body.

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -52,6 +52,18 @@ func TestParserConfigInvalidTimeParser(t *testing.T) {
 	require.Contains(t, err.Error(), "missing required configuration parameter `layout`")
 }
 
+func TestParserConfigBodyCollision(t *testing.T) {
+	cfg := NewParserConfig("test-id", "test-type")
+	cfg.ParseTo = entry.NewBodyField()
+
+	b := entry.NewAttributeField("message")
+	cfg.BodyField = &b
+
+	_, err := cfg.Build(testutil.Logger(t))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "`parse_to: body` not allowed when `body` is configured")
+}
+
 func TestParserConfigBuildValid(t *testing.T) {
 	cfg := NewParserConfig("test-id", "test-type")
 
@@ -505,6 +517,28 @@ func TestParserFields(t *testing.T) {
 						},
 					},
 				}
+				return e
+			},
+		},
+		{
+			"ParseAndSetBody",
+			func(cfg *ParserConfig) {
+				b := entry.NewAttributeField("key")
+				cfg.BodyField = &b
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Body = keyValue
+				return e
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Attributes = map[string]interface{}{
+					"key": "value",
+				}
+				e.Body = "value"
 				return e
 			},
 		},

--- a/unreleased/pkg-stanza-body-block.yaml
+++ b/unreleased/pkg-stanza-body-block.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "`filelog`, `journald`, `syslog`, `tcplog`, `udplog`, `windowseventlog` receivers"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ability to set log body when when parsing.
+
+# One or more tracking issues related to the change
+issues: [10274]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
This follows roughly the same pattern as other "sub-parsers".
The idea here is that a parser isolates individual values, which
may then be assigned to specific fields in the data model. Although
there are other ways, users often wish to perform these assignments
immediately after isolating the values, as it is a logical next
step and more concise.

Resolves #10274