### PR TITLE
[receiver/mongodbreceiver] Add metric version checks to prevent partial errors

### DIFF
--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -25,7 +25,6 @@ This receiver supports MongoDB versions:
 
 Mongodb recommends to set up a least privilege user (LPU) with a [`clusterMonitor` role](https://www.mongodb.com/docs/v5.0/reference/built-in-roles/#mongodb-authrole-clusterMonitor) in order to collect metrics. Please refer to [lpu.sh](./testdata/integration/scripts/lpu.sh) for an example of how to configure these permissions.
 
-Collecting metrics `mongodb.global_lock.time` and `mongodb.index.access.count` are only available for mongodb 4.0+.
 
 ## Configuration
 
@@ -66,6 +65,7 @@ The following metric are available with versions:
 - `mongodb.session.count` >= 3.0 with wiredTiger storage engine
 - `mongodb.cache.operations` >= 3.0 with wiredTiger storage engine
 - `mongodb.connection.count` for attribute `active` is available >= 4.0
+- `mongodb.index.access.count` >= 4.0
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -64,7 +64,7 @@ The following metric are available with versions:
 - `mongodb.extent.count` < 4.4 with mmapv1 storage engine
 - `mongodb.session.count` >= 3.0 with wiredTiger storage engine
 - `mongodb.cache.operations` >= 3.0 with wiredTiger storage engine
-- `mongodb.connection.count` for attribute `active` is available >= 4.0
+- `mongodb.connection.count` with attribute `active` is available >= 4.0
 - `mongodb.index.access.count` >= 4.0
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -63,6 +63,7 @@ The full list of settings exposed for this receiver are documented [here](./conf
 
 The following metric are available with versions:
 - `mongodb.extent.count` < 4.4 with mmapv1 storage engine
+- `mongodb.session.count` >= 3.0 with wiredTiger storage engine
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -64,6 +64,7 @@ The full list of settings exposed for this receiver are documented [here](./conf
 The following metric are available with versions:
 - `mongodb.extent.count` < 4.4 with mmapv1 storage engine
 - `mongodb.session.count` >= 3.0 with wiredTiger storage engine
+- `mongodb.cache.operations` >= 3.0 with wiredTiger storage engine
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -65,6 +65,7 @@ The following metric are available with versions:
 - `mongodb.extent.count` < 4.4 with mmapv1 storage engine
 - `mongodb.session.count` >= 3.0 with wiredTiger storage engine
 - `mongodb.cache.operations` >= 3.0 with wiredTiger storage engine
+- `mongodb.connection.count` for attribute `active` is available >= 4.0
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -61,6 +61,9 @@ The full list of settings exposed for this receiver are documented [here](./conf
 
 ## Metrics
 
+The following metric are available with versions:
+- `mongodb.extent.count` < 4.4 with mmapv1 storage engine
+
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -265,6 +265,13 @@ func (s *mongodbScraper) recordOperations(now pcommon.Timestamp, doc bson.M, err
 
 func (s *mongodbScraper) recordCacheOperations(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
 	// Collect Cache Hits & Misses if wiredTiger storage engine is used
+	// WiredTiger.cache metrics are available in 3.0+
+	// https://www.mongodb.com/docs/v4.0/reference/command/serverStatus/#serverstatus.wiredTiger.cache
+	mongo30, _ := version.NewVersion("3.0")
+	if s.mongoVersion.LessThan(mongo30) {
+		return
+	}
+
 	storageEngine, err := dig(doc, []string{"storageEngine", "name"})
 	if err != nil {
 		s.logger.Error("failed to find storage engine for cache operation", zap.Error(err))

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -211,7 +211,13 @@ func (s *mongodbScraper) recordDocumentOperations(now pcommon.Timestamp, doc bso
 }
 
 func (s *mongodbScraper) recordSessionCount(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
-	// Collect session count
+	// Collect session count for version 3.0+
+	// https://www.mongodb.com/docs/v3.0/reference/command/serverStatus/#serverStatus.wiredTiger.session
+	mongo30, _ := version.NewVersion("3.0")
+	if s.mongoVersion.LessThan(mongo30) {
+		return
+	}
+
 	storageEngine, err := dig(doc, []string{"storageEngine", "name"})
 	if err != nil {
 		s.logger.Error("failed to find storage engine for session count", zap.Error(err))

--- a/receiver/mongodbreceiver/testdata/integration/expected.3_0.json
+++ b/receiver/mongodbreceiver/testdata/integration/expected.3_0.json
@@ -13,8 +13,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -28,8 +28,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -43,12 +43,28 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
                      "unit": "{databases}"
+                  },
+                  {
+                     "description": "The time the global lock has been held.",
+                     "name": "mongodb.global_lock.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "60917",
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
                   },
                   {
                      "description": "The number of bytes received.",
@@ -58,8 +74,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2105",
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -73,8 +89,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4716",
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -88,8 +104,8 @@
                         "dataPoints": [
                            {
                               "asInt": "23",
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -107,64 +123,12 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "update"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "getmore"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
-                              "asInt": "24",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
                                        "stringValue": "insert"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            },
                            {
                               "asInt": "1",
@@ -176,8 +140,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "getmore"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
+                           {
+                              "asInt": "24",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ],
                         "isMonotonic": true
@@ -204,58 +220,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "295177",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "command"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
-                              "asInt": "29",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "update"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -265,8 +229,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            },
                            {
                               "asInt": "0",
@@ -278,8 +242,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
+                           {
+                              "asInt": "65779",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "command"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
+                           {
+                              "asInt": "29",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ],
                         "isMonotonic": true
@@ -324,8 +340,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -353,8 +369,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            },
                            {
                               "asInt": "3",
@@ -372,8 +388,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -395,8 +411,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -420,31 +436,12 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "testdb"
-                                    }
-                                 },
-                                 {
-                                    "key": "operation",
-                                    "value": {
                                        "stringValue": "update"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            },
                            {
                               "asInt": "0",
@@ -462,8 +459,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "testdb"
+                                    }
+                                 },
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "insert"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -485,8 +501,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -508,8 +524,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -531,8 +547,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -545,7 +561,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "81788928",
+                              "asInt": "79691776",
                               "attributes": [
                                  {
                                     "key": "database",
@@ -560,8 +576,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            },
                            {
                               "asInt": "543162368",
@@ -579,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -602,8 +618,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -625,8 +641,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ],
                         "isMonotonic": true
@@ -671,8 +687,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -700,8 +716,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            },
                            {
                               "asInt": "3",
@@ -719,8 +735,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -742,8 +758,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -771,8 +787,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            },
                            {
                               "asInt": "0",
@@ -790,8 +806,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            },
                            {
                               "asInt": "0",
@@ -809,8 +825,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -832,8 +848,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -855,8 +871,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -878,8 +894,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -891,6 +907,25 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "79691776",
+                              "attributes": [
+                                 {
+                                    "key": "database",
+                                    "value": {
+                                       "stringValue": "local"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "resident"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
+                           },
                            {
                               "asInt": "543162368",
                               "attributes": [
@@ -907,27 +942,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
-                           },
-                           {
-                              "asInt": "81788928",
-                              "attributes": [
-                                 {
-                                    "key": "database",
-                                    "value": {
-                                       "stringValue": "local"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "resident"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -949,8 +965,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ]
                      },
@@ -972,8 +988,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1659372711430846000",
-                              "timeUnixNano": "1659372771440281000"
+                              "startTimeUnixNano": "1660574530315941000",
+                              "timeUnixNano": "1660574590325232000"
                            }
                         ],
                         "isMonotonic": true

--- a/unreleased/mongodbreceiver-add-metric-version-checks.yaml
+++ b/unreleased/mongodbreceiver-add-metric-version-checks.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds metric versioning checks to prevent partial errors
+
+# One or more tracking issues related to the change
+issues: [13155]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
In use or in the integration tests, many partial errors are being emitted. A metric versioning and storage engine check can be applied before metrics are recorded to prevent these partial errors from occurring.

**Link to tracking Issue:**
#13155 

**Documentation:** <Describe the documentation added.>
Updated readme to include metric version / storage engine support