### PR TITLE
[docs] Update docs about the direction metrics attribute transition

### DIFF
--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -52,9 +52,8 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-Some elasticsearch metrics reported are transitioning from being reported with a `direction` attribute to being reported with the
-direction included in the metric name to adhere to the OpenTelemetry specification
-(https://github.com/open-telemetry/opentelemetry-specification/pull/2617):
+There is a proposal to change some elasticsearch metrics from being reported with a `direction` attribute to being
+reported with the direction included in the metric name.
 
 - `elasticsearch.node.cluster.io` will become:
   - `elasticsearch.node.cluster.io.received`
@@ -67,26 +66,8 @@ The following feature gates control the transition process:
 
 ##### Transition schedule:
 
-See this [tracking issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11815) for more details.
-
-1. Phase 1, v0.59.0, August 2022:
-
-- The new metrics are available for all scrapers, but disabled by default, they can be enabled with the feature gates.
-- `receiver.elasticsearchreceiver.emitMetricsWithDirectionAttribute` is enabled by default.
-- `receiver.elasticsearchreceiver.emitMetricsWithoutDirectionAttribute` is disabled by default.
-
-2. Phase 2, version and date TBD:
-
-- The new metrics are enabled by default, deprecated metrics disabled, they can be enabled with the feature gates.
-- `receiver.elasticsearchreceiver.emitMetricsWithDirectionAttribute` is disabled by default.
-- `receiver.elasticsearchreceiver.emitMetricsWithoutDirectionAttribute` is enabled by default.
-
-3. Phase 3, version and date TBD:
-
-- The feature gates are removed.
-- The new metrics without `direction` attribute are always emitted.
-- The deprecated metrics with `direction` attribute are no longer available.
-
+The final decision on the transition is not finalized yet. The transition is on hold until
+https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -135,9 +135,8 @@ service:
 
 #### Transition from metrics with "direction" attribute
 
-Some host metrics reported are transitioning from being reported with a `direction` attribute to being reported with the
-direction included in the metric name to adhere to the OpenTelemetry specification
-(https://github.com/open-telemetry/opentelemetry-specification/pull/2617):
+There is a proposal to change some host metrics from being reported with a `direction` attribute to being
+reported with the direction included in the metric name.
 
 - `disk` scraper metrics:
   - `system.disk.io` will become:
@@ -184,31 +183,8 @@ The following feature gates control the transition process:
 
 ##### Transition schedule:
 
-1. v0.55.0, July 2022:
-
-- Most of the scrapers except for `disk` scraper can emit the new metrics without the `direction` attribute if 
-  feature gates enabled.
-- `receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute` is enabled by default.
-- `receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute` is disabled by default.
-
-2. v0.56.0, July 2022:
-
-- The new metrics are available for all scrapers, but disabled by default, they can be enabled with the feature gates.
-- The old metrics with `direction` attribute are deprecated with a warning.
-- `receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute` is enabled by default.
-- `receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute` is disabled by default.
-
-3. v0.58.0, August 2022:
-
-- The new metrics are enabled by default, deprecated metrics disabled, they can be enabled with the feature gates.
-- `receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute` is disabled by default.
-- `receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute` is enabled by default.
-
-4. v0.60.0, September 2022:
-
-- The feature gates are removed.
-- The new metrics without `direction` attribute are always emitted.
-- The deprecated metrics with `direction` attribute are no longer available.
+The final decision on the transition is not finalized yet. The transition is on hold until
+https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
 
 ##### Usage:
 

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -195,9 +195,8 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-Some kubeletstats metrics reported are transitioning from being reported with a `direction` attribute to being reported with the
-direction included in the metric name to adhere to the OpenTelemetry specification
-(https://github.com/open-telemetry/opentelemetry-specification/pull/2617):
+There is a proposal to change some host metrics from being reported with a `direction` attribute to being
+reported with the direction included in the metric name.
 
 - `k8s.node.network.io` will become:
   - `k8s.node.network.io.transmit`
@@ -210,6 +209,11 @@ The following feature gates control the transition process:
 
 - **receiver.kubeletstatsreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without `direction` attribute are emitted by the receiver.
 - **receiver.kubeletstatsreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with `direction` attribute are emitted by the receiver.
+
+##### Transition schedule:
+
+The final decision on the transition is not finalized yet. The transition is on hold until
+https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/memcachedreceiver/README.md
+++ b/receiver/memcachedreceiver/README.md
@@ -50,9 +50,8 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-Some memcached metrics reported are transitioning from being reported with a `direction` attribute to being reported with the
-direction included in the metric name to adhere to the OpenTelemetry specification
-(https://github.com/open-telemetry/opentelemetry-specification/pull/2617):
+There is a proposal to change some memcached metrics from being reported with a `direction` attribute to being
+reported with the direction included in the metric name.
 
 - `memcached.network` will become:
   - `memcached.network.sent`
@@ -68,24 +67,8 @@ The following feature gates control the transition process:
 
 ##### Transition schedule:
 
-1. v0.56.0, July 2022:
-
-- The new metrics are available for all scrapers, but disabled by default, they can be enabled with the feature gates.
-- The old metrics with `direction` attribute are deprecated with a warning.
-- `receiver.memcachedreceiver.emitMetricsWithDirectionAttribute` is enabled by default.
-- `receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute` is disabled by default.
-
-2. v0.58.0, August 2022:
-
-- The new metrics are enabled by default, deprecated metrics disabled, they can be enabled with the feature gates.
-- `receiver.memcachedreceiver.emitMetricsWithDirectionAttribute` is disabled by default.
-- `receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute` is enabled by default.
-
-3. v0.60.0, September 2022:
-
-- The feature gates are removed.
-- The new metrics without `direction` attribute are always emitted.
-- The deprecated metrics with `direction` attribute are no longer available.
+The final decision on the transition is not finalized yet. The transition is on hold until
+https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/vcenterreceiver/README.md
+++ b/receiver/vcenterreceiver/README.md
@@ -51,9 +51,8 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-Some host metrics reported are transitioning from being reported with a `direction` attribute to being reported with the
-direction included in the metric name to adhere to the OpenTelemetry specification
-(https://github.com/open-telemetry/opentelemetry-specification/pull/2617):
+There is a proposal to change some memcached metrics from being reported with a `direction` attribute to being
+reported with the direction included in the metric name.
 
 - `vcenter.host.disk.throughput` will become:
   - `vcenter.host.disk.throughput.read`
@@ -90,24 +89,8 @@ The following feature gates control the transition process:
 
 ##### Transition schedule:
 
-1. v0.56.0, July 2022:
-
-- The new metrics are available for all scrapers, but disabled by default, they can be enabled with the feature gates.
-- The old metrics with `direction` attribute are deprecated with a warning.
-- `receiver.vcenterreceiver.emitMetricsWithDirectionAttribute` is enabled by default.
-- `receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute` is disabled by default.
-
-2. v0.58.0, August 2022:
-
-- The new metrics are enabled by default, deprecated metrics disabled, they can be enabled with the feature gates.
-- `receiver.vcenterreceiver.emitMetricsWithDirectionAttribute` is disabled by default.
-- `receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute` is enabled by default.
-
-3. v0.60.0, September 2022:
-
-- The feature gates are removed.
-- The new metrics without `direction` attribute are always emitted.
-- The deprecated metrics with `direction` attribute are no longer available.
+The final decision on the transition is not finalized yet. The transition is on hold until
+https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/zookeeperreceiver/README.md
+++ b/receiver/zookeeperreceiver/README.md
@@ -31,10 +31,8 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-Some zookeeper metrics reported are transitioning from being reported with
- a `direction` attribute to being reported with the
-direction included in the metric name to adhere to the OpenTelemetry specification
-(https://github.com/open-telemetry/opentelemetry-specification/pull/2617):
+There is a proposal to change some zookeeper metrics from being reported with a `direction` attribute to being 
+reported with the direction included in the metric name.
 
 - `zookeeper.packet.count` will become:
   - `zookeeper.packet.received.count`
@@ -47,24 +45,8 @@ The following feature gates control the transition process:
 
 ##### Transition schedule:
 
-1. v0.57.0, July 2022:
-
-- The new metrics are available for all scrapers, but disabled by default, they can be enabled with the feature gates.
-- The old metrics with `direction` attribute are deprecated with a warning.
-- `receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute` is enabled by default.
-- `receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute` is disabled by default.
-
-2. v0.58.0, August 2022:
-
-- The new metrics are enabled by default, deprecated metrics disabled, they can be enabled with the feature gates.
-- `receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute` is disabled by default.
-- `receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute` is enabled by default.
-
-3. v0.60.0, September 2022:
-
-- The feature gates are removed.
-- The new metrics without `direction` attribute are always emitted.
-- The deprecated metrics with `direction` attribute are no longer available.
+The final decision on the transition is not finalized yet. The transition is on hold until
+https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
 
 [in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
Hold off the transition and update the documentation according to https://github.com/open-telemetry/opentelemetry-specification/issues/2726

Replaces https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13256