### PR TITLE
[receiver/windowsevenlog] Migrate config unmarshaling to mapstructure

### DIFF
--- a/receiver/windowseventlogreceiver/go.mod
+++ b/receiver/windowseventlogreceiver/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.58.0
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -43,6 +42,7 @@ require (
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/receiver/windowseventlogreceiver/receiver_others.go
+++ b/receiver/windowseventlogreceiver/receiver_others.go
@@ -54,7 +54,6 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			Operators:        adapter.OperatorConfigs{},
 			Converter:        adapter.ConverterConfig{},
 		},
-		Input: adapter.InputConfig{},
 	}
 }
 
@@ -71,5 +70,4 @@ func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, 
 // WindowsLogConfig defines configuration for the windowseventlog receiver
 type WindowsLogConfig struct {
 	adapter.BaseConfig `mapstructure:",squash"`
-	Input              adapter.InputConfig `mapstructure:",remain"`
 }

--- a/receiver/windowseventlogreceiver/receiver_windows.go
+++ b/receiver/windowseventlogreceiver/receiver_windows.go
@@ -20,7 +20,6 @@ package windowseventlogreceiver // import "github.com/open-telemetry/opentelemet
 import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -54,7 +53,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			Operators:        adapter.OperatorConfigs{},
 			Converter:        adapter.ConverterConfig{},
 		},
-		Input: adapter.InputConfig{},
+		Config: *windows.NewConfig(),
 	}
 }
 
@@ -66,16 +65,11 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*WindowsLogConfig)
-	yamlBytes, _ := yaml.Marshal(logConfig.Input)
-	inputCfg := windows.NewConfig()
-	if err := yaml.Unmarshal(yamlBytes, &inputCfg); err != nil {
-		return nil, err
-	}
-	return &operator.Config{Builder: inputCfg}, nil
+	return &operator.Config{Builder: &logConfig.Config}, nil
 }
 
 // WindowsLogConfig defines configuration for the windowseventlog receiver
 type WindowsLogConfig struct {
+	windows.Config     `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`
-	Input              adapter.InputConfig `mapstructure:",remain"`
 }

--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/sys/windows/svc/eventlog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -62,11 +63,12 @@ func TestCreateWithInvalidInputConfig(t *testing.T) {
 
 	cfg := &WindowsLogConfig{
 		BaseConfig: adapter.BaseConfig{},
-		Input: adapter.InputConfig{
-			"start_at": "end",
-		},
+		Config: func() windows.Config {
+			c := windows.NewConfig()
+			c.StartAt = "middle"
+			return *c
+		}(),
 	}
-	cfg.Input["include"] = "not an array"
 
 	_, err := NewFactory().CreateLogsReceiver(
 		context.Background(),
@@ -139,9 +141,11 @@ func createTestConfig() *WindowsLogConfig {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Input: adapter.InputConfig{
-			"channel":  "application",
-			"start_at": "end",
-		},
+		Config: func() windows.Config {
+			c := windows.NewConfig()
+			c.Channel = "application"
+			c.StartAt = "end"
+			return *c
+		}(),
 	}
 }


### PR DESCRIPTION
pkg/stanza historically used yaml for configuration unmarshaling.
The process of migrating to mapstructure was begun long ago but
was never completed. This PR switches windowseventlog's underlying
operator to use mapstructure unmarshaling.