### PR TITLE
[pkg/stanza/adapater] Remove persister wrapper around storage.Client

### DIFF
--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -19,13 +19,11 @@ import (
 	"errors"
 	"time"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/storagetest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -128,14 +126,4 @@ func (f TestReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Conf
 		return nil, errors.New("unknown input type")
 	}
 	return &operator.Config{Builder: NewUnstartableConfig()}, nil
-}
-
-func newMockPersister() *persister {
-	return &persister{
-		client: storagetest.NewInMemoryClient(
-			component.KindReceiver,
-			config.NewComponentID("foolog"),
-			"test",
-		),
-	}
 }

--- a/pkg/stanza/adapter/receiver.go
+++ b/pkg/stanza/adapter/receiver.go
@@ -57,7 +57,7 @@ func (r *receiver) Start(ctx context.Context, host component.Host) error {
 		return fmt.Errorf("storage client: %w", err)
 	}
 
-	if err := r.pipe.Start(r.getPersister()); err != nil {
+	if err := r.pipe.Start(r.storageClient); err != nil {
 		return fmt.Errorf("start stanza: %w", err)
 	}
 

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -25,10 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/storagetest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/pipeline"
@@ -135,9 +137,15 @@ func BenchmarkReadLine(b *testing.B) {
 		require.NoError(b, err)
 	}
 
+	storageClient := storagetest.NewInMemoryClient(
+		component.KindReceiver,
+		config.NewComponentID("foolog"),
+		"test",
+	)
+
 	// // Run the actual benchmark
 	b.ResetTimer()
-	require.NoError(b, pipe.Start(newMockPersister()))
+	require.NoError(b, pipe.Start(storageClient))
 	for i := 0; i < b.N; i++ {
 		entries := <-emitter.logChan
 		for _, e := range entries {
@@ -196,9 +204,15 @@ func BenchmarkParseAndMap(b *testing.B) {
 		require.NoError(b, err)
 	}
 
+	storageClient := storagetest.NewInMemoryClient(
+		component.KindReceiver,
+		config.NewComponentID("foolog"),
+		"test",
+	)
+
 	// // Run the actual benchmark
 	b.ResetTimer()
-	require.NoError(b, pipe.Start(newMockPersister()))
+	require.NoError(b, pipe.Start(storageClient))
 	for i := 0; i < b.N; i++ {
 		entries := <-emitter.logChan
 		for _, e := range entries {

--- a/pkg/stanza/adapter/storage.go
+++ b/pkg/stanza/adapter/storage.go
@@ -21,8 +21,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/extension/experimental/storage"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
 func GetStorageClient(ctx context.Context, id config.ComponentID, componentKind component.Kind, host component.Host) (storage.Client, error) {
@@ -45,10 +43,6 @@ func GetStorageClient(ctx context.Context, id config.ComponentID, componentKind 
 	return storageExtension.GetClient(ctx, componentKind, id, "")
 }
 
-func GetPersister(storageClient storage.Client) operator.Persister {
-	return &persister{storageClient}
-}
-
 func (r *receiver) setStorageClient(ctx context.Context, host component.Host) error {
 	client, err := GetStorageClient(ctx, r.id, component.KindReceiver, host)
 	if err != nil {
@@ -57,26 +51,4 @@ func (r *receiver) setStorageClient(ctx context.Context, host component.Host) er
 
 	r.storageClient = client
 	return nil
-}
-
-func (r *receiver) getPersister() operator.Persister {
-	return GetPersister(r.storageClient)
-}
-
-type persister struct {
-	client storage.Client
-}
-
-var _ operator.Persister = &persister{}
-
-func (p *persister) Get(ctx context.Context, key string) ([]byte, error) {
-	return p.client.Get(ctx, key)
-}
-
-func (p *persister) Set(ctx context.Context, key string, value []byte) error {
-	return p.client.Set(ctx, key, value)
-}
-
-func (p *persister) Delete(ctx context.Context, key string) error {
-	return p.client.Delete(ctx, key)
 }

--- a/pkg/stanza/adapter/storage_test.go
+++ b/pkg/stanza/adapter/storage_test.go
@@ -99,19 +99,3 @@ func createReceiver(t *testing.T) *receiver {
 	require.True(t, ok)
 	return r
 }
-
-func TestPersisterImplementation(t *testing.T) {
-	ctx := context.Background()
-	myBytes := []byte("string")
-	p := newMockPersister()
-
-	err := p.Set(ctx, "key", myBytes)
-	require.NoError(t, err)
-
-	val, err := p.Get(ctx, "key")
-	require.NoError(t, err)
-	require.Equal(t, myBytes, val)
-
-	err = p.Delete(ctx, "key")
-	require.NoError(t, err)
-}

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -88,7 +88,7 @@ func (ltp *logsTransformProcessor) Start(ctx context.Context, host component.Hos
 	}
 
 	// There is no need for this processor to use storage
-	err = pipe.Start(adapter.GetPersister(storage.NewNopClient()))
+	err = pipe.Start(storage.NewNopClient())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
storage.Client already implements the necesssary interface, so this
abstraction is not needed.

This is a subset of #13418.