### PR TITLE
[receiver/receivercreator] Fix incorrect resource_attributes config example in README

### DIFF
--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -231,14 +231,14 @@ receivers:
         # Set a resource attribute based on endpoint value.
         rule: type == "port" && port == 6379
 
-      resource_attributes:
-        # Dynamic configuration values, overwriting default attributes`
-        pod:
-          service.name: '`labels["service_name"]`'
-          app: '`labels["app"]`'
-        port:
-          service.name: '`pod.labels["service_name"]`'
-          app: '`pod.labels["app"]`'
+    resource_attributes:
+      # Dynamic configuration values, overwriting default attributes`
+      pod:
+        service.name: '`labels["service_name"]`'
+        app: '`labels["app"]`'
+      port:
+        service.name: '`pod.labels["service_name"]`'
+        app: '`pod.labels["app"]`'
   receiver_creator/2:
     # Name of the extensions to watch for endpoints to start and stop.
     watch_observers: [host_observer]
@@ -246,8 +246,8 @@ receivers:
       redis/on_host:
         # If this rule matches an instance of this receiver will be started.
         rule: type == "port" && port == 6379 && is_ipv6 == true
-      resource_attributes:
-        service.name: redis_on_host
+        resource_attributes:
+          service.name: redis_on_host
   receiver_creator/3:
     watch_observers: [k8s_observer]
     receivers:


### PR DESCRIPTION
**Description:** There are two `resource_attributes` that are easily confused, and the example config is really wrong.

`resource_attributes` with EndpointType such as `port`, `k8s.node` are always in the receiver_creator Config block.

```go
// Config defines configuration for receiver_creator.
type Config struct {
	config.ReceiverSettings `mapstructure:",squash"`
	receiverTemplates       map[string]receiverTemplate
	// WatchObservers are the extensions to listen to endpoints from.
	WatchObservers []config.Type `mapstructure:"watch_observers"`
	// ResourceAttributes is a map of default resource attributes to add to each resource
	// object received by this receiver from dynamically created receivers.
	ResourceAttributes resourceAttributes `mapstructure:"resource_attributes"`
}
```
And `resource_attributes` in one receiverTemplate are custom attributes.

```go
// receiverTemplate is the configuration of a single subreceiver.
type receiverTemplate struct {
	receiverConfig

	// Rule is the discovery rule that when matched will create a receiver instance
	// based on receiverTemplate.
	Rule string `mapstructure:"rule"`
	// ResourceAttributes is a map of resource attributes to add to just this receiver's resource metrics.
	// It can contain expr expressions for endpoint env value expansion
	ResourceAttributes map[string]interface{} `mapstructure:"resource_attributes"`
	rule               rule
}
```


**Link to tracking Issue:**

**Testing:**

**Documentation:**