### PR TITLE
[receiver/expvar] Fix bug where measurement is recorded into wrong metric. 

### DIFF
--- a/receiver/expvarreceiver/scraper.go
+++ b/receiver/expvarreceiver/scraper.go
@@ -101,7 +101,7 @@ func (e *expVarScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	e.mb.RecordProcessRuntimeMemstatsMspanInuseDataPoint(now, int64(memStats.MSpanInuse))
 	e.mb.RecordProcessRuntimeMemstatsMspanSysDataPoint(now, int64(memStats.MSpanSys))
 	e.mb.RecordProcessRuntimeMemstatsMcacheInuseDataPoint(now, int64(memStats.MCacheInuse))
-	e.mb.RecordProcessRuntimeMemstatsMspanSysDataPoint(now, int64(memStats.MCacheSys))
+	e.mb.RecordProcessRuntimeMemstatsMcacheSysDataPoint(now, int64(memStats.MCacheSys))
 	e.mb.RecordProcessRuntimeMemstatsBuckHashSysDataPoint(now, int64(memStats.BuckHashSys))
 	e.mb.RecordProcessRuntimeMemstatsGcSysDataPoint(now, int64(memStats.GCSys))
 	e.mb.RecordProcessRuntimeMemstatsOtherSysDataPoint(now, int64(memStats.OtherSys))

--- a/receiver/expvarreceiver/testdata/metrics/expected_all_metrics.json
+++ b/receiver/expvarreceiver/testdata/metrics/expected_all_metrics.json
@@ -244,7 +244,17 @@
                     "startTimeUnixNano": "1653023581589787000",
                     "timeUnixNano": "1653023581592037000",
                     "asInt": "81600"
-                  },
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+              }
+            },
+            {
+              "name": "process.runtime.memstats.mcache_sys",
+              "description": "Bytes of memory obtained from the OS for mcache structures.",
+              "unit": "By",
+              "sum": {
+                "dataPoints": [
                   {
                     "startTimeUnixNano": "1653023581589787000",
                     "timeUnixNano": "1653023581592037000",

--- a/unreleased/expvar-bug-fix-#13172.yaml
+++ b/unreleased/expvar-bug-fix-#13172.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: expvarreceiver
+note: "Fixes an bug where the mSpanSys value was recorded into the mCacheSys metric."
+issues: [13171]


### PR DESCRIPTION
**Description:** 
Noticed a bug where the `mSpanSys` value was higher than it should be. Turns out we were recording to `mCacheSys` value to that metric as well. This resulted in no `mCacheSys` metric and an incorrect `mSpanSys` metric. This PR fixes the issue.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13171

**Testing:** 
The tests have been altered to expect the correct metrics, they were previously expecting slightly incorrect metrics.
