### PR TITLE
[internal/metadataproviders/azure]enable errceck

### DIFF
--- a/internal/metadataproviders/azure/metadata_test.go
+++ b/internal/metadataproviders/azure/metadata_test.go
@@ -73,7 +73,7 @@ func TestQueryEndpointCorrect(t *testing.T) {
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := w.Write(marshalledMetadata)
+		_, err = w.Write(marshalledMetadata)
 		assert.NoError(t, err)
 	}))
 	defer ts.Close()

--- a/internal/metadataproviders/azure/metadata_test.go
+++ b/internal/metadataproviders/azure/metadata_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:errcheck
 package azure
 
 import (
@@ -47,7 +46,8 @@ func TestQueryEndpointFailed(t *testing.T) {
 
 func TestQueryEndpointMalformed(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "{")
+		_, err := fmt.Fprintln(w, "{")
+		assert.NoError(t, err)
 	}))
 	defer ts.Close()
 
@@ -73,7 +73,8 @@ func TestQueryEndpointCorrect(t *testing.T) {
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(marshalledMetadata)
+		_, err := w.Write(marshalledMetadata)
+		assert.NoError(t, err)
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
enable errceck in internal/metadataproviders/azure

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9749

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>