### PR TITLE
Improve errors when combining summary and histogram metrics

### DIFF
--- a/receiver/prometheusreceiver/internal/otlp_metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricsbuilder.go
@@ -41,22 +41,23 @@ func isUsefulLabel(mType pmetric.MetricDataType, labelKey string) bool {
 }
 
 func getBoundary(metricType pmetric.MetricDataType, labels labels.Labels) (float64, error) {
-	labelName := ""
+	val := ""
 	switch metricType {
 	case pmetric.MetricDataTypeHistogram:
-		labelName = model.BucketLabel
+		val = labels.Get(model.BucketLabel)
+		if val == "" {
+			return 0, errEmptyLeLabel
+		}
 	case pmetric.MetricDataTypeSummary:
-		labelName = model.QuantileLabel
+		val = labels.Get(model.QuantileLabel)
+		if val == "" {
+			return 0, errEmptyQuantileLabel
+		}
 	default:
 		return 0, errNoBoundaryLabel
 	}
 
-	v := labels.Get(labelName)
-	if v == "" {
-		return 0, errEmptyBoundaryLabel
-	}
-
-	return strconv.ParseFloat(v, 64)
+	return strconv.ParseFloat(val, 64)
 }
 
 // convToMetricType returns the data type and if it is monotonic

--- a/receiver/prometheusreceiver/internal/otlp_metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricsbuilder_test.go
@@ -137,7 +137,7 @@ func TestGetBoundary(t *testing.T) {
 			labels: labels.Labels{
 				{Name: model.BucketLabel, Value: "11.71"},
 			},
-			wantErr: "QuantileLabel is empty",
+			wantErr: errEmptyQuantileLabel.Error(),
 		},
 		{
 			name:  "summary with quantile label",
@@ -153,7 +153,7 @@ func TestGetBoundary(t *testing.T) {
 			labels: labels.Labels{
 				{Name: model.BucketLabel, Value: "11.71"},
 			},
-			wantErr: "QuantileLabel is empty",
+			wantErr: errEmptyQuantileLabel.Error(),
 		},
 		{
 			name:  "other data types without matches",
@@ -161,7 +161,7 @@ func TestGetBoundary(t *testing.T) {
 			labels: labels.Labels{
 				{Name: model.BucketLabel, Value: "11.71"},
 			},
-			wantErr: "given metricType has no BucketLabel or QuantileLabel",
+			wantErr: errNoBoundaryLabel.Error(),
 		},
 	}
 
@@ -1229,7 +1229,7 @@ func Test_OTLPMetricBuilder_baddata(t *testing.T) {
 	t.Run("histogram-datapoint-no-bucket-label", func(t *testing.T) {
 		b := newMetricBuilder(newMockMetadataCache(testMetadata), true, "", zap.NewNop(), 0)
 		b.startTime = 1.0 // set to a non-zero value
-		if err := b.AddDataPoint(createLabels("hist_test", "k", "v"), startTs, 123); !errors.Is(err, errEmptyBoundaryLabel) {
+		if err := b.AddDataPoint(createLabels("hist_test", "k", "v"), startTs, 123); !errors.Is(err, errEmptyLeLabel) {
 			t.Error("expecting errEmptyBoundaryLabel error, but get nil")
 		}
 	})
@@ -1237,7 +1237,7 @@ func Test_OTLPMetricBuilder_baddata(t *testing.T) {
 	t.Run("summary-datapoint-no-quantile-label", func(t *testing.T) {
 		b := newMetricBuilder(newMockMetadataCache(testMetadata), true, "", zap.NewNop(), 0)
 		b.startTime = 1.0 // set to a non-zero value
-		if err := b.AddDataPoint(createLabels("summary_test", "k", "v"), startTs, 123); !errors.Is(err, errEmptyBoundaryLabel) {
+		if err := b.AddDataPoint(createLabels("summary_test", "k", "v"), startTs, 123); !errors.Is(err, errEmptyQuantileLabel) {
 			t.Error("expecting errEmptyBoundaryLabel error, but get nil")
 		}
 	})

--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -38,8 +38,9 @@ const (
 var (
 	trimmableSuffixes     = []string{metricsSuffixBucket, metricsSuffixCount, metricsSuffixSum, metricSuffixTotal, metricSuffixInfo}
 	errNoDataToBuild      = errors.New("there's no data to build")
-	errNoBoundaryLabel    = errors.New("given metricType has no BucketLabel or QuantileLabel")
-	errEmptyBoundaryLabel = errors.New("BucketLabel or QuantileLabel is empty")
+	errNoBoundaryLabel    = errors.New("given metricType has no 'le' or 'quantile' label")
+	errEmptyQuantileLabel = errors.New("'quantile' label on summary metric missing is empty")
+	errEmptyLeLabel       = errors.New("'le' label on histogram metric id missing or empty")
 	errMetricNameNotFound = errors.New("metricName not found from labels")
 	errTransactionAborted = errors.New("transaction aborted")
 	errNoJobInstance      = errors.New("job or instance cannot be found from labels")

--- a/unreleased/prom-errors.yaml
+++ b/unreleased/prom-errors.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make the error returned when dropping summary metrics that collide with histograms clearer.
+
+# One or more tracking issues related to the change
+issues: [12976]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12976

It makes the error messages more specific to the metric type.