### PR TITLE
[exporter/tanzuobservabilityexporter] Use 0.10.4 of wavefront-sdk-go

### DIFF
--- a/exporter/tanzuobservabilityexporter/exporter.go
+++ b/exporter/tanzuobservabilityexporter/exporter.go
@@ -70,7 +70,7 @@ func newTracesExporter(settings component.ExporterCreateSettings, c config.Expor
 	if !cfg.hasTracesEndpoint() {
 		return nil, fmt.Errorf("traces.endpoint required")
 	}
-	tracingHost, tracingPort, err := cfg.parseTracesEndpoint()
+	_, _, err := cfg.parseTracesEndpoint()
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse traces.endpoint: %w", err)
 	}
@@ -84,14 +84,11 @@ func newTracesExporter(settings component.ExporterCreateSettings, c config.Expor
 
 	// we specify a MetricsPort so the SDK can report its internal metrics
 	// but don't currently export any metrics from the pipeline
-	// nolint:staticcheck
-	s, err := senders.NewProxySender(&senders.ProxyConfiguration{
-		Host:                 tracingHost,
-		MetricsPort:          metricsPort,
-		TracingPort:          tracingPort,
-		FlushIntervalSeconds: 1,
-		SDKMetricsTags:       map[string]string{"otel.traces.collector_version": settings.BuildInfo.Version},
-	})
+	s, err := senders.NewSender(cfg.Traces.Endpoint,
+		senders.MetricsPort(metricsPort),
+		senders.FlushIntervalSeconds(60),
+		senders.SDKMetricsTags(map[string]string{"otel.traces.collector_version": settings.BuildInfo.Version}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy sender: %w", err)
 	}

--- a/exporter/tanzuobservabilityexporter/metrics_exporter.go
+++ b/exporter/tanzuobservabilityexporter/metrics_exporter.go
@@ -28,15 +28,11 @@ type metricsExporter struct {
 	consumer *metricsConsumer
 }
 
-func createMetricsConsumer(hostName string, port int, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
-	// nolint:staticcheck
-	s, err := senders.NewProxySender(&senders.ProxyConfiguration{
-		Host:                 hostName,
-		MetricsPort:          port,
-		DistributionPort:     port,
-		FlushIntervalSeconds: 1,
-		SDKMetricsTags:       map[string]string{"otel.metrics.collector_version": otelVersion},
-	})
+func createMetricsConsumer(endpoint string, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
+	s, err := senders.NewSender(endpoint,
+		senders.FlushIntervalSeconds(60),
+		senders.SDKMetricsTags(map[string]string{"otel.metrics.collector_version": otelVersion}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy sender: %w", err)
 	}
@@ -54,7 +50,7 @@ func createMetricsConsumer(hostName string, port int, settings component.Telemet
 		true), nil
 }
 
-type metricsConsumerCreator func(hostName string, port int, settings component.TelemetrySettings, otelVersion string) (
+type metricsConsumerCreator func(endpoint string, settings component.TelemetrySettings, otelVersion string) (
 	*metricsConsumer, error)
 
 func newMetricsExporter(settings component.ExporterCreateSettings, c config.Exporter, creator metricsConsumerCreator) (*metricsExporter, error) {
@@ -65,11 +61,10 @@ func newMetricsExporter(settings component.ExporterCreateSettings, c config.Expo
 	if !cfg.hasMetricsEndpoint() {
 		return nil, fmt.Errorf("metrics.endpoint required")
 	}
-	hostName, port, err := cfg.parseMetricsEndpoint()
-	if err != nil {
+	if _, _, err := cfg.parseMetricsEndpoint(); err != nil {
 		return nil, fmt.Errorf("failed to parse metrics.endpoint: %w", err)
 	}
-	consumer, err := creator(hostName, port, settings.TelemetrySettings, settings.BuildInfo.Version)
+	consumer, err := creator(cfg.Metrics.Endpoint, settings.TelemetrySettings, settings.BuildInfo.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/tanzuobservabilityexporter/metrics_exporter_test.go
+++ b/exporter/tanzuobservabilityexporter/metrics_exporter_test.go
@@ -63,7 +63,7 @@ func createMockMetricsExporter(
 	ourConfig := cfg.(*Config)
 	ourConfig.Metrics.Endpoint = "http://localhost:2878"
 	creator := func(
-		hostName string, port int, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
+		endpoint string, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
 		return newMetricsConsumer(
 			[]typedMetricConsumer{
 				newGaugeConsumer(sender, settings),

--- a/unreleased/tanzuobservabilityexporter-version-bump.yaml
+++ b/unreleased/tanzuobservabilityexporter-version-bump.yaml
@@ -1,0 +1,13 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/tanzuobservabilityexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+  This change causes tanzuobservabilityexporter to depend on 0.10.4 of the
+  wavefront-sdk-go library.
+
+# One or more tracking issues related to the change
+issues: [13417]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Use 0.10.4 of wavefront-sdk-go

**Link to tracking Issue:** #13417 