### PR TITLE
[receiver/postgresql] Add Index Metrics

### DIFF
--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -12,6 +12,8 @@ These are the metrics available for this scraper.
 | **postgresql.blocks_read** | The number of blocks read. | 1 | Sum(Int) | <ul> <li>database</li> <li>table</li> <li>source</li> </ul> |
 | **postgresql.commits** | The number of commits. | 1 | Sum(Int) | <ul> <li>database</li> </ul> |
 | **postgresql.db_size** | The database disk usage. | By | Sum(Int) | <ul> <li>database</li> </ul> |
+| **postgresql.index.scans** | The number of index scans on a table. | {scans} | Sum(Int) | <ul> </ul> |
+| **postgresql.index.size** | The number of index scans on a table. | By | Gauge(Int) | <ul> </ul> |
 | **postgresql.operations** | The number of db row operations. | 1 | Sum(Int) | <ul> <li>database</li> <li>table</li> <li>operation</li> </ul> |
 | **postgresql.rollbacks** | The number of rollbacks. | 1 | Sum(Int) | <ul> <li>database</li> </ul> |
 | **postgresql.rows** | The number of rows in the database. | 1 | Sum(Int) | <ul> <li>database</li> <li>table</li> <li>state</li> </ul> |
@@ -30,6 +32,7 @@ metrics:
 | Name | Description | Type |
 | ---- | ----------- | ---- |
 | postgresql.database.name | The name of the database. | String |
+| postgresql.index.name | The name of the index on a table. | String |
 | postgresql.table.name | The schema name followed by the table name. | String |
 
 ## Metric attributes

--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -13,7 +13,7 @@ These are the metrics available for this scraper.
 | **postgresql.commits** | The number of commits. | 1 | Sum(Int) | <ul> <li>database</li> </ul> |
 | **postgresql.db_size** | The database disk usage. | By | Sum(Int) | <ul> <li>database</li> </ul> |
 | **postgresql.index.scans** | The number of index scans on a table. | {scans} | Sum(Int) | <ul> </ul> |
