### PR TITLE
[pkg/stanza] Remove syslogreceiver.CreateDefault[TCP|UDP]ConfigBase funcs

### DIFF
--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
+	tcpop "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/tcp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
@@ -307,7 +308,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "syslog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["syslog"].CreateDefaultConfig().(*syslogreceiver.SysLogConfig)
-				cfg.TCP = syslogreceiver.CreateDefaultTCPConfigBase()
+				cfg.TCP = &tcpop.NewConfig("tcp_input").BaseConfig
 				cfg.TCP.ListenAddress = "0.0.0.0:0"
 				cfg.Protocol = "rfc5424"
 				return cfg

--- a/receiver/syslogreceiver/syslog.go
+++ b/receiver/syslogreceiver/syslog.go
@@ -80,18 +80,10 @@ func (cfg *SysLogConfig) Unmarshal(componentParser *confmap.Conf) error {
 	}
 
 	if componentParser.IsSet("tcp") {
-		cfg.TCP = CreateDefaultTCPConfigBase()
+		cfg.TCP = &tcp.NewConfig("tcp_input").BaseConfig
 	} else if componentParser.IsSet("udp") {
-		cfg.UDP = CreateDefaultUDPConfigBase()
+		cfg.UDP = &udp.NewConfig("udp_input").BaseConfig
 	}
 
 	return componentParser.UnmarshalExact(cfg)
-}
-
-func CreateDefaultTCPConfigBase() *tcp.BaseConfig {
-	return &tcp.NewConfig("tcp_input").BaseConfig
-}
-
-func CreateDefaultUDPConfigBase() *udp.BaseConfig {
-	return &udp.NewConfig("udp_input").BaseConfig
 }


### PR DESCRIPTION
These functions were added recently and unnecessarily expand the
collector's overall API.

See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13253#discussion_r944691556