### PR TITLE
[processor/spanmetricsprocessor] Add ms unit to latency buckets

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -282,6 +282,7 @@ func (p *processorImp) collectLatencyMetrics(ilm pmetric.ScopeMetrics) error {
 		mLatency := ilm.Metrics().AppendEmpty()
 		mLatency.SetDataType(pmetric.MetricDataTypeHistogram)
 		mLatency.SetName("latency")
+		mLatency.SetUnit("ms")
 		mLatency.Histogram().SetAggregationTemporality(p.config.GetAggregationTemporality())
 
 		timestamp := pcommon.NewTimestampFromTime(time.Now())

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -472,9 +472,12 @@ func verifyConsumeMetricsInput(t testing.TB, input pmetric.Metrics, expectedTemp
 	seenMetricIDs = make(map[metricID]bool)
 	// The remaining metrics are for latency.
 	for ; mi < m.Len(); mi++ {
-		assert.Equal(t, "latency", m.At(mi).Name())
+		metric := m.At(mi)
 
-		data := m.At(mi).Histogram()
+		assert.Equal(t, "latency", metric.Name())
+		assert.Equal(t, "ms", metric.Unit())
+
+		data := metric.Histogram()
 		assert.Equal(t, expectedTemporality, data.AggregationTemporality())
 
 		dps := data.DataPoints()

--- a/unreleased/spanmetrics.yaml
+++ b/unreleased/spanmetrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The unit of the `latency` metric is now explicitly defined.
+
+# One or more tracking issues related to the change
+issues: [13423]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** Define the `latency` metric unit as milliseconds for `spanmetricsprocessor`.
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Testing:** unit tests

**Documentation:** the metric was already documented as being in milliseconds.