-| **postgresql.index.size** | The number of index scans on a table. | By | Gauge(Int) | <ul> </ul> |
+| **postgresql.index.size** | The size of the index on disk. | By | Gauge(Int) | <ul> </ul> |
 | **postgresql.operations** | The number of db row operations. | 1 | Sum(Int) | <ul> <li>database</li> <li>table</li> <li>operation</li> </ul> |
 | **postgresql.rollbacks** | The number of rollbacks. | 1 | Sum(Int) | <ul> <li>database</li> </ul> |
 | **postgresql.rows** | The number of rows in the database. | 1 | Sum(Int) | <ul> <li>database</li> <li>table</li> <li>state</li> </ul> |

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
@@ -21,6 +21,8 @@ type MetricsSettings struct {
 	PostgresqlBlocksRead MetricSettings `mapstructure:"postgresql.blocks_read"`
 	PostgresqlCommits    MetricSettings `mapstructure:"postgresql.commits"`
 	PostgresqlDbSize     MetricSettings `mapstructure:"postgresql.db_size"`
+	PostgresqlIndexScans MetricSettings `mapstructure:"postgresql.index.scans"`
+	PostgresqlIndexSize  MetricSettings `mapstructure:"postgresql.index.size"`
 	PostgresqlOperations MetricSettings `mapstructure:"postgresql.operations"`
 	PostgresqlRollbacks  MetricSettings `mapstructure:"postgresql.rollbacks"`
 	PostgresqlRows       MetricSettings `mapstructure:"postgresql.rows"`
@@ -38,6 +40,12 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		PostgresqlDbSize: MetricSettings{
+			Enabled: true,
+		},
+		PostgresqlIndexScans: MetricSettings{
+			Enabled: true,
+		},
+		PostgresqlIndexSize: MetricSettings{
 			Enabled: true,
 		},
 		PostgresqlOperations: MetricSettings{
@@ -376,6 +384,106 @@ func newMetricPostgresqlDbSize(settings MetricSettings) metricPostgresqlDbSize {
 	return m
 }
 
+type metricPostgresqlIndexScans struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills postgresql.index.scans metric with initial data.
+func (m *metricPostgresqlIndexScans) init() {
+	m.data.SetName("postgresql.index.scans")
+	m.data.SetDescription("The number of index scans on a table.")
+	m.data.SetUnit("{scans}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricPostgresqlIndexScans) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricPostgresqlIndexScans) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricPostgresqlIndexScans) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricPostgresqlIndexScans(settings MetricSettings) metricPostgresqlIndexScans {
+	m := metricPostgresqlIndexScans{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricPostgresqlIndexSize struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills postgresql.index.size metric with initial data.
+func (m *metricPostgresqlIndexSize) init() {
+	m.data.SetName("postgresql.index.size")
+	m.data.SetDescription("The number of index scans on a table.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricPostgresqlIndexSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricPostgresqlIndexSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricPostgresqlIndexSize) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricPostgresqlIndexSize(settings MetricSettings) metricPostgresqlIndexSize {
+	m := metricPostgresqlIndexSize{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricPostgresqlOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -551,6 +659,8 @@ type MetricsBuilder struct {
 	metricPostgresqlBlocksRead metricPostgresqlBlocksRead
 	metricPostgresqlCommits    metricPostgresqlCommits
 	metricPostgresqlDbSize     metricPostgresqlDbSize
+	metricPostgresqlIndexScans metricPostgresqlIndexScans
+	metricPostgresqlIndexSize  metricPostgresqlIndexSize
 	metricPostgresqlOperations metricPostgresqlOperations
 	metricPostgresqlRollbacks  metricPostgresqlRollbacks
 	metricPostgresqlRows       metricPostgresqlRows
@@ -575,6 +685,8 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		metricPostgresqlBlocksRead: newMetricPostgresqlBlocksRead(settings.PostgresqlBlocksRead),
 		metricPostgresqlCommits:    newMetricPostgresqlCommits(settings.PostgresqlCommits),
 		metricPostgresqlDbSize:     newMetricPostgresqlDbSize(settings.PostgresqlDbSize),
+		metricPostgresqlIndexScans: newMetricPostgresqlIndexScans(settings.PostgresqlIndexScans),
+		metricPostgresqlIndexSize:  newMetricPostgresqlIndexSize(settings.PostgresqlIndexSize),
 		metricPostgresqlOperations: newMetricPostgresqlOperations(settings.PostgresqlOperations),
 		metricPostgresqlRollbacks:  newMetricPostgresqlRollbacks(settings.PostgresqlRollbacks),
 		metricPostgresqlRows:       newMetricPostgresqlRows(settings.PostgresqlRows),
@@ -602,6 +714,13 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 func WithPostgresqlDatabaseName(val string) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
 		rm.Resource().Attributes().UpsertString("postgresql.database.name", val)
+	}
+}
+
+// WithPostgresqlIndexName sets provided value as "postgresql.index.name" attribute for current resource.
+func WithPostgresqlIndexName(val string) ResourceMetricsOption {
+	return func(rm pmetric.ResourceMetrics) {
+		rm.Resource().Attributes().UpsertString("postgresql.index.name", val)
 	}
 }
 
@@ -648,6 +767,8 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricPostgresqlBlocksRead.emit(ils.Metrics())
 	mb.metricPostgresqlCommits.emit(ils.Metrics())
 	mb.metricPostgresqlDbSize.emit(ils.Metrics())
+	mb.metricPostgresqlIndexScans.emit(ils.Metrics())
+	mb.metricPostgresqlIndexSize.emit(ils.Metrics())
 	mb.metricPostgresqlOperations.emit(ils.Metrics())
 	mb.metricPostgresqlRollbacks.emit(ils.Metrics())
 	mb.metricPostgresqlRows.emit(ils.Metrics())
@@ -688,6 +809,16 @@ func (mb *MetricsBuilder) RecordPostgresqlCommitsDataPoint(ts pcommon.Timestamp,
 // RecordPostgresqlDbSizeDataPoint adds a data point to postgresql.db_size metric.
 func (mb *MetricsBuilder) RecordPostgresqlDbSizeDataPoint(ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
 	mb.metricPostgresqlDbSize.recordDataPoint(mb.startTime, ts, val, databaseAttributeValue)
+}
+
+// RecordPostgresqlIndexScansDataPoint adds a data point to postgresql.index.scans metric.
+func (mb *MetricsBuilder) RecordPostgresqlIndexScansDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricPostgresqlIndexScans.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordPostgresqlIndexSizeDataPoint adds a data point to postgresql.index.size metric.
+func (mb *MetricsBuilder) RecordPostgresqlIndexSizeDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricPostgresqlIndexSize.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordPostgresqlOperationsDataPoint adds a data point to postgresql.operations metric.

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
@@ -396,7 +396,7 @@ func (m *metricPostgresqlIndexScans) init() {
 	m.data.SetDescription("The number of index scans on a table.")
 	m.data.SetUnit("{scans}")
 	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
@@ -444,7 +444,7 @@ type metricPostgresqlIndexSize struct {
 // init fills postgresql.index.size metric with initial data.
 func (m *metricPostgresqlIndexSize) init() {
 	m.data.SetName("postgresql.index.size")
-	m.data.SetDescription("The number of index scans on a table.")
+	m.data.SetDescription("The size of the index on disk.")
 	m.data.SetUnit("By")
 	m.data.SetDataType(pmetric.MetricDataTypeGauge)
 }

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -7,6 +7,9 @@ resource_attributes:
   postgresql.table.name:
     description: The schema name followed by the table name.
     type: string
+  postgresql.index.name:
+    description: The name of the index on a table.
+    type: string
 
 attributes:
   database:
@@ -79,6 +82,22 @@ metrics:
       monotonic: false
       aggregation: cumulative
     attributes: [database, table, state]
+  postgresql.index.scans:
+    attributes: []
+    description: The number of index scans on a table.
+    enabled: true
+    sum:
+      aggregation: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{scans}"
+  postgresql.index.size:
+    attributes: []
+    description: The number of index scans on a table.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: "By"
   postgresql.operations:
     enabled: true
     description: The number of db row operations.

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -88,12 +88,12 @@ metrics:
     enabled: true
     sum:
       aggregation: cumulative
-      monotonic: false
+      monotonic: true
       value_type: int
     unit: "{scans}"
   postgresql.index.size:
     attributes: []
-    description: The number of index scans on a table.
+    description: The size of the index on disk.
     enabled: true
     gauge:
       value_type: int

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -16,6 +16,7 @@ package postgresqlreceiver
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -165,6 +166,11 @@ func (m *mockClient) getBlocksReadByTable(ctx context.Context, database string) 
 	return args.Get(0).(map[tableIdentifier]tableIOStats), args.Error(1)
 }
 
+func (m *mockClient) getIndexStats(ctx context.Context, database string) (map[indexIdentifer]indexStat, error) {
+	args := m.Called(ctx, database)
+	return args.Get(0).(map[indexIdentifer]indexStat), args.Error(1)
+}
+
 func (m *mockClient) listDatabases(_ context.Context) ([]string, error) {
 	args := m.Called()
 	return args.Get(0).([]string), args.Error(1)
@@ -265,5 +271,24 @@ func (m *mockClient) initMocks(database string, databases []string, index int) {
 		m.On("getDatabaseTableMetrics", mock.Anything, database).Return(tableMetrics, nil)
 		m.On("getBlocksReadByTable", mock.Anything, database).Return(blocksMetrics, nil)
 
+		index1 := fmt.Sprintf("%s_test1_pkey", database)
+		index2 := fmt.Sprintf("%s_test2_pkey", database)
+		indexStats := map[indexIdentifer]indexStat{
+			indexKey(database, table1, index1): {
+				database: database,
+				table:    table1,
+				index:    index1,
+				scans:    int64(index + 35),
+				size:     int64(index + 36),
+			},
+			indexKey(index2, table2, index2): {
+				database: database,
+				table:    table2,
+				index:    index2,
+				scans:    int64(index + 37),
+				size:     int64(index + 38),
+			},
+		}
+		m.On("getIndexStats", mock.Anything, database).Return(indexStats, nil)
 	}
 }

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_with_resource_attributes.json
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_with_resource_attributes.json
@@ -25,8 +25,8 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "11"
                                     }
                                 ],
@@ -41,9 +41,9 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "7256600"
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "7240216"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
@@ -56,8 +56,8 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     }
                                 ],
@@ -94,8 +94,8 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "3"
                                     }
                                 ],
@@ -109,8 +109,8 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "92"
                                     }
                                 ],
@@ -125,9 +125,9 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "7256600"
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "7297560"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
@@ -140,255 +140,13 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                                 "isMonotonic": true
-                            }
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "resource": {
-                "attributes": [
-                    {
-                        "key": "postgresql.database.name",
-                        "value": {
-                            "stringValue": "otel"
-                        }
-                    },
-                    {
-                        "key": "postgresql.table.name",
-                        "value": {
-                            "stringValue": "public.table1"
-                        }
-                    }
-                ]
-            },
-            "scopeMetrics": [
-                {
-                    "scope": {
-                        "name": "otelcol/postgresqlreceiver",
-                        "version": "latest"
-                    },
-                    "metrics": [
-                        {
-                            "name": "postgresql.blocks_read",
-                            "description": "The number of blocks read.",
-                            "unit": "1",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "heap_read"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "heap_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "idx_read"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "idx_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "toast_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "toast_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "tidx_read"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "tidx_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                                "isMonotonic": true
-                            }
-                        },
-                        {
-                            "name": "postgresql.operations",
-                            "description": "The number of db row operations.",
-                            "unit": "1",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "ins"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "del"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "upd"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "hot_upd"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                                "isMonotonic": true
-                            }
-                        },
-                        {
-                            "name": "postgresql.rows",
-                            "description": "The number of rows in the database.",
-                            "unit": "1",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "state",
-                                                "value": {
-                                                    "stringValue": "dead"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "state",
-                                                "value": {
-                                                    "stringValue": "live"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
                             }
                         }
                     ]
@@ -434,8 +192,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -447,8 +205,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -460,8 +218,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -473,8 +231,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -486,8 +244,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -499,8 +257,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -512,8 +270,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -525,8 +283,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     }
                                 ],
