### PR TITLE
[receiver/jaegerreceiver] Add remote sampling deprecation warning

### DIFF
--- a/unreleased/deprecate_jaeger_remote_sampling_on_receiver_#6633.yaml
+++ b/unreleased/deprecate_jaeger_remote_sampling_on_receiver_#6633.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: jaegerreceiver
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add remote sampling deprecation warning
+
+# One or more tracking issues related to the change
+issues: [6633]


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
with #6632 and #6694 remote sampling is offered as extention. This pr adds a deprecation warning to the remote sampling endpoint provided in the receiver.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6633 (part of)

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>