### PR TITLE
Move the OTel and OC metrics test helper utilities

### DIFF
--- a/exporter/carbonexporter/exporter_test.go
+++ b/exporter/carbonexporter/exporter_test.go
@@ -39,7 +39,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil/ocmetricstestutil"
 	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 )
 
@@ -88,13 +88,13 @@ func TestNew(t *testing.T) {
 func TestConsumeMetricsData(t *testing.T) {
 	t.Skip("skipping flaky test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/396")
 	smallBatch := internaldata.OCToMetrics(nil, nil, []*metricspb.Metric{
-		metricstestutil.Gauge(
+		ocmetricstestutil.Gauge(
 			"test_gauge",
 			[]string{"k0", "k1"},
-			metricstestutil.Timeseries(
+			ocmetricstestutil.Timeseries(
 				time.Now(),
 				[]string{"v0", "v1"},
-				metricstestutil.Double(time.Now(), 123))),
+				ocmetricstestutil.Double(time.Now(), 123))),
 	})
 
 	largeBatch := generateLargeBatch()
@@ -288,10 +288,10 @@ func generateLargeBatch() pmetric.Metrics {
 	ts := time.Now()
 	for i := 0; i < 65000; i++ {
 		metrics = append(metrics,
-			metricstestutil.Gauge(
+			ocmetricstestutil.Gauge(
 				"test_"+strconv.Itoa(i),
 				[]string{"k0", "k1"},
-				metricstestutil.Timeseries(
+				ocmetricstestutil.Timeseries(
 					time.Now(),
 					[]string{"v0", "v1"},
 					&metricspb.Point{

--- a/exporter/carbonexporter/metricdata_to_plaintext_test.go
+++ b/exporter/carbonexporter/metricdata_to_plaintext_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil/ocmetricstestutil"
 )
 
 func Test_sanitizeTagKey(t *testing.T) {
@@ -152,7 +152,7 @@ func Test_metricDataToPlaintext(t *testing.T) {
 
 	doubleVal := 1234.5678
 	expectedDobuleValStr := strconv.FormatFloat(doubleVal, 'g', -1, 64)
-	doublePt := metricstestutil.Double(tsUnix, doubleVal)
+	doublePt := ocmetricstestutil.Double(tsUnix, doubleVal)
 	int64Val := int64(123)
 	expectedInt64ValStr := "123"
 	int64Pt := &metricspb.Point{
@@ -162,19 +162,19 @@ func Test_metricDataToPlaintext(t *testing.T) {
 
 	distributionBounds := []float64{1.5, 2, 4}
 	distributionCounts := []int64{4, 2, 3, 7}
-	distributionTimeSeries := metricstestutil.Timeseries(
+	distributionTimeSeries := ocmetricstestutil.Timeseries(
 		tsUnix,
 		values,
-		metricstestutil.DistPt(tsUnix, distributionBounds, distributionCounts))
+		ocmetricstestutil.DistPt(tsUnix, distributionBounds, distributionCounts))
 	distributionPoints := distributionTimeSeries.GetPoints()
 	require.Equal(t, 1, len(distributionPoints))
 	distribubionPoint := distributionPoints[0].Value.(*metricspb.Point_DistributionValue)
 	distributionValue := distribubionPoint.DistributionValue
 
-	summaryTimeSeries := metricstestutil.Timeseries(
+	summaryTimeSeries := ocmetricstestutil.Timeseries(
 		tsUnix,
 		values,
-		metricstestutil.SummPt(
+		ocmetricstestutil.SummPt(
 			tsUnix,
 			11,
 			111,
@@ -197,14 +197,14 @@ func Test_metricDataToPlaintext(t *testing.T) {
 				return []*agentmetricspb.ExportMetricsServiceRequest{
 					{
 						Metrics: []*metricspb.Metric{
-							metricstestutil.Gauge("gauge_double_no_dims", nil, metricstestutil.Timeseries(tsUnix, nil, doublePt)),
-							metricstestutil.GaugeInt("gauge_int_no_dims", nil, metricstestutil.Timeseries(tsUnix, nil, int64Pt)),
+							ocmetricstestutil.Gauge("gauge_double_no_dims", nil, ocmetricstestutil.Timeseries(tsUnix, nil, doublePt)),
+							ocmetricstestutil.GaugeInt("gauge_int_no_dims", nil, ocmetricstestutil.Timeseries(tsUnix, nil, int64Pt)),
 						},
 					},
 					{
 						Metrics: []*metricspb.Metric{
-							metricstestutil.Cumulative("cumulative_double_no_dims", nil, metricstestutil.Timeseries(tsUnix, nil, doublePt)),
-							metricstestutil.CumulativeInt("cumulative_int_no_dims", nil, metricstestutil.Timeseries(tsUnix, nil, int64Pt)),
+							ocmetricstestutil.Cumulative("cumulative_double_no_dims", nil, ocmetricstestutil.Timeseries(tsUnix, nil, doublePt)),
+							ocmetricstestutil.CumulativeInt("cumulative_int_no_dims", nil, ocmetricstestutil.Timeseries(tsUnix, nil, int64Pt)),
 						},
 					},
 				}
@@ -223,10 +223,10 @@ func Test_metricDataToPlaintext(t *testing.T) {
 				return []*agentmetricspb.ExportMetricsServiceRequest{
 					{
 						Metrics: []*metricspb.Metric{
-							metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-							metricstestutil.GaugeInt("gauge_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
-							metricstestutil.Cumulative("cumulative_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-							metricstestutil.CumulativeInt("cumulative_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
+							ocmetricstestutil.Gauge("gauge_double_with_dims", keys, ocmetricstestutil.Timeseries(tsUnix, values, doublePt)),
+							ocmetricstestutil.GaugeInt("gauge_int_with_dims", keys, ocmetricstestutil.Timeseries(tsUnix, values, int64Pt)),
+							ocmetricstestutil.Cumulative("cumulative_double_with_dims", keys, ocmetricstestutil.Timeseries(tsUnix, values, doublePt)),
+							ocmetricstestutil.CumulativeInt("cumulative_int_with_dims", keys, ocmetricstestutil.Timeseries(tsUnix, values, int64Pt)),
 						},
 					},
 				}
@@ -245,7 +245,7 @@ func Test_metricDataToPlaintext(t *testing.T) {
 				return []*agentmetricspb.ExportMetricsServiceRequest{
 					{
 						Metrics: []*metricspb.Metric{
-							metricstestutil.GaugeDist("distrib", keys, distributionTimeSeries),
+							ocmetricstestutil.GaugeDist("distrib", keys, distributionTimeSeries),
 						},
 					},
 				}
@@ -264,7 +264,7 @@ func Test_metricDataToPlaintext(t *testing.T) {
 				return []*agentmetricspb.ExportMetricsServiceRequest{
 					{
 						Metrics: []*metricspb.Metric{
-							metricstestutil.Summary("summary", keys, summaryTimeSeries),
+							ocmetricstestutil.Summary("summary", keys, summaryTimeSeries),
 						},
 					},
 				}

--- a/exporter/googlecloudexporter/legacymetrics_test.go
+++ b/exporter/googlecloudexporter/legacymetrics_test.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil/ocmetricstestutil"
 	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 )
 
@@ -126,41 +126,41 @@ func TestGoogleCloudMetricExport(t *testing.T) {
 			},
 		},
 		Metrics: []*metricspb.Metric{
-			metricstestutil.Gauge(
+			ocmetricstestutil.Gauge(
 				"test_gauge1",
 				[]string{"k0"},
-				metricstestutil.Timeseries(
+				ocmetricstestutil.Timeseries(
 					time.Now(),
 					[]string{"v0"},
-					metricstestutil.Double(time.Now(), 1))),
-			metricstestutil.Gauge(
+					ocmetricstestutil.Double(time.Now(), 1))),
+			ocmetricstestutil.Gauge(
 				"test_gauge2",
 				[]string{"k0", "k1"},
-				metricstestutil.Timeseries(
+				ocmetricstestutil.Timeseries(
 					time.Now(),
 					[]string{"v0", "v1"},
-					metricstestutil.Double(time.Now(), 12))),
-			metricstestutil.Gauge(
+					ocmetricstestutil.Double(time.Now(), 12))),
+			ocmetricstestutil.Gauge(
 				"test_gauge3",
 				[]string{"k0", "k1", "k2"},
-				metricstestutil.Timeseries(
+				ocmetricstestutil.Timeseries(
 					time.Now(),
 					[]string{"v0", "v1", "v2"},
-					metricstestutil.Double(time.Now(), 123))),
-			metricstestutil.Gauge(
+					ocmetricstestutil.Double(time.Now(), 123))),
+			ocmetricstestutil.Gauge(
 				"test_gauge4",
 				[]string{"k0", "k1", "k2", "k3"},
-				metricstestutil.Timeseries(
+				ocmetricstestutil.Timeseries(
 					time.Now(),
 					[]string{"v0", "v1", "v2", "v3"},
-					metricstestutil.Double(time.Now(), 1234))),
-			metricstestutil.Gauge(
+					ocmetricstestutil.Double(time.Now(), 1234))),
+			ocmetricstestutil.Gauge(
 				"test_gauge5",
 				[]string{"k4", "k5"},
-				metricstestutil.Timeseries(
+				ocmetricstestutil.Timeseries(
 					time.Now(),
 					[]string{"v4", "v5"},
-					metricstestutil.Double(time.Now(), 34))),
+					ocmetricstestutil.Double(time.Now(), 34))),
 		},
 	}
 	md.Metrics[2].Resource = &resourcepb.Resource{

--- a/exporter/splunkhecexporter/exporter_test.go
+++ b/exporter/splunkhecexporter/exporter_test.go
@@ -42,7 +42,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil/ocmetricstestutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 )
@@ -89,13 +89,13 @@ func TestConsumeMetricsData(t *testing.T) {
 		},
 		Resource: &resourcepb.Resource{Type: "test"},
 		Metrics: []*metricspb.Metric{
-			metricstestutil.Gauge(
+			ocmetricstestutil.Gauge(
 				"test_gauge",
 				[]string{"k0", "k1"},
-				metricstestutil.Timeseries(
+				ocmetricstestutil.Timeseries(
 					time.Now(),
 					[]string{"v0", "v1"},
-					metricstestutil.Double(time.Now(), 123))),
+					ocmetricstestutil.Double(time.Now(), 123))),
 		},
 	}
 	tests := []struct {
@@ -199,10 +199,10 @@ func generateLargeBatch() *agentmetricspb.ExportMetricsServiceRequest {
 	ts := time.Now()
 	for i := 0; i < 65000; i++ {
 		md.Metrics = append(md.Metrics,
-			metricstestutil.Gauge(
+			ocmetricstestutil.Gauge(
 				"test_"+strconv.Itoa(i),
 				[]string{"k0", "k1"},
-				metricstestutil.Timeseries(
+				ocmetricstestutil.Timeseries(
 					time.Now(),
 					[]string{"v0", "v1"},
 					&metricspb.Point{

--- a/internal/coreinternal/metricstestutil/metric_diff.go
+++ b/internal/coreinternal/metricstestutil/metric_diff.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/correctnesstests/metrics"
+package metricstestutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
 
 import (
 	"fmt"
@@ -33,6 +33,10 @@ type MetricDiff struct {
 
 func (mf MetricDiff) String() string {
 	return fmt.Sprintf("{msg='%v' expected=[%v] actual=[%v]}\n", mf.Msg, mf.ExpectedValue, mf.ActualValue)
+}
+
+func DiffMetrics(diffs []*MetricDiff, expected, actual pmetric.Metrics) []*MetricDiff {
+	return append(diffs, diffMetricData(expected, actual)...)
 }
 
 func diffRMSlices(sent []pmetric.ResourceMetrics, recd []pmetric.ResourceMetrics) []*MetricDiff {
@@ -98,6 +102,19 @@ func diffMetrics(diffs []*MetricDiff, expected pmetric.MetricSlice, actual pmetr
 	return diffs
 }
 
+func diffMetricData(expected, actual pmetric.Metrics) []*MetricDiff {
+	expectedRMSlice := expected.ResourceMetrics()
+	actualRMSlice := actual.ResourceMetrics()
+	return diffRMSlices(toSlice(expectedRMSlice), toSlice(actualRMSlice))
+}
+
+func toSlice(s pmetric.ResourceMetricsSlice) (out []pmetric.ResourceMetrics) {
+	for i := 0; i < s.Len(); i++ {
+		out = append(out, s.At(i))
+	}
+	return out
+}
+
 func DiffMetric(diffs []*MetricDiff, expected pmetric.Metric, actual pmetric.Metric) []*MetricDiff {
 	var mismatch bool
 	diffs, mismatch = diffMetricDescriptor(diffs, expected, actual)
@@ -114,6 +131,12 @@ func DiffMetric(diffs []*MetricDiff, expected pmetric.Metric, actual pmetric.Met
 	case pmetric.MetricDataTypeHistogram:
 		diffs = diff(diffs, expected.Histogram().AggregationTemporality(), actual.Histogram().AggregationTemporality(), "Histogram AggregationTemporality")
 		diffs = diffHistogramPts(diffs, expected.Histogram().DataPoints(), actual.Histogram().DataPoints())
+	case pmetric.MetricDataTypeExponentialHistogram:
+		diffs = diff(diffs, expected.ExponentialHistogram().AggregationTemporality(), actual.ExponentialHistogram().AggregationTemporality(), "ExponentialHistogram AggregationTemporality")
+		diffs = diffExponentialHistogramPts(diffs, expected.ExponentialHistogram().DataPoints(), actual.ExponentialHistogram().DataPoints())
+	default:
+		// Note: Summary data points are not currently handled
+		panic("unsupported test case")
 	}
 	return diffs
 }
@@ -140,17 +163,21 @@ func diffNumberPts(
 		return diffs
 	}
 	for i := 0; i < expected.Len(); i++ {
-		diffs, mismatch = diffValues(diffs, expected.At(i).ValueType(), actual.At(i).ValueType(), "NumberDataPoint Value Type")
+		exPt := expected.At(i)
+		acPt := actual.At(i)
+
+		diffs = diffMetricAttrs(diffs, exPt.Attributes(), acPt.Attributes())
+		diffs, mismatch = diffValues(diffs, exPt.ValueType(), acPt.ValueType(), "NumberDataPoint Value Type")
 		if mismatch {
 			return diffs
 		}
-		switch expected.At(i).ValueType() {
+		switch exPt.ValueType() {
 		case pmetric.NumberDataPointValueTypeInt:
-			diffs = diff(diffs, expected.At(i).IntVal(), actual.At(i).IntVal(), "NumberDataPoint Value")
+			diffs = diff(diffs, exPt.IntVal(), acPt.IntVal(), "NumberDataPoint Value")
 		case pmetric.NumberDataPointValueTypeDouble:
-			diffs = diff(diffs, expected.At(i).DoubleVal(), actual.At(i).DoubleVal(), "NumberDataPoint Value")
+			diffs = diff(diffs, exPt.DoubleVal(), acPt.DoubleVal(), "NumberDataPoint Value")
 		}
-		diffExemplars(diffs, expected.At(i).Exemplars(), actual.At(i).Exemplars())
+		diffExemplars(diffs, exPt.Exemplars(), acPt.Exemplars())
 	}
 	return diffs
 }
@@ -166,22 +193,73 @@ func diffHistogramPts(
 		return diffs
 	}
 	for i := 0; i < expected.Len(); i++ {
-		diffs = diffDoubleHistogramPt(diffs, expected.At(i), actual.At(i))
+		diffs = diffHistogramPt(diffs, expected.At(i), actual.At(i))
 	}
 	return diffs
 }
 
-func diffDoubleHistogramPt(
+func diffHistogramPt(
 	diffs []*MetricDiff,
 	expected pmetric.HistogramDataPoint,
 	actual pmetric.HistogramDataPoint,
 ) []*MetricDiff {
+	diffs = diffMetricAttrs(diffs, expected.Attributes(), actual.Attributes())
 	diffs = diff(diffs, expected.Count(), actual.Count(), "HistogramDataPoint Count")
 	diffs = diff(diffs, expected.Sum(), actual.Sum(), "HistogramDataPoint Sum")
 	diffs = diff(diffs, expected.BucketCounts().AsRaw(), actual.BucketCounts().AsRaw(), "HistogramDataPoint BucketCounts")
 	diffs = diff(diffs, expected.ExplicitBounds().AsRaw(), actual.ExplicitBounds().AsRaw(), "HistogramDataPoint ExplicitBounds")
-	// todo LabelsMap()
 	return diffExemplars(diffs, expected.Exemplars(), actual.Exemplars())
+}
+
+func diffExponentialHistogramPts(
+	diffs []*MetricDiff,
+	expected pmetric.ExponentialHistogramDataPointSlice,
+	actual pmetric.ExponentialHistogramDataPointSlice,
+) []*MetricDiff {
+	var mismatch bool
+	diffs, mismatch = diffValues(diffs, expected.Len(), actual.Len(), "ExponentialHistogramDataPointSlice len")
+	if mismatch {
+		return diffs
+	}
+	for i := 0; i < expected.Len(); i++ {
+		diffs = diffExponentialHistogramPt(diffs, expected.At(i), actual.At(i))
+	}
+	return diffs
+}
+
+func diffExponentialHistogramPt(
+	diffs []*MetricDiff,
+	expected pmetric.ExponentialHistogramDataPoint,
+	actual pmetric.ExponentialHistogramDataPoint,
+) []*MetricDiff {
+	diffs = diffMetricAttrs(diffs, expected.Attributes(), actual.Attributes())
+	diffs = diff(diffs, expected.Count(), actual.Count(), "ExponentialHistogramDataPoint Count")
+	diffs = diff(diffs, expected.Sum(), actual.Sum(), "ExponentialHistogramDataPoint Sum")
+	diffs = diff(diffs, expected.ZeroCount(), actual.ZeroCount(), "ExponentialHistogramDataPoint ZeroCount")
+	diffs = diff(diffs, expected.Scale(), actual.Scale(), "ExponentialHistogramDataPoint Scale")
+
+	diffs = diffExponentialHistogramPtBuckets(diffs, expected.Positive(), actual.Positive())
+	diffs = diffExponentialHistogramPtBuckets(diffs, expected.Negative(), actual.Negative())
+
+	return diffExemplars(diffs, expected.Exemplars(), actual.Exemplars())
+}
+
+func diffExponentialHistogramPtBuckets(
+	diffs []*MetricDiff,
+	expected pmetric.Buckets,
+	actual pmetric.Buckets,
+) []*MetricDiff {
+	diffs = diff(diffs, expected.Offset(), actual.Offset(), "ExponentialHistogramDataPoint Buckets Offset")
+	exC := expected.BucketCounts()
+	acC := actual.BucketCounts()
+	diffs, mod := diffValues(diffs, exC.Len(), acC.Len(), "ExponentialHistogramDataPoint Buckets Len")
+	if mod {
+		return diffs
+	}
+	for i := 0; i < exC.Len(); i++ {
+		diffs = diff(diffs, exC.At(i), acC.At(i), fmt.Sprintf("ExponentialHistogramDataPoint Buckets Count[%d]", i))
+	}
+	return diffs
 }
 
 func diffExemplars(
@@ -207,15 +285,26 @@ func diffExemplars(
 }
 
 func diffResource(diffs []*MetricDiff, expected pcommon.Resource, actual pcommon.Resource) []*MetricDiff {
-	return diffAttrs(diffs, expected.Attributes(), actual.Attributes())
+	return diffResourceAttrs(diffs, expected.Attributes(), actual.Attributes())
 }
 
-func diffAttrs(diffs []*MetricDiff, expected pcommon.Map, actual pcommon.Map) []*MetricDiff {
+func diffResourceAttrs(diffs []*MetricDiff, expected pcommon.Map, actual pcommon.Map) []*MetricDiff {
 	if !reflect.DeepEqual(expected, actual) {
 		diffs = append(diffs, &MetricDiff{
 			ExpectedValue: attrMapToString(expected),
 			ActualValue:   attrMapToString(actual),
 			Msg:           "Resource attributes",
+		})
+	}
+	return diffs
+}
+
+func diffMetricAttrs(diffs []*MetricDiff, expected pcommon.Map, actual pcommon.Map) []*MetricDiff {
+	if !reflect.DeepEqual(expected, actual) {
+		diffs = append(diffs, &MetricDiff{
+			ExpectedValue: attrMapToString(expected),
+			ActualValue:   attrMapToString(actual),
+			Msg:           "Metric attributes",
 		})
 	}
 	return diffs

--- a/internal/coreinternal/metricstestutil/metric_diff_test.go
+++ b/internal/coreinternal/metricstestutil/metric_diff_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metrics
+package metricstestutil
 
 import (
 	"testing"
@@ -28,19 +28,6 @@ func TestSameMetrics(t *testing.T) {
 	actual := goldendataset.MetricsFromCfg(goldendataset.DefaultCfg())
 	diffs := diffMetricData(expected, actual)
 	assert.Nil(t, diffs)
-}
-
-func diffMetricData(expected pmetric.Metrics, actual pmetric.Metrics) []*MetricDiff {
-	expectedRMSlice := expected.ResourceMetrics()
-	actualRMSlice := actual.ResourceMetrics()
-	return diffRMSlices(toSlice(expectedRMSlice), toSlice(actualRMSlice))
-}
-
-func toSlice(s pmetric.ResourceMetricsSlice) (out []pmetric.ResourceMetrics) {
-	for i := 0; i < s.Len(); i++ {
-		out = append(out, s.At(i))
-	}
-	return out
 }
 
 func TestDifferentValues(t *testing.T) {

--- a/internal/coreinternal/metricstestutil/metric_diff_test.go
+++ b/internal/coreinternal/metricstestutil/metric_diff_test.go
@@ -68,3 +68,29 @@ func TestHistogram(t *testing.T) {
 	diffs := diffMetricData(expected, actual)
 	assert.Len(t, diffs, 3)
 }
+
+func TestAttributes(t *testing.T) {
+	cfg1 := goldendataset.DefaultCfg()
+	cfg1.MetricDescriptorType = pmetric.MetricDataTypeHistogram
+	cfg1.NumPtLabels = 1
+	expected := goldendataset.MetricsFromCfg(cfg1)
+	cfg2 := goldendataset.DefaultCfg()
+	cfg2.MetricDescriptorType = pmetric.MetricDataTypeHistogram
+	cfg2.NumPtLabels = 2
+	actual := goldendataset.MetricsFromCfg(cfg2)
+	diffs := DiffMetrics(nil, expected, actual)
+	assert.Len(t, diffs, 1)
+}
+
+func TestExponentialHistogram(t *testing.T) {
+	cfg1 := goldendataset.DefaultCfg()
+	cfg1.MetricDescriptorType = pmetric.MetricDataTypeHistogram
+	cfg1.PtVal = 1
+	expected := goldendataset.MetricsFromCfg(cfg1)
+	cfg2 := goldendataset.DefaultCfg()
+	cfg2.MetricDescriptorType = pmetric.MetricDataTypeHistogram
+	cfg2.PtVal = 3
+	actual := goldendataset.MetricsFromCfg(cfg2)
+	diffs := DiffMetrics(nil, expected, actual)
+	assert.Len(t, diffs, 3)
+}

--- a/internal/coreinternal/metricstestutil/ocmetricstestutil/ocmetricstestutil.go
+++ b/internal/coreinternal/metricstestutil/ocmetricstestutil/ocmetricstestutil.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metricstestutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
+package ocmetricstestutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil/ocmetricstestutil"
 
 import (
 	"time"

--- a/internal/coreinternal/metricstestutil/ocmetricstestutil/ocmetricstestutil_test.go
+++ b/internal/coreinternal/metricstestutil/ocmetricstestutil/ocmetricstestutil_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metricstestutil
+package ocmetricstestutil
 
 import (
 	"testing"

--- a/testbed/correctnesstests/metrics/metrics_correctness_test.go
+++ b/testbed/correctnesstests/metrics/metrics_correctness_test.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/goldendataset"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/correctnesstests"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )
@@ -107,7 +108,7 @@ func newDiffAccumulator() *diffAccumulator {
 	return &diffAccumulator{}
 }
 
-func (d *diffAccumulator) accept(metricName string, diffs []*MetricDiff) {
+func (d *diffAccumulator) accept(metricName string, diffs []*metricstestutil.MetricDiff) {
 	if len(diffs) > 0 {
 		d.numDiffs++
 		log.Printf("Found diffs for [%v]\n%v", metricName, diffs)

--- a/unreleased/metrics-test-helpers.yaml
+++ b/unreleased/metrics-test-helpers.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coreinternal
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move test utilities out of testbed into coreinternal, allow use of these lightweight helpers from other modules.
+
+# One or more tracking issues related to the change
+issues: [5742]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** 
Requested in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12951#discussion_r941586954.

**Link to tracking Issue:** Part of #5742.

**Testing:** New test helpers are added to validate attributes (was an existing TODO) and the exponential histogram data point.

**Documentation:** None.