### PR TITLE
[docs] Update links to metadata/generated_metrics.go

### DIFF
--- a/receiver/activedirectorydsreceiver/README.md
+++ b/receiver/activedirectorydsreceiver/README.md
@@ -10,7 +10,7 @@ The `active_directory_ds` receiver scrapes metric relating to an Active Director
 
 ## Configuration
 The following settings are optional:
-- `metrics` (default: see `DefaultMetricsSettings` [here](./internal/metadata/generated_metrics_v2.go)): Allows enabling and disabling specific metrics from being collected in this receiver.
+- `metrics` (default: see `DefaultMetricsSettings` [here](./internal/metadata/generated_metrics.go)): Allows enabling and disabling specific metrics from being collected in this receiver.
 - `collection_interval` (default = `10s`): The interval at which metrics are emitted by this receiver.
 
 Example:

--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -18,7 +18,7 @@ See the [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/refer
 ## Configuration
 
 The following settings are optional:
-- `metrics` (default: see `DefaultMetricsSettings` [here](./internal/metadata/generated_metrics_v2.go): Allows enabling and disabling specific metrics from being collected in this receiver.
+- `metrics` (default: see `DefaultMetricsSettings` [here](./internal/metadata/generated_metrics.go): Allows enabling and disabling specific metrics from being collected in this receiver.
 - `nodes` (default: `["_all"]`): Allows specifying node filters that define which nodes are scraped for node-level metrics. See [the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/cluster.html#cluster-nodes) for allowed filters. If this option is left explicitly empty, then no node-level metrics will be scraped.
 - `skip_cluster_metrics` (default: `false`): If true, cluster-level metrics will not be scraped.
 - `endpoint` (default = `http://localhost:9200`): The base URL of the Elasticsearch API for the cluster to monitor.

--- a/receiver/nsxtreceiver/README.md
+++ b/receiver/nsxtreceiver/README.md
@@ -38,7 +38,7 @@ This receiver supports NSX-T Datacenter versions:
 
 - `timeout`: (default = `1m`) The timeout of running commands against the NSX REST API.
 
-- `metrics` (default: see DefaultMetricsSettings [here])(./internal/metadata/generated_metrics_v2.go): Allows enabling and disabling specific metrics from being collected in this receiver.
+- `metrics` (default: see DefaultMetricsSettings [here])(./internal/metadata/generated_metrics.go): Allows enabling and disabling specific metrics from being collected in this receiver.
 
 ### Example Configuration
 


### PR DESCRIPTION
All metadata/generated_metrics_v2.go were renamed to metadata/generated_metrics.go with removal of the old metadata generator
