### PR TITLE
[processor/transform] Add split function for transform processor

### DIFF
--- a/pkg/telemetryquerylanguage/functions/tqlotel/README.md
+++ b/pkg/telemetryquerylanguage/functions/tqlotel/README.md
@@ -14,6 +14,7 @@ Functions
 - [limit](#limit)
 - [replace_all_matches](#replace_all_matches)
 - [replace_all_patterns](#replace_all_patterns)
+- [split](#split)
 
 ## SpanID
 
@@ -141,3 +142,16 @@ If one or more sections of `target` match `regex` they will get replaced with `r
 Examples:
 
 - `replace_all_patterns(attributes, "/account/\\d{4}", "/account/{accountId}")`
+## split
+
+`split(target, delimiter)`
+
+The `split` function converts a string attribute into an array of substrings split by the delimiter.
+
+`target` is a string attribute. `delimiter` is a string.
+
+If the `target` is not a string, or the `target` is not exist, the `split` function will not change anything.
+
+Examples:
+- If `attributes["flags"]` value is `"A|B|C"`, the following query will change the value to `["A", "B", "C"]`
+```split(attributes["flags"], "|")```

--- a/pkg/telemetryquerylanguage/functions/tqlotel/func_split.go
+++ b/pkg/telemetryquerylanguage/functions/tqlotel/func_split.go
@@ -1,0 +1,35 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tqlotel // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/functions/tqlotel"
+
+import (
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql"
+)
+
+func Split(target tql.GetSetter, delimiter string) (tql.ExprFunc, error) {
+	return func(ctx tql.TransformContext) interface{} {
+		if val := target.Get(ctx); val != nil {
+			if valStr, ok := val.(string); ok {
+				strSlice := strings.Split(valStr, delimiter)
+				if len(strSlice) > 0 {
+					target.Set(ctx, strSlice)
+				}
+			}
+		}
+		return nil
+	}, nil
+}

--- a/pkg/telemetryquerylanguage/functions/tqlotel/func_split_test.go
+++ b/pkg/telemetryquerylanguage/functions/tqlotel/func_split_test.go
@@ -1,0 +1,106 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tqlotel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql/tqltest"
+)
+
+func Test_split(t *testing.T) {
+	target := &tql.StandardGetSetter{
+		Getter: func(ctx tql.TransformContext) interface{} {
+			return ctx.GetItem().(pcommon.Value).StringVal()
+		},
+		Setter: func(ctx tql.TransformContext, val interface{}) {
+			switch tv := val.(type) {
+			case string:
+				ctx.GetItem().(pcommon.Value).SetStringVal(tv)
+			case []string:
+				newSlice := pcommon.NewValueSlice()
+				for i := 0; i < len(tv); i++ {
+					newSlice.SliceVal().AppendEmpty().SetStringVal(tv[i])
+				}
+				newSlice.CopyTo(ctx.GetItem().(pcommon.Value))
+			default:
+				fmt.Printf("<Invalid value type %T>", tv)
+			}
+		},
+	}
+
+	tests := []struct {
+		name      string
+		target    tql.GetSetter
+		value     string
+		delimiter string
+		want      func(pcommon.Value)
+	}{
+		{
+			name:      "split",
+			target:    target,
+			value:     "A|B|C",
+			delimiter: "|",
+			want: func(expectedValue pcommon.Value) {
+				expectedValue.SliceVal().AppendEmpty().SetStringVal("A")
+				expectedValue.SliceVal().AppendEmpty().SetStringVal("B")
+				expectedValue.SliceVal().AppendEmpty().SetStringVal("C")
+			},
+		},
+		{
+			name:      "split empty string",
+			target:    target,
+			value:     "",
+			delimiter: "|",
+			want: func(expectedValue pcommon.Value) {
+				expectedValue.SliceVal().AppendEmpty().SetStringVal("")
+			},
+		},
+		{
+			name:      "delimiter empty",
+			target:    target,
+			value:     "A|B|C",
+			delimiter: "",
+			want: func(expectedValue pcommon.Value) {
+				expectedValue.SliceVal().AppendEmpty().SetStringVal("A")
+				expectedValue.SliceVal().AppendEmpty().SetStringVal("|")
+				expectedValue.SliceVal().AppendEmpty().SetStringVal("B")
+				expectedValue.SliceVal().AppendEmpty().SetStringVal("|")
+				expectedValue.SliceVal().AppendEmpty().SetStringVal("C")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scenarioValue := pcommon.NewValueString(tt.value)
+			ctx := tqltest.TestTransformContext{
+				Item: scenarioValue,
+			}
+
+			exprFunc, _ := Split(tt.target, tt.delimiter)
+			exprFunc(ctx)
+
+			expected := pcommon.NewValueSlice()
+			tt.want(expected)
+
+			assert.Equal(t, expected, scenarioValue)
+		})
+	}
+}

--- a/processor/transformprocessor/internal/common/functions.go
+++ b/processor/transformprocessor/internal/common/functions.go
@@ -33,6 +33,7 @@ var registry = map[string]interface{}{
 	"replace_all_patterns": tqlotel.ReplaceAllPatterns,
 	"delete_key":           tqlotel.DeleteKey,
 	"delete_matching_keys": tqlotel.DeleteMatchingKeys,
+	"split":                tqlotel.Split,
 }
 
 func Functions() map[string]interface{} {

--- a/unreleased/transformprocessor-add-split-function.yaml
+++ b/unreleased/transformprocessor-add-split-function.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: transformprocessor, telemetryquerylanguage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add split function to convert a string attribute into an array of substrings split by the delimiter.
+
+# One or more tracking issues related to the change
+issues: [11790]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add `split` function to convert a string attribute into an array of substrings split by the delimiter. The scenario is also described in issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11790
* Added the `split` function in TQL
* Import the function to the transform processor 

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11790

**Testing:** 
Updated unit tests

**Documentation:** 
Updated readme in tqlotel