### PR TITLE
setting TraceID and SpanID fields in Exemplar objects in spanmetricsp…

### DIFF
--- a/.chloggen/spanmetrics_exemplars_type_fields.yaml
+++ b/.chloggen/spanmetrics_exemplars_type_fields.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Sets TraceID and SpanID fields in Exemplar type (as per the spec) and removes the use of FilteredAttributes to pass these values around.
+
+# One or more tracking issues related to the change
+issues: [13401]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -15,6 +15,7 @@
 package prometheusexporter
 
 import (
+	"encoding/hex"
 	"strings"
 	"testing"
 	"time"
@@ -103,48 +104,33 @@ func TestConvertDoubleHistogramExemplar(t *testing.T) {
 	metric.SetUnit("T")
 
 	// initialize empty datapoint
-	hd := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
+	histogramDataPoint := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 
-	hd.ExplicitBounds().FromRaw([]float64{5, 25, 90})
-	hd.BucketCounts().FromRaw([]uint64{2, 35, 70})
+	histogramDataPoint.ExplicitBounds().FromRaw([]float64{5, 25, 90})
+	histogramDataPoint.BucketCounts().FromRaw([]uint64{2, 35, 70})
+
+	// add test exemplar values to the metric
+	promExporterExemplars := histogramDataPoint.Exemplars().AppendEmpty()
+	var tBytes [16]byte
+	testTraceID, _ := hex.DecodeString("641d68e314a58152cc2581e7663435d1")
+	copy(tBytes[:], testTraceID)
+	traceID := pcommon.TraceID(tBytes)
+	promExporterExemplars.SetTraceID(traceID)
+
+	var sBytes [8]byte
+	testSpanID, _ := hex.DecodeString("7436d6ac76178623")
+	copy(sBytes[:], testSpanID)
+	spanID := pcommon.SpanID(sBytes)
+	promExporterExemplars.SetSpanID(spanID)
 
 	exemplarTs, _ := time.Parse("unix", "Mon Jan _2 15:04:05 MST 2006")
-	exemplars := []prometheus.Exemplar{
-		{
-			Timestamp: exemplarTs,
-			Value:     3,
-			Labels:    prometheus.Labels{"test_label_0": "label_value_0"},
-		},
-		{
-			Timestamp: exemplarTs,
-			Value:     50,
-			Labels:    prometheus.Labels{"test_label_1": "label_value_1"},
-		},
-		{
-			Timestamp: exemplarTs,
-			Value:     78,
-			Labels:    prometheus.Labels{"test_label_2": "label_value_2"},
-		},
-		{
-			Timestamp: exemplarTs,
-			Value:     100,
-			Labels:    prometheus.Labels{"test_label_3": "label_value_3"},
-		},
-	}
-
-	// add each exemplar value to the metric
-	for _, e := range exemplars {
-		pde := hd.Exemplars().AppendEmpty()
-		pde.SetDoubleValue(e.Value)
-		for k, v := range e.Labels {
-			pde.FilteredAttributes().PutStr(k, v)
-		}
-		pde.SetTimestamp(pcommon.NewTimestampFromTime(e.Timestamp))
-	}
+	promExporterExemplars.SetTimestamp(pcommon.NewTimestampFromTime(exemplarTs))
+	promExporterExemplars.SetDoubleValue(3.0)
 
 	pMap := pcommon.NewMap()
 
 	c := collector{
+
 		accumulator: &mockAccumulator{
 			metrics:            []pmetric.Metric{metric},
 			resourceAttributes: pMap,
@@ -161,29 +147,17 @@ func TestConvertDoubleHistogramExemplar(t *testing.T) {
 
 	buckets := m.GetHistogram().GetBucket()
 
-	require.Equal(t, 4, len(buckets))
+	require.Equal(t, 3, len(buckets))
 
 	require.Equal(t, 3.0, buckets[0].GetExemplar().GetValue())
 	require.Equal(t, int32(128654848), buckets[0].GetExemplar().GetTimestamp().GetNanos())
-	require.Equal(t, 1, len(buckets[0].GetExemplar().GetLabel()))
-	require.Equal(t, "test_label_0", buckets[0].GetExemplar().GetLabel()[0].GetName())
-	require.Equal(t, "label_value_0", buckets[0].GetExemplar().GetLabel()[0].GetValue())
-
-	require.Equal(t, 0.0, buckets[1].GetExemplar().GetValue())
-	require.Equal(t, int32(0), buckets[1].GetExemplar().GetTimestamp().GetNanos())
-	require.Equal(t, 0, len(buckets[1].GetExemplar().GetLabel()))
-
-	require.Equal(t, 78.0, buckets[2].GetExemplar().GetValue())
-	require.Equal(t, int32(128654848), buckets[2].GetExemplar().GetTimestamp().GetNanos())
-	require.Equal(t, 1, len(buckets[2].GetExemplar().GetLabel()))
-	require.Equal(t, "test_label_2", buckets[2].GetExemplar().GetLabel()[0].GetName())
-	require.Equal(t, "label_value_2", buckets[2].GetExemplar().GetLabel()[0].GetValue())
-
-	require.Equal(t, 100.0, buckets[3].GetExemplar().GetValue())
-	require.Equal(t, int32(128654848), buckets[3].GetExemplar().GetTimestamp().GetNanos())
-	require.Equal(t, 1, len(buckets[3].GetExemplar().GetLabel()))
-	require.Equal(t, "test_label_3", buckets[3].GetExemplar().GetLabel()[0].GetName())
-	require.Equal(t, "label_value_3", buckets[3].GetExemplar().GetLabel()[0].GetValue())
+	require.Equal(t, 2, len(buckets[0].GetExemplar().GetLabel()))
+	ml := make(map[string]string)
+	for _, l := range buckets[0].GetExemplar().GetLabel() {
+		ml[l.GetName()] = l.GetValue()
+	}
+	require.Equal(t, "641d68e314a58152cc2581e7663435d1", ml["trace_id"])
+	require.Equal(t, "7436d6ac76178623", ml["span_id"])
 }
 
 // errorCheckCore keeps track of logged errors


### PR DESCRIPTION
Currently TraceID and SpanID fields of Examplar are set in `FilteredAttributes` ([here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/7b7626bcb0d7125919d7f5e3ea2352fe4a73c437/processor/spanmetricsprocessor/processor.go#L572)) in `spanmetricsprocessor` and passed around but these fields are not part of `FilteredAttributes` as per the data model: https://pkg.go.dev/go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1#Exemplar

- This PR sets TraceID and SpanID fields in Exemplar and also adds SpanID to `spanmetricsprocessor`
- `prometheusexporter` is updated to use TraceID, SpanID fields in `Exemplar`.

**Testing:**
Unit tests are updated to test TraceID and SpanID fields instead of checking for those in `FilteredAttributes`
