### PR TITLE
[receiver/syslog] Migrate config unmarshaling from yaml to mapstructure

### DIFF
--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -307,12 +307,9 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "syslog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["syslog"].CreateDefaultConfig().(*syslogreceiver.SysLogConfig)
-				cfg.Input = adapter.InputConfig{
-					"tcp": map[string]interface{}{
-						"listen_address": "0.0.0.0:0",
-					},
-					"protocol": "rfc5424",
-				}
+				cfg.TCP = syslogreceiver.CreateDefaultTCPConfigBase()
+				cfg.TCP.ListenAddress = "0.0.0.0:0"
+				cfg.Protocol = "rfc5424"
 				return cfg
 			},
 		},

--- a/pkg/stanza/operator/input/syslog/syslog.go
+++ b/pkg/stanza/operator/input/syslog/syslog.go
@@ -36,10 +36,10 @@ func NewConfig(operatorID string) *Config {
 }
 
 type Config struct {
-	helper.InputConfig `yaml:",inline"`
-	syslog.BaseConfig  `yaml:",inline"`
-	TCP                *tcp.BaseConfig `json:"tcp" yaml:"tcp"`
-	UDP                *udp.BaseConfig `json:"udp" yaml:"udp"`
+	helper.InputConfig `mapstructure:",squash" yaml:",inline"`
+	syslog.BaseConfig  `mapstructure:",squash" yaml:",inline"`
+	TCP                *tcp.BaseConfig `mapstructure:"tcp" json:"tcp" yaml:"tcp"`
+	UDP                *udp.BaseConfig `mapstructure:"udp" json:"udp" yaml:"udp"`
 }
 
 func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -59,8 +59,8 @@ func NewConfig(operatorID string) *Config {
 
 // Config is the configuration of a tcp input operator.
 type Config struct {
-	helper.InputConfig `yaml:",inline"`
-	BaseConfig         `yaml:",inline"`
+	helper.InputConfig `mapstructure:",squash" yaml:",inline"`
+	BaseConfig         `mapstructure:",squash" yaml:",inline"`
 }
 
 // BaseConfig is the detailed configuration of a tcp input operator.

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -54,8 +54,8 @@ func NewConfig(operatorID string) *Config {
 
 // Config is the configuration of a udp input operator.
 type Config struct {
-	helper.InputConfig `yaml:",inline"`
-	BaseConfig         `yaml:",inline"`
+	helper.InputConfig `mapstructure:",squash" yaml:",inline"`
+	BaseConfig         `mapstructure:",squash" yaml:",inline"`
 }
 
 // BaseConfig is the details configuration of a udp input operator.

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.58.0
 	go.opentelemetry.io/collector/pdata v0.58.0
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -45,6 +44,7 @@ require (
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/receiver/syslogreceiver/syslog.go
+++ b/receiver/syslogreceiver/syslog.go
@@ -80,18 +80,10 @@ func (cfg *SysLogConfig) Unmarshal(componentParser *confmap.Conf) error {
 	}
 
 	if componentParser.IsSet("tcp") {
-		cfg.TCP = CreateDefaultTCPConfigBase()
+		cfg.TCP = &tcp.NewConfig("tcp_input").BaseConfig
 	} else if componentParser.IsSet("udp") {
-		cfg.UDP = CreateDefaultUDPConfigBase()
+		cfg.UDP = &udp.NewConfig("udp_input").BaseConfig
 	}
 
 	return componentParser.UnmarshalExact(cfg)
-}
-
-func CreateDefaultTCPConfigBase() *tcp.BaseConfig {
-	return &tcp.NewConfig("tcp_input").BaseConfig
-}
-
-func CreateDefaultUDPConfigBase() *udp.BaseConfig {
-	return &udp.NewConfig("udp_input").BaseConfig
 }

--- a/receiver/syslogreceiver/syslog.go
+++ b/receiver/syslogreceiver/syslog.go
@@ -80,10 +80,18 @@ func (cfg *SysLogConfig) Unmarshal(componentParser *confmap.Conf) error {
 	}
 
 	if componentParser.IsSet("tcp") {
-		cfg.TCP = &tcp.NewConfig("tcp_input").BaseConfig
+		cfg.TCP = CreateDefaultTCPConfigBase()
 	} else if componentParser.IsSet("udp") {
-		cfg.UDP = &udp.NewConfig("udp_input").BaseConfig
+		cfg.UDP = CreateDefaultUDPConfigBase()
 	}
 
 	return componentParser.UnmarshalExact(cfg)
+}
+
+func CreateDefaultTCPConfigBase() *tcp.BaseConfig {
+	return &tcp.NewConfig("tcp_input").BaseConfig
+}
+
+func CreateDefaultUDPConfigBase() *udp.BaseConfig {
+	return &udp.NewConfig("udp_input").BaseConfig
 }


### PR DESCRIPTION
pkg/stanza historically used yaml for configuration unmarshaling.
The process of migrating to mapstructure was begun long ago but
was never completed. This PR switches syslog's underlying operators
to use mapstructure unmarshaling.