@@ -549,8 +307,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -562,8 +320,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -575,8 +333,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -588,8 +346,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     }
                                 ],
@@ -612,8 +370,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -625,12 +383,380 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.table1"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.blocks_read",
+                            "description": "The number of blocks read.",
+                            "unit": "1",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "heap_read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "heap_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "idx_read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "idx_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "toast_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "toast_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "tidx_read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "tidx_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "postgresql.operations",
+                            "description": "The number of db row operations.",
+                            "unit": "1",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "operation",
+                                                "value": {
+                                                    "stringValue": "ins"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "operation",
+                                                "value": {
+                                                    "stringValue": "del"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "operation",
+                                                "value": {
+                                                    "stringValue": "upd"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "operation",
+                                                "value": {
+                                                    "stringValue": "hot_upd"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "postgresql.rows",
+                            "description": "The number of rows in the database.",
+                            "unit": "1",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "dead"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "live"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "table1"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "table1_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "8192"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "table2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "table2_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "8192"
+                                    }
+                                ]
                             }
                         }
                     ]
@@ -662,9 +788,9 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "20"
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "23"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -678,9 +804,9 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "7256600"
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "7313944"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
@@ -693,255 +819,13 @@
                             "sum": {
                                 "dataPoints": [
                                     {
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                                 "isMonotonic": true
-                            }
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "resource": {
-                "attributes": [
-                    {
-                        "key": "postgresql.database.name",
-                        "value": {
-                            "stringValue": "otel2"
-                        }
-                    },
-                    {
-                        "key": "postgresql.table.name",
-                        "value": {
-                            "stringValue": "public.test2"
-                        }
-                    }
-                ]
-            },
-            "scopeMetrics": [
-                {
-                    "scope": {
-                        "name": "otelcol/postgresqlreceiver",
-                        "version": "latest"
-                    },
-                    "metrics": [
-                        {
-                            "name": "postgresql.blocks_read",
-                            "description": "The number of blocks read.",
-                            "unit": "1",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "heap_read"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "heap_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "idx_read"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "idx_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "toast_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "toast_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "tidx_read"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "source",
-                                                "value": {
-                                                    "stringValue": "tidx_hit"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                                "isMonotonic": true
-                            }
-                        },
-                        {
-                            "name": "postgresql.operations",
-                            "description": "The number of db row operations.",
-                            "unit": "1",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "ins"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "del"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "upd"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "operation",
-                                                "value": {
-                                                    "stringValue": "hot_upd"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                                "isMonotonic": true
-                            }
-                        },
-                        {
-                            "name": "postgresql.rows",
-                            "description": "The number of rows in the database.",
-                            "unit": "1",
-                            "sum": {
-                                "dataPoints": [
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "state",
-                                                "value": {
-                                                    "stringValue": "dead"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    },
-                                    {
-                                        "attributes": [
-                                            {
-                                                "key": "state",
-                                                "value": {
-                                                    "stringValue": "live"
-                                                }
-                                            }
-                                        ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
-                                        "asInt": "0"
-                                    }
-                                ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
                             }
                         }
                     ]
@@ -987,8 +871,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1000,8 +884,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1013,8 +897,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1026,8 +910,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1039,8 +923,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1052,8 +936,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1065,8 +949,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1078,8 +962,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     }
                                 ],
@@ -1102,8 +986,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1115,8 +999,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1128,8 +1012,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1141,8 +1025,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     }
                                 ],
@@ -1165,8 +1049,8 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     },
                                     {
@@ -1178,12 +1062,506 @@
                                                 }
                                             }
                                         ],
