### PR TITLE
[exporter/sentryexporter] make status more detailed

### DIFF
--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -38,12 +38,44 @@ const (
 	otelSentryExporterName    = "sentry.opentelemetry"
 )
 
-// canonicalCodes maps OpenTelemetry span codes to Sentry's span status.
-// See numeric codes in https://github.com/open-telemetry/opentelemetry-proto/blob/6cf77b2f544f6bc7fe1e4b4a8a52e5a42cb50ead/opentelemetry/proto/trace/v1/trace.proto#L303
-var canonicalCodes = [...]sentry.SpanStatus{
-	sentry.SpanStatusUndefined,
-	sentry.SpanStatusOK,
-	sentry.SpanStatusUnknown,
+// See OpenTelemetry span statuses in https://github.com/open-telemetry/opentelemetry-proto/blob/6cf77b2f544f6bc7fe1e4b4a8a52e5a42cb50ead/opentelemetry/proto/trace/v1/trace.proto#L303
+
+// OpenTelemetry span status can be Unset, Ok, Error. HTTP and Grpc codes contained in tags can make it more detailed.
+
+// canonicalCodesHTTPMap maps some HTTP codes to Sentry's span statuses. See possible mapping in https://develop.sentry.dev/sdk/event-payloads/span/
+var canonicalCodesHTTPMap = map[string]sentry.SpanStatus{
+	"400": sentry.SpanStatusFailedPrecondition, // SpanStatusInvalidArgument, SpanStatusOutOfRange
+	"401": sentry.SpanStatusUnauthenticated,
+	"403": sentry.SpanStatusPermissionDenied,
+	"404": sentry.SpanStatusNotFound,
+	"409": sentry.SpanStatusAborted, // SpanStatusAlreadyExists
+	"429": sentry.SpanStatusResourceExhausted,
+	"499": sentry.SpanStatusCanceled,
+	"500": sentry.SpanStatusInternalError, // SpanStatusDataLoss, SpanStatusUnknown
+	"501": sentry.SpanStatusUnimplemented,
+	"503": sentry.SpanStatusUnavailable,
+	"504": sentry.SpanStatusDeadlineExceeded,
+}
+
+// canonicalCodesGrpcMap maps GRPC codes to Sentry's span statuses. See description in grpc documentation.
+var canonicalCodesGrpcMap = map[string]sentry.SpanStatus{
+	"0":  sentry.SpanStatusOK,
+	"1":  sentry.SpanStatusCanceled,
+	"2":  sentry.SpanStatusUnknown,
+	"3":  sentry.SpanStatusInvalidArgument,
+	"4":  sentry.SpanStatusDeadlineExceeded,
+	"5":  sentry.SpanStatusNotFound,
+	"6":  sentry.SpanStatusAlreadyExists,
+	"7":  sentry.SpanStatusPermissionDenied,
+	"8":  sentry.SpanStatusResourceExhausted,
+	"9":  sentry.SpanStatusFailedPrecondition,
+	"10": sentry.SpanStatusAborted,
+	"11": sentry.SpanStatusOutOfRange,
+	"12": sentry.SpanStatusUnimplemented,
+	"13": sentry.SpanStatusInternalError,
+	"14": sentry.SpanStatusUnavailable,
+	"15": sentry.SpanStatusDataLoss,
+	"16": sentry.SpanStatusUnauthenticated,
 }
 
 // SentryExporter defines the Sentry Exporter.
@@ -235,7 +267,7 @@ func convertToSentrySpan(span ptrace.Span, library pcommon.InstrumentationScope,
 		tags[k] = v
 	}
 
-	status, message := statusFromSpanStatus(span.Status())
+	status, message := statusFromSpanStatus(span.Status(), tags)
 
 	if message != "" {
 		tags["status_message"] = message
@@ -360,13 +392,48 @@ func generateTagsFromAttributes(attrs pcommon.Map) map[string]string {
 	return tags
 }
 
-func statusFromSpanStatus(spanStatus ptrace.SpanStatus) (status sentry.SpanStatus, message string) {
+func statusFromSpanStatus(spanStatus ptrace.SpanStatus, tags map[string]string) (status sentry.SpanStatus, message string) {
 	code := spanStatus.Code()
-	if code < 0 || int(code) >= len(canonicalCodes) {
+	if code < 0 || int(code) > 2 {
 		return sentry.SpanStatusUnknown, fmt.Sprintf("error code %d", code)
 	}
-
-	return canonicalCodes[code], spanStatus.Message()
+	httpCode, foundHTTPCode := tags["http.status_code"]
+	grpcCode, foundGrpcCode := tags["rpc.grpc.status_code"]
+	var sentryStatus sentry.SpanStatus
+	switch {
+	case code == 1:
+		sentryStatus = sentry.SpanStatusOK
+	case foundHTTPCode:
+		httpStatus, foundHTTPStatus := canonicalCodesHTTPMap[httpCode]
+		switch {
+		case foundHTTPStatus:
+			sentryStatus = httpStatus
+		case code == 2:
+			sentryStatus = sentry.SpanStatusUnknown
+		default:
+			httpCodeInt, err := strconv.Atoi(httpCode)
+			if err == nil && httpCodeInt >= 200 && httpCodeInt < 300 {
+				sentryStatus = sentry.SpanStatusOK
+			} else {
+				sentryStatus = sentry.SpanStatusUndefined
+			}
+		}
+	case foundGrpcCode:
+		grpcStatus, foundGrpcStatus := canonicalCodesGrpcMap[grpcCode]
+		switch {
+		case foundGrpcStatus:
+			sentryStatus = grpcStatus
+		case code == 2:
+			sentryStatus = sentry.SpanStatusUnknown
+		default:
+			sentryStatus = sentry.SpanStatusUndefined
+		}
+	case code == 2:
+		sentryStatus = sentry.SpanStatusUnknown
+	default:
+		sentryStatus = sentry.SpanStatusUndefined
+	}
+	return sentryStatus, spanStatus.Message()
 }
 
 // spanIsTransaction determines if a span should be sent to Sentry as a transaction.


### PR DESCRIPTION
**Description:** 
Make sentry status more detailed.

We use opentelemetry-javaagent v1.16.0, this collector and Sentry. Javaagent sends only 2 statuses - STATUS_CODE_UNSET (if there is no error) and STATUS_CODE_ERROR. According to current logic in statusFromSpanStatus we always see in Sentry "unknown" statuses for transaction and spans.
I suggest using HTTP and Grpc status codes from tags to clarify Sentry status. Grpc and Sentry statuses map one to one. With HTTP statuses it is not so clear. I use https://develop.sentry.dev/sdk/event-payloads/span/, but they suggest multiple HTTP statuses for one Sentry status.
And I don't know how to process STATUS_CODE_UNSET. I found this: https://github.com/open-telemetry/opentelemetry-collector/blob/pdata/v0.58.0/pdata/internal/generated_ptrace.go#L1180 . Should I set status Ok, if I receive STATUS_CODE_UNSET (instead of Undefined) and find no mapping in HTTP or Grpc codes? It seems that it will be correct. Because javaagent uses only STATUS_CODE_UNSET and STATUS_CODE_ERROR. And for database operations there is no http or grpc code.

**Link to tracking Issue:**
 n/a

**Testing:**
Tests for spans with http and grpc statuses were added.

**Documentation:**
 n/a