### PR TITLE
[exporter/loadbalancing] Skip flaky TestRollingUpdatesWhenConsumeLogs

### DIFF
--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -333,6 +333,7 @@ func TestLogsWithoutTraceID(t *testing.T) {
 }
 
 func TestRollingUpdatesWhenConsumeLogs(t *testing.T) {
+	t.Skip("Flaky Test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11116")
 	// this test is based on the discussion in the following issue for this exporter:
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1690
 	// prepare


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11116