### PR TITLE
[pkg/stanza] Enable debugging operators 'file_output' and 'stdout'

### DIFF
--- a/pkg/stanza/adapter/register.go
+++ b/pkg/stanza/adapter/register.go
@@ -16,6 +16,8 @@ package adapter // import "github.com/open-telemetry/opentelemetry-collector-con
 
 import (
 	// Register parsers and transformers for stanza-based log receivers
+	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/output/file"
+	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/output/stdout"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/csv"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/json"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"

--- a/unreleased/pkg-stanza-debugging-outputs.yaml
+++ b/unreleased/pkg-stanza-debugging-outputs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "`filelog`, `journald`, `syslog`, `tcplog`, `udplog`, `windowseventlog` receivers"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enable debugging operators `stdout` and `file_output`"
+
+# One or more tracking issues related to the change
+issues: [13394]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
These operators are useful for developing log receiver configurations.
They can be temporarily inserted into a stanza pipeline in order to
print a json representation of the log entry to stdout or a file.

Resolves #13394