### PR TITLE
[exporter/signalfx] Update export metric exclude rules

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -273,7 +273,7 @@ func TestCreateMetricsExporterWithDefaultExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 12, len(config.ExcludeMetrics))
+	assert.Equal(t, 13, len(config.ExcludeMetrics))
 }
 
 func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
@@ -293,7 +293,7 @@ func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 13, len(config.ExcludeMetrics))
+	assert.Equal(t, 14, len(config.ExcludeMetrics))
 }
 
 func TestCreateMetricsExporterWithEmptyExcludeMetrics(t *testing.T) {
@@ -657,7 +657,7 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	require.NoError(t, err)
 
 	md := getMetrics(metrics)
-	require.Equal(t, 71, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, 93, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	dps := converter.MetricsToSignalFxV2(md)
 	require.Equal(t, 0, len(dps))
 }

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -70,18 +70,41 @@ exclude_metrics:
 - metric_names:
   - system.disk.merged
   - system.disk.io
+  - system.disk.io.read
+  - system.disk.io.write
   - system.disk.time
   - system.disk.io_time
+  - system.disk.merged.read
+  - system.disk.merged.write
   - system.disk.operation_time
+  - system.disk.operation_time.read
+  - system.disk.operation_time.write
+  - system.disk.operations.read
+  - system.disk.operations.write
   - system.disk.pending_operations
   - system.disk.weighted_io_time
 
 # Network-IO metrics.
 - metric_names:
-  - system.network.packets
   - system.network.dropped
+  - system.network.dropped.receive
+  - system.network.dropped.transmit
+  - system.network.errors.receive
+  - system.network.errors.transmit
+  - system.network.io.receive
+  - system.network.io.transmit
+  - system.network.packets
+  - system.network.packets.receive
+  - system.network.packets.transmit
   - system.network.tcp_connections
   - system.network.connections
+
+# Process metrics
+- metric_names:
+  - process.disk.io.read
+  - process.disk.io.write
+  - process.network.io.receive
+  - process.network.io.transmit
 
 # Processes metrics
 - metric_names:
@@ -92,6 +115,8 @@ exclude_metrics:
 - metric_names:
   - system.paging.faults
   - system.paging.usage
+  - system.paging.operations.page_in
+  - system.paging.operations.page_out
 - metric_name: system.paging.operations
   dimensions:
     type: [minor]

--- a/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
+++ b/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
@@ -220,5 +220,71 @@
   },
   {
     "k8s.volume.inodes.used": null
+  },
+  {
+    "process.disk.io.read": null
+  },
+  {
+    "process.disk.io.write": null
+  },
+  {
+    "process.network.io.receive": null
+  },
+  {
+    "process.network.io.transmit": null
+  },
+  {
+    "system.paging.operations.page_in": null
+  },
+  {
+    "system.paging.operations.page_out": null
+  },
+  {
+    "system.disk.io.read": null
+  },
+  {
+    "system.disk.io.write": null
+  },
+  {
+    "system.disk.operations.read": null
+  },
+  {
+    "system.disk.operations.write": null
+  },
+  {
+    "system.disk.operation_time.read": null
+  },
+  {
+    "system.disk.operation_time.write": null
+  },
+  {
+    "system.disk.merged.read": null
+  },
+  {
+    "system.disk.merged.write": null
+  },
+  {
+    "system.network.dropped.receive": null
+  },
+  {
+    "system.network.dropped.transmit": null
+  },
+  {
+    "system.network.errors.receive": null
+  },
+  {
+    "system.network.errors.transmit": null
+  },
+  {
+    "system.network.packets.receive": null
+  },
+  {
+    "system.network.packets.transmit": null
+  },
+  {
+    "system.network.io.receive": null
+  },
+  {
+    "system.network.io.transmit": null
   }
 ]

--- a/unreleased/sfx_export_exclude_update.yaml
+++ b/unreleased/sfx_export_exclude_update.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update metric exclude rules
+
+# One or more tracking issues related to the change
+issues: [12641]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The format of metrics is being changed to remove the "direction" attribute, and move the direction into the metric name instead. The signalfx exporter backend does not yet fully support the new metric naming, so the exporter needs to exclude these metrics until they're supported. Metrics will continue to be exported in their original format for now.

**Link to tracking Issue:** <Issue number if applicable>
#12641

**Testing:** <Describe what testing was performed and which tests were added.>
Tests have been updated to ensure no new metrics are being exported.

**Documentation:** <Describe the documentation added.>