-                                        "startTimeUnixNano": "1660149731480073000",
-                                        "timeUnixNano": "1660149741492944000",
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
                                         "asInt": "0"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.test2"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.blocks_read",
+                            "description": "The number of blocks read.",
+                            "unit": "1",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "heap_read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "heap_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "idx_read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "2"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "idx_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "toast_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "toast_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "tidx_read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "source",
+                                                "value": {
+                                                    "stringValue": "tidx_hit"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "postgresql.operations",
+                            "description": "The number of db row operations.",
+                            "unit": "1",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "operation",
+                                                "value": {
+                                                    "stringValue": "ins"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "operation",
+                                                "value": {
+                                                    "stringValue": "del"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "operation",
+                                                "value": {
+                                                    "stringValue": "upd"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "operation",
+                                                "value": {
+                                                    "stringValue": "hot_upd"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "postgresql.rows",
+                            "description": "The number of rows in the database.",
+                            "unit": "1",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "dead"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "live"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "test2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "otel2index"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "8192"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "test1"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "test1_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "8192"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "test2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "test2_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "8192"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "test1"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "otelindex"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164736795002000",
+                                        "timeUnixNano": "1660164746808894000",
+                                        "asInt": "8192"
+                                    }
+                                ]
                             }
                         }
                     ]

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_with_resource_attributes.json
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_with_resource_attributes.json
@@ -679,12 +679,13 @@
                                         "asInt": "0"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -742,12 +743,13 @@
                                         "asInt": "0"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -1358,12 +1360,13 @@
                                         "asInt": "0"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -1421,12 +1424,13 @@
                                         "asInt": "0"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -1484,12 +1488,13 @@
                                         "asInt": "0"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -1547,12 +1552,13 @@
                                         "asInt": "0"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [

--- a/receiver/postgresqlreceiver/testdata/integration/init.sql
+++ b/receiver/postgresqlreceiver/testdata/integration/init.sql
@@ -1,10 +1,24 @@
 CREATE USER otel WITH PASSWORD 'otel';
 GRANT SELECT ON pg_stat_database TO otel;
 
-CREATE TABLE table1 ();
-CREATE TABLE table2 ();
+CREATE TABLE table1 (
+    id serial PRIMARY KEY
+);
+CREATE TABLE table2 (
+    id serial PRIMARY KEY
+);
 
 CREATE DATABASE otel2;
 \c otel2
-CREATE TABLE test1 ();
-CREATE TABLE test2 ();
+CREATE TABLE test1 (
+    id serial PRIMARY KEY
+);
+CREATE TABLE test2 (
+    id serial PRIMARY KEY
+);
+
+CREATE INDEX otelindex ON test1(id);
+CREATE INDEX otel2index ON test2(id);
+
+-- Generating usage of index
+SELECT * FROM test2; 

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.json
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.json
@@ -610,12 +610,13 @@
                                         "asInt": "35"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -673,12 +674,13 @@
                                         "asInt": "37"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -1304,12 +1306,13 @@
                                         "asInt": "36"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -1367,12 +1370,13 @@
                                         "asInt": "38"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -1998,12 +2002,13 @@
                                         "asInt": "37"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -2061,12 +2066,13 @@
                                         "asInt": "39"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.json
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.json
@@ -574,6 +574,132 @@
                     {
                         "key": "postgresql.database.name",
                         "value": {
+                            "stringValue": "otel"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.table1"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "otel_test1_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "35"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "36"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.table2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "otel_test2_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "37"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "38"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
                             "stringValue": "open"
                         }
                     }
@@ -1142,6 +1268,132 @@
                     {
                         "key": "postgresql.database.name",
                         "value": {
+                            "stringValue": "open"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.table1"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "open_test1_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "36"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "37"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "open"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.table2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "open_test2_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "38"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "39"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
                             "stringValue": "telemetry"
                         }
                     }
@@ -1698,6 +1950,132 @@
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "telemetry"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.table1"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "telemetry_test1_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "37"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "38"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "telemetry"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.table2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "telemetry_test2_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "39"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660164011292024000",
+                                        "timeUnixNano": "1660164011292184000",
+                                        "asInt": "40"
+                                    }
+                                ]
                             }
                         }
                     ]

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.json
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.json
@@ -567,6 +567,132 @@
                     ]
                 }
             ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.table1"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "otel_test1_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660163860281285000",
