### PR TITLE
[Makefile] Fix docker-otelcontribcol make target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,6 @@
 - `spanmetricsprocessor`: Fix panic caused by race condition when accessing span attributes. (#12644)
 - `awsxrayexporter`: Stop dropping exception in aws xray events for non error codes (#12643)
 - `signalfxexporter`: use azure.vm.name instead of host.name to build azure resource id (#12779)
-- `otelcontribcol`: Enabled multi-arch build for local development container builds (#11873)
 - `receiver/hostmetrics`: Do not throw scraping errors if conntrack metrics collection is disabled (#12799)
 - `kubeletstatsreceiver`: Fetch metadata from initContainers (#12887)
 - `metricstransformprocessor`: Fix logic in merging exponential histogram. (#12865)

--- a/Makefile
+++ b/Makefile
@@ -238,8 +238,8 @@ run:
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component
-	GOOS=$(GOOS) GOARCH=$(GOARCH) $(MAKE) $(COMPONENT)
-	cp ./bin/$(COMPONENT)_$(GOOS)_$(GOARCH)$(EXTENSION) ./cmd/$(COMPONENT)/$(COMPONENT)
+	GOOS=linux GOARCH=amd64 $(MAKE) $(COMPONENT)
+	cp ./bin/$(COMPONENT)_linux_amd64 ./cmd/$(COMPONENT)/$(COMPONENT)
 	docker build -t $(COMPONENT) ./cmd/$(COMPONENT)/
 	rm ./cmd/$(COMPONENT)/$(COMPONENT)
 


### PR DESCRIPTION
This change reverts https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12217 that broke `docker-otelcontribcol` make target as an incorrect attempt to create multi arch docker images.

This change also removes the changelog entry line for https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12217 since it's not a user facing change.