### PR TITLE
[receiver/filelog] Migrate config from yaml to mapstructure

### DIFF
--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -132,11 +132,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "filelog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["filelog"].CreateDefaultConfig().(*filelogreceiver.FileLogConfig)
-				cfg.Input = adapter.InputConfig{
-					"include": []string{
-						filepath.Join(t.TempDir(), "*"),
-					},
-				}
+				cfg.Include = []string{filepath.Join(t.TempDir(), "*")}
 				return cfg
 			},
 		},

--- a/receiver/filelogreceiver/filelog.go
+++ b/receiver/filelogreceiver/filelog.go
@@ -17,7 +17,6 @@ package filelogreceiver // import "github.com/open-telemetry/opentelemetry-colle
 import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -54,7 +53,7 @@ func createDefaultConfig() *FileLogConfig {
 			Operators:        adapter.OperatorConfigs{},
 			Converter:        adapter.ConverterConfig{},
 		},
-		Input: adapter.InputConfig{},
+		Config: *file.NewConfig("file_input"),
 	}
 }
 
@@ -65,17 +64,12 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 
 // FileLogConfig defines configuration for the filelog receiver
 type FileLogConfig struct {
+	file.Config        `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`
-	Input              adapter.InputConfig `mapstructure:",remain"`
 }
 
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*FileLogConfig)
-	yamlBytes, _ := yaml.Marshal(logConfig.Input)
-	inputCfg := file.NewConfig("file_input")
-	if err := yaml.Unmarshal(yamlBytes, &inputCfg); err != nil {
-		return nil, err
-	}
-	return &operator.Config{Builder: inputCfg}, nil
+	return &operator.Config{Builder: &logConfig.Config}, nil
 }

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.57.2
 	go.opentelemetry.io/collector/pdata v0.57.2
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -45,6 +44,7 @@ require (
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/receiver/filelogreceiver/storage_test.go
+++ b/receiver/filelogreceiver/storage_test.go
@@ -42,7 +42,7 @@ func TestStorage(t *testing.T) {
 
 	f := NewFactory()
 
-	cfg := testdataRotateTestYamlAsMap(logsDir)
+	cfg := rotationTestConfig(logsDir)
 	cfg.Converter.MaxFlushCount = 1
 	cfg.Converter.FlushInterval = time.Millisecond
 	cfg.Operators = nil // not testing processing, just read the lines


### PR DESCRIPTION
pkg/stanza historically used yaml for configuration unmarshaling.
The process of migrating to mapstructure was begun long ago but
was never completed. This PR switches filelog's underlying input
operator to use mapstructure unmarshaling.