### PR TITLE
[pkg/stanza] Fix bug where original severity text was not preserved

### DIFF
--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -338,7 +338,11 @@ func convertInto(ent *entry.Entry, dest plog.LogRecord) {
 	}
 	dest.SetObservedTimestamp(pcommon.NewTimestampFromTime(ent.ObservedTimestamp))
 	dest.SetSeverityNumber(sevMap[ent.Severity])
-	dest.SetSeverityText(sevTextMap[ent.Severity])
+	if ent.SeverityText == "" {
+		dest.SetSeverityText(defaultSevTextMap[ent.Severity])
+	} else {
+		dest.SetSeverityText(ent.SeverityText)
+	}
 
 	insertToAttributeMap(ent.Attributes, dest.Attributes())
 	insertToAttributeVal(ent.Body, dest.Body())
@@ -510,32 +514,32 @@ var sevMap = map[entry.Severity]plog.SeverityNumber{
 	entry.Fatal4:  plog.SeverityNumberFATAL4,
 }
 
-var sevTextMap = map[entry.Severity]string{
+var defaultSevTextMap = map[entry.Severity]string{
 	entry.Default: "",
-	entry.Trace:   "Trace",
-	entry.Trace2:  "Trace2",
-	entry.Trace3:  "Trace3",
-	entry.Trace4:  "Trace4",
-	entry.Debug:   "Debug",
-	entry.Debug2:  "Debug2",
-	entry.Debug3:  "Debug3",
-	entry.Debug4:  "Debug4",
-	entry.Info:    "Info",
-	entry.Info2:   "Info2",
-	entry.Info3:   "Info3",
-	entry.Info4:   "Info4",
-	entry.Warn:    "Warn",
-	entry.Warn2:   "Warn2",
-	entry.Warn3:   "Warn3",
-	entry.Warn4:   "Warn4",
-	entry.Error:   "Error",
-	entry.Error2:  "Error2",
-	entry.Error3:  "Error3",
-	entry.Error4:  "Error4",
-	entry.Fatal:   "Fatal",
-	entry.Fatal2:  "Fatal2",
-	entry.Fatal3:  "Fatal3",
-	entry.Fatal4:  "Fatal4",
+	entry.Trace:   "TRACE",
+	entry.Trace2:  "TRACE2",
+	entry.Trace3:  "TRACE3",
+	entry.Trace4:  "TRACE4",
+	entry.Debug:   "DEBUG",
+	entry.Debug2:  "DEBUG2",
+	entry.Debug3:  "DEBUG3",
+	entry.Debug4:  "DEBUG4",
+	entry.Info:    "INFO",
+	entry.Info2:   "INFO2",
+	entry.Info3:   "INFO3",
+	entry.Info4:   "INFO4",
+	entry.Warn:    "WARN",
+	entry.Warn2:   "WARN2",
+	entry.Warn3:   "WARN3",
+	entry.Warn4:   "WARN4",
+	entry.Error:   "ERROR",
+	entry.Error2:  "ERROR2",
+	entry.Error3:  "ERROR3",
+	entry.Error4:  "ERROR4",
+	entry.Fatal:   "FATAL",
+	entry.Fatal2:  "FATAL2",
+	entry.Fatal3:  "FATAL3",
+	entry.Fatal4:  "FATAL4",
 }
 
 // pairSep is chosen to be an invalid byte for a utf-8 sequence

--- a/unreleased/pkg-stanza-sevtext-conv.yaml
+++ b/unreleased/pkg-stanza-sevtext-conv.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "`filelog`, `journald`, `syslog`, `tcplog`, `udplog`, and `windowseventlog` receivers"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a bug where original severity text was not preserved.
+
+# One or more tracking issues related to the change
+issues: [13263]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
When converting from entry.Entry to plog.Logs, the severity text
was not copied over. Instead, it was automatically assigned based
on the severity number.

This change does two things:
1. If the severity text is not empty, it is preserved
2. If the severity text is empty, it is assigned based on the severity
number. However, the values assigned were also incorrect, in that they
did not match the case defined in the data model. Previously, a
capitalized style (eg "Info") was used. Now, an all caps style is used.
It is rare that severity number is specified while severity text is not,
but the data model explicitly calls for this handling, so it is implemented
as such.

Resolves #13263 
Resolves #10278