+                                        "timeUnixNano": "1660163860281410000",
+                                        "asInt": "35"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660163860281285000",
+                                        "timeUnixNano": "1660163860281410000",
+                                        "asInt": "36"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "postgresql.database.name",
+                        "value": {
+                            "stringValue": "otel"
+                        }
+                    },
+                    {
+                        "key": "postgresql.table.name",
+                        "value": {
+                            "stringValue": "public.table2"
+                        }
+                    },
+                    {
+                        "key": "postgresql.index.name",
+                        "value": {
+                            "stringValue": "otel_test2_pkey"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/postgresqlreceiver",
+                        "version": "latest"
+                    },
+                    "metrics": [
+                        {
+                            "name": "postgresql.index.scans",
+                            "description": "The number of index scans on a table.",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660163860281285000",
+                                        "timeUnixNano": "1660163860281410000",
+                                        "asInt": "37"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "postgresql.index.size",
+                            "description": "The number of index scans on a table.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1660163860281285000",
+                                        "timeUnixNano": "1660163860281410000",
+                                        "asInt": "38"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.json
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.json
@@ -610,12 +610,14 @@
                                         "asInt": "35"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [
@@ -673,12 +675,13 @@
                                         "asInt": "37"
                                     }
                                 ],
-                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
                             }
                         },
                         {
                             "name": "postgresql.index.size",
-                            "description": "The number of index scans on a table.",
+                            "description": "The size of the index on disk.",
                             "unit": "By",
                             "gauge": {
                                 "dataPoints": [

--- a/unreleased/postgres-index-metrics.yaml
+++ b/unreleased/postgres-index-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds Index Resource Attribute and Metrics Collection.
+
+# One or more tracking issues related to the change
+issues: [13167]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This enhancement will only be enabled with the receiver.postgresql.emitMetricsWithResourceAttributes feature gate being enabled.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Adding index metrics to the `postgresqlreceiver`. Curious if we want to enhance non-resource attribute collection but decided to just add metrics with resource attributes. Let me know if that seems reasonable. 

**Link to tracking Issue:** Resolves #13167 

**Testing:** scraper test and integration testing

**Documentation:** Changelog entry has been added