### PR TITLE
[processor/k8sattributes] use docker library for parsing image name a tag

### DIFF
--- a/processor/k8sattributesprocessor/go.mod
+++ b/processor/k8sattributesprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sat
 go 1.19
 
 require (
+	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.79.0
@@ -26,7 +27,6 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1269,7 +1269,7 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 			InitContainers: []api_v1.Container{
 				{
 					Name:  "init_container",
-					Image: "test/init-image:1.0.2",
+					Image: "test/init-image@sha256:938b5909efe517c9cfdada4c23a93a2e003756603e353977ae0b2684268346eb",
 				},
 			},
 		},
@@ -1450,7 +1450,7 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 					},
 					"init_container": {
 						ImageName: "test/init-image",
-						ImageTag:  "1.0.2",
+						ImageTag:  "sha256:938b5909efe517c9cfdada4c23a93a2e003756603e353977ae0b2684268346eb",
 						Statuses: map[int]ContainerStatus{
 							0: {ContainerID: "init-container-id-123"},
 						},


### PR DESCRIPTION
**Description:** 
Use reference parse from `docker/distribution` to support digest in the image reference.
Image reference containing digest like `test/init-image@sha256:938b5909efe517c9cfdada4c23a93a2e003756603e353977ae0b2684268346eb` are now wrongly parsed into `test/init-image@sha256` name and `938b5909efe517c9cfdada4c23a93a2e003756603e353977ae0b2684268346eb` tag.