### PR TITLE
[pkg/stanza] Add NewConfigWithID func to each operator

### DIFF
--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -317,7 +317,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "syslog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["syslog"].CreateDefaultConfig().(*syslogreceiver.SysLogConfig)
-				cfg.TCP = &tcpop.NewConfig("tcp_input").BaseConfig
+				cfg.TCP = &tcpop.NewConfig().BaseConfig
 				cfg.TCP.ListenAddress = "0.0.0.0:0"
 				cfg.Protocol = "rfc5424"
 				return cfg

--- a/pkg/stanza/adapter/integration_test.go
+++ b/pkg/stanza/adapter/integration_test.go
@@ -41,7 +41,7 @@ func createNoopReceiver(workerCount int, nextConsumer consumer.Logs) (*receiver,
 	pipe, err := pipeline.Config{
 		Operators: []operator.Config{
 			{
-				Builder: noop.NewConfig(""),
+				Builder: noop.NewConfig(),
 			},
 		},
 	}.Build(zap.NewNop().Sugar())

--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -120,7 +120,7 @@ func (f TestReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Conf
 
 	// Allow tests to run without implementing input config
 	if testConfig.Input["type"] == nil {
-		return &operator.Config{Builder: noop.NewConfig("nop")}, nil
+		return &operator.Config{Builder: noop.NewConfig()}, nil
 	}
 
 	// Allow tests to explicitly prompt a failure

--- a/pkg/stanza/operator/input/file/benchmark_test.go
+++ b/pkg/stanza/operator/input/file/benchmark_test.go
@@ -56,7 +56,7 @@ func BenchmarkFileInput(b *testing.B) {
 				"file0.log",
 			},
 			config: func() *Config {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.Include = []string{
 					"file0.log",
 				}
@@ -72,7 +72,7 @@ func BenchmarkFileInput(b *testing.B) {
 				"file3.log",
 			},
 			config: func() *Config {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.Include = []string{"file*.log"}
 				return cfg
 			},
@@ -86,7 +86,7 @@ func BenchmarkFileInput(b *testing.B) {
 				"log1.log",
 			},
 			config: func() *Config {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.Include = []string{
 					"file*.log",
 					"log*.log",
@@ -103,7 +103,7 @@ func BenchmarkFileInput(b *testing.B) {
 				"file3.log",
 			},
 			config: func() *Config {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.Include = []string{
 					"file*.log",
 				}
@@ -117,7 +117,7 @@ func BenchmarkFileInput(b *testing.B) {
 				"file0.log",
 			},
 			config: func() *Config {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.Include = []string{
 					"file*.log",
 				}
@@ -131,7 +131,7 @@ func BenchmarkFileInput(b *testing.B) {
 				"file0.log",
 			},
 			config: func() *Config {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.Include = []string{
 					"file*.log",
 				}

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -22,14 +22,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "file_input"
+
 func init() {
-	operator.Register("file_input", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new input config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new input config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		InputConfig: helper.NewInputConfig(operatorID, "file_input"),
+		InputConfig: helper.NewInputConfig(operatorID, operatorType),
 		Config:      *fileconsumer.NewConfig(),
 	}
 }

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -45,7 +45,7 @@ func TestUnmarshal(t *testing.T) {
 		{
 			Name:      "id_custom",
 			ExpectErr: false,
-			Expect:    NewConfig("test_id"),
+			Expect:    NewConfigWithID("test_id"),
 		},
 		{
 			Name:      "include_one",
@@ -520,7 +520,7 @@ func TestBuild(t *testing.T) {
 	fakeOutput := testutil.NewMockOperator("fake")
 
 	basicConfig := func() *Config {
-		cfg := NewConfig("testfile")
+		cfg := NewConfigWithID("testfile")
 		cfg.OutputIDs = []string{"fake"}
 		cfg.Include = []string{"/var/log/testpath.*"}
 		cfg.Exclude = []string{"/var/log/testpath.ex*"}
@@ -747,11 +747,11 @@ func requireSamePreEmitOptions(t *testing.T, expect, actual []preEmitOption) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("file_input")
+	return NewConfig()
 }
 
 func NewTestConfig() *Config {
-	cfg := NewConfig("config_test")
+	cfg := NewConfigWithID("config_test")
 	cfg.Include = []string{"i1", "i2"}
 	cfg.Exclude = []string{"e1", "e2"}
 	cfg.Splitter = helper.NewSplitterConfig()

--- a/pkg/stanza/operator/input/file/util_test.go
+++ b/pkg/stanza/operator/input/file/util_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func newDefaultConfig(tempDir string) *Config {
-	cfg := NewConfig("testfile")
+	cfg := NewConfigWithID("testfile")
 	cfg.PollInterval = helper.Duration{Duration: 200 * time.Millisecond}
 	cfg.StartAt = "beginning"
 	cfg.Include = []string{fmt.Sprintf("%s/*", tempDir)}

--- a/pkg/stanza/operator/input/journald/journald.go
+++ b/pkg/stanza/operator/input/journald/journald.go
@@ -36,13 +36,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "journald_input"
+
 func init() {
-	operator.Register("journald_input", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
-func NewConfig(operatorID string) *Config {
+// NewConfig creates a new input config with default values
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new input config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		InputConfig: helper.NewInputConfig(operatorID, "journald_input"),
+		InputConfig: helper.NewInputConfig(operatorID, operatorType),
 		StartAt:     "end",
 		Priority:    "info",
 	}

--- a/pkg/stanza/operator/input/journald/journald_test.go
+++ b/pkg/stanza/operator/input/journald/journald_test.go
@@ -47,7 +47,7 @@ func (f *fakeJournaldCmd) StdoutPipe() (io.ReadCloser, error) {
 }
 
 func TestInputJournald(t *testing.T) {
-	cfg := NewConfig("my_journald_input")
+	cfg := NewConfigWithID("my_journald_input")
 	cfg.OutputIDs = []string{"output"}
 
 	op, err := cfg.Build(testutil.Logger(t))
@@ -118,7 +118,7 @@ func TestInputJournald(t *testing.T) {
 }
 
 func TestConfig(t *testing.T) {
-	expect := NewConfig("my_journald_input")
+	expect := NewConfigWithID("my_journald_input")
 
 	input := map[string]interface{}{
 		"id":         "my_journald_input",

--- a/pkg/stanza/operator/input/syslog/syslog.go
+++ b/pkg/stanza/operator/input/syslog/syslog.go
@@ -26,12 +26,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/syslog"
 )
 
+const operatorType = "syslog_input"
+
 func init() {
-	operator.Register("syslog_input", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
-func NewConfig(operatorID string) *Config {
+
+// NewConfig creates a new input config with default values
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new input config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		InputConfig: helper.NewInputConfig(operatorID, "syslog_input"),
+		InputConfig: helper.NewInputConfig(operatorID, operatorType),
 	}
 }
 
@@ -48,7 +57,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		return nil, err
 	}
 
-	syslogParserCfg := syslog.NewConfig(inputBase.ID() + "_internal_tcp")
+	syslogParserCfg := syslog.NewConfigWithID(inputBase.ID() + "_internal_tcp")
 	syslogParserCfg.BaseConfig = c.BaseConfig
 	syslogParserCfg.SetID(inputBase.ID() + "_internal_parser")
 	syslogParserCfg.OutputIDs = c.OutputIDs
@@ -58,7 +67,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	}
 
 	if c.TCP != nil {
-		tcpInputCfg := tcp.NewConfig(inputBase.ID() + "_internal_tcp")
+		tcpInputCfg := tcp.NewConfigWithID(inputBase.ID() + "_internal_tcp")
 		tcpInputCfg.BaseConfig = *c.TCP
 
 		tcpInput, err := tcpInputCfg.Build(logger)
@@ -79,7 +88,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	}
 
 	if c.UDP != nil {
-		udpInputCfg := udp.NewConfig(inputBase.ID() + "_internal_udp")
+		udpInputCfg := udp.NewConfigWithID(inputBase.ID() + "_internal_udp")
 		udpInputCfg.BaseConfig = *c.UDP
 
 		udpInput, err := udpInputCfg.Build(logger)

--- a/pkg/stanza/operator/input/syslog/syslog_test.go
+++ b/pkg/stanza/operator/input/syslog/syslog_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestInput(t *testing.T) {
 	basicConfig := func() *syslog.Config {
-		cfg := syslog.NewConfig("test_syslog_parser")
+		cfg := syslog.NewConfigWithID("test_syslog_parser")
 		return cfg
 	}
 
@@ -98,7 +98,7 @@ func InputTest(t *testing.T, cfg *Config, tc syslog.Case) {
 
 func TestSyslogIDs(t *testing.T) {
 	basicConfig := func() *syslog.BaseConfig {
-		cfg := syslog.NewConfig("test_syslog_parser")
+		cfg := syslog.NewConfigWithID("test_syslog_parser")
 		cfg.Protocol = "RFC3164"
 		return &cfg.BaseConfig
 	}
@@ -128,18 +128,18 @@ func TestSyslogIDs(t *testing.T) {
 }
 
 func NewConfigWithTCP(syslogCfg *syslog.BaseConfig) *Config {
-	cfg := NewConfig("test_syslog")
+	cfg := NewConfigWithID("test_syslog")
 	cfg.BaseConfig = *syslogCfg
-	cfg.TCP = &tcp.NewConfig("test_syslog_tcp").BaseConfig
+	cfg.TCP = &tcp.NewConfigWithID("test_syslog_tcp").BaseConfig
 	cfg.TCP.ListenAddress = ":14201"
 	cfg.OutputIDs = []string{"fake"}
 	return cfg
 }
 
 func NewConfigWithUDP(syslogCfg *syslog.BaseConfig) *Config {
-	cfg := NewConfig("test_syslog")
+	cfg := NewConfigWithID("test_syslog")
 	cfg.BaseConfig = *syslogCfg
-	cfg.UDP = &udp.NewConfig("test_syslog_udp").BaseConfig
+	cfg.UDP = &udp.NewConfigWithID("test_syslog_udp").BaseConfig
 	cfg.UDP.ListenAddress = ":12032"
 	cfg.OutputIDs = []string{"fake"}
 	return cfg

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -33,6 +33,8 @@ import (
 )
 
 const (
+	operatorType = "tcp_input"
+
 	// minMaxLogSize is the minimal size which can be used for buffering
 	// TCP input
 	minMaxLogSize = 64 * 1024
@@ -43,13 +45,18 @@ const (
 )
 
 func init() {
-	operator.Register("tcp_input", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
-// NewConfig creates a new TCP input config with default values
-func NewConfig(operatorID string) *Config {
+// NewConfigWithID creates a new TCP input config with default values
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new TCP input config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		InputConfig: helper.NewInputConfig(operatorID, "tcp_input"),
+		InputConfig: helper.NewInputConfig(operatorID, operatorType),
 		BaseConfig: BaseConfig{
 			Multiline: helper.NewMultilineConfig(),
 			Encoding:  helper.NewEncodingConfig(),

--- a/pkg/stanza/operator/input/tcp/tcp_test.go
+++ b/pkg/stanza/operator/input/tcp/tcp_test.go
@@ -87,7 +87,7 @@ zv9WEy+9p05Aet+12x3dzRu93+yRIEYbSZ35NOUWfQ+gspF5rGgpxA==
 
 func tcpInputTest(input []byte, expected []string) func(t *testing.T) {
 	return func(t *testing.T) {
-		cfg := NewConfig("test_id")
+		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = ":0"
 
 		op, err := cfg.Build(testutil.Logger(t))
@@ -135,7 +135,7 @@ func tcpInputTest(input []byte, expected []string) func(t *testing.T) {
 
 func tcpInputAttributesTest(input []byte, expected []string) func(t *testing.T) {
 	return func(t *testing.T) {
-		cfg := NewConfig("test_id")
+		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
@@ -216,7 +216,7 @@ func tlsInputTest(input []byte, expected []string) func(t *testing.T) {
 		require.NoError(t, err)
 		f.Close()
 
-		cfg := NewConfig("test_id")
+		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = ":0"
 		cfg.TLS = helper.NewTLSServerConfig(&configtls.TLSServerSetting{
 			TLSSetting: configtls.TLSSetting{
@@ -346,7 +346,7 @@ func TestBuild(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := NewConfig("test_id")
+			cfg := NewConfigWithID("test_id")
 			cfg.ListenAddress = tc.inputBody.ListenAddress
 			cfg.MaxLogSize = tc.inputBody.MaxLogSize
 			cfg.TLS = tc.inputBody.TLS
@@ -393,7 +393,7 @@ func TestFailToBind(t *testing.T) {
 	}
 
 	var startTCP = func(int) (*Input, error) {
-		cfg := NewConfig("test_id")
+		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
 		op, err := cfg.Build(testutil.Logger(t))
 		require.NoError(t, err)
@@ -419,7 +419,7 @@ func TestFailToBind(t *testing.T) {
 }
 
 func BenchmarkTCPInput(b *testing.B) {
-	cfg := NewConfig("test_id")
+	cfg := NewConfigWithID("test_id")
 	cfg.ListenAddress = ":0"
 
 	op, err := cfg.Build(testutil.Logger(b))

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -30,18 +30,25 @@ import (
 )
 
 const (
+	operatorType = "udp_input"
+
 	// Maximum UDP packet size
 	MaxUDPSize = 64 * 1024
 )
 
 func init() {
-	operator.Register("udp_input", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new UDP input config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new UDP input config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		InputConfig: helper.NewInputConfig(operatorID, "udp_input"),
+		InputConfig: helper.NewInputConfig(operatorID, operatorType),
 		BaseConfig: BaseConfig{
 			Encoding: helper.NewEncodingConfig(),
 			Multiline: helper.MultilineConfig{

--- a/pkg/stanza/operator/input/udp/udp_test.go
+++ b/pkg/stanza/operator/input/udp/udp_test.go
@@ -31,7 +31,7 @@ import (
 
 func udpInputTest(input []byte, expected []string) func(t *testing.T) {
 	return func(t *testing.T) {
-		cfg := NewConfig("test_input")
+		cfg := NewConfigWithID("test_input")
 		cfg.ListenAddress = ":0"
 
 		op, err := cfg.Build(testutil.Logger(t))
@@ -81,7 +81,7 @@ func udpInputTest(input []byte, expected []string) func(t *testing.T) {
 
 func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) {
 	return func(t *testing.T) {
-		cfg := NewConfig("test_input")
+		cfg := NewConfigWithID("test_input")
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
@@ -180,7 +180,7 @@ func TestFailToBind(t *testing.T) {
 	}
 
 	var startUDP = func(int) (*Input, error) {
-		cfg := NewConfig("test_input")
+		cfg := NewConfigWithID("test_input")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
 
 		op, err := cfg.Build(testutil.Logger(t))
@@ -212,7 +212,7 @@ func TestFailToBind(t *testing.T) {
 }
 
 func BenchmarkUDPInput(b *testing.B) {
-	cfg := NewConfig("test_id")
+	cfg := NewConfigWithID("test_id")
 	cfg.ListenAddress = ":0"
 
 	op, err := cfg.Build(testutil.Logger(b))

--- a/pkg/stanza/operator/input/windows/operator.go
+++ b/pkg/stanza/operator/input/windows/operator.go
@@ -29,8 +29,27 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "windows_eventlog_input"
+
 func init() {
-	operator.Register("windows_eventlog_input", func() operator.Builder { return NewConfig() })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
+}
+
+// NewConfig will return an event log config with default values.
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfig will return an event log config with default values.
+func NewConfigWithID(operatorID string) *Config {
+	return &Config{
+		InputConfig: helper.NewInputConfig(operatorID, operatorType),
+		MaxReads:    100,
+		StartAt:     "end",
+		PollInterval: helper.Duration{
+			Duration: 1 * time.Second,
+		},
+	}
 }
 
 // Config is the configuration of a windows event log operator.
@@ -69,18 +88,6 @@ func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		startAt:       c.StartAt,
 		pollInterval:  c.PollInterval,
 	}, nil
-}
-
-// NewConfig will return an event log config with default values.
-func NewConfig() *Config {
-	return &Config{
-		InputConfig: helper.NewInputConfig("", "windows_eventlog_input"),
-		MaxReads:    100,
-		StartAt:     "end",
-		PollInterval: helper.Duration{
-			Duration: 1 * time.Second,
-		},
-	}
 }
 
 // Input is an operator that creates entries using the windows event log api.

--- a/pkg/stanza/operator/input/windows/operator_test.go
+++ b/pkg/stanza/operator/input/windows/operator_test.go
@@ -29,7 +29,7 @@ func TestConfig(t *testing.T) {
 	expect := NewConfig()
 
 	input := map[string]interface{}{
-		"id":            "",
+		"id":            "windows_eventlog_input",
 		"type":          "windows_eventlog_input",
 		"max_reads":     100,
 		"start_at":      "end",

--- a/pkg/stanza/operator/parser/csv/config_test.go
+++ b/pkg/stanza/operator/parser/csv/config_test.go
@@ -86,5 +86,5 @@ func TestConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("json_parser")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/parser/csv/csv.go
+++ b/pkg/stanza/operator/parser/csv/csv.go
@@ -28,14 +28,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "csv_parser"
+
 func init() {
-	operator.Register("csv_parser", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new csv parser config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new csv parser config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		ParserConfig: helper.NewParserConfig(operatorID, "csv_parser"),
+		ParserConfig: helper.NewParserConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/parser/csv/csv_test.go
+++ b/pkg/stanza/operator/parser/csv/csv_test.go
@@ -28,7 +28,7 @@ import (
 var testHeader = "name,sev,msg"
 
 func newTestParser(t *testing.T) *Parser {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
 	op, err := cfg.Build(testutil.Logger(t))
 	require.NoError(t, err)
@@ -36,7 +36,7 @@ func newTestParser(t *testing.T) *Parser {
 }
 
 func TestParserBuildFailure(t *testing.T) {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
 	_, err := cfg.Build(testutil.Logger(t))
 	require.Error(t, err)
@@ -44,7 +44,7 @@ func TestParserBuildFailure(t *testing.T) {
 }
 
 func TestParserBuildFailureInvalidDelimiter(t *testing.T) {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
 	cfg.FieldDelimiter = ";;"
 	_, err := cfg.Build(testutil.Logger(t))
@@ -53,7 +53,7 @@ func TestParserBuildFailureInvalidDelimiter(t *testing.T) {
 }
 
 func TestParserBuildFailureBadHeaderConfig(t *testing.T) {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	cfg.Header = "testheader"
 	cfg.HeaderAttribute = "testheader"
 	_, err := cfg.Build(testutil.Logger(t))
@@ -615,7 +615,7 @@ func TestParserCSV(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := NewConfig("test")
+			cfg := NewConfigWithID("test")
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
@@ -858,7 +858,7 @@ cc""",dddd,eeee`,
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := NewConfig("test")
+			cfg := NewConfigWithID("test")
 			cfg.ParseTo = entry.NewBodyField()
 			cfg.OutputIDs = []string{"fake"}
 			cfg.Header = "A,B,C,D,E"
@@ -881,7 +881,7 @@ cc""",dddd,eeee`,
 
 func TestParserCSVInvalidJSONInput(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		cfg := NewConfig("test")
+		cfg := NewConfigWithID("test")
 		cfg.OutputIDs = []string{"fake"}
 		cfg.Header = testHeader
 
@@ -901,7 +901,7 @@ func TestParserCSVInvalidJSONInput(t *testing.T) {
 
 func TestBuildParserCSV(t *testing.T) {
 	newBasicParser := func() *Config {
-		cfg := NewConfig("test")
+		cfg := NewConfigWithID("test")
 		cfg.OutputIDs = []string{"test"}
 		cfg.Header = "name,position,number"
 		cfg.FieldDelimiter = ","

--- a/pkg/stanza/operator/parser/json/config_test.go
+++ b/pkg/stanza/operator/parser/json/config_test.go
@@ -103,5 +103,5 @@ func TestConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("json_parser")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/parser/json/json.go
+++ b/pkg/stanza/operator/parser/json/json.go
@@ -26,14 +26,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "json_parser"
+
 func init() {
-	operator.Register("json_parser", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new JSON parser config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new JSON parser config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		ParserConfig: helper.NewParserConfig(operatorID, "json_parser"),
+		ParserConfig: helper.NewParserConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/parser/json/json_test.go
+++ b/pkg/stanza/operator/parser/json/json_test.go
@@ -29,21 +29,21 @@ import (
 )
 
 func newTestParser(t *testing.T) *Parser {
-	config := NewConfig("test")
+	config := NewConfigWithID("test")
 	op, err := config.Build(testutil.Logger(t))
 	require.NoError(t, err)
 	return op.(*Parser)
 }
 
 func TestConfigBuild(t *testing.T) {
-	config := NewConfig("test")
+	config := NewConfigWithID("test")
 	op, err := config.Build(testutil.Logger(t))
 	require.NoError(t, err)
 	require.IsType(t, &Parser{}, op)
 }
 
 func TestConfigBuildFailure(t *testing.T) {
-	config := NewConfig("test")
+	config := NewConfigWithID("test")
 	config.OnError = "invalid_on_error"
 	_, err := config.Build(testutil.Logger(t))
 	require.Error(t, err)
@@ -151,7 +151,7 @@ func TestParser(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := NewConfig("test")
+			cfg := NewConfigWithID("test")
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
@@ -173,7 +173,7 @@ func TestParser(t *testing.T) {
 }
 
 func TestJsonParserConfig(t *testing.T) {
-	expect := NewConfig("test")
+	expect := NewConfigWithID("test")
 	expect.ParseFrom = entry.NewBodyField("from")
 	expect.ParseTo = entry.NewBodyField("to")
 

--- a/pkg/stanza/operator/parser/regex/config_test.go
+++ b/pkg/stanza/operator/parser/regex/config_test.go
@@ -121,5 +121,5 @@ func TestParserGoldenConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("regex_parser")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/parser/regex/regex.go
+++ b/pkg/stanza/operator/parser/regex/regex.go
@@ -27,14 +27,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "regex_parser"
+
 func init() {
-	operator.Register("regex_parser", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new regex parser config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new regex parser config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		ParserConfig: helper.NewParserConfig(operatorID, "regex_parser"),
+		ParserConfig: helper.NewParserConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/parser/regex/regex_test.go
+++ b/pkg/stanza/operator/parser/regex/regex_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func newTestParser(t *testing.T, regex string, cacheSize uint16) *Parser {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	cfg.Regex = regex
 	if cacheSize > 0 {
 		cfg.Cache.Size = cacheSize
@@ -43,7 +43,7 @@ func newTestParser(t *testing.T, regex string, cacheSize uint16) *Parser {
 }
 
 func TestParserBuildFailure(t *testing.T) {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
 	_, err := cfg.Build(testutil.Logger(t))
 	require.Error(t, err)
@@ -141,7 +141,7 @@ func TestParserRegex(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := NewConfig("test")
+			cfg := NewConfigWithID("test")
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
@@ -165,7 +165,7 @@ func TestParserRegex(t *testing.T) {
 
 func TestBuildParserRegex(t *testing.T) {
 	newBasicParser := func() *Config {
-		cfg := NewConfig("test")
+		cfg := NewConfigWithID("test")
 		cfg.OutputIDs = []string{"test"}
 		cfg.Regex = "(?P<all>.*)"
 		return cfg
@@ -209,7 +209,7 @@ func TestBuildParserRegex(t *testing.T) {
 }
 
 func TestConfig(t *testing.T) {
-	expect := NewConfig("test")
+	expect := NewConfigWithID("test")
 	expect.Regex = "test123"
 	expect.ParseFrom = entry.NewBodyField("from")
 	expect.ParseTo = entry.NewBodyField("to")
@@ -269,7 +269,7 @@ const benchParsePattern = `^(?P<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9
 var benchParsePatterns = benchParseInput()
 
 func newTestBenchParser(t *testing.T, cacheSize uint16) *Parser {
-	cfg := NewConfig("bench")
+	cfg := NewConfigWithID("bench")
 	cfg.Regex = benchParsePattern
 	cfg.Cache.Size = cacheSize
 

--- a/pkg/stanza/operator/parser/scope/scope_name.go
+++ b/pkg/stanza/operator/parser/scope/scope_name.go
@@ -24,14 +24,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "scope_name_parser"
+
 func init() {
-	operator.Register("scope_name_parser", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new logger name parser config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new logger name parser config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "scope_name_parser"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 		ScopeNameParser:   helper.NewScopeNameParser(),
 	}
 }

--- a/pkg/stanza/operator/parser/scope/scope_name_test.go
+++ b/pkg/stanza/operator/parser/scope/scope_name_test.go
@@ -39,7 +39,7 @@ func TestScopeNameParser(t *testing.T) {
 		{
 			name: "root_string",
 			config: func() *Config {
-				cfg := NewConfig("test")
+				cfg := NewConfigWithID("test")
 				cfg.ParseFrom = entry.NewBodyField()
 				return cfg
 			}(),
@@ -60,7 +60,7 @@ func TestScopeNameParser(t *testing.T) {
 		{
 			name: "nondestructive_error",
 			config: func() *Config {
-				cfg := NewConfig("test")
+				cfg := NewConfigWithID("test")
 				cfg.ParseFrom = entry.NewBodyField()
 				return cfg
 			}(),
@@ -81,7 +81,7 @@ func TestScopeNameParser(t *testing.T) {
 		{
 			name: "nonroot_string",
 			config: func() *Config {
-				cfg := NewConfig("test")
+				cfg := NewConfigWithID("test")
 				cfg.ParseFrom = entry.NewBodyField("logger")
 				return cfg
 			}(),

--- a/pkg/stanza/operator/parser/severity/severity.go
+++ b/pkg/stanza/operator/parser/severity/severity.go
@@ -24,14 +24,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "severity_parser"
+
 func init() {
-	operator.Register("severity_parser", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new severity parser config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new severity parser config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "severity_parser"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 		SeverityConfig:    helper.NewSeverityConfig(),
 	}
 }

--- a/pkg/stanza/operator/parser/severity/severity_test.go
+++ b/pkg/stanza/operator/parser/severity/severity_test.go
@@ -262,7 +262,7 @@ func runSeverityParseTest(cfg *Config, ent *entry.Entry, buildErr bool, parseErr
 }
 
 func parseSeverityTestConfig(parseFrom entry.Field, preset string, mapping map[interface{}]interface{}) *Config {
-	cfg := NewConfig("test_operator_id")
+	cfg := NewConfigWithID("test_operator_id")
 	cfg.OutputIDs = []string{"output1"}
 	cfg.SeverityConfig = helper.SeverityConfig{
 		ParseFrom: &parseFrom,
@@ -279,7 +279,7 @@ func makeTestEntry(t *testing.T, field entry.Field, value interface{}) *entry.En
 }
 
 func TestConfig(t *testing.T) {
-	expect := NewConfig("test")
+	expect := NewConfigWithID("test")
 	parseFrom := entry.NewBodyField("from")
 	expect.ParseFrom = &parseFrom
 	expect.Preset = "test"

--- a/pkg/stanza/operator/parser/syslog/syslog.go
+++ b/pkg/stanza/operator/parser/syslog/syslog.go
@@ -29,17 +29,26 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
-const RFC3164 = "rfc3164"
-const RFC5424 = "rfc5424"
+const (
+	operatorType = "syslog_parser"
+
+	RFC3164 = "rfc3164"
+	RFC5424 = "rfc5424"
+)
 
 func init() {
-	operator.Register("syslog_parser", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new syslog parser config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new syslog parser config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		ParserConfig: helper.NewParserConfig(operatorID, "syslog_parser"),
+		ParserConfig: helper.NewParserConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/parser/syslog/syslog_test.go
+++ b/pkg/stanza/operator/parser/syslog/syslog_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func basicConfig() *Config {
-	cfg := NewConfig("test_operator_id")
+	cfg := NewConfigWithID("test_operator_id")
 	cfg.OutputIDs = []string{"fake"}
 	return cfg
 }
@@ -92,7 +92,7 @@ func TestSyslogParseRFC5424_SDNameTooLong(t *testing.T) {
 }
 
 func TestConfig(t *testing.T) {
-	expect := NewConfig("test")
+	expect := NewConfigWithID("test")
 	expect.Protocol = RFC3164
 	expect.ParseFrom = entry.NewBodyField("from")
 	expect.ParseTo = entry.NewBodyField("to")
@@ -128,7 +128,7 @@ parse_to: body.to`
 }
 
 func TestParserInvalidLocation(t *testing.T) {
-	config := NewConfig("test")
+	config := NewConfigWithID("test")
 	config.Location = "not_a_location"
 	config.Protocol = RFC3164
 

--- a/pkg/stanza/operator/parser/time/time.go
+++ b/pkg/stanza/operator/parser/time/time.go
@@ -24,14 +24,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "time_parser"
+
 func init() {
-	operator.Register("time_parser", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new time parser config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new time parser config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "time_parser"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 		TimeParser:        helper.NewTimeParser(),
 	}
 }

--- a/pkg/stanza/operator/parser/time/time_test.go
+++ b/pkg/stanza/operator/parser/time/time_test.go
@@ -57,7 +57,7 @@ func TestBuild(t *testing.T) {
 		{
 			"basic",
 			func() (*Config, error) {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				parseFrom, err := entry.NewField("body.app_time")
 				if err != nil {
 					return cfg, err
@@ -98,7 +98,7 @@ func TestProcess(t *testing.T) {
 		{
 			name: "promote",
 			config: func() (*Config, error) {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				parseFrom, err := entry.NewField("body.app_time")
 				if err != nil {
 					return nil, err
@@ -544,7 +544,7 @@ func runLossyTimeParseTest(_ *testing.T, cfg *Config, ent *entry.Entry, buildErr
 }
 
 func parseTimeTestConfig(layoutType, layout string, parseFrom entry.Field) *Config {
-	cfg := NewConfig("test_operator_id")
+	cfg := NewConfigWithID("test_operator_id")
 	cfg.OutputIDs = []string{"output1"}
 	cfg.TimeParser = helper.TimeParser{
 		LayoutType: layoutType,

--- a/pkg/stanza/operator/parser/trace/config_test.go
+++ b/pkg/stanza/operator/parser/trace/config_test.go
@@ -81,5 +81,5 @@ func TestConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("trace_parser")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/parser/trace/trace.go
+++ b/pkg/stanza/operator/parser/trace/trace.go
@@ -24,14 +24,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "trace_parser"
+
 func init() {
-	operator.Register("trace_parser", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new trace parser config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new trace parser config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "trace_parser"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 		TraceParser:       helper.NewTraceParser(),
 	}
 }

--- a/pkg/stanza/operator/parser/trace/trace_test.go
+++ b/pkg/stanza/operator/parser/trace/trace_test.go
@@ -32,7 +32,7 @@ func TestInit(t *testing.T) {
 	require.Equal(t, "trace_parser", builder().Type())
 }
 func TestDefaultParser(t *testing.T) {
-	traceParserConfig := NewConfig("")
+	traceParserConfig := NewConfig()
 	_, err := traceParserConfig.Build(testutil.Logger(t))
 	require.NoError(t, err)
 }
@@ -53,7 +53,7 @@ func TestBuild(t *testing.T) {
 		{
 			"default",
 			func() (*Config, error) {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				return cfg, nil
 			},
 			false,
@@ -62,7 +62,7 @@ func TestBuild(t *testing.T) {
 			"spanid",
 			func() (*Config, error) {
 				parseFrom := entry.NewBodyField("app_span_id")
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.SpanID.ParseFrom = &parseFrom
 				return cfg, nil
 			},
@@ -72,7 +72,7 @@ func TestBuild(t *testing.T) {
 			"traceid",
 			func() (*Config, error) {
 				parseFrom := entry.NewBodyField("app_trace_id")
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.TraceID.ParseFrom = &parseFrom
 				return cfg, nil
 			},
@@ -82,7 +82,7 @@ func TestBuild(t *testing.T) {
 			"trace-flags",
 			func() (*Config, error) {
 				parseFrom := entry.NewBodyField("trace-flags-field")
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.TraceFlags.ParseFrom = &parseFrom
 				return cfg, nil
 			},
@@ -119,7 +119,7 @@ func TestProcess(t *testing.T) {
 		{
 			"no-op",
 			func() (operator.Operator, error) {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				return cfg.Build(testutil.Logger(t))
 			},
 			&entry.Entry{
@@ -132,7 +132,7 @@ func TestProcess(t *testing.T) {
 		{
 			"all",
 			func() (operator.Operator, error) {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				spanFrom := entry.NewBodyField("app_span_id")
 				traceFrom := entry.NewBodyField("app_trace_id")
 				flagsFrom := entry.NewBodyField("trace_flags_field")
@@ -268,7 +268,7 @@ func TestTraceParserParse(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			traceParserConfig := NewConfig("")
+			traceParserConfig := NewConfigWithID("")
 			_, _ = traceParserConfig.Build(testutil.Logger(t))
 			e := entry.New()
 			e.Body = tc.inputRecord

--- a/pkg/stanza/operator/parser/uri/config_test.go
+++ b/pkg/stanza/operator/parser/uri/config_test.go
@@ -93,5 +93,5 @@ func TestParserGoldenConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("uri_parser")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/parser/uri/uri.go
+++ b/pkg/stanza/operator/parser/uri/uri.go
@@ -27,14 +27,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "uri_parser"
+
 func init() {
-	operator.Register("uri_parser", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new uri parser config with default values.
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new uri parser config with default values.
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		ParserConfig: helper.NewParserConfig(operatorID, "uri_parser"),
+		ParserConfig: helper.NewParserConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/parser/uri/uri_test.go
+++ b/pkg/stanza/operator/parser/uri/uri_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newTestParser(t *testing.T) *Parser {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	op, err := cfg.Build(testutil.Logger(t))
 	require.NoError(t, err)
 	return op.(*Parser)
@@ -42,7 +42,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestParserBuildFailure(t *testing.T) {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
 	_, err := cfg.Build(testutil.Logger(t))
 	require.Error(t, err)
@@ -80,7 +80,7 @@ func TestProcess(t *testing.T) {
 		{
 			"default",
 			func() (operator.Operator, error) {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				return cfg.Build(testutil.Logger(t))
 			},
 			&entry.Entry{
@@ -104,7 +104,7 @@ func TestProcess(t *testing.T) {
 		{
 			"parse-to",
 			func() (operator.Operator, error) {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
 				cfg.ParseTo = entry.NewBodyField("url2")
 				return cfg.Build(testutil.Logger(t))
@@ -134,7 +134,7 @@ func TestProcess(t *testing.T) {
 		{
 			"parse-from",
 			func() (operator.Operator, error) {
-				cfg := NewConfig("test_id")
+				cfg := NewConfigWithID("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
 				return cfg.Build(testutil.Logger(t))
 			},
@@ -496,7 +496,7 @@ func TestParseURI(t *testing.T) {
 
 func TestBuildParserURL(t *testing.T) {
 	newBasicParser := func() *Config {
-		cfg := NewConfig("test")
+		cfg := NewConfigWithID("test")
 		cfg.OutputIDs = []string{"test"}
 		return cfg
 	}
@@ -709,7 +709,7 @@ func BenchmarkQueryParamValuesToMap(b *testing.B) {
 }
 
 func TestConfig(t *testing.T) {
-	expect := NewConfig("test")
+	expect := NewConfigWithID("test")
 	expect.ParseFrom = entry.NewBodyField("from")
 	expect.ParseTo = entry.NewBodyField("to")
 

--- a/pkg/stanza/operator/transformer/add/add.go
+++ b/pkg/stanza/operator/transformer/add/add.go
@@ -28,14 +28,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "add"
+
 func init() {
-	operator.Register("add", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new add operator config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new add operator config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "add"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/transformer/add/config_test.go
+++ b/pkg/stanza/operator/transformer/add/config_test.go
@@ -156,5 +156,5 @@ func TestGoldenConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("add")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/transformer/copy/config_test.go
+++ b/pkg/stanza/operator/transformer/copy/config_test.go
@@ -86,5 +86,5 @@ func TestGoldenConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("copy")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/transformer/copy/copy.go
+++ b/pkg/stanza/operator/transformer/copy/copy.go
@@ -25,14 +25,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "copy"
+
 func init() {
-	operator.Register("copy", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new copy operator config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new copy operator config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "copy"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/transformer/filter/filter.go
+++ b/pkg/stanza/operator/transformer/filter/filter.go
@@ -29,18 +29,26 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "filter"
+
+var (
+	upperBound = big.NewInt(1000)
+	randInt    = rand.Int // allow override for testing
+)
+
 func init() {
-	operator.Register("filter", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
-var upperBound = big.NewInt(1000)
-
-var randInt = rand.Int // allow override for testing
-
 // NewConfig creates a filter operator config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a filter operator config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "filter"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 		DropRatio:         1,
 	}
 }

--- a/pkg/stanza/operator/transformer/filter/filter_test.go
+++ b/pkg/stanza/operator/transformer/filter/filter_test.go
@@ -167,7 +167,7 @@ func TestTransformer(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := NewConfig("test")
+			cfg := NewConfigWithID("test")
 			cfg.Expression = tc.expression
 
 			op, err := cfg.Build(testutil.Logger(t))
@@ -192,7 +192,7 @@ func TestTransformer(t *testing.T) {
 }
 
 func TestFilterDropRatio(t *testing.T) {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	cfg.Expression = `body.message == "test_message"`
 	cfg.DropRatio = 0.5
 	op, err := cfg.Build(testutil.Logger(t))

--- a/pkg/stanza/operator/transformer/flatten/config_test.go
+++ b/pkg/stanza/operator/transformer/flatten/config_test.go
@@ -128,5 +128,5 @@ func configFromFileViaMapstructure(file string) (*Config, error) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("flatten")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/transformer/flatten/flatten.go
+++ b/pkg/stanza/operator/transformer/flatten/flatten.go
@@ -27,14 +27,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "flatten"
+
 func init() {
-	operator.Register("flatten", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new flatten operator config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new flatten operator config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "flatten"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/transformer/move/config_test.go
+++ b/pkg/stanza/operator/transformer/move/config_test.go
@@ -168,5 +168,5 @@ func TestGoldenConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("move")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/transformer/move/move.go
+++ b/pkg/stanza/operator/transformer/move/move.go
@@ -25,14 +25,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "move"
+
 func init() {
-	operator.Register("move", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new move operator config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new move operator config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "move"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/transformer/move/move_test.go
+++ b/pkg/stanza/operator/transformer/move/move_test.go
@@ -1,5 +1,3 @@
-package move
-
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@ package move
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+package move
 
 import (
 	"context"

--- a/pkg/stanza/operator/transformer/noop/noop.go
+++ b/pkg/stanza/operator/transformer/noop/noop.go
@@ -24,14 +24,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "noop"
+
 func init() {
-	operator.Register("noop", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new noop operator config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new noop operator config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "noop"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/transformer/noop/noop_test.go
+++ b/pkg/stanza/operator/transformer/noop/noop_test.go
@@ -26,21 +26,21 @@ import (
 )
 
 func TestBuildValid(t *testing.T) {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	op, err := cfg.Build(testutil.Logger(t))
 	require.NoError(t, err)
 	require.IsType(t, &Transformer{}, op)
 }
 
 func TestBuildInvalid(t *testing.T) {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	_, err := cfg.Build(nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "build context is missing a logger")
 }
 
 func TestProcess(t *testing.T) {
-	cfg := NewConfig("test")
+	cfg := NewConfigWithID("test")
 	cfg.OutputIDs = []string{"fake"}
 	op, err := cfg.Build(testutil.Logger(t))
 	require.NoError(t, err)

--- a/pkg/stanza/operator/transformer/recombine/config_test.go
+++ b/pkg/stanza/operator/transformer/recombine/config_test.go
@@ -90,5 +90,5 @@ func TestConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("recombine")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/transformer/recombine/recombine.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine.go
@@ -30,14 +30,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "recombine"
+
 func init() {
-	operator.Register("recombine", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new recombine config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new recombine config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "recombine"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 		MaxBatchSize:      1000,
 		MaxSources:        1000,
 		CombineWith:       "\n",

--- a/pkg/stanza/operator/transformer/recombine/recombine_test.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine_test.go
@@ -60,7 +60,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"NoEntriesFirst",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsFirstEntry = MatchAll
 				cfg.OutputIDs = []string{"fake"}
@@ -72,7 +72,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"NoEntriesLast",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsLastEntry = MatchAll
 				cfg.OutputIDs = []string{"fake"}
@@ -84,7 +84,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"OneEntryFirst",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsFirstEntry = MatchAll
 				cfg.OutputIDs = []string{"fake"}
@@ -96,7 +96,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"OneEntryLast",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsLastEntry = MatchAll
 				cfg.OutputIDs = []string{"fake"}
@@ -108,7 +108,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"TwoEntriesLast",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsLastEntry = "body == 'test2'"
 				cfg.OutputIDs = []string{"fake"}
@@ -123,7 +123,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"ThreeEntriesFirstNewest",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsFirstEntry = "body == 'test1'"
 				cfg.OutputIDs = []string{"fake"}
@@ -142,7 +142,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"EntriesNonMatchingForFirstEntry",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsFirstEntry = "$body == 'test1'"
 				cfg.OutputIDs = []string{"fake"}
@@ -163,7 +163,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"EntriesMatchingForFirstEntryOneFileOnly",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsFirstEntry = "body == 'file1'"
 				cfg.OutputIDs = []string{"fake"}
@@ -189,7 +189,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"CombineWithEmptyString",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.CombineWith = ""
 				cfg.IsLastEntry = "body == 'test2'"
@@ -205,7 +205,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"TestDefaultSourceIdentifier",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsLastEntry = "body == 'end'"
 				cfg.OutputIDs = []string{"fake"}
@@ -225,7 +225,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"TestCustomSourceIdentifier",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsLastEntry = "body == 'end'"
 				cfg.OutputIDs = []string{"fake"}
@@ -246,7 +246,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"TestMaxSources",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsLastEntry = "body == 'end'"
 				cfg.OutputIDs = []string{"fake"}
@@ -265,7 +265,7 @@ func TestTransformer(t *testing.T) {
 		{
 			"TestMaxBatchSize",
 			func() *Config {
-				cfg := NewConfig("")
+				cfg := NewConfig()
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsLastEntry = "body == 'end'"
 				cfg.OutputIDs = []string{"fake"}
@@ -314,7 +314,7 @@ func TestTransformer(t *testing.T) {
 	}
 
 	t.Run("FlushesOnShutdown", func(t *testing.T) {
-		cfg := NewConfig("")
+		cfg := NewConfig()
 		cfg.CombineField = entry.NewBodyField()
 		cfg.IsFirstEntry = MatchAll
 		cfg.OutputIDs = []string{"fake"}
@@ -349,7 +349,7 @@ func TestTransformer(t *testing.T) {
 }
 
 func BenchmarkRecombine(b *testing.B) {
-	cfg := NewConfig("")
+	cfg := NewConfig()
 	cfg.CombineField = entry.NewBodyField()
 	cfg.IsFirstEntry = "false"
 	cfg.OutputIDs = []string{"fake"}
@@ -386,7 +386,7 @@ func BenchmarkRecombine(b *testing.B) {
 func TestTimeout(t *testing.T) {
 	t.Parallel()
 
-	cfg := NewConfig("")
+	cfg := NewConfig()
 	cfg.CombineField = entry.NewBodyField()
 	cfg.IsFirstEntry = MatchAll
 	cfg.OutputIDs = []string{"fake"}

--- a/pkg/stanza/operator/transformer/remove/config_test.go
+++ b/pkg/stanza/operator/transformer/remove/config_test.go
@@ -104,7 +104,7 @@ func TestGoldenConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("move")
+	return NewConfig()
 }
 
 func newBodyField(keys ...string) rootableField {

--- a/pkg/stanza/operator/transformer/remove/remove.go
+++ b/pkg/stanza/operator/transformer/remove/remove.go
@@ -25,14 +25,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "remove"
+
 func init() {
-	operator.Register("remove", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new remove operator config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new remove operator config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "remove"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/transformer/retain/config_test.go
+++ b/pkg/stanza/operator/transformer/retain/config_test.go
@@ -106,5 +106,5 @@ func TestGoldenConfigs(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("retain")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/transformer/retain/retain.go
+++ b/pkg/stanza/operator/transformer/retain/retain.go
@@ -26,14 +26,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "retain"
+
 func init() {
-	operator.Register("retain", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new retain operator config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new retain operator config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "retain"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/operator/transformer/router/config_test.go
+++ b/pkg/stanza/operator/transformer/router/config_test.go
@@ -103,5 +103,5 @@ func TestRouterGoldenConfig(t *testing.T) {
 }
 
 func defaultCfg() *Config {
-	return NewConfig("router")
+	return NewConfig()
 }

--- a/pkg/stanza/operator/transformer/router/router.go
+++ b/pkg/stanza/operator/transformer/router/router.go
@@ -27,14 +27,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
+const operatorType = "router"
+
 func init() {
-	operator.Register("router", func() operator.Builder { return NewConfig("") })
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig config creates a new router operator config with default values
-func NewConfig(operatorID string) *Config {
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID config creates a new router operator config with default values
+func NewConfigWithID(operatorID string) *Config {
 	return &Config{
-		BasicConfig: helper.NewBasicConfig(operatorID, "router"),
+		BasicConfig: helper.NewBasicConfig(operatorID, operatorType),
 	}
 }
 

--- a/pkg/stanza/pipeline/config_test.go
+++ b/pkg/stanza/pipeline/config_test.go
@@ -31,7 +31,7 @@ func TestBuildPipelineSuccess(t *testing.T) {
 	cfg := Config{
 		Operators: []operator.Config{
 			{
-				Builder: noop.NewConfig("noop"),
+				Builder: noop.NewConfigWithID("noop"),
 			},
 		},
 	}
@@ -45,7 +45,7 @@ func TestBuildPipelineNoLogger(t *testing.T) {
 	cfg := Config{
 		Operators: []operator.Config{
 			{
-				Builder: noop.NewConfig("noop"),
+				Builder: noop.NewConfigWithID("noop"),
 			},
 		},
 	}
@@ -77,10 +77,10 @@ func TestBuildAPipelineDefaultOperator(t *testing.T) {
 	cfg := Config{
 		Operators: []operator.Config{
 			{
-				Builder: noop.NewConfig("noop"),
+				Builder: noop.NewConfigWithID("noop"),
 			},
 			{
-				Builder: noop.NewConfig("noop1"),
+				Builder: noop.NewConfigWithID("noop1"),
 			},
 		},
 		DefaultOutput: testutil.NewFakeOutput(t),
@@ -398,9 +398,9 @@ func TestUpdateOutputIDs(t *testing.T) {
 }
 
 func newDummyJSON(dummyID string) operator.Config {
-	return operator.Config{Builder: json.NewConfig(dummyID)}
+	return operator.Config{Builder: json.NewConfigWithID(dummyID)}
 }
 
 func newDummyCopy(dummyID string) operator.Config {
-	return operator.Config{Builder: copy.NewConfig(dummyID)}
+	return operator.Config{Builder: copy.NewConfigWithID(dummyID)}
 }

--- a/receiver/filelogreceiver/filelog.go
+++ b/receiver/filelogreceiver/filelog.go
@@ -53,7 +53,7 @@ func createDefaultConfig() *FileLogConfig {
 			Operators:        adapter.OperatorConfigs{},
 			Converter:        adapter.ConverterConfig{},
 		},
-		Config: *file.NewConfig("file_input"),
+		Config: *file.NewConfig(),
 	}
 }
 

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -278,7 +278,7 @@ func testdataConfigYaml() *FileLogConfig {
 			},
 		},
 		Config: func() file.Config {
-			c := file.NewConfig("file_input")
+			c := file.NewConfig()
 			c.Include = []string{"testdata/simple.log"}
 			c.StartAt = "beginning"
 			return *c
@@ -303,7 +303,7 @@ func rotationTestConfig(tempDir string) *FileLogConfig {
 			Converter: adapter.ConverterConfig{},
 		},
 		Config: func() file.Config {
-			c := file.NewConfig("file_input")
+			c := file.NewConfig()
 			c.Include = []string{fmt.Sprintf("%s/*", tempDir)}
 			c.StartAt = "beginning"
 			c.PollInterval = helper.Duration{Duration: 10 * time.Millisecond}

--- a/receiver/journaldreceiver/journald.go
+++ b/receiver/journaldreceiver/journald.go
@@ -72,7 +72,7 @@ type JournaldConfig struct {
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*JournaldConfig)
 	yamlBytes, _ := yaml.Marshal(logConfig.Input)
-	inputCfg := journald.NewConfig("journald_input")
+	inputCfg := journald.NewConfig()
 
 	if err := yaml.Unmarshal(yamlBytes, &inputCfg); err != nil {
 		return nil, err

--- a/receiver/syslogreceiver/syslog.go
+++ b/receiver/syslogreceiver/syslog.go
@@ -52,7 +52,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: *syslog.NewConfig("syslog_input"),
+		Config: *syslog.NewConfig(),
 	}
 }
 
@@ -80,9 +80,9 @@ func (cfg *SysLogConfig) Unmarshal(componentParser *confmap.Conf) error {
 	}
 
 	if componentParser.IsSet("tcp") {
-		cfg.TCP = &tcp.NewConfig("tcp_input").BaseConfig
+		cfg.TCP = &tcp.NewConfig().BaseConfig
 	} else if componentParser.IsSet("udp") {
-		cfg.UDP = &udp.NewConfig("udp_input").BaseConfig
+		cfg.UDP = &udp.NewConfig().BaseConfig
 	}
 
 	return componentParser.UnmarshalExact(cfg)

--- a/receiver/syslogreceiver/syslog_test.go
+++ b/receiver/syslogreceiver/syslog_test.go
@@ -111,8 +111,8 @@ func testdataConfigYaml() *SysLogConfig {
 			},
 		},
 		Config: func() syslog.Config {
-			c := syslog.NewConfig("syslog_input")
-			c.TCP = &tcp.NewConfig("tcp_input").BaseConfig
+			c := syslog.NewConfig()
+			c.TCP = &tcp.NewConfig().BaseConfig
 			c.TCP.ListenAddress = "0.0.0.0:29018"
 			c.Protocol = "rfc5424"
 			return *c
@@ -131,8 +131,8 @@ func testdataUDPConfig() *SysLogConfig {
 			},
 		},
 		Config: func() syslog.Config {
-			c := syslog.NewConfig("syslog_input")
-			c.UDP = &udp.NewConfig("udp_input").BaseConfig
+			c := syslog.NewConfig()
+			c.UDP = &udp.NewConfig().BaseConfig
 			c.UDP.ListenAddress = "0.0.0.0:29018"
 			c.Protocol = "rfc5424"
 			return *c
@@ -149,8 +149,8 @@ func TestDecodeInputConfigFailure(t *testing.T) {
 			Operators:        adapter.OperatorConfigs{},
 		},
 		Config: func() syslog.Config {
-			c := syslog.NewConfig("syslog_input")
-			c.TCP = &tcp.NewConfig("tcp_input").BaseConfig
+			c := syslog.NewConfig()
+			c.TCP = &tcp.NewConfig().BaseConfig
 			c.Protocol = "fake"
 			return *c
 		}(),

--- a/receiver/tcplogreceiver/tcp.go
+++ b/receiver/tcplogreceiver/tcp.go
@@ -49,7 +49,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: *tcp.NewConfig("tcp_input"),
+		Config: *tcp.NewConfig(),
 	}
 }
 

--- a/receiver/tcplogreceiver/tcp_test.go
+++ b/receiver/tcplogreceiver/tcp_test.go
@@ -96,7 +96,7 @@ func testdataConfigYaml() *TCPLogConfig {
 			},
 		},
 		Config: func() tcp.Config {
-			c := tcp.NewConfig("tcp_input")
+			c := tcp.NewConfig()
 			c.ListenAddress = "0.0.0.0:29018"
 			return *c
 		}(),
@@ -111,7 +111,7 @@ func TestDecodeInputConfigFailure(t *testing.T) {
 			Operators:        adapter.OperatorConfigs{},
 		},
 		Config: func() tcp.Config {
-			c := tcp.NewConfig("tcp_input")
+			c := tcp.NewConfig()
 			c.Encoding.Encoding = "fake"
 			return *c
 		}(),

--- a/receiver/udplogreceiver/udp.go
+++ b/receiver/udplogreceiver/udp.go
@@ -49,7 +49,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: *udp.NewConfig("udp_input"),
+		Config: *udp.NewConfig(),
 	}
 }
 

--- a/receiver/udplogreceiver/udp_test.go
+++ b/receiver/udplogreceiver/udp_test.go
@@ -97,7 +97,7 @@ func testdataConfigYaml() *UDPLogConfig {
 			Operators:        adapter.OperatorConfigs{},
 		},
 		Config: func() udp.Config {
-			c := udp.NewConfig("udp_input")
+			c := udp.NewConfig()
 			c.ListenAddress = "0.0.0.0:29018"
 			return *c
 		}(),
@@ -113,7 +113,7 @@ func TestDecodeInputConfigFailure(t *testing.T) {
 			Operators:        adapter.OperatorConfigs{},
 		},
 		Config: func() udp.Config {
-			c := udp.NewConfig("udp_input")
+			c := udp.NewConfig()
 			c.Encoding.Encoding = "fake"
 			return *c
 		}(),


### PR DESCRIPTION
The notion of operator IDs in this module was once very prominent.
No operator could be specified without an ID, in any context,
including in a config file. Usability improvements have since
made operator IDs optional in the config file, in most cases.
This change does the same for development, where often operator
IDs are irrelevant to the scenario.