### PR TITLE
[exporter/sentryexporter] Omit empty parent span id

### DIFF
--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -381,7 +381,7 @@ func transactionFromSpan(span *sentry.Span) *sentry.Event {
 	transaction := sentry.NewEvent()
 	transaction.EventID = generateEventID()
 
-	transaction.Contexts["trace"] = sentry.TraceContext{
+	transaction.Contexts["trace"] = &sentry.TraceContext{
 		TraceID:      span.TraceID,
 		SpanID:       span.SpanID,
 		ParentSpanID: span.ParentSpanID,

--- a/exporter/sentryexporter/sentry_exporter_test.go
+++ b/exporter/sentryexporter/sentry_exporter_test.go
@@ -17,6 +17,7 @@ package sentryexporter
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -682,6 +683,47 @@ func TestPushTraceData(t *testing.T) {
 			err := s.pushTraceData(context.Background(), test.td)
 			assert.Nil(t, err)
 			assert.Equal(t, test.called, transport.called)
+		})
+	}
+}
+
+type TransactionFromSpanMarshalEventTestCase struct {
+	testName string
+	// input
+	span *sentry.Span
+	// output
+	wantContains string
+}
+
+func TestTransactionFromSpanMarshalEvent(t *testing.T) {
+	testCases := []TransactionFromSpanMarshalEventTestCase{
+		{
+			testName: "with parent span id",
+			span: &sentry.Span{
+				TraceID:      TraceIDFromHex("1915f8aa35ff8fbebbfeedb9d7e07216"),
+				SpanID:       SpanIDFromHex("ea4864700408805c"),
+				ParentSpanID: SpanIDFromHex("4c577fe4aec9523b"),
+			},
+			wantContains: `"contexts":{"trace":{"trace_id":"1915f8aa35ff8fbebbfeedb9d7e07216","span_id":"ea4864700408805c","parent_span_id":"4c577fe4aec9523b"}}`,
+		},
+		{
+			testName: "without parent span id",
+			span: &sentry.Span{
+				TraceID: TraceIDFromHex("11ab4adc8ac6ed96f245cd96b5b6d141"),
+				SpanID:  SpanIDFromHex("cc55ac735f0170ac"),
+			},
+			wantContains: `"contexts":{"trace":{"trace_id":"11ab4adc8ac6ed96f245cd96b5b6d141","span_id":"cc55ac735f0170ac"}}`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.testName, func(t *testing.T) {
+			event := transactionFromSpan(test.span)
+			// mimic what sentry is doing internally
+			// see: https://github.com/getsentry/sentry-go/blob/v0.13.0/transport.go#L66-L70
+			d, err := json.Marshal(event)
+			assert.NoError(t, err)
+			assert.Contains(t, string(d), test.wantContains)
 		})
 	}
 }

--- a/unreleased/empty-parent.yaml
+++ b/unreleased/empty-parent.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sentryexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Omit empty parent span id"
+
+# One or more tracking issues related to the change
+issues: [13415]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
When events without a parent span id is sent to Sentry, the trace context parent span id will have a value of `0000000000000000` when the parent span id field should be omitted if empty. This is because when `sentry.TraceContext` is added to the event context it is not a pointer, thus the custom `MarshalJSON()` func of `sentry.TraceContext` (with pointer receiver) is not used.
This PR changes the `sentry.TraceContext` form value to pointer when added to the event context.

**Link to tracking Issue:**

**Testing:**
Added tests to confirm that the event is marshalled properly with and without a parent span id.

**Documentation:**