### PR TITLE
[pkg/stanza] Add parsers readme

### DIFF
--- a/pkg/stanza/docs/operators/csv_parser.md
+++ b/pkg/stanza/docs/operators/csv_parser.md
@@ -18,6 +18,10 @@ The `csv_parser` operator parses the string-type field selected by `parse_from` 
 | `timestamp`        | `nil`                                    | An optional [timestamp](../types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator. |
 | `severity`         | `nil`                                    | An optional [severity](../types/severity.md) block which will parse a severity field before passing the entry to the output operator. |
 
+### Embedded Operations
+
+The `csv_parser` can be configured to embed certain operations such as timestamp and severity parsing. For more information, see [complex parsers](../types/parsers.md#complex-parsers).
+
 ### Example Configurations
 
 #### Parse the field `message` with a csv parser

--- a/pkg/stanza/docs/operators/json_parser.md
+++ b/pkg/stanza/docs/operators/json_parser.md
@@ -15,6 +15,10 @@ The `json_parser` operator parses the string-type field selected by `parse_from`
 | `timestamp`   | `nil`            | An optional [timestamp](../types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator. |
 | `severity`    | `nil`            | An optional [severity](../types/severity.md) block which will parse a severity field before passing the entry to the output operator. |
 
+### Embedded Operations
+
+The `json_parser` can be configured to embed certain operations such as timestamp and severity parsing. For more information, see [complex parsers](../types/parsers.md#complex-parsers).
+
 
 ### Example Configurations
 

--- a/pkg/stanza/docs/operators/key_value_parser.md
+++ b/pkg/stanza/docs/operators/key_value_parser.md
@@ -17,6 +17,9 @@ The `key_value_parser` operator parses the string-type field selected by `parse_
 | `timestamp`      | `nil`               | An optional [timestamp](../types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator.                                                                                               |
 | `severity`       | `nil`               | An optional [severity](../types/severity.md) block which will parse a severity field before passing the entry to the output operator.                                                                                                  |
 
+### Embedded Operations
+
+The `key_value_parser` can be configured to embed certain operations such as timestamp and severity parsing. For more information, see [complex parsers](../types/parsers.md#complex-parsers).
 
 ### Example Configurations
 

--- a/pkg/stanza/docs/operators/scope_name_parser.md
+++ b/pkg/stanza/docs/operators/scope_name_parser.md
@@ -1,0 +1,17 @@
+## `scope_name_parser` operator
+
+The `scope_name_parser` operator sets the scope name on an entry by parsing a value from the specified [field](../types/field.md).
+
+### Configuration Fields
+
+| Field                    | Default             | Description |
+| ---                      | ---                 | ---         |
+| `id`                     | `scope_name_parser` | A unique identifier for the operator. |
+| `output`                 | Next in pipeline    | The `id` for the operator to send parsed entries to. |
+| `parse_from`             | `body`              | A [field](../types/field.md) that indicates the field to be parsed as the scope name. |
+| `on_error`               | `send`              | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
+
+
+### Example Configurations
+
+Several detailed examples are available [here](../types/scope_name.md).

--- a/pkg/stanza/docs/operators/syslog_parser.md
+++ b/pkg/stanza/docs/operators/syslog_parser.md
@@ -17,6 +17,10 @@ The `syslog_parser` operator parses the string-type field selected by `parse_fro
 | `severity`    | `nil`            | An optional [severity](../types/severity.md) block which will parse a severity field before passing the entry to the output operator                                                                                                  |
 | `if`          |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
 
+### Embedded Operations
+
+The `syslog_parser` can be configured to embed certain operations such as timestamp and severity parsing. For more information, see [complex parsers](../types/parsers.md#complex-parsers).
+
 ### Example Configurations
 
 

--- a/pkg/stanza/docs/operators/uri_parser.md
+++ b/pkg/stanza/docs/operators/uri_parser.md
@@ -22,6 +22,9 @@ The `uri_parser` operator parses the string-type field selected by `parse_from` 
 | `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
 | `if`          |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
 
+### Embedded Operations
+
+The `uri_parser` can be configured to embed certain operations such as timestamp and severity parsing. For more information, see [complex parsers](../types/parsers.md#complex-parsers).
 
 ### Output Fields
 

--- a/pkg/stanza/docs/types/field.md
+++ b/pkg/stanza/docs/types/field.md
@@ -14,7 +14,7 @@ Body fields can be nested arbitrarily deeply, such as `body.my_value.my_nested_v
 
 If a field does not start with `resource`, `attributes`, or `body`, then `body` is assumed. For example, `my_value` is equivalent to `body.my_value`.
 
-## Examples
+### Examples
 
 #### Using fields with the add and remove operators.
 

--- a/pkg/stanza/docs/types/parsers.md
+++ b/pkg/stanza/docs/types/parsers.md
@@ -16,9 +16,9 @@ List of simple parsers:
 ### Complex Parsers
 
 Complex parsers differ from simple parsers in several ways.
-1. Parsing produces an object, typically containing multiple key/value pairs. The values contained within this object may be strings, ints, arrays, or further objects.
-2. By default, this parsed object will be merged onto the log entry's `attributes` field. In the case of collisions between keys, the newly parsed value will override the previous value. Alternately, [field](../types/field.md) to which the object is written can be configured using the `parse_to` setting.
-3. The configuration may "embed" certain followup operations. Generally, these embedded operations are equivalent to simple parsers. These embedded operations are applied immediately after the primary parsing operation, and only if the primary operation was successful. These operations are executed independently of each other. (e.g. failure to parse a timestamp will not prevent an attempt to parse severity.)
+1. Parsing produces multiple key/value pairs, where the values may be strings, ints, arrays, or objects.
+2. By default, these key/value pairs will be added to log entry's `attributes` field. In the case of collisions between keys, the newly parsed value will override the existing value. Alternately, the [field](../types/field.md) to which the object is written can be configured using the `parse_to` setting.
+3. The configuration may "embed" certain followup operations. Generally, these operations correlate to the simple parsers listed above. Embedded operations are applied immediately after the primary parsing operation, and only if the primary operation was successful. Each embedded operation is executed independently of the others. (e.g. failure to parse a timestamp will not prevent an attempt to parse severity.)
 
 The following examples illustrate how a `json_parser` may embed timestamp and severity parsers.
 
@@ -38,7 +38,7 @@ Consider a simple json log: `{"message":"foo", "ts":"2022-08-10", "sev":"INFO"}`
     parse_from: attributes.sev
 ```
 
-Note that when configuring embedded operations, the primary operation must be assumed to have already been completed. In the above example, the values specified in the `parse_from` fields have taken into account that the `json_parser` will write key/value pairs to `attributes`.
+Note that when configuring embedded operations, it is typically necessary to reference a field that was set by the primary operation. In the above example, the values specified in the `parse_from` fields have taken into account that the `json_parser` will write key/value pairs to `attributes`.
 
 List of complex parsers:
 - [`json_parser`](../operators/json_parser.md)
@@ -53,5 +53,3 @@ List of embeddable operations:
 - [`severity`](./severity.md)
 - [`trace`](./trace.md)
 - [`scope_name`](./scope_name.md)
-
-## TODO link to this doc from parsers & from receivers

--- a/pkg/stanza/docs/types/parsers.md
+++ b/pkg/stanza/docs/types/parsers.md
@@ -1,0 +1,57 @@
+## Parsers
+
+Parser operators are used to isolate values from a string. There are two classes of parsers, simple and complex.
+
+### Simple Parsers
+
+Simple parsers perform a very specific operation where the result is assigned to a predetermined field in the log data model.
+For example, the [`time_parser`](../operators/time_parser.md) will parse a timestamp and assign it to the a log record's `Timestamp` field.
+
+List of simple parsers:
+- [`time_parser`](../operators/time_parser.md)
+- [`severity_parser`](../operators/severity_parser.md)
+- [`trace_parser`](../operators/trace_parser.md)
+- [`scope_name_parser`](../operators/scope_name_parser.md)
+
+### Complex Parsers
+
+Complex parsers differ from simple parsers in several ways.
+1. Parsing produces an object, typically containing multiple key/value pairs. The values contained within this object may be strings, ints, arrays, or further objects.
+2. By default, this parsed object will be merged onto the log entry's `attributes` field. In the case of collisions between keys, the newly parsed value will override the previous value. Alternately, [field](../types/field.md) to which the object is written can be configured using the `parse_to` setting.
+3. The configuration may "embed" certain followup operations. Generally, these embedded operations are equivalent to simple parsers. These embedded operations are applied immediately after the primary parsing operation, and only if the primary operation was successful. These operations are executed independently of each other. (e.g. failure to parse a timestamp will not prevent an attempt to parse severity.)
+
+The following examples illustrate how a `json_parser` may embed timestamp and severity parsers.
+
+Consider a simple json log: `{"message":"foo", "ts":"2022-08-10", "sev":"INFO"}`
+
+```yaml
+# Standalone json parser
+- type: json_parser
+
+# Regex parser with embedded timestamp and severity parsers
+- type: json_parser
+  timestamp:
+    parse_from: attributes.ts
+    layout_type: strptime
+    layout: '%Y-%m-%d'
+  severity:
+    parse_from: attributes.sev
+```
+
+Note that when configuring embedded operations, the primary operation must be assumed to have already been completed. In the above example, the values specified in the `parse_from` fields have taken into account that the `json_parser` will write key/value pairs to `attributes`.
+
+List of complex parsers:
+- [`json_parser`](../operators/json_parser.md)
+- [`regex_parser`](../operators/regex_parser.md)
+- [`csv_parser`](../operators/csv_parser.md)
+- [`key_value_parser`](../operators/key_value_parser.md)
+- [`uri_parser`](../operators/uri_parser.md)
+- [`syslog_parser`](../operators/syslog_parser.md)
+
+List of embeddable operations:
+- [`timestamp`](./timestamp.md)
+- [`severity`](./severity.md)
+- [`trace`](./trace.md)
+- [`scope_name`](./scope_name.md)
+
+## TODO link to this doc from parsers & from receivers

--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -71,9 +71,10 @@ Other less common encodings are supported on a best-effort basis. See [https://w
 - An [entry](../../pkg/stanza/docs/types/entry.md) is the base representation of log data as it moves through a pipeline. All operators either create, modify, or consume entries.
 - A [field](../../pkg/stanza/docs/types/field.md) is used to reference values in an entry.
 - A common [expression](../../pkg/stanza/docs/types/expression.md) syntax is used in several operators. For example, expressions can be used to [filter](../../pkg/stanza/docs/operators/filter.md) or [route](../../pkg/stanza/docs/operators/router.md) entries.
-- [timestamp](../../pkg/stanza/docs/types/timestamp.md) parsing is available as a block within all parser operators, and also as a standalone operator. Many common timestamp layouts are supported.
-- [severity](../../pkg/stanza/docs/types/severity.md) parsing is available as a block within all parser operators, and also as a standalone operator. Stanza uses a flexible severity representation which is automatically interpreted by the stanza receiver.
 
+### Parsers with Embedded Operations
+
+Many parsers operators can be configured to embed certain followup operations such as timestamp and severity parsing. For more information, see [complex parsers](../../pkg/stanza/docs/types/parsers.md#complex-parsers).
 
 ## Example - Tailing a simple json file
 

--- a/receiver/syslogreceiver/README.md
+++ b/receiver/syslogreceiver/README.md
@@ -61,8 +61,10 @@ The `tcp_input` operator supports TLS, disabled by default.
 - An [entry](../../pkg/stanza/docs/types/entry.md) is the base representation of log data as it moves through a pipeline. All operators either create, modify, or consume entries.
 - A [field](../../pkg/stanza/docs/types/field.md) is used to reference values in an entry.
 - A common [expression](../../pkg/stanza/docs/types/expression.md) syntax is used in several operators. For example, expressions can be used to [filter](../../pkg/stanza/docs/operators/filter.md) or [route](../../pkg/stanza/docs/operators/router.md) entries.
-- [timestamp](../../pkg/stanza/docs/types/timestamp.md) parsing is available as a block within all parser operators, and also as a standalone operator. Many common timestamp layouts are supported.
-- [severity](../../pkg/stanza/docs/types/severity.md) parsing is available as a block within all parser operators, and also as a standalone operator. Stanza uses a flexible severity representation which is automatically interpreted by the stanza receiver.
+
+### Parsers with Embedded Operations
+
+Many parsers operators can be configured to embed certain followup operations such as timestamp and severity parsing. For more information, see [complex parsers](../../pkg/stanza/docs/types/parsers.md#complex-parsers).
 
 ## Example Configurations
 

--- a/receiver/tcplogreceiver/README.md
+++ b/receiver/tcplogreceiver/README.md
@@ -43,6 +43,10 @@ Each operator performs a simple responsibility, such as parsing a timestamp or J
 - Operators will output to the next operator in the pipeline. The last operator in the pipeline will emit from the receiver. Optionally, the `output` parameter can be used to specify the `id` of another operator to which logs will be passed directly.
 - Only parsers and general purpose operators should be used.
 
+### Parsers with Embedded Operations
+
+Many parsers operators can be configured to embed certain followup operations such as timestamp and severity parsing. For more information, see [complex parsers](../../pkg/stanza/docs/types/parsers.md#complex-parsers).
+
 #### `multiline` configuration
 
 If set, the `multiline` configuration block instructs the `tcplog` receiver to split log entries on a pattern other than newlines.

--- a/receiver/udplogreceiver/README.md
+++ b/receiver/udplogreceiver/README.md
@@ -29,6 +29,10 @@ Each operator performs a simple responsibility, such as parsing a timestamp or J
 - Operators will output to the next operator in the pipeline. The last operator in the pipeline will emit from the receiver. Optionally, the `output` parameter can be used to specify the `id` of another operator to which logs will be passed directly.
 - Only parsers and general purpose operators should be used.
 
+### Parsers with Embedded Operations
+
+Many parsers operators can be configured to embed certain followup operations such as timestamp and severity parsing. For more information, see [complex parsers](../../pkg/stanza/docs/types/parsers.md#complex-parsers).
+
 ### `multiline` configuration
 
 If set, the `multiline` configuration block instructs the `udplog` receiver to split log entries on a pattern other than newlines.


### PR DESCRIPTION
This is purely a documentation enhancement. It differentiates all parsers into two categories
and explains the common capabilities of each category.

Prerequisite to #13130