### PR TITLE
[project] Fix linting picking up local dir

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ run:
   # from this option's value (see skip-dirs-use-default).
   skip-dirs:
     - third_party
+    - local
 
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -24,6 +24,7 @@ ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | sort)
 
 ALL_SRC := $(shell find $(ALL_PKG_DIRS) -name '*.go' \
                                 -not -path '*/third_party/*' \
+                                -not -path '*/local/*' \
                                 -type f | sort)
 
 # All source code and documents. Used in spell check.


### PR DESCRIPTION
**Description:**

While working on #13410 I encountered a linting error. When running `make lint` locally, the linter was failing for two reasons:

1. It wanted a license block added to a Go file in the `local/` directory
2. It didn't like that a function was unused in the same Go file in the `local/` directory

The `.gitignore` specifically excludes the `local/` directory:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/2892f123682ca0899bef45765933fe708e9c18bc/.gitignore#L1

We should not lint code in that directory.

Does this PR need a changelog yaml file?