### PR TITLE
Fix doc - processor batch does not exist

### DIFF
--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -93,7 +93,7 @@ receivers:
         endpoint: "localhost:55677"
 
 processors:
-  batch:
+  batch: {}
   spanmetrics:
     metrics_exporter: otlp/spanmetrics
     latency_histogram_buckets: [100us, 1ms, 2ms, 6ms, 10ms, 100ms, 250ms]


### PR DESCRIPTION
**Description:** 

`batch: {}` should be used instead of `batch: `

`Error: failed to get config: invalid configuration: pipeline "traces" references processor "batch" which does not exist`

This change is related to https://github.com/open-telemetry/opentelemetry-helm-charts/issues/23#issuecomment-910885716 

**Testing:**

 helm chart was applied with an example configuration 

**Documentation:** 

`batch: {}` instead of `batch: `