### PR TITLE
[processor/tailsampling] Fix SpanCount sampler not using the correct span count for decision

### DIFF
--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
@@ -38,14 +38,8 @@ func NewSpanCount(logger *zap.Logger, minSpans int32) PolicyEvaluator {
 func (c *spanCount) Evaluate(_ pcommon.TraceID, traceData *TraceData) (Decision, error) {
 	c.logger.Debug("Evaluating spans counts in filter")
 
-	traceData.Lock()
-	batches := traceData.ReceivedBatches
-	traceData.Unlock()
-
-	for _, trace := range batches {
-		if trace.SpanCount() >= int(c.minSpans) {
-			return Sampled, nil
-		}
+	if int(traceData.SpanCount.Load()) >= int(c.minSpans) {
+		return Sampled, nil
 	}
 	return NotSampled, nil
 }

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
@@ -42,23 +42,30 @@ func TestEvaluate_NumberSpans(t *testing.T) {
 			NotSampled,
 		},
 		{
-			"Less spans than the threshold",
+			"Bigger amount of spans than the threshold, in one single batch",
 			[]int32{
-				1, 1, 1,
-			},
-			NotSampled,
-		},
-		{
-			"Same number of spans than the threshold",
-			[]int32{
-				1, 2, 1,
+				3,
 			},
 			Sampled,
 		},
 		{
-			"Bigger amount of spans than the threashold",
+			"Same number of spans as the threshold, in one single batch",
 			[]int32{
-				1, 3, 1,
+				2,
+			},
+			Sampled,
+		},
+		{
+			"Bigger amount of spans than the threshold, across multiple batches",
+			[]int32{
+				1, 1, 1,
+			},
+			Sampled,
+		},
+		{
+			"Same number of spans as the threshold, across multiple batches",
+			[]int32{
+				1, 1,
 			},
 			Sampled,
 		},

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
 
@@ -75,6 +76,7 @@ func TestEvaluate_NumberSpans(t *testing.T) {
 
 func newTraceWithMultipleSpans(numberSpans []int32) *TraceData {
 	var traceBatches []ptrace.Traces
+	var totalNumberSpans = int32(0)
 
 	// For each trace, going to create the number of spans defined in the array
 	for i := range numberSpans {
@@ -89,9 +91,11 @@ func newTraceWithMultipleSpans(numberSpans []int32) *TraceData {
 			span.SetSpanID(pcommon.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
 		}
 		traceBatches = append(traceBatches, traces)
+		totalNumberSpans += numberSpans[i]
 	}
 
 	return &TraceData{
 		ReceivedBatches: traceBatches,
+		SpanCount:       atomic.NewInt64(int64(totalNumberSpans)),
 	}
 }

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
@@ -49,6 +49,13 @@ func TestEvaluate_NumberSpans(t *testing.T) {
 			Sampled,
 		},
 		{
+			"Bigger amount of spans than the threshold, with different span count per batch",
+			[]int32{
+				1, 2, 1,
+			},
+			Sampled,
+		},
+		{
 			"Same number of spans as the threshold, in one single batch",
 			[]int32{
 				2,
@@ -59,6 +66,13 @@ func TestEvaluate_NumberSpans(t *testing.T) {
 			"Bigger amount of spans than the threshold, across multiple batches",
 			[]int32{
 				1, 1, 1,
+			},
+			Sampled,
+		},
+		{
+			"Bigger amount of spans than the threshold, with a different number",
+			[]int32{
+				1, 3, 1,
 			},
 			Sampled,
 		},

--- a/unreleased/fix-span-count-incorrect-tracking.yaml
+++ b/unreleased/fix-span-count-incorrect-tracking.yaml
@@ -8,7 +8,7 @@ component: tailsamplingprocessor
 note: Fixes SpanCount sampler not using the correct span count for decision.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [13865]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/unreleased/fix-span-count-incorrect-tracking.yaml
+++ b/unreleased/fix-span-count-incorrect-tracking.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes SpanCount sampler not using the correct span count for decision.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 


### PR DESCRIPTION
Fixes #13865
**Description:**
There is a bug with the SpanCount sampler. If spans are put in different batches, it may make a wrong decision.

e.g.
With SpanCount minSpans set to `2`; if 2 spans of the same trace are put into different batches, the trace will not be sampled.