### PR TITLE
[receiver/tcp|udplog] Migrate config unmarshaling from yaml to mapstructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.58.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.58.0
@@ -434,7 +435,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.58.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.58.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.58.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.58.0
@@ -435,6 +434,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.58.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.58.0 // indirect

--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -33,7 +33,6 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	tcpop "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/tcp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver"
@@ -318,9 +317,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "tcplog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["tcplog"].CreateDefaultConfig().(*tcplogreceiver.TCPLogConfig)
-				cfg.Input = adapter.InputConfig{
-					"listen_address": "0.0.0.0:0",
-				}
+				cfg.ListenAddress = "0.0.0.0:0"
 				return cfg
 			},
 		},
@@ -328,9 +325,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "udplog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["udplog"].CreateDefaultConfig().(*udplogreceiver.UDPLogConfig)
-				cfg.Input = adapter.InputConfig{
-					"listen_address": "0.0.0.0:0",
-				}
+				cfg.ListenAddress = "0.0.0.0:0"
 				return cfg
 			},
 		},

--- a/pkg/stanza/operator/parser/csv/csv_test.go
+++ b/pkg/stanza/operator/parser/csv/csv_test.go
@@ -293,10 +293,10 @@ func TestParserCSV(t *testing.T) {
 				{
 					Attributes: map[string]interface{}{
 						"columns": "name	age	height	number",
-						"name":    "stanza dev",
-						"age":     "1",
-						"height":  "400",
-						"number":  "555-555-5555",
+						"name":   "stanza dev",
+						"age":    "1",
+						"height": "400",
+						"number": "555-555-5555",
 					},
 					Body: "stanza dev	1	400	555-555-5555",
 				},

--- a/pkg/stanza/operator/parser/csv/csv_test.go
+++ b/pkg/stanza/operator/parser/csv/csv_test.go
@@ -291,13 +291,16 @@ func TestParserCSV(t *testing.T) {
 			},
 			[]entry.Entry{
 				{
-					Attributes: map[string]interface{}{
-						"columns": "name	age	height	number",
-						"name":   "stanza dev",
-						"age":    "1",
-						"height": "400",
-						"number": "555-555-5555",
-					},
+					Attributes: func() map[string]interface{} {
+						m := map[string]interface{}{
+							"name":   "stanza dev",
+							"age":    "1",
+							"height": "400",
+							"number": "555-555-5555",
+						}
+						m["columns"] = "name	age	height	number"
+						return m
+					}(),
 					Body: "stanza dev	1	400	555-555-5555",
 				},
 			},

--- a/receiver/tcplogreceiver/go.mod
+++ b/receiver/tcplogreceiver/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.58.0
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.58.0
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -44,6 +43,7 @@ require (
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/receiver/tcplogreceiver/tcp.go
+++ b/receiver/tcplogreceiver/tcp.go
@@ -17,7 +17,6 @@ package tcplogreceiver // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -50,7 +49,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Input: adapter.InputConfig{},
+		Config: *tcp.NewConfig("tcp_input"),
 	}
 }
 
@@ -61,19 +60,12 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 
 // TCPLogConfig defines configuration for the tcp receiver
 type TCPLogConfig struct {
+	tcp.Config         `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`
-	Input              adapter.InputConfig `mapstructure:",remain"`
 }
 
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*TCPLogConfig)
-	yamlBytes, _ := yaml.Marshal(logConfig.Input)
-	inputCfg := tcp.NewConfig("tcp_input")
-
-	if err := yaml.Unmarshal(yamlBytes, &inputCfg); err != nil {
-		return nil, err
-	}
-
-	return &operator.Config{Builder: inputCfg}, nil
+	return &operator.Config{Builder: &logConfig.Config}, nil
 }

--- a/receiver/udplogreceiver/go.mod
+++ b/receiver/udplogreceiver/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.58.0
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.58.0
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -43,6 +42,7 @@ require (
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/receiver/udplogreceiver/udp.go
+++ b/receiver/udplogreceiver/udp.go
@@ -17,7 +17,6 @@ package udplogreceiver // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -50,7 +49,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Input: adapter.InputConfig{},
+		Config: *udp.NewConfig("udp_input"),
 	}
 }
 
@@ -61,19 +60,12 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 
 // UDPLogConfig defines configuration for the udp receiver
 type UDPLogConfig struct {
+	udp.Config         `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`
-	Input              adapter.InputConfig `mapstructure:",remain"`
 }
 
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*UDPLogConfig)
-	yamlBytes, _ := yaml.Marshal(logConfig.Input)
-	inputCfg := udp.NewConfig("udp_input")
-
-	if err := yaml.Unmarshal(yamlBytes, &inputCfg); err != nil {
-		return nil, err
-	}
-
-	return &operator.Config{Builder: inputCfg}, nil
+	return &operator.Config{Builder: &logConfig.Config}, nil
 }


### PR DESCRIPTION
pkg/stanza historically used yaml for configuration unmarshaling.
The process of migrating to mapstructure was begun long ago but
was never completed. This PR switches tcplog & udplog underlying operators
to use mapstructure unmarshaling.