### PR TITLE
Add more Elasticsearch receiver metrics

### DIFF
--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -82,7 +82,7 @@ func newElasticsearchClient(settings component.TelemetrySettings, c Config, h co
 // nodeStatsMetrics is a comma separated list of metrics that will be gathered from NodeStats.
 // The available metrics are documented here for Elasticsearch 7.9:
 // https://www.elastic.co/guide/en/elasticsearch/reference/7.9/cluster-nodes-stats.html#cluster-nodes-stats-api-path-params
-const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http,fs"
+const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http,fs,indexing_pressure,ingest,indices,adaptive_selection"
 
 // nodeStatsIndexMetrics is a comma separated list of index metrics that will be gathered from NodeStats.
 const nodeStatsIndexMetrics = "store,docs,indexing,get,search,merge,refresh,flush,warmer,query_cache,fielddata"

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -18,13 +18,8 @@ These are the metrics available for this scraper.
 | **elasticsearch.cluster.published_states.full** | Number of published cluster states. | 1 | Sum(Int) | <ul> </ul> |
 | **elasticsearch.cluster.shards** | The number of shards in the cluster. | {shards} | Sum(Int) | <ul> <li>shard_state</li> </ul> |
 | **elasticsearch.cluster.state_queue** | Number of cluster states in queue. | 1 | Sum(Int) | <ul> <li>cluster_state_queue_state</li> </ul> |
-| **elasticsearch.cluster.state_update.commit_time** | The cumulative amount of time spent waiting for a cluster state update to commit. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.cluster.state_update.completion_time** | The cumulative amount of time spent waiting for a cluster state update to complete. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.cluster.state_update.computation_time** | The cumulative amount of time spent computing cluster state updates since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.cluster.state_update.context_construction_time** | The cumulative amount of time spent constructing a publication context since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.cluster.state_update.count** | The number of cluster state update attempts that changed the cluster state since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.cluster.state_update.master_apply_time** | The cumulative amount of time spent applying cluster state updates on the elected master since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.cluster.state_update.notification_time** | The cumulative amount of time spent notifying listeners of a cluster state update since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.cluster.state_update.count** | The number of cluster state update attempts that changed the cluster state since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_state</li> </ul> |
+| **elasticsearch.cluster.state_update.time** | The cumulative amount of time updating the cluster state since the node started. | ms | Sum(Int) | <ul> <li>cluster_state_update_state</li> <li>cluster_state_update_type</li> </ul> |
 | **elasticsearch.indexing_pressure.memory.limit** | Configured memory limit, in bytes, for the indexing requests. | By | Gauge(Int) | <ul> </ul> |
 | **elasticsearch.indexing_pressure.memory.total.primary_rejections** | Cumulative number of indexing requests rejected in the primary stage. | 1 | Sum(Int) | <ul> </ul> |
 | **elasticsearch.indexing_pressure.memory.total.replica_rejections** | Number of indexing requests rejected in the replica stage. | 1 | Sum(Int) | <ul> </ul> |
@@ -102,7 +97,8 @@ metrics:
 | circuit_breaker_name (name) | The name of circuit breaker. |  |
 | cluster_published_difference_state (state) | State of the published differences | incompatible, compatible |
 | cluster_state_queue_state (state) | State of the published differences | pending, committed |
-| cluster_state_update_type (status) | Type of cluster state update | unchanged, success, failure |
+| cluster_state_update_state (state) | State of cluster state update |  |
+| cluster_state_update_type (type) | Type of cluster state update | computation, context_construction, commit, completion, master_apply, notification |
 | collector_name (name) | The name of the garbage collector. |  |
 | direction | The direction of network data. | received, sent |
 | document_state (state) | The state of the document. | active, deleted |

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -14,45 +14,41 @@ These are the metrics available for this scraper.
 | **elasticsearch.cluster.data_nodes** | The number of data nodes in the cluster. | {nodes} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.cluster.health** | The health status of the cluster. Health status is based on the state of its primary and replica shards. Green indicates all shards are assigned. Yellow indicates that one or more replica shards are unassigned. Red indicates that one or more primary shards are unassigned, making some data unavailable. | {status} | Sum(Int) | <ul> <li>health_status</li> </ul> |
 | **elasticsearch.cluster.nodes** | The total number of nodes in the cluster. | {nodes} | Sum(Int) | <ul> </ul> |
+| **elasticsearch.cluster.published_states.differences** | Number of differences between published cluster states. | 1 | Sum(Int) | <ul> <li>cluster_published_difference_state</li> </ul> |
+| **elasticsearch.cluster.published_states.full** | Number of published cluster states. | 1 | Sum(Int) | <ul> </ul> |
 | **elasticsearch.cluster.shards** | The number of shards in the cluster. | {shards} | Sum(Int) | <ul> <li>shard_state</li> </ul> |
-| **elasticsearch.indexing_pressure.memory.coordinating** | Memory consumed, in bytes, by indexing requests in the coordinating stage. | By | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.cluster.state_queue** | Number of cluster states in queue. | 1 | Sum(Int) | <ul> <li>cluster_state_queue_state</li> </ul> |
+| **elasticsearch.cluster.state_update.commit_time** | The cumulative amount of time spent waiting for a cluster state update to commit. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.cluster.state_update.completion_time** | The cumulative amount of time spent waiting for a cluster state update to complete. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.cluster.state_update.computation_time** | The cumulative amount of time spent computing cluster state updates since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.cluster.state_update.context_construction_time** | The cumulative amount of time spent constructing a publication context since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.cluster.state_update.count** | The number of cluster state update attempts that changed the cluster state since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.cluster.state_update.master_apply_time** | The cumulative amount of time spent applying cluster state updates on the elected master since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.cluster.state_update.notification_time** | The cumulative amount of time spent notifying listeners of a cluster state update since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
 | **elasticsearch.indexing_pressure.memory.limit** | Configured memory limit, in bytes, for the indexing requests. | By | Gauge(Int) | <ul> </ul> |
-| **elasticsearch.indexing_pressure.memory.primary** | Memory consumed, in bytes, by indexing requests in the primary stage. | By | Gauge(Int) | <ul> </ul> |
-| **elasticsearch.indexing_pressure.memory.replica** | Memory consumed, in bytes, by indexing requests in the primary stage. | By | Gauge(Int) | <ul> </ul> |
 | **elasticsearch.indexing_pressure.memory.total.primary_rejections** | Cumulative number of indexing requests rejected in the primary stage. | 1 | Sum(Int) | <ul> </ul> |
 | **elasticsearch.indexing_pressure.memory.total.replica_rejections** | Number of indexing requests rejected in the replica stage. | 1 | Sum(Int) | <ul> </ul> |
+| **elasticsearch.memory.indexing_pressure** | Memory consumed, in bytes, by indexing requests in the specified stage. | By | Sum(Int) | <ul> <li>indexing_pressure_stage</li> </ul> |
 | **elasticsearch.node.cache.evictions** | The number of evictions from the cache. | {evictions} | Sum(Int) | <ul> <li>cache_name</li> </ul> |
 | **elasticsearch.node.cache.memory.usage** | The size in bytes of the cache. | By | Sum(Int) | <ul> <li>cache_name</li> </ul> |
 | **elasticsearch.node.cluster.connections** | The number of open tcp connections for internal cluster communication. | {connections} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.cluster.io** | The number of bytes sent and received on the network for internal cluster communication. | By | Sum(Int) | <ul> <li>direction</li> </ul> |
 | **elasticsearch.node.cluster.io.received** | The number of bytes received on the network for internal cluster communication. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.cluster.io.sent** | The number of bytes sent on the network for internal cluster communication. | By | Sum(Int) | <ul> </ul> |
-| **elasticsearch.node.cluster.published_states.compatible** | Number of compatible differences between published cluster states. | 1 | Gauge(Int) | <ul> </ul> |
-| **elasticsearch.node.cluster.published_states.full** | Number of published cluster states. | 1 | Gauge(Int) | <ul> </ul> |
-| **elasticsearch.node.cluster.published_states.incompatible** | Number of incompatible differences between published cluster states. | 1 | Gauge(Int) | <ul> </ul> |
-| **elasticsearch.node.cluster.state_queue.committed** | Number of pending cluster states in queue. | 1 | Gauge(Int) | <ul> </ul> |
-| **elasticsearch.node.cluster.state_queue.pending** | Number of pending cluster states in queue. | 1 | Gauge(Int) | <ul> </ul> |
-| **elasticsearch.node.cluster.state_update.commit_time** | The cumulative amount of time spent waiting for a cluster state update to commit. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.node.cluster.state_update.completion_time** | The cumulative amount of time spent waiting for a cluster state update to complete. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.node.cluster.state_update.computation_time** | The cumulative amount of time spent computing cluster state updates since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.node.cluster.state_update.context_construction_time** | The cumulative amount of time spent constructing a publication context since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.node.cluster.state_update.count** | The number of cluster state update attempts that changed the cluster state since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.node.cluster.state_update.master_apply_time** | The cumulative amount of time spent applying cluster state updates on the elected master since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
-| **elasticsearch.node.cluster.state_update.notification_time** | The cumulative amount of time spent notifying listeners of a cluster state update since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
 | **elasticsearch.node.disk.io.read** | The total number of kilobytes read across all file stores for this node. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.disk.io.write** | The total number of kilobytes written across all file stores for this node. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.documents** | The number of documents on the node. | {documents} | Sum(Int) | <ul> <li>document_state</li> </ul> |
 | **elasticsearch.node.fs.disk.available** | The amount of disk space available across all file stores for this node. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.http.connections** | The number of HTTP connections to the node. | {connections} | Sum(Int) | <ul> </ul> |
-| **elasticsearch.node.ingest.count** | Total number of documents ingested during the lifetime of this node. | {documents} | Sum(Int) | <ul> </ul> |
-| **elasticsearch.node.ingest.current** | Total number of documents currently being ingested. | {documents} | Gauge(Int) | <ul> </ul> |
-| **elasticsearch.node.ingest.failed** | Total number of failed ingest operations during the lifetime of this node. | {operation} | Sum(Int) | <ul> </ul> |
-| **elasticsearch.node.ingest.pipeline.count** | Total number of documents ingested during the lifetime of this node. | {documents} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
-| **elasticsearch.node.ingest.pipeline.current** | Total number of documents currently being ingested by a pipeline. | {documents} | Gauge(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
-| **elasticsearch.node.ingest.pipeline.failed** | Total number of failed operations for the ingest pipeline. | {operation} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
+| **elasticsearch.node.ingest.documents** | Total number of documents ingested during the lifetime of this node. | {documents} | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.ingest.documents.current** | Total number of documents currently being ingested. | {documents} | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.ingest.operations.failed** | Total number of failed ingest operations during the lifetime of this node. | {operation} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.open_files** | The number of open file descriptors held by the node. | {files} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.operations.completed** | The number of operations completed. | {operations} | Sum(Int) | <ul> <li>operation</li> </ul> |
 | **elasticsearch.node.operations.time** | Time spent on operations. | ms | Sum(Int) | <ul> <li>operation</li> </ul> |
+| **elasticsearch.node.pipeline.ingest.documents.current** | Total number of documents currently being ingested by a pipeline. | {documents} | Gauge(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
+| **elasticsearch.node.pipeline.ingest.documents.preprocessed** | Number of documents preprocessed by the ingest pipeline. | {documents} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
+| **elasticsearch.node.pipeline.ingest.operations.failed** | Total number of failed operations for the ingest pipeline. | {operation} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
 | **elasticsearch.node.script.cache_evictions** | Total number of times the script cache has evicted old data. | 1 | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.script.compilation_limit_triggered** | Total number of times the script compilation circuit breaker has limited inline script compilations. | 1 | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.script.compilations** | Total number of inline script compilations performed by the node. | {compilations} | Sum(Int) | <ul> </ul> |
@@ -104,6 +100,8 @@ metrics:
 | ---- | ----------- | ------ |
 | cache_name | The name of cache. | fielddata, query |
 | circuit_breaker_name (name) | The name of circuit breaker. |  |
+| cluster_published_difference_state (state) | State of the published differences | incompatible, compatible |
+| cluster_state_queue_state (state) | State of the published differences | pending, committed |
 | cluster_state_update_type (status) | Type of cluster state update | unchanged, success, failure |
 | collector_name (name) | The name of the garbage collector. |  |
 | direction | The direction of network data. | received, sent |
@@ -111,6 +109,7 @@ metrics:
 | fs_direction (direction) | The direction of filesystem IO. | read, write |
 | health_status (status) | The health status of the cluster. | green, yellow, red |
 | indexing_memory_state (state) | State of the indexing memory | current, total |
+| indexing_pressure_stage (stage) | Stage of the indexing pressure | coordinating, primary, replica |
 | ingest_pipeline_name (name) | Name of the ingest pipeline. |  |
 | memory_pool_name (name) | The name of the JVM memory pool. |  |
 | memory_state (state) | State of the memory | free, used |

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -15,20 +15,47 @@ These are the metrics available for this scraper.
 | **elasticsearch.cluster.health** | The health status of the cluster. Health status is based on the state of its primary and replica shards. Green indicates all shards are assigned. Yellow indicates that one or more replica shards are unassigned. Red indicates that one or more primary shards are unassigned, making some data unavailable. | {status} | Sum(Int) | <ul> <li>health_status</li> </ul> |
 | **elasticsearch.cluster.nodes** | The total number of nodes in the cluster. | {nodes} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.cluster.shards** | The number of shards in the cluster. | {shards} | Sum(Int) | <ul> <li>shard_state</li> </ul> |
+| **elasticsearch.indexing_pressure.memory.coordinating** | Memory consumed, in bytes, by indexing requests in the coordinating stage. | By | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.indexing_pressure.memory.limit** | Configured memory limit, in bytes, for the indexing requests. | By | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.indexing_pressure.memory.primary** | Memory consumed, in bytes, by indexing requests in the primary stage. | By | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.indexing_pressure.memory.replica** | Memory consumed, in bytes, by indexing requests in the primary stage. | By | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.indexing_pressure.memory.total.primary_rejections** | Cumulative number of indexing requests rejected in the primary stage. | 1 | Sum(Int) | <ul> </ul> |
+| **elasticsearch.indexing_pressure.memory.total.replica_rejections** | Number of indexing requests rejected in the replica stage. | 1 | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.cache.evictions** | The number of evictions from the cache. | {evictions} | Sum(Int) | <ul> <li>cache_name</li> </ul> |
 | **elasticsearch.node.cache.memory.usage** | The size in bytes of the cache. | By | Sum(Int) | <ul> <li>cache_name</li> </ul> |
 | **elasticsearch.node.cluster.connections** | The number of open tcp connections for internal cluster communication. | {connections} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.cluster.io** | The number of bytes sent and received on the network for internal cluster communication. | By | Sum(Int) | <ul> <li>direction</li> </ul> |
 | **elasticsearch.node.cluster.io.received** | The number of bytes received on the network for internal cluster communication. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.cluster.io.sent** | The number of bytes sent on the network for internal cluster communication. | By | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.cluster.published_states.compatible** | Number of compatible differences between published cluster states. | 1 | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.node.cluster.published_states.full** | Number of published cluster states. | 1 | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.node.cluster.published_states.incompatible** | Number of incompatible differences between published cluster states. | 1 | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.node.cluster.state_queue.committed** | Number of pending cluster states in queue. | 1 | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.node.cluster.state_queue.pending** | Number of pending cluster states in queue. | 1 | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.node.cluster.state_update.commit_time** | The cumulative amount of time spent waiting for a cluster state update to commit. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.node.cluster.state_update.completion_time** | The cumulative amount of time spent waiting for a cluster state update to complete. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.node.cluster.state_update.computation_time** | The cumulative amount of time spent computing cluster state updates since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.node.cluster.state_update.context_construction_time** | The cumulative amount of time spent constructing a publication context since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.node.cluster.state_update.count** | The number of cluster state update attempts that changed the cluster state since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.node.cluster.state_update.master_apply_time** | The cumulative amount of time spent applying cluster state updates on the elected master since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
+| **elasticsearch.node.cluster.state_update.notification_time** | The cumulative amount of time spent notifying listeners of a cluster state update since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_type</li> </ul> |
 | **elasticsearch.node.disk.io.read** | The total number of kilobytes read across all file stores for this node. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.disk.io.write** | The total number of kilobytes written across all file stores for this node. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.documents** | The number of documents on the node. | {documents} | Sum(Int) | <ul> <li>document_state</li> </ul> |
 | **elasticsearch.node.fs.disk.available** | The amount of disk space available across all file stores for this node. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.http.connections** | The number of HTTP connections to the node. | {connections} | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.ingest.count** | Total number of documents ingested during the lifetime of this node. | {documents} | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.ingest.current** | Total number of documents currently being ingested. | {documents} | Gauge(Int) | <ul> </ul> |
+| **elasticsearch.node.ingest.failed** | Total number of failed ingest operations during the lifetime of this node. | {operation} | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.ingest.pipeline.count** | Total number of documents ingested during the lifetime of this node. | {documents} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
+| **elasticsearch.node.ingest.pipeline.current** | Total number of documents currently being ingested by a pipeline. | {documents} | Gauge(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
+| **elasticsearch.node.ingest.pipeline.failed** | Total number of failed operations for the ingest pipeline. | {operation} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
 | **elasticsearch.node.open_files** | The number of open file descriptors held by the node. | {files} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.operations.completed** | The number of operations completed. | {operations} | Sum(Int) | <ul> <li>operation</li> </ul> |
 | **elasticsearch.node.operations.time** | Time spent on operations. | ms | Sum(Int) | <ul> <li>operation</li> </ul> |
+| **elasticsearch.node.script.cache_evictions** | Total number of times the script cache has evicted old data. | 1 | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.script.compilation_limit_triggered** | Total number of times the script compilation circuit breaker has limited inline script compilations. | 1 | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.script.compilations** | Total number of inline script compilations performed by the node. | {compilations} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.shards.data_set.size** | Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.shards.reserved.size** | A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.shards.size** | The size of the shards assigned to this node. | By | Sum(Int) | <ul> </ul> |
@@ -42,7 +69,7 @@ These are the metrics available for this scraper.
 | **elasticsearch.os.cpu.load_avg.1m** | One-minute load average on the system (field is not present if one-minute load average is not available). | 1 | Gauge(Double) | <ul> </ul> |
 | **elasticsearch.os.cpu.load_avg.5m** | Five-minute load average on the system (field is not present if five-minute load average is not available). | 1 | Gauge(Double) | <ul> </ul> |
 | **elasticsearch.os.cpu.usage** | Recent CPU usage for the whole system, or -1 if not supported. | % | Gauge(Int) | <ul> </ul> |
-| **elasticsearch.os.memory** | Amount of physical memory. | By | Sum(Int) | <ul> <li>memory_state</li> </ul> |
+| **elasticsearch.os.memory** | Amount of physical memory. | By | Gauge(Int) | <ul> <li>memory_state</li> </ul> |
 | **jvm.classes.loaded** | The number of loaded classes | 1 | Gauge(Int) | <ul> </ul> |
 | **jvm.gc.collections.count** | The total number of garbage collections that have occurred | 1 | Sum(Int) | <ul> <li>collector_name</li> </ul> |
 | **jvm.gc.collections.elapsed** | The approximate accumulated collection elapsed time | ms | Sum(Int) | <ul> <li>collector_name</li> </ul> |
@@ -77,11 +104,14 @@ metrics:
 | ---- | ----------- | ------ |
 | cache_name | The name of cache. | fielddata, query |
 | circuit_breaker_name (name) | The name of circuit breaker. |  |
+| cluster_state_update_type (status) | Type of cluster state update | unchanged, success, failure |
 | collector_name (name) | The name of the garbage collector. |  |
 | direction | The direction of network data. | received, sent |
 | document_state (state) | The state of the document. | active, deleted |
 | fs_direction (direction) | The direction of filesystem IO. | read, write |
 | health_status (status) | The health status of the cluster. | green, yellow, red |
+| indexing_memory_state (state) | State of the indexing memory | current, total |
+| ingest_pipeline_name (name) | Name of the ingest pipeline. |  |
 | memory_pool_name (name) | The name of the JVM memory pool. |  |
 | memory_state (state) | State of the memory | free, used |
 | operation (operation) | The type of operation. | index, delete, get, query, fetch, scroll, suggest, merge, refresh, flush, warmer |

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -46,7 +46,7 @@ These are the metrics available for this scraper.
 | **elasticsearch.node.open_files** | The number of open file descriptors held by the node. | {files} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.operations.completed** | The number of operations completed. | {operations} | Sum(Int) | <ul> <li>operation</li> </ul> |
 | **elasticsearch.node.operations.time** | Time spent on operations. | ms | Sum(Int) | <ul> <li>operation</li> </ul> |
-| **elasticsearch.node.pipeline.ingest.documents.current** | Total number of documents currently being ingested by a pipeline. | {documents} | Gauge(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
+| **elasticsearch.node.pipeline.ingest.documents.current** | Total number of documents currently being ingested by a pipeline. | {documents} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
 | **elasticsearch.node.pipeline.ingest.documents.preprocessed** | Number of documents preprocessed by the ingest pipeline. | {documents} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
 | **elasticsearch.node.pipeline.ingest.operations.failed** | Total number of failed operations for the ingest pipeline. | {operation} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
 | **elasticsearch.node.script.cache_evictions** | Total number of times the script cache has evicted old data. | 1 | Sum(Int) | <ul> </ul> |

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -17,52 +17,79 @@ type MetricSettings struct {
 
 // MetricsSettings provides settings for elasticsearchreceiver metrics.
 type MetricsSettings struct {
-	ElasticsearchBreakerMemoryEstimated      MetricSettings `mapstructure:"elasticsearch.breaker.memory.estimated"`
-	ElasticsearchBreakerMemoryLimit          MetricSettings `mapstructure:"elasticsearch.breaker.memory.limit"`
-	ElasticsearchBreakerTripped              MetricSettings `mapstructure:"elasticsearch.breaker.tripped"`
-	ElasticsearchClusterDataNodes            MetricSettings `mapstructure:"elasticsearch.cluster.data_nodes"`
-	ElasticsearchClusterHealth               MetricSettings `mapstructure:"elasticsearch.cluster.health"`
-	ElasticsearchClusterNodes                MetricSettings `mapstructure:"elasticsearch.cluster.nodes"`
-	ElasticsearchClusterShards               MetricSettings `mapstructure:"elasticsearch.cluster.shards"`
-	ElasticsearchNodeCacheEvictions          MetricSettings `mapstructure:"elasticsearch.node.cache.evictions"`
-	ElasticsearchNodeCacheMemoryUsage        MetricSettings `mapstructure:"elasticsearch.node.cache.memory.usage"`
-	ElasticsearchNodeClusterConnections      MetricSettings `mapstructure:"elasticsearch.node.cluster.connections"`
-	ElasticsearchNodeClusterIo               MetricSettings `mapstructure:"elasticsearch.node.cluster.io"`
-	ElasticsearchNodeClusterIoReceived       MetricSettings `mapstructure:"elasticsearch.node.cluster.io.received"`
-	ElasticsearchNodeClusterIoSent           MetricSettings `mapstructure:"elasticsearch.node.cluster.io.sent"`
-	ElasticsearchNodeDiskIoRead              MetricSettings `mapstructure:"elasticsearch.node.disk.io.read"`
-	ElasticsearchNodeDiskIoWrite             MetricSettings `mapstructure:"elasticsearch.node.disk.io.write"`
-	ElasticsearchNodeDocuments               MetricSettings `mapstructure:"elasticsearch.node.documents"`
-	ElasticsearchNodeFsDiskAvailable         MetricSettings `mapstructure:"elasticsearch.node.fs.disk.available"`
-	ElasticsearchNodeHTTPConnections         MetricSettings `mapstructure:"elasticsearch.node.http.connections"`
-	ElasticsearchNodeOpenFiles               MetricSettings `mapstructure:"elasticsearch.node.open_files"`
-	ElasticsearchNodeOperationsCompleted     MetricSettings `mapstructure:"elasticsearch.node.operations.completed"`
-	ElasticsearchNodeOperationsTime          MetricSettings `mapstructure:"elasticsearch.node.operations.time"`
-	ElasticsearchNodeShardsDataSetSize       MetricSettings `mapstructure:"elasticsearch.node.shards.data_set.size"`
-	ElasticsearchNodeShardsReservedSize      MetricSettings `mapstructure:"elasticsearch.node.shards.reserved.size"`
-	ElasticsearchNodeShardsSize              MetricSettings `mapstructure:"elasticsearch.node.shards.size"`
-	ElasticsearchNodeThreadPoolTasksFinished MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.finished"`
-	ElasticsearchNodeThreadPoolTasksQueued   MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.queued"`
-	ElasticsearchNodeThreadPoolThreads       MetricSettings `mapstructure:"elasticsearch.node.thread_pool.threads"`
-	ElasticsearchNodeTranslogOperations      MetricSettings `mapstructure:"elasticsearch.node.translog.operations"`
-	ElasticsearchNodeTranslogSize            MetricSettings `mapstructure:"elasticsearch.node.translog.size"`
-	ElasticsearchNodeTranslogUncommittedSize MetricSettings `mapstructure:"elasticsearch.node.translog.uncommitted.size"`
-	ElasticsearchOsCPULoadAvg15m             MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.15m"`
-	ElasticsearchOsCPULoadAvg1m              MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.1m"`
-	ElasticsearchOsCPULoadAvg5m              MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.5m"`
-	ElasticsearchOsCPUUsage                  MetricSettings `mapstructure:"elasticsearch.os.cpu.usage"`
-	ElasticsearchOsMemory                    MetricSettings `mapstructure:"elasticsearch.os.memory"`
-	JvmClassesLoaded                         MetricSettings `mapstructure:"jvm.classes.loaded"`
-	JvmGcCollectionsCount                    MetricSettings `mapstructure:"jvm.gc.collections.count"`
-	JvmGcCollectionsElapsed                  MetricSettings `mapstructure:"jvm.gc.collections.elapsed"`
-	JvmMemoryHeapCommitted                   MetricSettings `mapstructure:"jvm.memory.heap.committed"`
-	JvmMemoryHeapMax                         MetricSettings `mapstructure:"jvm.memory.heap.max"`
-	JvmMemoryHeapUsed                        MetricSettings `mapstructure:"jvm.memory.heap.used"`
-	JvmMemoryNonheapCommitted                MetricSettings `mapstructure:"jvm.memory.nonheap.committed"`
-	JvmMemoryNonheapUsed                     MetricSettings `mapstructure:"jvm.memory.nonheap.used"`
-	JvmMemoryPoolMax                         MetricSettings `mapstructure:"jvm.memory.pool.max"`
-	JvmMemoryPoolUsed                        MetricSettings `mapstructure:"jvm.memory.pool.used"`
-	JvmThreadsCount                          MetricSettings `mapstructure:"jvm.threads.count"`
+	ElasticsearchBreakerMemoryEstimated                        MetricSettings `mapstructure:"elasticsearch.breaker.memory.estimated"`
+	ElasticsearchBreakerMemoryLimit                            MetricSettings `mapstructure:"elasticsearch.breaker.memory.limit"`
+	ElasticsearchBreakerTripped                                MetricSettings `mapstructure:"elasticsearch.breaker.tripped"`
+	ElasticsearchClusterDataNodes                              MetricSettings `mapstructure:"elasticsearch.cluster.data_nodes"`
+	ElasticsearchClusterHealth                                 MetricSettings `mapstructure:"elasticsearch.cluster.health"`
+	ElasticsearchClusterNodes                                  MetricSettings `mapstructure:"elasticsearch.cluster.nodes"`
+	ElasticsearchClusterShards                                 MetricSettings `mapstructure:"elasticsearch.cluster.shards"`
+	ElasticsearchIndexingPressureMemoryCoordinating            MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.coordinating"`
+	ElasticsearchIndexingPressureMemoryLimit                   MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.limit"`
+	ElasticsearchIndexingPressureMemoryPrimary                 MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.primary"`
+	ElasticsearchIndexingPressureMemoryReplica                 MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.replica"`
+	ElasticsearchIndexingPressureMemoryTotalPrimaryRejections  MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.total.primary_rejections"`
+	ElasticsearchIndexingPressureMemoryTotalReplicaRejections  MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.total.replica_rejections"`
+	ElasticsearchNodeCacheEvictions                            MetricSettings `mapstructure:"elasticsearch.node.cache.evictions"`
+	ElasticsearchNodeCacheMemoryUsage                          MetricSettings `mapstructure:"elasticsearch.node.cache.memory.usage"`
+	ElasticsearchNodeClusterConnections                        MetricSettings `mapstructure:"elasticsearch.node.cluster.connections"`
+	ElasticsearchNodeClusterIo                                 MetricSettings `mapstructure:"elasticsearch.node.cluster.io"`
+	ElasticsearchNodeClusterIoReceived                         MetricSettings `mapstructure:"elasticsearch.node.cluster.io.received"`
+	ElasticsearchNodeClusterIoSent                             MetricSettings `mapstructure:"elasticsearch.node.cluster.io.sent"`
+	ElasticsearchNodeClusterPublishedStatesCompatible          MetricSettings `mapstructure:"elasticsearch.node.cluster.published_states.compatible"`
+	ElasticsearchNodeClusterPublishedStatesFull                MetricSettings `mapstructure:"elasticsearch.node.cluster.published_states.full"`
+	ElasticsearchNodeClusterPublishedStatesIncompatible        MetricSettings `mapstructure:"elasticsearch.node.cluster.published_states.incompatible"`
+	ElasticsearchNodeClusterStateQueueCommitted                MetricSettings `mapstructure:"elasticsearch.node.cluster.state_queue.committed"`
+	ElasticsearchNodeClusterStateQueuePending                  MetricSettings `mapstructure:"elasticsearch.node.cluster.state_queue.pending"`
+	ElasticsearchNodeClusterStateUpdateCommitTime              MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.commit_time"`
+	ElasticsearchNodeClusterStateUpdateCompletionTime          MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.completion_time"`
+	ElasticsearchNodeClusterStateUpdateComputationTime         MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.computation_time"`
+	ElasticsearchNodeClusterStateUpdateContextConstructionTime MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.context_construction_time"`
+	ElasticsearchNodeClusterStateUpdateCount                   MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.count"`
+	ElasticsearchNodeClusterStateUpdateMasterApplyTime         MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.master_apply_time"`
+	ElasticsearchNodeClusterStateUpdateNotificationTime        MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.notification_time"`
+	ElasticsearchNodeDiskIoRead                                MetricSettings `mapstructure:"elasticsearch.node.disk.io.read"`
+	ElasticsearchNodeDiskIoWrite                               MetricSettings `mapstructure:"elasticsearch.node.disk.io.write"`
+	ElasticsearchNodeDocuments                                 MetricSettings `mapstructure:"elasticsearch.node.documents"`
+	ElasticsearchNodeFsDiskAvailable                           MetricSettings `mapstructure:"elasticsearch.node.fs.disk.available"`
+	ElasticsearchNodeHTTPConnections                           MetricSettings `mapstructure:"elasticsearch.node.http.connections"`
+	ElasticsearchNodeIngestCount                               MetricSettings `mapstructure:"elasticsearch.node.ingest.count"`
+	ElasticsearchNodeIngestCurrent                             MetricSettings `mapstructure:"elasticsearch.node.ingest.current"`
+	ElasticsearchNodeIngestFailed                              MetricSettings `mapstructure:"elasticsearch.node.ingest.failed"`
+	ElasticsearchNodeIngestPipelineCount                       MetricSettings `mapstructure:"elasticsearch.node.ingest.pipeline.count"`
+	ElasticsearchNodeIngestPipelineCurrent                     MetricSettings `mapstructure:"elasticsearch.node.ingest.pipeline.current"`
+	ElasticsearchNodeIngestPipelineFailed                      MetricSettings `mapstructure:"elasticsearch.node.ingest.pipeline.failed"`
+	ElasticsearchNodeOpenFiles                                 MetricSettings `mapstructure:"elasticsearch.node.open_files"`
+	ElasticsearchNodeOperationsCompleted                       MetricSettings `mapstructure:"elasticsearch.node.operations.completed"`
+	ElasticsearchNodeOperationsTime                            MetricSettings `mapstructure:"elasticsearch.node.operations.time"`
+	ElasticsearchNodeScriptCacheEvictions                      MetricSettings `mapstructure:"elasticsearch.node.script.cache_evictions"`
+	ElasticsearchNodeScriptCompilationLimitTriggered           MetricSettings `mapstructure:"elasticsearch.node.script.compilation_limit_triggered"`
+	ElasticsearchNodeScriptCompilations                        MetricSettings `mapstructure:"elasticsearch.node.script.compilations"`
+	ElasticsearchNodeShardsDataSetSize                         MetricSettings `mapstructure:"elasticsearch.node.shards.data_set.size"`
+	ElasticsearchNodeShardsReservedSize                        MetricSettings `mapstructure:"elasticsearch.node.shards.reserved.size"`
+	ElasticsearchNodeShardsSize                                MetricSettings `mapstructure:"elasticsearch.node.shards.size"`
+	ElasticsearchNodeThreadPoolTasksFinished                   MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.finished"`
+	ElasticsearchNodeThreadPoolTasksQueued                     MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.queued"`
+	ElasticsearchNodeThreadPoolThreads                         MetricSettings `mapstructure:"elasticsearch.node.thread_pool.threads"`
+	ElasticsearchNodeTranslogOperations                        MetricSettings `mapstructure:"elasticsearch.node.translog.operations"`
+	ElasticsearchNodeTranslogSize                              MetricSettings `mapstructure:"elasticsearch.node.translog.size"`
+	ElasticsearchNodeTranslogUncommittedSize                   MetricSettings `mapstructure:"elasticsearch.node.translog.uncommitted.size"`
+	ElasticsearchOsCPULoadAvg15m                               MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.15m"`
+	ElasticsearchOsCPULoadAvg1m                                MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.1m"`
+	ElasticsearchOsCPULoadAvg5m                                MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.5m"`
+	ElasticsearchOsCPUUsage                                    MetricSettings `mapstructure:"elasticsearch.os.cpu.usage"`
+	ElasticsearchOsMemory                                      MetricSettings `mapstructure:"elasticsearch.os.memory"`
+	JvmClassesLoaded                                           MetricSettings `mapstructure:"jvm.classes.loaded"`
+	JvmGcCollectionsCount                                      MetricSettings `mapstructure:"jvm.gc.collections.count"`
+	JvmGcCollectionsElapsed                                    MetricSettings `mapstructure:"jvm.gc.collections.elapsed"`
+	JvmMemoryHeapCommitted                                     MetricSettings `mapstructure:"jvm.memory.heap.committed"`
+	JvmMemoryHeapMax                                           MetricSettings `mapstructure:"jvm.memory.heap.max"`
+	JvmMemoryHeapUsed                                          MetricSettings `mapstructure:"jvm.memory.heap.used"`
+	JvmMemoryNonheapCommitted                                  MetricSettings `mapstructure:"jvm.memory.nonheap.committed"`
+	JvmMemoryNonheapUsed                                       MetricSettings `mapstructure:"jvm.memory.nonheap.used"`
+	JvmMemoryPoolMax                                           MetricSettings `mapstructure:"jvm.memory.pool.max"`
+	JvmMemoryPoolUsed                                          MetricSettings `mapstructure:"jvm.memory.pool.used"`
+	JvmThreadsCount                                            MetricSettings `mapstructure:"jvm.threads.count"`
 }
 
 func DefaultMetricsSettings() MetricsSettings {
@@ -88,6 +115,24 @@ func DefaultMetricsSettings() MetricsSettings {
 		ElasticsearchClusterShards: MetricSettings{
 			Enabled: true,
 		},
+		ElasticsearchIndexingPressureMemoryCoordinating: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchIndexingPressureMemoryLimit: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchIndexingPressureMemoryPrimary: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchIndexingPressureMemoryReplica: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchIndexingPressureMemoryTotalPrimaryRejections: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchIndexingPressureMemoryTotalReplicaRejections: MetricSettings{
+			Enabled: true,
+		},
 		ElasticsearchNodeCacheEvictions: MetricSettings{
 			Enabled: true,
 		},
@@ -106,6 +151,42 @@ func DefaultMetricsSettings() MetricsSettings {
 		ElasticsearchNodeClusterIoSent: MetricSettings{
 			Enabled: true,
 		},
+		ElasticsearchNodeClusterPublishedStatesCompatible: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterPublishedStatesFull: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterPublishedStatesIncompatible: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterStateQueueCommitted: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterStateQueuePending: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterStateUpdateCommitTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterStateUpdateCompletionTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterStateUpdateComputationTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterStateUpdateContextConstructionTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterStateUpdateCount: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterStateUpdateMasterApplyTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeClusterStateUpdateNotificationTime: MetricSettings{
+			Enabled: true,
+		},
 		ElasticsearchNodeDiskIoRead: MetricSettings{
 			Enabled: true,
 		},
@@ -121,6 +202,24 @@ func DefaultMetricsSettings() MetricsSettings {
 		ElasticsearchNodeHTTPConnections: MetricSettings{
 			Enabled: true,
 		},
+		ElasticsearchNodeIngestCount: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeIngestCurrent: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeIngestFailed: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeIngestPipelineCount: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeIngestPipelineCurrent: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeIngestPipelineFailed: MetricSettings{
+			Enabled: true,
+		},
 		ElasticsearchNodeOpenFiles: MetricSettings{
 			Enabled: true,
 		},
@@ -128,6 +227,15 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		ElasticsearchNodeOperationsTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeScriptCacheEvictions: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeScriptCompilationLimitTriggered: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodeScriptCompilations: MetricSettings{
 			Enabled: true,
 		},
 		ElasticsearchNodeShardsDataSetSize: MetricSettings{
@@ -232,6 +340,36 @@ func (av AttributeCacheName) String() string {
 var MapAttributeCacheName = map[string]AttributeCacheName{
 	"fielddata": AttributeCacheNameFielddata,
 	"query":     AttributeCacheNameQuery,
+}
+
+// AttributeClusterStateUpdateType specifies the a value cluster_state_update_type attribute.
+type AttributeClusterStateUpdateType int
+
+const (
+	_ AttributeClusterStateUpdateType = iota
+	AttributeClusterStateUpdateTypeUnchanged
+	AttributeClusterStateUpdateTypeSuccess
+	AttributeClusterStateUpdateTypeFailure
+)
+
+// String returns the string representation of the AttributeClusterStateUpdateType.
+func (av AttributeClusterStateUpdateType) String() string {
+	switch av {
+	case AttributeClusterStateUpdateTypeUnchanged:
+		return "unchanged"
+	case AttributeClusterStateUpdateTypeSuccess:
+		return "success"
+	case AttributeClusterStateUpdateTypeFailure:
+		return "failure"
+	}
+	return ""
+}
+
+// MapAttributeClusterStateUpdateType is a helper map of string to AttributeClusterStateUpdateType attribute value.
+var MapAttributeClusterStateUpdateType = map[string]AttributeClusterStateUpdateType{
+	"unchanged": AttributeClusterStateUpdateTypeUnchanged,
+	"success":   AttributeClusterStateUpdateTypeSuccess,
+	"failure":   AttributeClusterStateUpdateTypeFailure,
 }
 
 // AttributeDirection specifies the a value direction attribute.
@@ -340,6 +478,32 @@ var MapAttributeHealthStatus = map[string]AttributeHealthStatus{
 	"green":  AttributeHealthStatusGreen,
 	"yellow": AttributeHealthStatusYellow,
 	"red":    AttributeHealthStatusRed,
+}
+
+// AttributeIndexingMemoryState specifies the a value indexing_memory_state attribute.
+type AttributeIndexingMemoryState int
+
+const (
+	_ AttributeIndexingMemoryState = iota
+	AttributeIndexingMemoryStateCurrent
+	AttributeIndexingMemoryStateTotal
+)
+
+// String returns the string representation of the AttributeIndexingMemoryState.
+func (av AttributeIndexingMemoryState) String() string {
+	switch av {
+	case AttributeIndexingMemoryStateCurrent:
+		return "current"
+	case AttributeIndexingMemoryStateTotal:
+		return "total"
+	}
+	return ""
+}
+
+// MapAttributeIndexingMemoryState is a helper map of string to AttributeIndexingMemoryState attribute value.
+var MapAttributeIndexingMemoryState = map[string]AttributeIndexingMemoryState{
+	"current": AttributeIndexingMemoryStateCurrent,
+	"total":   AttributeIndexingMemoryStateTotal,
 }
 
 // AttributeMemoryState specifies the a value memory_state attribute.
@@ -881,6 +1045,304 @@ func newMetricElasticsearchClusterShards(settings MetricSettings) metricElastics
 	return m
 }
 
+type metricElasticsearchIndexingPressureMemoryCoordinating struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.indexing_pressure.memory.coordinating metric with initial data.
+func (m *metricElasticsearchIndexingPressureMemoryCoordinating) init() {
+	m.data.SetName("elasticsearch.indexing_pressure.memory.coordinating")
+	m.data.SetDescription("Memory consumed, in bytes, by indexing requests in the coordinating stage.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchIndexingPressureMemoryCoordinating) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchIndexingPressureMemoryCoordinating) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchIndexingPressureMemoryCoordinating) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchIndexingPressureMemoryCoordinating(settings MetricSettings) metricElasticsearchIndexingPressureMemoryCoordinating {
+	m := metricElasticsearchIndexingPressureMemoryCoordinating{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchIndexingPressureMemoryLimit struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.indexing_pressure.memory.limit metric with initial data.
+func (m *metricElasticsearchIndexingPressureMemoryLimit) init() {
+	m.data.SetName("elasticsearch.indexing_pressure.memory.limit")
+	m.data.SetDescription("Configured memory limit, in bytes, for the indexing requests.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchIndexingPressureMemoryLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchIndexingPressureMemoryLimit) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchIndexingPressureMemoryLimit) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchIndexingPressureMemoryLimit(settings MetricSettings) metricElasticsearchIndexingPressureMemoryLimit {
+	m := metricElasticsearchIndexingPressureMemoryLimit{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchIndexingPressureMemoryPrimary struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.indexing_pressure.memory.primary metric with initial data.
+func (m *metricElasticsearchIndexingPressureMemoryPrimary) init() {
+	m.data.SetName("elasticsearch.indexing_pressure.memory.primary")
+	m.data.SetDescription("Memory consumed, in bytes, by indexing requests in the primary stage.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchIndexingPressureMemoryPrimary) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchIndexingPressureMemoryPrimary) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchIndexingPressureMemoryPrimary) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchIndexingPressureMemoryPrimary(settings MetricSettings) metricElasticsearchIndexingPressureMemoryPrimary {
+	m := metricElasticsearchIndexingPressureMemoryPrimary{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchIndexingPressureMemoryReplica struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.indexing_pressure.memory.replica metric with initial data.
+func (m *metricElasticsearchIndexingPressureMemoryReplica) init() {
+	m.data.SetName("elasticsearch.indexing_pressure.memory.replica")
+	m.data.SetDescription("Memory consumed, in bytes, by indexing requests in the primary stage.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchIndexingPressureMemoryReplica) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchIndexingPressureMemoryReplica) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchIndexingPressureMemoryReplica) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchIndexingPressureMemoryReplica(settings MetricSettings) metricElasticsearchIndexingPressureMemoryReplica {
+	m := metricElasticsearchIndexingPressureMemoryReplica{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.indexing_pressure.memory.total.primary_rejections metric with initial data.
+func (m *metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections) init() {
+	m.data.SetName("elasticsearch.indexing_pressure.memory.total.primary_rejections")
+	m.data.SetDescription("Cumulative number of indexing requests rejected in the primary stage.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchIndexingPressureMemoryTotalPrimaryRejections(settings MetricSettings) metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections {
+	m := metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchIndexingPressureMemoryTotalReplicaRejections struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.indexing_pressure.memory.total.replica_rejections metric with initial data.
+func (m *metricElasticsearchIndexingPressureMemoryTotalReplicaRejections) init() {
+	m.data.SetName("elasticsearch.indexing_pressure.memory.total.replica_rejections")
+	m.data.SetDescription("Number of indexing requests rejected in the replica stage.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricElasticsearchIndexingPressureMemoryTotalReplicaRejections) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchIndexingPressureMemoryTotalReplicaRejections) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchIndexingPressureMemoryTotalReplicaRejections) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchIndexingPressureMemoryTotalReplicaRejections(settings MetricSettings) metricElasticsearchIndexingPressureMemoryTotalReplicaRejections {
+	m := metricElasticsearchIndexingPressureMemoryTotalReplicaRejections{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricElasticsearchNodeCacheEvictions struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1193,6 +1655,622 @@ func newMetricElasticsearchNodeClusterIoSent(settings MetricSettings) metricElas
 	return m
 }
 
+type metricElasticsearchNodeClusterPublishedStatesCompatible struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.published_states.compatible metric with initial data.
+func (m *metricElasticsearchNodeClusterPublishedStatesCompatible) init() {
+	m.data.SetName("elasticsearch.node.cluster.published_states.compatible")
+	m.data.SetDescription("Number of compatible differences between published cluster states.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchNodeClusterPublishedStatesCompatible) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterPublishedStatesCompatible) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterPublishedStatesCompatible) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterPublishedStatesCompatible(settings MetricSettings) metricElasticsearchNodeClusterPublishedStatesCompatible {
+	m := metricElasticsearchNodeClusterPublishedStatesCompatible{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterPublishedStatesFull struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.published_states.full metric with initial data.
+func (m *metricElasticsearchNodeClusterPublishedStatesFull) init() {
+	m.data.SetName("elasticsearch.node.cluster.published_states.full")
+	m.data.SetDescription("Number of published cluster states.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchNodeClusterPublishedStatesFull) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterPublishedStatesFull) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterPublishedStatesFull) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterPublishedStatesFull(settings MetricSettings) metricElasticsearchNodeClusterPublishedStatesFull {
+	m := metricElasticsearchNodeClusterPublishedStatesFull{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterPublishedStatesIncompatible struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.published_states.incompatible metric with initial data.
+func (m *metricElasticsearchNodeClusterPublishedStatesIncompatible) init() {
+	m.data.SetName("elasticsearch.node.cluster.published_states.incompatible")
+	m.data.SetDescription("Number of incompatible differences between published cluster states.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchNodeClusterPublishedStatesIncompatible) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterPublishedStatesIncompatible) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterPublishedStatesIncompatible) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterPublishedStatesIncompatible(settings MetricSettings) metricElasticsearchNodeClusterPublishedStatesIncompatible {
+	m := metricElasticsearchNodeClusterPublishedStatesIncompatible{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterStateQueueCommitted struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.state_queue.committed metric with initial data.
+func (m *metricElasticsearchNodeClusterStateQueueCommitted) init() {
+	m.data.SetName("elasticsearch.node.cluster.state_queue.committed")
+	m.data.SetDescription("Number of pending cluster states in queue.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchNodeClusterStateQueueCommitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterStateQueueCommitted) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterStateQueueCommitted) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterStateQueueCommitted(settings MetricSettings) metricElasticsearchNodeClusterStateQueueCommitted {
+	m := metricElasticsearchNodeClusterStateQueueCommitted{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterStateQueuePending struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.state_queue.pending metric with initial data.
+func (m *metricElasticsearchNodeClusterStateQueuePending) init() {
+	m.data.SetName("elasticsearch.node.cluster.state_queue.pending")
+	m.data.SetDescription("Number of pending cluster states in queue.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchNodeClusterStateQueuePending) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterStateQueuePending) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterStateQueuePending) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterStateQueuePending(settings MetricSettings) metricElasticsearchNodeClusterStateQueuePending {
+	m := metricElasticsearchNodeClusterStateQueuePending{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterStateUpdateCommitTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.state_update.commit_time metric with initial data.
+func (m *metricElasticsearchNodeClusterStateUpdateCommitTime) init() {
+	m.data.SetName("elasticsearch.node.cluster.state_update.commit_time")
+	m.data.SetDescription("The cumulative amount of time spent waiting for a cluster state update to commit.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeClusterStateUpdateCommitTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterStateUpdateCommitTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterStateUpdateCommitTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterStateUpdateCommitTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateCommitTime {
+	m := metricElasticsearchNodeClusterStateUpdateCommitTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterStateUpdateCompletionTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.state_update.completion_time metric with initial data.
+func (m *metricElasticsearchNodeClusterStateUpdateCompletionTime) init() {
+	m.data.SetName("elasticsearch.node.cluster.state_update.completion_time")
+	m.data.SetDescription("The cumulative amount of time spent waiting for a cluster state update to complete.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeClusterStateUpdateCompletionTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterStateUpdateCompletionTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterStateUpdateCompletionTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterStateUpdateCompletionTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateCompletionTime {
+	m := metricElasticsearchNodeClusterStateUpdateCompletionTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterStateUpdateComputationTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.state_update.computation_time metric with initial data.
+func (m *metricElasticsearchNodeClusterStateUpdateComputationTime) init() {
+	m.data.SetName("elasticsearch.node.cluster.state_update.computation_time")
+	m.data.SetDescription("The cumulative amount of time spent computing cluster state updates since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeClusterStateUpdateComputationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterStateUpdateComputationTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterStateUpdateComputationTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterStateUpdateComputationTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateComputationTime {
+	m := metricElasticsearchNodeClusterStateUpdateComputationTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterStateUpdateContextConstructionTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.state_update.context_construction_time metric with initial data.
+func (m *metricElasticsearchNodeClusterStateUpdateContextConstructionTime) init() {
+	m.data.SetName("elasticsearch.node.cluster.state_update.context_construction_time")
+	m.data.SetDescription("The cumulative amount of time spent constructing a publication context since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeClusterStateUpdateContextConstructionTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterStateUpdateContextConstructionTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterStateUpdateContextConstructionTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterStateUpdateContextConstructionTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateContextConstructionTime {
+	m := metricElasticsearchNodeClusterStateUpdateContextConstructionTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterStateUpdateCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.state_update.count metric with initial data.
+func (m *metricElasticsearchNodeClusterStateUpdateCount) init() {
+	m.data.SetName("elasticsearch.node.cluster.state_update.count")
+	m.data.SetDescription("The number of cluster state update attempts that changed the cluster state since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeClusterStateUpdateCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterStateUpdateCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterStateUpdateCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterStateUpdateCount(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateCount {
+	m := metricElasticsearchNodeClusterStateUpdateCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterStateUpdateMasterApplyTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.state_update.master_apply_time metric with initial data.
+func (m *metricElasticsearchNodeClusterStateUpdateMasterApplyTime) init() {
+	m.data.SetName("elasticsearch.node.cluster.state_update.master_apply_time")
+	m.data.SetDescription("The cumulative amount of time spent applying cluster state updates on the elected master since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeClusterStateUpdateMasterApplyTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterStateUpdateMasterApplyTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterStateUpdateMasterApplyTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterStateUpdateMasterApplyTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateMasterApplyTime {
+	m := metricElasticsearchNodeClusterStateUpdateMasterApplyTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeClusterStateUpdateNotificationTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.cluster.state_update.notification_time metric with initial data.
+func (m *metricElasticsearchNodeClusterStateUpdateNotificationTime) init() {
+	m.data.SetName("elasticsearch.node.cluster.state_update.notification_time")
+	m.data.SetDescription("The cumulative amount of time spent notifying listeners of a cluster state update since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeClusterStateUpdateNotificationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeClusterStateUpdateNotificationTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeClusterStateUpdateNotificationTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeClusterStateUpdateNotificationTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateNotificationTime {
+	m := metricElasticsearchNodeClusterStateUpdateNotificationTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricElasticsearchNodeDiskIoRead struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1450,6 +2528,314 @@ func newMetricElasticsearchNodeHTTPConnections(settings MetricSettings) metricEl
 	return m
 }
 
+type metricElasticsearchNodeIngestCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.ingest.count metric with initial data.
+func (m *metricElasticsearchNodeIngestCount) init() {
+	m.data.SetName("elasticsearch.node.ingest.count")
+	m.data.SetDescription("Total number of documents ingested during the lifetime of this node.")
+	m.data.SetUnit("{documents}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricElasticsearchNodeIngestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeIngestCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeIngestCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeIngestCount(settings MetricSettings) metricElasticsearchNodeIngestCount {
+	m := metricElasticsearchNodeIngestCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeIngestCurrent struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.ingest.current metric with initial data.
+func (m *metricElasticsearchNodeIngestCurrent) init() {
+	m.data.SetName("elasticsearch.node.ingest.current")
+	m.data.SetDescription("Total number of documents currently being ingested.")
+	m.data.SetUnit("{documents}")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricElasticsearchNodeIngestCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeIngestCurrent) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeIngestCurrent) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeIngestCurrent(settings MetricSettings) metricElasticsearchNodeIngestCurrent {
+	m := metricElasticsearchNodeIngestCurrent{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeIngestFailed struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.ingest.failed metric with initial data.
+func (m *metricElasticsearchNodeIngestFailed) init() {
+	m.data.SetName("elasticsearch.node.ingest.failed")
+	m.data.SetDescription("Total number of failed ingest operations during the lifetime of this node.")
+	m.data.SetUnit("{operation}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricElasticsearchNodeIngestFailed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeIngestFailed) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeIngestFailed) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeIngestFailed(settings MetricSettings) metricElasticsearchNodeIngestFailed {
+	m := metricElasticsearchNodeIngestFailed{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeIngestPipelineCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.ingest.pipeline.count metric with initial data.
+func (m *metricElasticsearchNodeIngestPipelineCount) init() {
+	m.data.SetName("elasticsearch.node.ingest.pipeline.count")
+	m.data.SetDescription("Total number of documents ingested during the lifetime of this node.")
+	m.data.SetUnit("{documents}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeIngestPipelineCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("name", ingestPipelineNameAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeIngestPipelineCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeIngestPipelineCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeIngestPipelineCount(settings MetricSettings) metricElasticsearchNodeIngestPipelineCount {
+	m := metricElasticsearchNodeIngestPipelineCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeIngestPipelineCurrent struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.ingest.pipeline.current metric with initial data.
+func (m *metricElasticsearchNodeIngestPipelineCurrent) init() {
+	m.data.SetName("elasticsearch.node.ingest.pipeline.current")
+	m.data.SetDescription("Total number of documents currently being ingested by a pipeline.")
+	m.data.SetUnit("{documents}")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeIngestPipelineCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("name", ingestPipelineNameAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeIngestPipelineCurrent) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeIngestPipelineCurrent) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeIngestPipelineCurrent(settings MetricSettings) metricElasticsearchNodeIngestPipelineCurrent {
+	m := metricElasticsearchNodeIngestPipelineCurrent{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeIngestPipelineFailed struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.ingest.pipeline.failed metric with initial data.
+func (m *metricElasticsearchNodeIngestPipelineFailed) init() {
+	m.data.SetName("elasticsearch.node.ingest.pipeline.failed")
+	m.data.SetDescription("Total number of failed operations for the ingest pipeline.")
+	m.data.SetUnit("{operation}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodeIngestPipelineFailed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("name", ingestPipelineNameAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeIngestPipelineFailed) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeIngestPipelineFailed) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeIngestPipelineFailed(settings MetricSettings) metricElasticsearchNodeIngestPipelineFailed {
+	m := metricElasticsearchNodeIngestPipelineFailed{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricElasticsearchNodeOpenFiles struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1600,6 +2986,159 @@ func (m *metricElasticsearchNodeOperationsTime) emit(metrics pmetric.MetricSlice
 
 func newMetricElasticsearchNodeOperationsTime(settings MetricSettings) metricElasticsearchNodeOperationsTime {
 	m := metricElasticsearchNodeOperationsTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeScriptCacheEvictions struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.script.cache_evictions metric with initial data.
+func (m *metricElasticsearchNodeScriptCacheEvictions) init() {
+	m.data.SetName("elasticsearch.node.script.cache_evictions")
+	m.data.SetDescription("Total number of times the script cache has evicted old data.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricElasticsearchNodeScriptCacheEvictions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeScriptCacheEvictions) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeScriptCacheEvictions) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeScriptCacheEvictions(settings MetricSettings) metricElasticsearchNodeScriptCacheEvictions {
+	m := metricElasticsearchNodeScriptCacheEvictions{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeScriptCompilationLimitTriggered struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.script.compilation_limit_triggered metric with initial data.
+func (m *metricElasticsearchNodeScriptCompilationLimitTriggered) init() {
+	m.data.SetName("elasticsearch.node.script.compilation_limit_triggered")
+	m.data.SetDescription("Total number of times the script compilation circuit breaker has limited inline script compilations.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricElasticsearchNodeScriptCompilationLimitTriggered) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeScriptCompilationLimitTriggered) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeScriptCompilationLimitTriggered) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeScriptCompilationLimitTriggered(settings MetricSettings) metricElasticsearchNodeScriptCompilationLimitTriggered {
+	m := metricElasticsearchNodeScriptCompilationLimitTriggered{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodeScriptCompilations struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.script.compilations metric with initial data.
+func (m *metricElasticsearchNodeScriptCompilations) init() {
+	m.data.SetName("elasticsearch.node.script.compilations")
+	m.data.SetDescription("Total number of inline script compilations performed by the node.")
+	m.data.SetUnit("{compilations}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricElasticsearchNodeScriptCompilations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodeScriptCompilations) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodeScriptCompilations) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodeScriptCompilations(settings MetricSettings) metricElasticsearchNodeScriptCompilations {
+	m := metricElasticsearchNodeScriptCompilations{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -2281,17 +3820,15 @@ func (m *metricElasticsearchOsMemory) init() {
 	m.data.SetName("elasticsearch.os.memory")
 	m.data.SetDescription("Amount of physical memory.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
 func (m *metricElasticsearchOsMemory) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, memoryStateAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -2300,14 +3837,14 @@ func (m *metricElasticsearchOsMemory) recordDataPoint(start pcommon.Timestamp, t
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricElasticsearchOsMemory) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchOsMemory) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -2877,57 +4414,84 @@ func newMetricJvmThreadsCount(settings MetricSettings) metricJvmThreadsCount {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                                      pcommon.Timestamp   // start time that will be applied to all recorded data points.
-	metricsCapacity                                int                 // maximum observed number of metrics per resource.
-	resourceCapacity                               int                 // maximum observed number of resource attributes.
-	metricsBuffer                                  pmetric.Metrics     // accumulates metrics data before emitting.
-	buildInfo                                      component.BuildInfo // contains version information
-	metricElasticsearchBreakerMemoryEstimated      metricElasticsearchBreakerMemoryEstimated
-	metricElasticsearchBreakerMemoryLimit          metricElasticsearchBreakerMemoryLimit
-	metricElasticsearchBreakerTripped              metricElasticsearchBreakerTripped
-	metricElasticsearchClusterDataNodes            metricElasticsearchClusterDataNodes
-	metricElasticsearchClusterHealth               metricElasticsearchClusterHealth
-	metricElasticsearchClusterNodes                metricElasticsearchClusterNodes
-	metricElasticsearchClusterShards               metricElasticsearchClusterShards
-	metricElasticsearchNodeCacheEvictions          metricElasticsearchNodeCacheEvictions
-	metricElasticsearchNodeCacheMemoryUsage        metricElasticsearchNodeCacheMemoryUsage
-	metricElasticsearchNodeClusterConnections      metricElasticsearchNodeClusterConnections
-	metricElasticsearchNodeClusterIo               metricElasticsearchNodeClusterIo
-	metricElasticsearchNodeClusterIoReceived       metricElasticsearchNodeClusterIoReceived
-	metricElasticsearchNodeClusterIoSent           metricElasticsearchNodeClusterIoSent
-	metricElasticsearchNodeDiskIoRead              metricElasticsearchNodeDiskIoRead
-	metricElasticsearchNodeDiskIoWrite             metricElasticsearchNodeDiskIoWrite
-	metricElasticsearchNodeDocuments               metricElasticsearchNodeDocuments
-	metricElasticsearchNodeFsDiskAvailable         metricElasticsearchNodeFsDiskAvailable
-	metricElasticsearchNodeHTTPConnections         metricElasticsearchNodeHTTPConnections
-	metricElasticsearchNodeOpenFiles               metricElasticsearchNodeOpenFiles
-	metricElasticsearchNodeOperationsCompleted     metricElasticsearchNodeOperationsCompleted
-	metricElasticsearchNodeOperationsTime          metricElasticsearchNodeOperationsTime
-	metricElasticsearchNodeShardsDataSetSize       metricElasticsearchNodeShardsDataSetSize
-	metricElasticsearchNodeShardsReservedSize      metricElasticsearchNodeShardsReservedSize
-	metricElasticsearchNodeShardsSize              metricElasticsearchNodeShardsSize
-	metricElasticsearchNodeThreadPoolTasksFinished metricElasticsearchNodeThreadPoolTasksFinished
-	metricElasticsearchNodeThreadPoolTasksQueued   metricElasticsearchNodeThreadPoolTasksQueued
-	metricElasticsearchNodeThreadPoolThreads       metricElasticsearchNodeThreadPoolThreads
-	metricElasticsearchNodeTranslogOperations      metricElasticsearchNodeTranslogOperations
-	metricElasticsearchNodeTranslogSize            metricElasticsearchNodeTranslogSize
-	metricElasticsearchNodeTranslogUncommittedSize metricElasticsearchNodeTranslogUncommittedSize
-	metricElasticsearchOsCPULoadAvg15m             metricElasticsearchOsCPULoadAvg15m
-	metricElasticsearchOsCPULoadAvg1m              metricElasticsearchOsCPULoadAvg1m
-	metricElasticsearchOsCPULoadAvg5m              metricElasticsearchOsCPULoadAvg5m
-	metricElasticsearchOsCPUUsage                  metricElasticsearchOsCPUUsage
-	metricElasticsearchOsMemory                    metricElasticsearchOsMemory
-	metricJvmClassesLoaded                         metricJvmClassesLoaded
-	metricJvmGcCollectionsCount                    metricJvmGcCollectionsCount
-	metricJvmGcCollectionsElapsed                  metricJvmGcCollectionsElapsed
-	metricJvmMemoryHeapCommitted                   metricJvmMemoryHeapCommitted
-	metricJvmMemoryHeapMax                         metricJvmMemoryHeapMax
-	metricJvmMemoryHeapUsed                        metricJvmMemoryHeapUsed
-	metricJvmMemoryNonheapCommitted                metricJvmMemoryNonheapCommitted
-	metricJvmMemoryNonheapUsed                     metricJvmMemoryNonheapUsed
-	metricJvmMemoryPoolMax                         metricJvmMemoryPoolMax
-	metricJvmMemoryPoolUsed                        metricJvmMemoryPoolUsed
-	metricJvmThreadsCount                          metricJvmThreadsCount
+	startTime                                                        pcommon.Timestamp   // start time that will be applied to all recorded data points.
+	metricsCapacity                                                  int                 // maximum observed number of metrics per resource.
+	resourceCapacity                                                 int                 // maximum observed number of resource attributes.
+	metricsBuffer                                                    pmetric.Metrics     // accumulates metrics data before emitting.
+	buildInfo                                                        component.BuildInfo // contains version information
+	metricElasticsearchBreakerMemoryEstimated                        metricElasticsearchBreakerMemoryEstimated
+	metricElasticsearchBreakerMemoryLimit                            metricElasticsearchBreakerMemoryLimit
+	metricElasticsearchBreakerTripped                                metricElasticsearchBreakerTripped
+	metricElasticsearchClusterDataNodes                              metricElasticsearchClusterDataNodes
+	metricElasticsearchClusterHealth                                 metricElasticsearchClusterHealth
+	metricElasticsearchClusterNodes                                  metricElasticsearchClusterNodes
+	metricElasticsearchClusterShards                                 metricElasticsearchClusterShards
+	metricElasticsearchIndexingPressureMemoryCoordinating            metricElasticsearchIndexingPressureMemoryCoordinating
+	metricElasticsearchIndexingPressureMemoryLimit                   metricElasticsearchIndexingPressureMemoryLimit
+	metricElasticsearchIndexingPressureMemoryPrimary                 metricElasticsearchIndexingPressureMemoryPrimary
+	metricElasticsearchIndexingPressureMemoryReplica                 metricElasticsearchIndexingPressureMemoryReplica
+	metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections  metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections
+	metricElasticsearchIndexingPressureMemoryTotalReplicaRejections  metricElasticsearchIndexingPressureMemoryTotalReplicaRejections
+	metricElasticsearchNodeCacheEvictions                            metricElasticsearchNodeCacheEvictions
+	metricElasticsearchNodeCacheMemoryUsage                          metricElasticsearchNodeCacheMemoryUsage
+	metricElasticsearchNodeClusterConnections                        metricElasticsearchNodeClusterConnections
+	metricElasticsearchNodeClusterIo                                 metricElasticsearchNodeClusterIo
+	metricElasticsearchNodeClusterIoReceived                         metricElasticsearchNodeClusterIoReceived
+	metricElasticsearchNodeClusterIoSent                             metricElasticsearchNodeClusterIoSent
+	metricElasticsearchNodeClusterPublishedStatesCompatible          metricElasticsearchNodeClusterPublishedStatesCompatible
+	metricElasticsearchNodeClusterPublishedStatesFull                metricElasticsearchNodeClusterPublishedStatesFull
+	metricElasticsearchNodeClusterPublishedStatesIncompatible        metricElasticsearchNodeClusterPublishedStatesIncompatible
+	metricElasticsearchNodeClusterStateQueueCommitted                metricElasticsearchNodeClusterStateQueueCommitted
+	metricElasticsearchNodeClusterStateQueuePending                  metricElasticsearchNodeClusterStateQueuePending
+	metricElasticsearchNodeClusterStateUpdateCommitTime              metricElasticsearchNodeClusterStateUpdateCommitTime
+	metricElasticsearchNodeClusterStateUpdateCompletionTime          metricElasticsearchNodeClusterStateUpdateCompletionTime
+	metricElasticsearchNodeClusterStateUpdateComputationTime         metricElasticsearchNodeClusterStateUpdateComputationTime
+	metricElasticsearchNodeClusterStateUpdateContextConstructionTime metricElasticsearchNodeClusterStateUpdateContextConstructionTime
+	metricElasticsearchNodeClusterStateUpdateCount                   metricElasticsearchNodeClusterStateUpdateCount
+	metricElasticsearchNodeClusterStateUpdateMasterApplyTime         metricElasticsearchNodeClusterStateUpdateMasterApplyTime
+	metricElasticsearchNodeClusterStateUpdateNotificationTime        metricElasticsearchNodeClusterStateUpdateNotificationTime
+	metricElasticsearchNodeDiskIoRead                                metricElasticsearchNodeDiskIoRead
+	metricElasticsearchNodeDiskIoWrite                               metricElasticsearchNodeDiskIoWrite
+	metricElasticsearchNodeDocuments                                 metricElasticsearchNodeDocuments
+	metricElasticsearchNodeFsDiskAvailable                           metricElasticsearchNodeFsDiskAvailable
+	metricElasticsearchNodeHTTPConnections                           metricElasticsearchNodeHTTPConnections
+	metricElasticsearchNodeIngestCount                               metricElasticsearchNodeIngestCount
+	metricElasticsearchNodeIngestCurrent                             metricElasticsearchNodeIngestCurrent
+	metricElasticsearchNodeIngestFailed                              metricElasticsearchNodeIngestFailed
+	metricElasticsearchNodeIngestPipelineCount                       metricElasticsearchNodeIngestPipelineCount
+	metricElasticsearchNodeIngestPipelineCurrent                     metricElasticsearchNodeIngestPipelineCurrent
+	metricElasticsearchNodeIngestPipelineFailed                      metricElasticsearchNodeIngestPipelineFailed
+	metricElasticsearchNodeOpenFiles                                 metricElasticsearchNodeOpenFiles
+	metricElasticsearchNodeOperationsCompleted                       metricElasticsearchNodeOperationsCompleted
+	metricElasticsearchNodeOperationsTime                            metricElasticsearchNodeOperationsTime
+	metricElasticsearchNodeScriptCacheEvictions                      metricElasticsearchNodeScriptCacheEvictions
+	metricElasticsearchNodeScriptCompilationLimitTriggered           metricElasticsearchNodeScriptCompilationLimitTriggered
+	metricElasticsearchNodeScriptCompilations                        metricElasticsearchNodeScriptCompilations
+	metricElasticsearchNodeShardsDataSetSize                         metricElasticsearchNodeShardsDataSetSize
+	metricElasticsearchNodeShardsReservedSize                        metricElasticsearchNodeShardsReservedSize
+	metricElasticsearchNodeShardsSize                                metricElasticsearchNodeShardsSize
+	metricElasticsearchNodeThreadPoolTasksFinished                   metricElasticsearchNodeThreadPoolTasksFinished
+	metricElasticsearchNodeThreadPoolTasksQueued                     metricElasticsearchNodeThreadPoolTasksQueued
+	metricElasticsearchNodeThreadPoolThreads                         metricElasticsearchNodeThreadPoolThreads
+	metricElasticsearchNodeTranslogOperations                        metricElasticsearchNodeTranslogOperations
+	metricElasticsearchNodeTranslogSize                              metricElasticsearchNodeTranslogSize
+	metricElasticsearchNodeTranslogUncommittedSize                   metricElasticsearchNodeTranslogUncommittedSize
+	metricElasticsearchOsCPULoadAvg15m                               metricElasticsearchOsCPULoadAvg15m
+	metricElasticsearchOsCPULoadAvg1m                                metricElasticsearchOsCPULoadAvg1m
+	metricElasticsearchOsCPULoadAvg5m                                metricElasticsearchOsCPULoadAvg5m
+	metricElasticsearchOsCPUUsage                                    metricElasticsearchOsCPUUsage
+	metricElasticsearchOsMemory                                      metricElasticsearchOsMemory
+	metricJvmClassesLoaded                                           metricJvmClassesLoaded
+	metricJvmGcCollectionsCount                                      metricJvmGcCollectionsCount
+	metricJvmGcCollectionsElapsed                                    metricJvmGcCollectionsElapsed
+	metricJvmMemoryHeapCommitted                                     metricJvmMemoryHeapCommitted
+	metricJvmMemoryHeapMax                                           metricJvmMemoryHeapMax
+	metricJvmMemoryHeapUsed                                          metricJvmMemoryHeapUsed
+	metricJvmMemoryNonheapCommitted                                  metricJvmMemoryNonheapCommitted
+	metricJvmMemoryNonheapUsed                                       metricJvmMemoryNonheapUsed
+	metricJvmMemoryPoolMax                                           metricJvmMemoryPoolMax
+	metricJvmMemoryPoolUsed                                          metricJvmMemoryPoolUsed
+	metricJvmThreadsCount                                            metricJvmThreadsCount
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -2945,52 +4509,79 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		startTime:     pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer: pmetric.NewMetrics(),
 		buildInfo:     buildInfo,
-		metricElasticsearchBreakerMemoryEstimated:      newMetricElasticsearchBreakerMemoryEstimated(settings.ElasticsearchBreakerMemoryEstimated),
-		metricElasticsearchBreakerMemoryLimit:          newMetricElasticsearchBreakerMemoryLimit(settings.ElasticsearchBreakerMemoryLimit),
-		metricElasticsearchBreakerTripped:              newMetricElasticsearchBreakerTripped(settings.ElasticsearchBreakerTripped),
-		metricElasticsearchClusterDataNodes:            newMetricElasticsearchClusterDataNodes(settings.ElasticsearchClusterDataNodes),
-		metricElasticsearchClusterHealth:               newMetricElasticsearchClusterHealth(settings.ElasticsearchClusterHealth),
-		metricElasticsearchClusterNodes:                newMetricElasticsearchClusterNodes(settings.ElasticsearchClusterNodes),
-		metricElasticsearchClusterShards:               newMetricElasticsearchClusterShards(settings.ElasticsearchClusterShards),
-		metricElasticsearchNodeCacheEvictions:          newMetricElasticsearchNodeCacheEvictions(settings.ElasticsearchNodeCacheEvictions),
-		metricElasticsearchNodeCacheMemoryUsage:        newMetricElasticsearchNodeCacheMemoryUsage(settings.ElasticsearchNodeCacheMemoryUsage),
-		metricElasticsearchNodeClusterConnections:      newMetricElasticsearchNodeClusterConnections(settings.ElasticsearchNodeClusterConnections),
-		metricElasticsearchNodeClusterIo:               newMetricElasticsearchNodeClusterIo(settings.ElasticsearchNodeClusterIo),
-		metricElasticsearchNodeClusterIoReceived:       newMetricElasticsearchNodeClusterIoReceived(settings.ElasticsearchNodeClusterIoReceived),
-		metricElasticsearchNodeClusterIoSent:           newMetricElasticsearchNodeClusterIoSent(settings.ElasticsearchNodeClusterIoSent),
-		metricElasticsearchNodeDiskIoRead:              newMetricElasticsearchNodeDiskIoRead(settings.ElasticsearchNodeDiskIoRead),
-		metricElasticsearchNodeDiskIoWrite:             newMetricElasticsearchNodeDiskIoWrite(settings.ElasticsearchNodeDiskIoWrite),
-		metricElasticsearchNodeDocuments:               newMetricElasticsearchNodeDocuments(settings.ElasticsearchNodeDocuments),
-		metricElasticsearchNodeFsDiskAvailable:         newMetricElasticsearchNodeFsDiskAvailable(settings.ElasticsearchNodeFsDiskAvailable),
-		metricElasticsearchNodeHTTPConnections:         newMetricElasticsearchNodeHTTPConnections(settings.ElasticsearchNodeHTTPConnections),
-		metricElasticsearchNodeOpenFiles:               newMetricElasticsearchNodeOpenFiles(settings.ElasticsearchNodeOpenFiles),
-		metricElasticsearchNodeOperationsCompleted:     newMetricElasticsearchNodeOperationsCompleted(settings.ElasticsearchNodeOperationsCompleted),
-		metricElasticsearchNodeOperationsTime:          newMetricElasticsearchNodeOperationsTime(settings.ElasticsearchNodeOperationsTime),
-		metricElasticsearchNodeShardsDataSetSize:       newMetricElasticsearchNodeShardsDataSetSize(settings.ElasticsearchNodeShardsDataSetSize),
-		metricElasticsearchNodeShardsReservedSize:      newMetricElasticsearchNodeShardsReservedSize(settings.ElasticsearchNodeShardsReservedSize),
-		metricElasticsearchNodeShardsSize:              newMetricElasticsearchNodeShardsSize(settings.ElasticsearchNodeShardsSize),
-		metricElasticsearchNodeThreadPoolTasksFinished: newMetricElasticsearchNodeThreadPoolTasksFinished(settings.ElasticsearchNodeThreadPoolTasksFinished),
-		metricElasticsearchNodeThreadPoolTasksQueued:   newMetricElasticsearchNodeThreadPoolTasksQueued(settings.ElasticsearchNodeThreadPoolTasksQueued),
-		metricElasticsearchNodeThreadPoolThreads:       newMetricElasticsearchNodeThreadPoolThreads(settings.ElasticsearchNodeThreadPoolThreads),
-		metricElasticsearchNodeTranslogOperations:      newMetricElasticsearchNodeTranslogOperations(settings.ElasticsearchNodeTranslogOperations),
-		metricElasticsearchNodeTranslogSize:            newMetricElasticsearchNodeTranslogSize(settings.ElasticsearchNodeTranslogSize),
-		metricElasticsearchNodeTranslogUncommittedSize: newMetricElasticsearchNodeTranslogUncommittedSize(settings.ElasticsearchNodeTranslogUncommittedSize),
-		metricElasticsearchOsCPULoadAvg15m:             newMetricElasticsearchOsCPULoadAvg15m(settings.ElasticsearchOsCPULoadAvg15m),
-		metricElasticsearchOsCPULoadAvg1m:              newMetricElasticsearchOsCPULoadAvg1m(settings.ElasticsearchOsCPULoadAvg1m),
-		metricElasticsearchOsCPULoadAvg5m:              newMetricElasticsearchOsCPULoadAvg5m(settings.ElasticsearchOsCPULoadAvg5m),
-		metricElasticsearchOsCPUUsage:                  newMetricElasticsearchOsCPUUsage(settings.ElasticsearchOsCPUUsage),
-		metricElasticsearchOsMemory:                    newMetricElasticsearchOsMemory(settings.ElasticsearchOsMemory),
-		metricJvmClassesLoaded:                         newMetricJvmClassesLoaded(settings.JvmClassesLoaded),
-		metricJvmGcCollectionsCount:                    newMetricJvmGcCollectionsCount(settings.JvmGcCollectionsCount),
-		metricJvmGcCollectionsElapsed:                  newMetricJvmGcCollectionsElapsed(settings.JvmGcCollectionsElapsed),
-		metricJvmMemoryHeapCommitted:                   newMetricJvmMemoryHeapCommitted(settings.JvmMemoryHeapCommitted),
-		metricJvmMemoryHeapMax:                         newMetricJvmMemoryHeapMax(settings.JvmMemoryHeapMax),
-		metricJvmMemoryHeapUsed:                        newMetricJvmMemoryHeapUsed(settings.JvmMemoryHeapUsed),
-		metricJvmMemoryNonheapCommitted:                newMetricJvmMemoryNonheapCommitted(settings.JvmMemoryNonheapCommitted),
-		metricJvmMemoryNonheapUsed:                     newMetricJvmMemoryNonheapUsed(settings.JvmMemoryNonheapUsed),
-		metricJvmMemoryPoolMax:                         newMetricJvmMemoryPoolMax(settings.JvmMemoryPoolMax),
-		metricJvmMemoryPoolUsed:                        newMetricJvmMemoryPoolUsed(settings.JvmMemoryPoolUsed),
-		metricJvmThreadsCount:                          newMetricJvmThreadsCount(settings.JvmThreadsCount),
+		metricElasticsearchBreakerMemoryEstimated:                        newMetricElasticsearchBreakerMemoryEstimated(settings.ElasticsearchBreakerMemoryEstimated),
+		metricElasticsearchBreakerMemoryLimit:                            newMetricElasticsearchBreakerMemoryLimit(settings.ElasticsearchBreakerMemoryLimit),
+		metricElasticsearchBreakerTripped:                                newMetricElasticsearchBreakerTripped(settings.ElasticsearchBreakerTripped),
+		metricElasticsearchClusterDataNodes:                              newMetricElasticsearchClusterDataNodes(settings.ElasticsearchClusterDataNodes),
+		metricElasticsearchClusterHealth:                                 newMetricElasticsearchClusterHealth(settings.ElasticsearchClusterHealth),
+		metricElasticsearchClusterNodes:                                  newMetricElasticsearchClusterNodes(settings.ElasticsearchClusterNodes),
+		metricElasticsearchClusterShards:                                 newMetricElasticsearchClusterShards(settings.ElasticsearchClusterShards),
+		metricElasticsearchIndexingPressureMemoryCoordinating:            newMetricElasticsearchIndexingPressureMemoryCoordinating(settings.ElasticsearchIndexingPressureMemoryCoordinating),
+		metricElasticsearchIndexingPressureMemoryLimit:                   newMetricElasticsearchIndexingPressureMemoryLimit(settings.ElasticsearchIndexingPressureMemoryLimit),
+		metricElasticsearchIndexingPressureMemoryPrimary:                 newMetricElasticsearchIndexingPressureMemoryPrimary(settings.ElasticsearchIndexingPressureMemoryPrimary),
+		metricElasticsearchIndexingPressureMemoryReplica:                 newMetricElasticsearchIndexingPressureMemoryReplica(settings.ElasticsearchIndexingPressureMemoryReplica),
+		metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections:  newMetricElasticsearchIndexingPressureMemoryTotalPrimaryRejections(settings.ElasticsearchIndexingPressureMemoryTotalPrimaryRejections),
+		metricElasticsearchIndexingPressureMemoryTotalReplicaRejections:  newMetricElasticsearchIndexingPressureMemoryTotalReplicaRejections(settings.ElasticsearchIndexingPressureMemoryTotalReplicaRejections),
+		metricElasticsearchNodeCacheEvictions:                            newMetricElasticsearchNodeCacheEvictions(settings.ElasticsearchNodeCacheEvictions),
+		metricElasticsearchNodeCacheMemoryUsage:                          newMetricElasticsearchNodeCacheMemoryUsage(settings.ElasticsearchNodeCacheMemoryUsage),
+		metricElasticsearchNodeClusterConnections:                        newMetricElasticsearchNodeClusterConnections(settings.ElasticsearchNodeClusterConnections),
+		metricElasticsearchNodeClusterIo:                                 newMetricElasticsearchNodeClusterIo(settings.ElasticsearchNodeClusterIo),
+		metricElasticsearchNodeClusterIoReceived:                         newMetricElasticsearchNodeClusterIoReceived(settings.ElasticsearchNodeClusterIoReceived),
+		metricElasticsearchNodeClusterIoSent:                             newMetricElasticsearchNodeClusterIoSent(settings.ElasticsearchNodeClusterIoSent),
+		metricElasticsearchNodeClusterPublishedStatesCompatible:          newMetricElasticsearchNodeClusterPublishedStatesCompatible(settings.ElasticsearchNodeClusterPublishedStatesCompatible),
+		metricElasticsearchNodeClusterPublishedStatesFull:                newMetricElasticsearchNodeClusterPublishedStatesFull(settings.ElasticsearchNodeClusterPublishedStatesFull),
+		metricElasticsearchNodeClusterPublishedStatesIncompatible:        newMetricElasticsearchNodeClusterPublishedStatesIncompatible(settings.ElasticsearchNodeClusterPublishedStatesIncompatible),
+		metricElasticsearchNodeClusterStateQueueCommitted:                newMetricElasticsearchNodeClusterStateQueueCommitted(settings.ElasticsearchNodeClusterStateQueueCommitted),
+		metricElasticsearchNodeClusterStateQueuePending:                  newMetricElasticsearchNodeClusterStateQueuePending(settings.ElasticsearchNodeClusterStateQueuePending),
+		metricElasticsearchNodeClusterStateUpdateCommitTime:              newMetricElasticsearchNodeClusterStateUpdateCommitTime(settings.ElasticsearchNodeClusterStateUpdateCommitTime),
+		metricElasticsearchNodeClusterStateUpdateCompletionTime:          newMetricElasticsearchNodeClusterStateUpdateCompletionTime(settings.ElasticsearchNodeClusterStateUpdateCompletionTime),
+		metricElasticsearchNodeClusterStateUpdateComputationTime:         newMetricElasticsearchNodeClusterStateUpdateComputationTime(settings.ElasticsearchNodeClusterStateUpdateComputationTime),
+		metricElasticsearchNodeClusterStateUpdateContextConstructionTime: newMetricElasticsearchNodeClusterStateUpdateContextConstructionTime(settings.ElasticsearchNodeClusterStateUpdateContextConstructionTime),
+		metricElasticsearchNodeClusterStateUpdateCount:                   newMetricElasticsearchNodeClusterStateUpdateCount(settings.ElasticsearchNodeClusterStateUpdateCount),
+		metricElasticsearchNodeClusterStateUpdateMasterApplyTime:         newMetricElasticsearchNodeClusterStateUpdateMasterApplyTime(settings.ElasticsearchNodeClusterStateUpdateMasterApplyTime),
+		metricElasticsearchNodeClusterStateUpdateNotificationTime:        newMetricElasticsearchNodeClusterStateUpdateNotificationTime(settings.ElasticsearchNodeClusterStateUpdateNotificationTime),
+		metricElasticsearchNodeDiskIoRead:                                newMetricElasticsearchNodeDiskIoRead(settings.ElasticsearchNodeDiskIoRead),
+		metricElasticsearchNodeDiskIoWrite:                               newMetricElasticsearchNodeDiskIoWrite(settings.ElasticsearchNodeDiskIoWrite),
+		metricElasticsearchNodeDocuments:                                 newMetricElasticsearchNodeDocuments(settings.ElasticsearchNodeDocuments),
+		metricElasticsearchNodeFsDiskAvailable:                           newMetricElasticsearchNodeFsDiskAvailable(settings.ElasticsearchNodeFsDiskAvailable),
+		metricElasticsearchNodeHTTPConnections:                           newMetricElasticsearchNodeHTTPConnections(settings.ElasticsearchNodeHTTPConnections),
+		metricElasticsearchNodeIngestCount:                               newMetricElasticsearchNodeIngestCount(settings.ElasticsearchNodeIngestCount),
+		metricElasticsearchNodeIngestCurrent:                             newMetricElasticsearchNodeIngestCurrent(settings.ElasticsearchNodeIngestCurrent),
+		metricElasticsearchNodeIngestFailed:                              newMetricElasticsearchNodeIngestFailed(settings.ElasticsearchNodeIngestFailed),
+		metricElasticsearchNodeIngestPipelineCount:                       newMetricElasticsearchNodeIngestPipelineCount(settings.ElasticsearchNodeIngestPipelineCount),
+		metricElasticsearchNodeIngestPipelineCurrent:                     newMetricElasticsearchNodeIngestPipelineCurrent(settings.ElasticsearchNodeIngestPipelineCurrent),
+		metricElasticsearchNodeIngestPipelineFailed:                      newMetricElasticsearchNodeIngestPipelineFailed(settings.ElasticsearchNodeIngestPipelineFailed),
+		metricElasticsearchNodeOpenFiles:                                 newMetricElasticsearchNodeOpenFiles(settings.ElasticsearchNodeOpenFiles),
+		metricElasticsearchNodeOperationsCompleted:                       newMetricElasticsearchNodeOperationsCompleted(settings.ElasticsearchNodeOperationsCompleted),
+		metricElasticsearchNodeOperationsTime:                            newMetricElasticsearchNodeOperationsTime(settings.ElasticsearchNodeOperationsTime),
+		metricElasticsearchNodeScriptCacheEvictions:                      newMetricElasticsearchNodeScriptCacheEvictions(settings.ElasticsearchNodeScriptCacheEvictions),
+		metricElasticsearchNodeScriptCompilationLimitTriggered:           newMetricElasticsearchNodeScriptCompilationLimitTriggered(settings.ElasticsearchNodeScriptCompilationLimitTriggered),
+		metricElasticsearchNodeScriptCompilations:                        newMetricElasticsearchNodeScriptCompilations(settings.ElasticsearchNodeScriptCompilations),
+		metricElasticsearchNodeShardsDataSetSize:                         newMetricElasticsearchNodeShardsDataSetSize(settings.ElasticsearchNodeShardsDataSetSize),
+		metricElasticsearchNodeShardsReservedSize:                        newMetricElasticsearchNodeShardsReservedSize(settings.ElasticsearchNodeShardsReservedSize),
+		metricElasticsearchNodeShardsSize:                                newMetricElasticsearchNodeShardsSize(settings.ElasticsearchNodeShardsSize),
+		metricElasticsearchNodeThreadPoolTasksFinished:                   newMetricElasticsearchNodeThreadPoolTasksFinished(settings.ElasticsearchNodeThreadPoolTasksFinished),
+		metricElasticsearchNodeThreadPoolTasksQueued:                     newMetricElasticsearchNodeThreadPoolTasksQueued(settings.ElasticsearchNodeThreadPoolTasksQueued),
+		metricElasticsearchNodeThreadPoolThreads:                         newMetricElasticsearchNodeThreadPoolThreads(settings.ElasticsearchNodeThreadPoolThreads),
+		metricElasticsearchNodeTranslogOperations:                        newMetricElasticsearchNodeTranslogOperations(settings.ElasticsearchNodeTranslogOperations),
+		metricElasticsearchNodeTranslogSize:                              newMetricElasticsearchNodeTranslogSize(settings.ElasticsearchNodeTranslogSize),
+		metricElasticsearchNodeTranslogUncommittedSize:                   newMetricElasticsearchNodeTranslogUncommittedSize(settings.ElasticsearchNodeTranslogUncommittedSize),
+		metricElasticsearchOsCPULoadAvg15m:                               newMetricElasticsearchOsCPULoadAvg15m(settings.ElasticsearchOsCPULoadAvg15m),
+		metricElasticsearchOsCPULoadAvg1m:                                newMetricElasticsearchOsCPULoadAvg1m(settings.ElasticsearchOsCPULoadAvg1m),
+		metricElasticsearchOsCPULoadAvg5m:                                newMetricElasticsearchOsCPULoadAvg5m(settings.ElasticsearchOsCPULoadAvg5m),
+		metricElasticsearchOsCPUUsage:                                    newMetricElasticsearchOsCPUUsage(settings.ElasticsearchOsCPUUsage),
+		metricElasticsearchOsMemory:                                      newMetricElasticsearchOsMemory(settings.ElasticsearchOsMemory),
+		metricJvmClassesLoaded:                                           newMetricJvmClassesLoaded(settings.JvmClassesLoaded),
+		metricJvmGcCollectionsCount:                                      newMetricJvmGcCollectionsCount(settings.JvmGcCollectionsCount),
+		metricJvmGcCollectionsElapsed:                                    newMetricJvmGcCollectionsElapsed(settings.JvmGcCollectionsElapsed),
+		metricJvmMemoryHeapCommitted:                                     newMetricJvmMemoryHeapCommitted(settings.JvmMemoryHeapCommitted),
+		metricJvmMemoryHeapMax:                                           newMetricJvmMemoryHeapMax(settings.JvmMemoryHeapMax),
+		metricJvmMemoryHeapUsed:                                          newMetricJvmMemoryHeapUsed(settings.JvmMemoryHeapUsed),
+		metricJvmMemoryNonheapCommitted:                                  newMetricJvmMemoryNonheapCommitted(settings.JvmMemoryNonheapCommitted),
+		metricJvmMemoryNonheapUsed:                                       newMetricJvmMemoryNonheapUsed(settings.JvmMemoryNonheapUsed),
+		metricJvmMemoryPoolMax:                                           newMetricJvmMemoryPoolMax(settings.JvmMemoryPoolMax),
+		metricJvmMemoryPoolUsed:                                          newMetricJvmMemoryPoolUsed(settings.JvmMemoryPoolUsed),
+		metricJvmThreadsCount:                                            newMetricJvmThreadsCount(settings.JvmThreadsCount),
 	}
 	for _, op := range options {
 		op(mb)
@@ -3064,20 +4655,47 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricElasticsearchClusterHealth.emit(ils.Metrics())
 	mb.metricElasticsearchClusterNodes.emit(ils.Metrics())
 	mb.metricElasticsearchClusterShards.emit(ils.Metrics())
+	mb.metricElasticsearchIndexingPressureMemoryCoordinating.emit(ils.Metrics())
+	mb.metricElasticsearchIndexingPressureMemoryLimit.emit(ils.Metrics())
+	mb.metricElasticsearchIndexingPressureMemoryPrimary.emit(ils.Metrics())
+	mb.metricElasticsearchIndexingPressureMemoryReplica.emit(ils.Metrics())
+	mb.metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections.emit(ils.Metrics())
+	mb.metricElasticsearchIndexingPressureMemoryTotalReplicaRejections.emit(ils.Metrics())
 	mb.metricElasticsearchNodeCacheEvictions.emit(ils.Metrics())
 	mb.metricElasticsearchNodeCacheMemoryUsage.emit(ils.Metrics())
 	mb.metricElasticsearchNodeClusterConnections.emit(ils.Metrics())
 	mb.metricElasticsearchNodeClusterIo.emit(ils.Metrics())
 	mb.metricElasticsearchNodeClusterIoReceived.emit(ils.Metrics())
 	mb.metricElasticsearchNodeClusterIoSent.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterPublishedStatesCompatible.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterPublishedStatesFull.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterPublishedStatesIncompatible.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterStateQueueCommitted.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterStateQueuePending.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterStateUpdateCommitTime.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterStateUpdateCompletionTime.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterStateUpdateComputationTime.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterStateUpdateContextConstructionTime.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterStateUpdateCount.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterStateUpdateMasterApplyTime.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterStateUpdateNotificationTime.emit(ils.Metrics())
 	mb.metricElasticsearchNodeDiskIoRead.emit(ils.Metrics())
 	mb.metricElasticsearchNodeDiskIoWrite.emit(ils.Metrics())
 	mb.metricElasticsearchNodeDocuments.emit(ils.Metrics())
 	mb.metricElasticsearchNodeFsDiskAvailable.emit(ils.Metrics())
 	mb.metricElasticsearchNodeHTTPConnections.emit(ils.Metrics())
+	mb.metricElasticsearchNodeIngestCount.emit(ils.Metrics())
+	mb.metricElasticsearchNodeIngestCurrent.emit(ils.Metrics())
+	mb.metricElasticsearchNodeIngestFailed.emit(ils.Metrics())
+	mb.metricElasticsearchNodeIngestPipelineCount.emit(ils.Metrics())
+	mb.metricElasticsearchNodeIngestPipelineCurrent.emit(ils.Metrics())
+	mb.metricElasticsearchNodeIngestPipelineFailed.emit(ils.Metrics())
 	mb.metricElasticsearchNodeOpenFiles.emit(ils.Metrics())
 	mb.metricElasticsearchNodeOperationsCompleted.emit(ils.Metrics())
 	mb.metricElasticsearchNodeOperationsTime.emit(ils.Metrics())
+	mb.metricElasticsearchNodeScriptCacheEvictions.emit(ils.Metrics())
+	mb.metricElasticsearchNodeScriptCompilationLimitTriggered.emit(ils.Metrics())
+	mb.metricElasticsearchNodeScriptCompilations.emit(ils.Metrics())
 	mb.metricElasticsearchNodeShardsDataSetSize.emit(ils.Metrics())
 	mb.metricElasticsearchNodeShardsReservedSize.emit(ils.Metrics())
 	mb.metricElasticsearchNodeShardsSize.emit(ils.Metrics())
@@ -3157,6 +4775,36 @@ func (mb *MetricsBuilder) RecordElasticsearchClusterShardsDataPoint(ts pcommon.T
 	mb.metricElasticsearchClusterShards.recordDataPoint(mb.startTime, ts, val, shardStateAttributeValue.String())
 }
 
+// RecordElasticsearchIndexingPressureMemoryCoordinatingDataPoint adds a data point to elasticsearch.indexing_pressure.memory.coordinating metric.
+func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryCoordinatingDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchIndexingPressureMemoryCoordinating.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchIndexingPressureMemoryLimitDataPoint adds a data point to elasticsearch.indexing_pressure.memory.limit metric.
+func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryLimitDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchIndexingPressureMemoryLimit.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchIndexingPressureMemoryPrimaryDataPoint adds a data point to elasticsearch.indexing_pressure.memory.primary metric.
+func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryPrimaryDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchIndexingPressureMemoryPrimary.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchIndexingPressureMemoryReplicaDataPoint adds a data point to elasticsearch.indexing_pressure.memory.replica metric.
+func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryReplicaDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchIndexingPressureMemoryReplica.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchIndexingPressureMemoryTotalPrimaryRejectionsDataPoint adds a data point to elasticsearch.indexing_pressure.memory.total.primary_rejections metric.
+func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryTotalPrimaryRejectionsDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchIndexingPressureMemoryTotalReplicaRejectionsDataPoint adds a data point to elasticsearch.indexing_pressure.memory.total.replica_rejections metric.
+func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryTotalReplicaRejectionsDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchIndexingPressureMemoryTotalReplicaRejections.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordElasticsearchNodeCacheEvictionsDataPoint adds a data point to elasticsearch.node.cache.evictions metric.
 func (mb *MetricsBuilder) RecordElasticsearchNodeCacheEvictionsDataPoint(ts pcommon.Timestamp, val int64, cacheNameAttributeValue AttributeCacheName) {
 	mb.metricElasticsearchNodeCacheEvictions.recordDataPoint(mb.startTime, ts, val, cacheNameAttributeValue.String())
@@ -3187,6 +4835,66 @@ func (mb *MetricsBuilder) RecordElasticsearchNodeClusterIoSentDataPoint(ts pcomm
 	mb.metricElasticsearchNodeClusterIoSent.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordElasticsearchNodeClusterPublishedStatesCompatibleDataPoint adds a data point to elasticsearch.node.cluster.published_states.compatible metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterPublishedStatesCompatibleDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeClusterPublishedStatesCompatible.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeClusterPublishedStatesFullDataPoint adds a data point to elasticsearch.node.cluster.published_states.full metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterPublishedStatesFullDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeClusterPublishedStatesFull.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeClusterPublishedStatesIncompatibleDataPoint adds a data point to elasticsearch.node.cluster.published_states.incompatible metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterPublishedStatesIncompatibleDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeClusterPublishedStatesIncompatible.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeClusterStateQueueCommittedDataPoint adds a data point to elasticsearch.node.cluster.state_queue.committed metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateQueueCommittedDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeClusterStateQueueCommitted.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeClusterStateQueuePendingDataPoint adds a data point to elasticsearch.node.cluster.state_queue.pending metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateQueuePendingDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeClusterStateQueuePending.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeClusterStateUpdateCommitTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.commit_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateCommitTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchNodeClusterStateUpdateCommitTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchNodeClusterStateUpdateCompletionTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.completion_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateCompletionTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchNodeClusterStateUpdateCompletionTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchNodeClusterStateUpdateComputationTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.computation_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateComputationTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchNodeClusterStateUpdateComputationTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchNodeClusterStateUpdateContextConstructionTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.context_construction_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateContextConstructionTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchNodeClusterStateUpdateContextConstructionTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchNodeClusterStateUpdateCountDataPoint adds a data point to elasticsearch.node.cluster.state_update.count metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateCountDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchNodeClusterStateUpdateCount.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchNodeClusterStateUpdateMasterApplyTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.master_apply_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateMasterApplyTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchNodeClusterStateUpdateMasterApplyTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchNodeClusterStateUpdateNotificationTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.notification_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateNotificationTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchNodeClusterStateUpdateNotificationTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
 // RecordElasticsearchNodeDiskIoReadDataPoint adds a data point to elasticsearch.node.disk.io.read metric.
 func (mb *MetricsBuilder) RecordElasticsearchNodeDiskIoReadDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricElasticsearchNodeDiskIoRead.recordDataPoint(mb.startTime, ts, val)
@@ -3212,6 +4920,36 @@ func (mb *MetricsBuilder) RecordElasticsearchNodeHTTPConnectionsDataPoint(ts pco
 	mb.metricElasticsearchNodeHTTPConnections.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordElasticsearchNodeIngestCountDataPoint adds a data point to elasticsearch.node.ingest.count metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeIngestCountDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeIngestCount.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeIngestCurrentDataPoint adds a data point to elasticsearch.node.ingest.current metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeIngestCurrentDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeIngestCurrent.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeIngestFailedDataPoint adds a data point to elasticsearch.node.ingest.failed metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeIngestFailedDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeIngestFailed.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeIngestPipelineCountDataPoint adds a data point to elasticsearch.node.ingest.pipeline.count metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeIngestPipelineCountDataPoint(ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	mb.metricElasticsearchNodeIngestPipelineCount.recordDataPoint(mb.startTime, ts, val, ingestPipelineNameAttributeValue)
+}
+
+// RecordElasticsearchNodeIngestPipelineCurrentDataPoint adds a data point to elasticsearch.node.ingest.pipeline.current metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeIngestPipelineCurrentDataPoint(ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	mb.metricElasticsearchNodeIngestPipelineCurrent.recordDataPoint(mb.startTime, ts, val, ingestPipelineNameAttributeValue)
+}
+
+// RecordElasticsearchNodeIngestPipelineFailedDataPoint adds a data point to elasticsearch.node.ingest.pipeline.failed metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeIngestPipelineFailedDataPoint(ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	mb.metricElasticsearchNodeIngestPipelineFailed.recordDataPoint(mb.startTime, ts, val, ingestPipelineNameAttributeValue)
+}
+
 // RecordElasticsearchNodeOpenFilesDataPoint adds a data point to elasticsearch.node.open_files metric.
 func (mb *MetricsBuilder) RecordElasticsearchNodeOpenFilesDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricElasticsearchNodeOpenFiles.recordDataPoint(mb.startTime, ts, val)
@@ -3225,6 +4963,21 @@ func (mb *MetricsBuilder) RecordElasticsearchNodeOperationsCompletedDataPoint(ts
 // RecordElasticsearchNodeOperationsTimeDataPoint adds a data point to elasticsearch.node.operations.time metric.
 func (mb *MetricsBuilder) RecordElasticsearchNodeOperationsTimeDataPoint(ts pcommon.Timestamp, val int64, operationAttributeValue AttributeOperation) {
 	mb.metricElasticsearchNodeOperationsTime.recordDataPoint(mb.startTime, ts, val, operationAttributeValue.String())
+}
+
+// RecordElasticsearchNodeScriptCacheEvictionsDataPoint adds a data point to elasticsearch.node.script.cache_evictions metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeScriptCacheEvictionsDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeScriptCacheEvictions.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeScriptCompilationLimitTriggeredDataPoint adds a data point to elasticsearch.node.script.compilation_limit_triggered metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeScriptCompilationLimitTriggeredDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeScriptCompilationLimitTriggered.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchNodeScriptCompilationsDataPoint adds a data point to elasticsearch.node.script.compilations metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeScriptCompilationsDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeScriptCompilations.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordElasticsearchNodeShardsDataSetSizeDataPoint adds a data point to elasticsearch.node.shards.data_set.size metric.

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -2733,15 +2733,17 @@ func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) init() {
 	m.data.SetName("elasticsearch.node.pipeline.ingest.documents.current")
 	m.data.SetDescription("Total number of documents currently being ingested by a pipeline.")
 	m.data.SetUnit("{documents}")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
 func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -2750,14 +2752,14 @@ func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) recordDataPoint(
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -17,79 +17,75 @@ type MetricSettings struct {
 
 // MetricsSettings provides settings for elasticsearchreceiver metrics.
 type MetricsSettings struct {
-	ElasticsearchBreakerMemoryEstimated                        MetricSettings `mapstructure:"elasticsearch.breaker.memory.estimated"`
-	ElasticsearchBreakerMemoryLimit                            MetricSettings `mapstructure:"elasticsearch.breaker.memory.limit"`
-	ElasticsearchBreakerTripped                                MetricSettings `mapstructure:"elasticsearch.breaker.tripped"`
-	ElasticsearchClusterDataNodes                              MetricSettings `mapstructure:"elasticsearch.cluster.data_nodes"`
-	ElasticsearchClusterHealth                                 MetricSettings `mapstructure:"elasticsearch.cluster.health"`
-	ElasticsearchClusterNodes                                  MetricSettings `mapstructure:"elasticsearch.cluster.nodes"`
-	ElasticsearchClusterShards                                 MetricSettings `mapstructure:"elasticsearch.cluster.shards"`
-	ElasticsearchIndexingPressureMemoryCoordinating            MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.coordinating"`
-	ElasticsearchIndexingPressureMemoryLimit                   MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.limit"`
-	ElasticsearchIndexingPressureMemoryPrimary                 MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.primary"`
-	ElasticsearchIndexingPressureMemoryReplica                 MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.replica"`
-	ElasticsearchIndexingPressureMemoryTotalPrimaryRejections  MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.total.primary_rejections"`
-	ElasticsearchIndexingPressureMemoryTotalReplicaRejections  MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.total.replica_rejections"`
-	ElasticsearchNodeCacheEvictions                            MetricSettings `mapstructure:"elasticsearch.node.cache.evictions"`
-	ElasticsearchNodeCacheMemoryUsage                          MetricSettings `mapstructure:"elasticsearch.node.cache.memory.usage"`
-	ElasticsearchNodeClusterConnections                        MetricSettings `mapstructure:"elasticsearch.node.cluster.connections"`
-	ElasticsearchNodeClusterIo                                 MetricSettings `mapstructure:"elasticsearch.node.cluster.io"`
-	ElasticsearchNodeClusterIoReceived                         MetricSettings `mapstructure:"elasticsearch.node.cluster.io.received"`
-	ElasticsearchNodeClusterIoSent                             MetricSettings `mapstructure:"elasticsearch.node.cluster.io.sent"`
-	ElasticsearchNodeClusterPublishedStatesCompatible          MetricSettings `mapstructure:"elasticsearch.node.cluster.published_states.compatible"`
-	ElasticsearchNodeClusterPublishedStatesFull                MetricSettings `mapstructure:"elasticsearch.node.cluster.published_states.full"`
-	ElasticsearchNodeClusterPublishedStatesIncompatible        MetricSettings `mapstructure:"elasticsearch.node.cluster.published_states.incompatible"`
-	ElasticsearchNodeClusterStateQueueCommitted                MetricSettings `mapstructure:"elasticsearch.node.cluster.state_queue.committed"`
-	ElasticsearchNodeClusterStateQueuePending                  MetricSettings `mapstructure:"elasticsearch.node.cluster.state_queue.pending"`
-	ElasticsearchNodeClusterStateUpdateCommitTime              MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.commit_time"`
-	ElasticsearchNodeClusterStateUpdateCompletionTime          MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.completion_time"`
-	ElasticsearchNodeClusterStateUpdateComputationTime         MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.computation_time"`
-	ElasticsearchNodeClusterStateUpdateContextConstructionTime MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.context_construction_time"`
-	ElasticsearchNodeClusterStateUpdateCount                   MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.count"`
-	ElasticsearchNodeClusterStateUpdateMasterApplyTime         MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.master_apply_time"`
-	ElasticsearchNodeClusterStateUpdateNotificationTime        MetricSettings `mapstructure:"elasticsearch.node.cluster.state_update.notification_time"`
-	ElasticsearchNodeDiskIoRead                                MetricSettings `mapstructure:"elasticsearch.node.disk.io.read"`
-	ElasticsearchNodeDiskIoWrite                               MetricSettings `mapstructure:"elasticsearch.node.disk.io.write"`
-	ElasticsearchNodeDocuments                                 MetricSettings `mapstructure:"elasticsearch.node.documents"`
-	ElasticsearchNodeFsDiskAvailable                           MetricSettings `mapstructure:"elasticsearch.node.fs.disk.available"`
-	ElasticsearchNodeHTTPConnections                           MetricSettings `mapstructure:"elasticsearch.node.http.connections"`
-	ElasticsearchNodeIngestCount                               MetricSettings `mapstructure:"elasticsearch.node.ingest.count"`
-	ElasticsearchNodeIngestCurrent                             MetricSettings `mapstructure:"elasticsearch.node.ingest.current"`
-	ElasticsearchNodeIngestFailed                              MetricSettings `mapstructure:"elasticsearch.node.ingest.failed"`
-	ElasticsearchNodeIngestPipelineCount                       MetricSettings `mapstructure:"elasticsearch.node.ingest.pipeline.count"`
-	ElasticsearchNodeIngestPipelineCurrent                     MetricSettings `mapstructure:"elasticsearch.node.ingest.pipeline.current"`
-	ElasticsearchNodeIngestPipelineFailed                      MetricSettings `mapstructure:"elasticsearch.node.ingest.pipeline.failed"`
-	ElasticsearchNodeOpenFiles                                 MetricSettings `mapstructure:"elasticsearch.node.open_files"`
-	ElasticsearchNodeOperationsCompleted                       MetricSettings `mapstructure:"elasticsearch.node.operations.completed"`
-	ElasticsearchNodeOperationsTime                            MetricSettings `mapstructure:"elasticsearch.node.operations.time"`
-	ElasticsearchNodeScriptCacheEvictions                      MetricSettings `mapstructure:"elasticsearch.node.script.cache_evictions"`
-	ElasticsearchNodeScriptCompilationLimitTriggered           MetricSettings `mapstructure:"elasticsearch.node.script.compilation_limit_triggered"`
-	ElasticsearchNodeScriptCompilations                        MetricSettings `mapstructure:"elasticsearch.node.script.compilations"`
-	ElasticsearchNodeShardsDataSetSize                         MetricSettings `mapstructure:"elasticsearch.node.shards.data_set.size"`
-	ElasticsearchNodeShardsReservedSize                        MetricSettings `mapstructure:"elasticsearch.node.shards.reserved.size"`
-	ElasticsearchNodeShardsSize                                MetricSettings `mapstructure:"elasticsearch.node.shards.size"`
-	ElasticsearchNodeThreadPoolTasksFinished                   MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.finished"`
-	ElasticsearchNodeThreadPoolTasksQueued                     MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.queued"`
-	ElasticsearchNodeThreadPoolThreads                         MetricSettings `mapstructure:"elasticsearch.node.thread_pool.threads"`
-	ElasticsearchNodeTranslogOperations                        MetricSettings `mapstructure:"elasticsearch.node.translog.operations"`
-	ElasticsearchNodeTranslogSize                              MetricSettings `mapstructure:"elasticsearch.node.translog.size"`
-	ElasticsearchNodeTranslogUncommittedSize                   MetricSettings `mapstructure:"elasticsearch.node.translog.uncommitted.size"`
-	ElasticsearchOsCPULoadAvg15m                               MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.15m"`
-	ElasticsearchOsCPULoadAvg1m                                MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.1m"`
-	ElasticsearchOsCPULoadAvg5m                                MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.5m"`
-	ElasticsearchOsCPUUsage                                    MetricSettings `mapstructure:"elasticsearch.os.cpu.usage"`
-	ElasticsearchOsMemory                                      MetricSettings `mapstructure:"elasticsearch.os.memory"`
-	JvmClassesLoaded                                           MetricSettings `mapstructure:"jvm.classes.loaded"`
-	JvmGcCollectionsCount                                      MetricSettings `mapstructure:"jvm.gc.collections.count"`
-	JvmGcCollectionsElapsed                                    MetricSettings `mapstructure:"jvm.gc.collections.elapsed"`
-	JvmMemoryHeapCommitted                                     MetricSettings `mapstructure:"jvm.memory.heap.committed"`
-	JvmMemoryHeapMax                                           MetricSettings `mapstructure:"jvm.memory.heap.max"`
-	JvmMemoryHeapUsed                                          MetricSettings `mapstructure:"jvm.memory.heap.used"`
-	JvmMemoryNonheapCommitted                                  MetricSettings `mapstructure:"jvm.memory.nonheap.committed"`
-	JvmMemoryNonheapUsed                                       MetricSettings `mapstructure:"jvm.memory.nonheap.used"`
-	JvmMemoryPoolMax                                           MetricSettings `mapstructure:"jvm.memory.pool.max"`
-	JvmMemoryPoolUsed                                          MetricSettings `mapstructure:"jvm.memory.pool.used"`
-	JvmThreadsCount                                            MetricSettings `mapstructure:"jvm.threads.count"`
+	ElasticsearchBreakerMemoryEstimated                       MetricSettings `mapstructure:"elasticsearch.breaker.memory.estimated"`
+	ElasticsearchBreakerMemoryLimit                           MetricSettings `mapstructure:"elasticsearch.breaker.memory.limit"`
+	ElasticsearchBreakerTripped                               MetricSettings `mapstructure:"elasticsearch.breaker.tripped"`
+	ElasticsearchClusterDataNodes                             MetricSettings `mapstructure:"elasticsearch.cluster.data_nodes"`
+	ElasticsearchClusterHealth                                MetricSettings `mapstructure:"elasticsearch.cluster.health"`
+	ElasticsearchClusterNodes                                 MetricSettings `mapstructure:"elasticsearch.cluster.nodes"`
+	ElasticsearchClusterPublishedStatesDifferences            MetricSettings `mapstructure:"elasticsearch.cluster.published_states.differences"`
+	ElasticsearchClusterPublishedStatesFull                   MetricSettings `mapstructure:"elasticsearch.cluster.published_states.full"`
+	ElasticsearchClusterShards                                MetricSettings `mapstructure:"elasticsearch.cluster.shards"`
+	ElasticsearchClusterStateQueue                            MetricSettings `mapstructure:"elasticsearch.cluster.state_queue"`
+	ElasticsearchClusterStateUpdateCommitTime                 MetricSettings `mapstructure:"elasticsearch.cluster.state_update.commit_time"`
+	ElasticsearchClusterStateUpdateCompletionTime             MetricSettings `mapstructure:"elasticsearch.cluster.state_update.completion_time"`
+	ElasticsearchClusterStateUpdateComputationTime            MetricSettings `mapstructure:"elasticsearch.cluster.state_update.computation_time"`
+	ElasticsearchClusterStateUpdateContextConstructionTime    MetricSettings `mapstructure:"elasticsearch.cluster.state_update.context_construction_time"`
+	ElasticsearchClusterStateUpdateCount                      MetricSettings `mapstructure:"elasticsearch.cluster.state_update.count"`
+	ElasticsearchClusterStateUpdateMasterApplyTime            MetricSettings `mapstructure:"elasticsearch.cluster.state_update.master_apply_time"`
+	ElasticsearchClusterStateUpdateNotificationTime           MetricSettings `mapstructure:"elasticsearch.cluster.state_update.notification_time"`
+	ElasticsearchIndexingPressureMemoryLimit                  MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.limit"`
+	ElasticsearchIndexingPressureMemoryTotalPrimaryRejections MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.total.primary_rejections"`
+	ElasticsearchIndexingPressureMemoryTotalReplicaRejections MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.total.replica_rejections"`
+	ElasticsearchMemoryIndexingPressure                       MetricSettings `mapstructure:"elasticsearch.memory.indexing_pressure"`
+	ElasticsearchNodeCacheEvictions                           MetricSettings `mapstructure:"elasticsearch.node.cache.evictions"`
+	ElasticsearchNodeCacheMemoryUsage                         MetricSettings `mapstructure:"elasticsearch.node.cache.memory.usage"`
+	ElasticsearchNodeClusterConnections                       MetricSettings `mapstructure:"elasticsearch.node.cluster.connections"`
+	ElasticsearchNodeClusterIo                                MetricSettings `mapstructure:"elasticsearch.node.cluster.io"`
+	ElasticsearchNodeClusterIoReceived                        MetricSettings `mapstructure:"elasticsearch.node.cluster.io.received"`
+	ElasticsearchNodeClusterIoSent                            MetricSettings `mapstructure:"elasticsearch.node.cluster.io.sent"`
+	ElasticsearchNodeDiskIoRead                               MetricSettings `mapstructure:"elasticsearch.node.disk.io.read"`
+	ElasticsearchNodeDiskIoWrite                              MetricSettings `mapstructure:"elasticsearch.node.disk.io.write"`
+	ElasticsearchNodeDocuments                                MetricSettings `mapstructure:"elasticsearch.node.documents"`
+	ElasticsearchNodeFsDiskAvailable                          MetricSettings `mapstructure:"elasticsearch.node.fs.disk.available"`
+	ElasticsearchNodeHTTPConnections                          MetricSettings `mapstructure:"elasticsearch.node.http.connections"`
+	ElasticsearchNodeIngestDocuments                          MetricSettings `mapstructure:"elasticsearch.node.ingest.documents"`
+	ElasticsearchNodeIngestDocumentsCurrent                   MetricSettings `mapstructure:"elasticsearch.node.ingest.documents.current"`
+	ElasticsearchNodeIngestOperationsFailed                   MetricSettings `mapstructure:"elasticsearch.node.ingest.operations.failed"`
+	ElasticsearchNodeOpenFiles                                MetricSettings `mapstructure:"elasticsearch.node.open_files"`
+	ElasticsearchNodeOperationsCompleted                      MetricSettings `mapstructure:"elasticsearch.node.operations.completed"`
+	ElasticsearchNodeOperationsTime                           MetricSettings `mapstructure:"elasticsearch.node.operations.time"`
+	ElasticsearchNodePipelineIngestDocumentsCurrent           MetricSettings `mapstructure:"elasticsearch.node.pipeline.ingest.documents.current"`
+	ElasticsearchNodePipelineIngestDocumentsPreprocessed      MetricSettings `mapstructure:"elasticsearch.node.pipeline.ingest.documents.preprocessed"`
+	ElasticsearchNodePipelineIngestOperationsFailed           MetricSettings `mapstructure:"elasticsearch.node.pipeline.ingest.operations.failed"`
+	ElasticsearchNodeScriptCacheEvictions                     MetricSettings `mapstructure:"elasticsearch.node.script.cache_evictions"`
+	ElasticsearchNodeScriptCompilationLimitTriggered          MetricSettings `mapstructure:"elasticsearch.node.script.compilation_limit_triggered"`
+	ElasticsearchNodeScriptCompilations                       MetricSettings `mapstructure:"elasticsearch.node.script.compilations"`
+	ElasticsearchNodeShardsDataSetSize                        MetricSettings `mapstructure:"elasticsearch.node.shards.data_set.size"`
+	ElasticsearchNodeShardsReservedSize                       MetricSettings `mapstructure:"elasticsearch.node.shards.reserved.size"`
+	ElasticsearchNodeShardsSize                               MetricSettings `mapstructure:"elasticsearch.node.shards.size"`
+	ElasticsearchNodeThreadPoolTasksFinished                  MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.finished"`
+	ElasticsearchNodeThreadPoolTasksQueued                    MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.queued"`
+	ElasticsearchNodeThreadPoolThreads                        MetricSettings `mapstructure:"elasticsearch.node.thread_pool.threads"`
+	ElasticsearchNodeTranslogOperations                       MetricSettings `mapstructure:"elasticsearch.node.translog.operations"`
+	ElasticsearchNodeTranslogSize                             MetricSettings `mapstructure:"elasticsearch.node.translog.size"`
+	ElasticsearchNodeTranslogUncommittedSize                  MetricSettings `mapstructure:"elasticsearch.node.translog.uncommitted.size"`
+	ElasticsearchOsCPULoadAvg15m                              MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.15m"`
+	ElasticsearchOsCPULoadAvg1m                               MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.1m"`
+	ElasticsearchOsCPULoadAvg5m                               MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.5m"`
+	ElasticsearchOsCPUUsage                                   MetricSettings `mapstructure:"elasticsearch.os.cpu.usage"`
+	ElasticsearchOsMemory                                     MetricSettings `mapstructure:"elasticsearch.os.memory"`
+	JvmClassesLoaded                                          MetricSettings `mapstructure:"jvm.classes.loaded"`
+	JvmGcCollectionsCount                                     MetricSettings `mapstructure:"jvm.gc.collections.count"`
+	JvmGcCollectionsElapsed                                   MetricSettings `mapstructure:"jvm.gc.collections.elapsed"`
+	JvmMemoryHeapCommitted                                    MetricSettings `mapstructure:"jvm.memory.heap.committed"`
+	JvmMemoryHeapMax                                          MetricSettings `mapstructure:"jvm.memory.heap.max"`
+	JvmMemoryHeapUsed                                         MetricSettings `mapstructure:"jvm.memory.heap.used"`
+	JvmMemoryNonheapCommitted                                 MetricSettings `mapstructure:"jvm.memory.nonheap.committed"`
+	JvmMemoryNonheapUsed                                      MetricSettings `mapstructure:"jvm.memory.nonheap.used"`
+	JvmMemoryPoolMax                                          MetricSettings `mapstructure:"jvm.memory.pool.max"`
+	JvmMemoryPoolUsed                                         MetricSettings `mapstructure:"jvm.memory.pool.used"`
+	JvmThreadsCount                                           MetricSettings `mapstructure:"jvm.threads.count"`
 }
 
 func DefaultMetricsSettings() MetricsSettings {
@@ -112,25 +108,49 @@ func DefaultMetricsSettings() MetricsSettings {
 		ElasticsearchClusterNodes: MetricSettings{
 			Enabled: true,
 		},
+		ElasticsearchClusterPublishedStatesDifferences: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchClusterPublishedStatesFull: MetricSettings{
+			Enabled: true,
+		},
 		ElasticsearchClusterShards: MetricSettings{
 			Enabled: true,
 		},
-		ElasticsearchIndexingPressureMemoryCoordinating: MetricSettings{
+		ElasticsearchClusterStateQueue: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchClusterStateUpdateCommitTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchClusterStateUpdateCompletionTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchClusterStateUpdateComputationTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchClusterStateUpdateContextConstructionTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchClusterStateUpdateCount: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchClusterStateUpdateMasterApplyTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchClusterStateUpdateNotificationTime: MetricSettings{
 			Enabled: true,
 		},
 		ElasticsearchIndexingPressureMemoryLimit: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchIndexingPressureMemoryPrimary: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchIndexingPressureMemoryReplica: MetricSettings{
 			Enabled: true,
 		},
 		ElasticsearchIndexingPressureMemoryTotalPrimaryRejections: MetricSettings{
 			Enabled: true,
 		},
 		ElasticsearchIndexingPressureMemoryTotalReplicaRejections: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchMemoryIndexingPressure: MetricSettings{
 			Enabled: true,
 		},
 		ElasticsearchNodeCacheEvictions: MetricSettings{
@@ -151,42 +171,6 @@ func DefaultMetricsSettings() MetricsSettings {
 		ElasticsearchNodeClusterIoSent: MetricSettings{
 			Enabled: true,
 		},
-		ElasticsearchNodeClusterPublishedStatesCompatible: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterPublishedStatesFull: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterPublishedStatesIncompatible: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterStateQueueCommitted: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterStateQueuePending: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterStateUpdateCommitTime: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterStateUpdateCompletionTime: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterStateUpdateComputationTime: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterStateUpdateContextConstructionTime: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterStateUpdateCount: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterStateUpdateMasterApplyTime: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeClusterStateUpdateNotificationTime: MetricSettings{
-			Enabled: true,
-		},
 		ElasticsearchNodeDiskIoRead: MetricSettings{
 			Enabled: true,
 		},
@@ -202,22 +186,13 @@ func DefaultMetricsSettings() MetricsSettings {
 		ElasticsearchNodeHTTPConnections: MetricSettings{
 			Enabled: true,
 		},
-		ElasticsearchNodeIngestCount: MetricSettings{
+		ElasticsearchNodeIngestDocuments: MetricSettings{
 			Enabled: true,
 		},
-		ElasticsearchNodeIngestCurrent: MetricSettings{
+		ElasticsearchNodeIngestDocumentsCurrent: MetricSettings{
 			Enabled: true,
 		},
-		ElasticsearchNodeIngestFailed: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeIngestPipelineCount: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeIngestPipelineCurrent: MetricSettings{
-			Enabled: true,
-		},
-		ElasticsearchNodeIngestPipelineFailed: MetricSettings{
+		ElasticsearchNodeIngestOperationsFailed: MetricSettings{
 			Enabled: true,
 		},
 		ElasticsearchNodeOpenFiles: MetricSettings{
@@ -227,6 +202,15 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		ElasticsearchNodeOperationsTime: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodePipelineIngestDocumentsCurrent: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodePipelineIngestDocumentsPreprocessed: MetricSettings{
+			Enabled: true,
+		},
+		ElasticsearchNodePipelineIngestOperationsFailed: MetricSettings{
 			Enabled: true,
 		},
 		ElasticsearchNodeScriptCacheEvictions: MetricSettings{
@@ -340,6 +324,58 @@ func (av AttributeCacheName) String() string {
 var MapAttributeCacheName = map[string]AttributeCacheName{
 	"fielddata": AttributeCacheNameFielddata,
 	"query":     AttributeCacheNameQuery,
+}
+
+// AttributeClusterPublishedDifferenceState specifies the a value cluster_published_difference_state attribute.
+type AttributeClusterPublishedDifferenceState int
+
+const (
+	_ AttributeClusterPublishedDifferenceState = iota
+	AttributeClusterPublishedDifferenceStateIncompatible
+	AttributeClusterPublishedDifferenceStateCompatible
+)
+
+// String returns the string representation of the AttributeClusterPublishedDifferenceState.
+func (av AttributeClusterPublishedDifferenceState) String() string {
+	switch av {
+	case AttributeClusterPublishedDifferenceStateIncompatible:
+		return "incompatible"
+	case AttributeClusterPublishedDifferenceStateCompatible:
+		return "compatible"
+	}
+	return ""
+}
+
+// MapAttributeClusterPublishedDifferenceState is a helper map of string to AttributeClusterPublishedDifferenceState attribute value.
+var MapAttributeClusterPublishedDifferenceState = map[string]AttributeClusterPublishedDifferenceState{
+	"incompatible": AttributeClusterPublishedDifferenceStateIncompatible,
+	"compatible":   AttributeClusterPublishedDifferenceStateCompatible,
+}
+
+// AttributeClusterStateQueueState specifies the a value cluster_state_queue_state attribute.
+type AttributeClusterStateQueueState int
+
+const (
+	_ AttributeClusterStateQueueState = iota
+	AttributeClusterStateQueueStatePending
+	AttributeClusterStateQueueStateCommitted
+)
+
+// String returns the string representation of the AttributeClusterStateQueueState.
+func (av AttributeClusterStateQueueState) String() string {
+	switch av {
+	case AttributeClusterStateQueueStatePending:
+		return "pending"
+	case AttributeClusterStateQueueStateCommitted:
+		return "committed"
+	}
+	return ""
+}
+
+// MapAttributeClusterStateQueueState is a helper map of string to AttributeClusterStateQueueState attribute value.
+var MapAttributeClusterStateQueueState = map[string]AttributeClusterStateQueueState{
+	"pending":   AttributeClusterStateQueueStatePending,
+	"committed": AttributeClusterStateQueueStateCommitted,
 }
 
 // AttributeClusterStateUpdateType specifies the a value cluster_state_update_type attribute.
@@ -504,6 +540,36 @@ func (av AttributeIndexingMemoryState) String() string {
 var MapAttributeIndexingMemoryState = map[string]AttributeIndexingMemoryState{
 	"current": AttributeIndexingMemoryStateCurrent,
 	"total":   AttributeIndexingMemoryStateTotal,
+}
+
+// AttributeIndexingPressureStage specifies the a value indexing_pressure_stage attribute.
+type AttributeIndexingPressureStage int
+
+const (
+	_ AttributeIndexingPressureStage = iota
+	AttributeIndexingPressureStageCoordinating
+	AttributeIndexingPressureStagePrimary
+	AttributeIndexingPressureStageReplica
+)
+
+// String returns the string representation of the AttributeIndexingPressureStage.
+func (av AttributeIndexingPressureStage) String() string {
+	switch av {
+	case AttributeIndexingPressureStageCoordinating:
+		return "coordinating"
+	case AttributeIndexingPressureStagePrimary:
+		return "primary"
+	case AttributeIndexingPressureStageReplica:
+		return "replica"
+	}
+	return ""
+}
+
+// MapAttributeIndexingPressureStage is a helper map of string to AttributeIndexingPressureStage attribute value.
+var MapAttributeIndexingPressureStage = map[string]AttributeIndexingPressureStage{
+	"coordinating": AttributeIndexingPressureStageCoordinating,
+	"primary":      AttributeIndexingPressureStagePrimary,
+	"replica":      AttributeIndexingPressureStageReplica,
 }
 
 // AttributeMemoryState specifies the a value memory_state attribute.
@@ -992,6 +1058,110 @@ func newMetricElasticsearchClusterNodes(settings MetricSettings) metricElasticse
 	return m
 }
 
+type metricElasticsearchClusterPublishedStatesDifferences struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.cluster.published_states.differences metric with initial data.
+func (m *metricElasticsearchClusterPublishedStatesDifferences) init() {
+	m.data.SetName("elasticsearch.cluster.published_states.differences")
+	m.data.SetDescription("Number of differences between published cluster states.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchClusterPublishedStatesDifferences) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterPublishedDifferenceStateAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("state", clusterPublishedDifferenceStateAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchClusterPublishedStatesDifferences) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchClusterPublishedStatesDifferences) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchClusterPublishedStatesDifferences(settings MetricSettings) metricElasticsearchClusterPublishedStatesDifferences {
+	m := metricElasticsearchClusterPublishedStatesDifferences{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchClusterPublishedStatesFull struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.cluster.published_states.full metric with initial data.
+func (m *metricElasticsearchClusterPublishedStatesFull) init() {
+	m.data.SetName("elasticsearch.cluster.published_states.full")
+	m.data.SetDescription("Number of published cluster states.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricElasticsearchClusterPublishedStatesFull) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchClusterPublishedStatesFull) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchClusterPublishedStatesFull) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchClusterPublishedStatesFull(settings MetricSettings) metricElasticsearchClusterPublishedStatesFull {
+	m := metricElasticsearchClusterPublishedStatesFull{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricElasticsearchClusterShards struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1045,48 +1215,423 @@ func newMetricElasticsearchClusterShards(settings MetricSettings) metricElastics
 	return m
 }
 
-type metricElasticsearchIndexingPressureMemoryCoordinating struct {
+type metricElasticsearchClusterStateQueue struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills elasticsearch.indexing_pressure.memory.coordinating metric with initial data.
-func (m *metricElasticsearchIndexingPressureMemoryCoordinating) init() {
-	m.data.SetName("elasticsearch.indexing_pressure.memory.coordinating")
-	m.data.SetDescription("Memory consumed, in bytes, by indexing requests in the coordinating stage.")
-	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+// init fills elasticsearch.cluster.state_queue metric with initial data.
+func (m *metricElasticsearchClusterStateQueue) init() {
+	m.data.SetName("elasticsearch.cluster.state_queue")
+	m.data.SetDescription("Number of cluster states in queue.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricElasticsearchIndexingPressureMemoryCoordinating) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricElasticsearchClusterStateQueue) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateQueueStateAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
+	dp.Attributes().InsertString("state", clusterStateQueueStateAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchIndexingPressureMemoryCoordinating) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+func (m *metricElasticsearchClusterStateQueue) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchIndexingPressureMemoryCoordinating) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+func (m *metricElasticsearchClusterStateQueue) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexingPressureMemoryCoordinating(settings MetricSettings) metricElasticsearchIndexingPressureMemoryCoordinating {
-	m := metricElasticsearchIndexingPressureMemoryCoordinating{settings: settings}
+func newMetricElasticsearchClusterStateQueue(settings MetricSettings) metricElasticsearchClusterStateQueue {
+	m := metricElasticsearchClusterStateQueue{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchClusterStateUpdateCommitTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.cluster.state_update.commit_time metric with initial data.
+func (m *metricElasticsearchClusterStateUpdateCommitTime) init() {
+	m.data.SetName("elasticsearch.cluster.state_update.commit_time")
+	m.data.SetDescription("The cumulative amount of time spent waiting for a cluster state update to commit.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchClusterStateUpdateCommitTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchClusterStateUpdateCommitTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchClusterStateUpdateCommitTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchClusterStateUpdateCommitTime(settings MetricSettings) metricElasticsearchClusterStateUpdateCommitTime {
+	m := metricElasticsearchClusterStateUpdateCommitTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchClusterStateUpdateCompletionTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.cluster.state_update.completion_time metric with initial data.
+func (m *metricElasticsearchClusterStateUpdateCompletionTime) init() {
+	m.data.SetName("elasticsearch.cluster.state_update.completion_time")
+	m.data.SetDescription("The cumulative amount of time spent waiting for a cluster state update to complete.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchClusterStateUpdateCompletionTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchClusterStateUpdateCompletionTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchClusterStateUpdateCompletionTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchClusterStateUpdateCompletionTime(settings MetricSettings) metricElasticsearchClusterStateUpdateCompletionTime {
+	m := metricElasticsearchClusterStateUpdateCompletionTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchClusterStateUpdateComputationTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.cluster.state_update.computation_time metric with initial data.
+func (m *metricElasticsearchClusterStateUpdateComputationTime) init() {
+	m.data.SetName("elasticsearch.cluster.state_update.computation_time")
+	m.data.SetDescription("The cumulative amount of time spent computing cluster state updates since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchClusterStateUpdateComputationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchClusterStateUpdateComputationTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchClusterStateUpdateComputationTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchClusterStateUpdateComputationTime(settings MetricSettings) metricElasticsearchClusterStateUpdateComputationTime {
+	m := metricElasticsearchClusterStateUpdateComputationTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchClusterStateUpdateContextConstructionTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.cluster.state_update.context_construction_time metric with initial data.
+func (m *metricElasticsearchClusterStateUpdateContextConstructionTime) init() {
+	m.data.SetName("elasticsearch.cluster.state_update.context_construction_time")
+	m.data.SetDescription("The cumulative amount of time spent constructing a publication context since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchClusterStateUpdateContextConstructionTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchClusterStateUpdateContextConstructionTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchClusterStateUpdateContextConstructionTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchClusterStateUpdateContextConstructionTime(settings MetricSettings) metricElasticsearchClusterStateUpdateContextConstructionTime {
+	m := metricElasticsearchClusterStateUpdateContextConstructionTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchClusterStateUpdateCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.cluster.state_update.count metric with initial data.
+func (m *metricElasticsearchClusterStateUpdateCount) init() {
+	m.data.SetName("elasticsearch.cluster.state_update.count")
+	m.data.SetDescription("The number of cluster state update attempts that changed the cluster state since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchClusterStateUpdateCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchClusterStateUpdateCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchClusterStateUpdateCount) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchClusterStateUpdateCount(settings MetricSettings) metricElasticsearchClusterStateUpdateCount {
+	m := metricElasticsearchClusterStateUpdateCount{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchClusterStateUpdateMasterApplyTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.cluster.state_update.master_apply_time metric with initial data.
+func (m *metricElasticsearchClusterStateUpdateMasterApplyTime) init() {
+	m.data.SetName("elasticsearch.cluster.state_update.master_apply_time")
+	m.data.SetDescription("The cumulative amount of time spent applying cluster state updates on the elected master since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchClusterStateUpdateMasterApplyTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchClusterStateUpdateMasterApplyTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchClusterStateUpdateMasterApplyTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchClusterStateUpdateMasterApplyTime(settings MetricSettings) metricElasticsearchClusterStateUpdateMasterApplyTime {
+	m := metricElasticsearchClusterStateUpdateMasterApplyTime{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchClusterStateUpdateNotificationTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.cluster.state_update.notification_time metric with initial data.
+func (m *metricElasticsearchClusterStateUpdateNotificationTime) init() {
+	m.data.SetName("elasticsearch.cluster.state_update.notification_time")
+	m.data.SetDescription("The cumulative amount of time spent notifying listeners of a cluster state update since the node started.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchClusterStateUpdateNotificationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchClusterStateUpdateNotificationTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchClusterStateUpdateNotificationTime) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchClusterStateUpdateNotificationTime(settings MetricSettings) metricElasticsearchClusterStateUpdateNotificationTime {
+	m := metricElasticsearchClusterStateUpdateNotificationTime{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -1136,104 +1681,6 @@ func (m *metricElasticsearchIndexingPressureMemoryLimit) emit(metrics pmetric.Me
 
 func newMetricElasticsearchIndexingPressureMemoryLimit(settings MetricSettings) metricElasticsearchIndexingPressureMemoryLimit {
 	m := metricElasticsearchIndexingPressureMemoryLimit{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchIndexingPressureMemoryPrimary struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.indexing_pressure.memory.primary metric with initial data.
-func (m *metricElasticsearchIndexingPressureMemoryPrimary) init() {
-	m.data.SetName("elasticsearch.indexing_pressure.memory.primary")
-	m.data.SetDescription("Memory consumed, in bytes, by indexing requests in the primary stage.")
-	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
-}
-
-func (m *metricElasticsearchIndexingPressureMemoryPrimary) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchIndexingPressureMemoryPrimary) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchIndexingPressureMemoryPrimary) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchIndexingPressureMemoryPrimary(settings MetricSettings) metricElasticsearchIndexingPressureMemoryPrimary {
-	m := metricElasticsearchIndexingPressureMemoryPrimary{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchIndexingPressureMemoryReplica struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.indexing_pressure.memory.replica metric with initial data.
-func (m *metricElasticsearchIndexingPressureMemoryReplica) init() {
-	m.data.SetName("elasticsearch.indexing_pressure.memory.replica")
-	m.data.SetDescription("Memory consumed, in bytes, by indexing requests in the primary stage.")
-	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
-}
-
-func (m *metricElasticsearchIndexingPressureMemoryReplica) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchIndexingPressureMemoryReplica) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchIndexingPressureMemoryReplica) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchIndexingPressureMemoryReplica(settings MetricSettings) metricElasticsearchIndexingPressureMemoryReplica {
-	m := metricElasticsearchIndexingPressureMemoryReplica{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -1336,6 +1783,59 @@ func (m *metricElasticsearchIndexingPressureMemoryTotalReplicaRejections) emit(m
 
 func newMetricElasticsearchIndexingPressureMemoryTotalReplicaRejections(settings MetricSettings) metricElasticsearchIndexingPressureMemoryTotalReplicaRejections {
 	m := metricElasticsearchIndexingPressureMemoryTotalReplicaRejections{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchMemoryIndexingPressure struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.memory.indexing_pressure metric with initial data.
+func (m *metricElasticsearchMemoryIndexingPressure) init() {
+	m.data.SetName("elasticsearch.memory.indexing_pressure")
+	m.data.SetDescription("Memory consumed, in bytes, by indexing requests in the specified stage.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchMemoryIndexingPressure) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexingPressureStageAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("stage", indexingPressureStageAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchMemoryIndexingPressure) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchMemoryIndexingPressure) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchMemoryIndexingPressure(settings MetricSettings) metricElasticsearchMemoryIndexingPressure {
+	m := metricElasticsearchMemoryIndexingPressure{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -1655,622 +2155,6 @@ func newMetricElasticsearchNodeClusterIoSent(settings MetricSettings) metricElas
 	return m
 }
 
-type metricElasticsearchNodeClusterPublishedStatesCompatible struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.published_states.compatible metric with initial data.
-func (m *metricElasticsearchNodeClusterPublishedStatesCompatible) init() {
-	m.data.SetName("elasticsearch.node.cluster.published_states.compatible")
-	m.data.SetDescription("Number of compatible differences between published cluster states.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
-}
-
-func (m *metricElasticsearchNodeClusterPublishedStatesCompatible) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterPublishedStatesCompatible) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterPublishedStatesCompatible) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterPublishedStatesCompatible(settings MetricSettings) metricElasticsearchNodeClusterPublishedStatesCompatible {
-	m := metricElasticsearchNodeClusterPublishedStatesCompatible{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterPublishedStatesFull struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.published_states.full metric with initial data.
-func (m *metricElasticsearchNodeClusterPublishedStatesFull) init() {
-	m.data.SetName("elasticsearch.node.cluster.published_states.full")
-	m.data.SetDescription("Number of published cluster states.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
-}
-
-func (m *metricElasticsearchNodeClusterPublishedStatesFull) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterPublishedStatesFull) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterPublishedStatesFull) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterPublishedStatesFull(settings MetricSettings) metricElasticsearchNodeClusterPublishedStatesFull {
-	m := metricElasticsearchNodeClusterPublishedStatesFull{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterPublishedStatesIncompatible struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.published_states.incompatible metric with initial data.
-func (m *metricElasticsearchNodeClusterPublishedStatesIncompatible) init() {
-	m.data.SetName("elasticsearch.node.cluster.published_states.incompatible")
-	m.data.SetDescription("Number of incompatible differences between published cluster states.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
-}
-
-func (m *metricElasticsearchNodeClusterPublishedStatesIncompatible) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterPublishedStatesIncompatible) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterPublishedStatesIncompatible) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterPublishedStatesIncompatible(settings MetricSettings) metricElasticsearchNodeClusterPublishedStatesIncompatible {
-	m := metricElasticsearchNodeClusterPublishedStatesIncompatible{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterStateQueueCommitted struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.state_queue.committed metric with initial data.
-func (m *metricElasticsearchNodeClusterStateQueueCommitted) init() {
-	m.data.SetName("elasticsearch.node.cluster.state_queue.committed")
-	m.data.SetDescription("Number of pending cluster states in queue.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
-}
-
-func (m *metricElasticsearchNodeClusterStateQueueCommitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterStateQueueCommitted) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterStateQueueCommitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterStateQueueCommitted(settings MetricSettings) metricElasticsearchNodeClusterStateQueueCommitted {
-	m := metricElasticsearchNodeClusterStateQueueCommitted{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterStateQueuePending struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.state_queue.pending metric with initial data.
-func (m *metricElasticsearchNodeClusterStateQueuePending) init() {
-	m.data.SetName("elasticsearch.node.cluster.state_queue.pending")
-	m.data.SetDescription("Number of pending cluster states in queue.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
-}
-
-func (m *metricElasticsearchNodeClusterStateQueuePending) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterStateQueuePending) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterStateQueuePending) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterStateQueuePending(settings MetricSettings) metricElasticsearchNodeClusterStateQueuePending {
-	m := metricElasticsearchNodeClusterStateQueuePending{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterStateUpdateCommitTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.state_update.commit_time metric with initial data.
-func (m *metricElasticsearchNodeClusterStateUpdateCommitTime) init() {
-	m.data.SetName("elasticsearch.node.cluster.state_update.commit_time")
-	m.data.SetDescription("The cumulative amount of time spent waiting for a cluster state update to commit.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeClusterStateUpdateCommitTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterStateUpdateCommitTime) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterStateUpdateCommitTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterStateUpdateCommitTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateCommitTime {
-	m := metricElasticsearchNodeClusterStateUpdateCommitTime{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterStateUpdateCompletionTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.state_update.completion_time metric with initial data.
-func (m *metricElasticsearchNodeClusterStateUpdateCompletionTime) init() {
-	m.data.SetName("elasticsearch.node.cluster.state_update.completion_time")
-	m.data.SetDescription("The cumulative amount of time spent waiting for a cluster state update to complete.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeClusterStateUpdateCompletionTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterStateUpdateCompletionTime) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterStateUpdateCompletionTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterStateUpdateCompletionTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateCompletionTime {
-	m := metricElasticsearchNodeClusterStateUpdateCompletionTime{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterStateUpdateComputationTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.state_update.computation_time metric with initial data.
-func (m *metricElasticsearchNodeClusterStateUpdateComputationTime) init() {
-	m.data.SetName("elasticsearch.node.cluster.state_update.computation_time")
-	m.data.SetDescription("The cumulative amount of time spent computing cluster state updates since the node started.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeClusterStateUpdateComputationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterStateUpdateComputationTime) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterStateUpdateComputationTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterStateUpdateComputationTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateComputationTime {
-	m := metricElasticsearchNodeClusterStateUpdateComputationTime{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterStateUpdateContextConstructionTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.state_update.context_construction_time metric with initial data.
-func (m *metricElasticsearchNodeClusterStateUpdateContextConstructionTime) init() {
-	m.data.SetName("elasticsearch.node.cluster.state_update.context_construction_time")
-	m.data.SetDescription("The cumulative amount of time spent constructing a publication context since the node started.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeClusterStateUpdateContextConstructionTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterStateUpdateContextConstructionTime) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterStateUpdateContextConstructionTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterStateUpdateContextConstructionTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateContextConstructionTime {
-	m := metricElasticsearchNodeClusterStateUpdateContextConstructionTime{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterStateUpdateCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.state_update.count metric with initial data.
-func (m *metricElasticsearchNodeClusterStateUpdateCount) init() {
-	m.data.SetName("elasticsearch.node.cluster.state_update.count")
-	m.data.SetDescription("The number of cluster state update attempts that changed the cluster state since the node started.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeClusterStateUpdateCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterStateUpdateCount) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterStateUpdateCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterStateUpdateCount(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateCount {
-	m := metricElasticsearchNodeClusterStateUpdateCount{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterStateUpdateMasterApplyTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.state_update.master_apply_time metric with initial data.
-func (m *metricElasticsearchNodeClusterStateUpdateMasterApplyTime) init() {
-	m.data.SetName("elasticsearch.node.cluster.state_update.master_apply_time")
-	m.data.SetDescription("The cumulative amount of time spent applying cluster state updates on the elected master since the node started.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeClusterStateUpdateMasterApplyTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterStateUpdateMasterApplyTime) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterStateUpdateMasterApplyTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterStateUpdateMasterApplyTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateMasterApplyTime {
-	m := metricElasticsearchNodeClusterStateUpdateMasterApplyTime{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeClusterStateUpdateNotificationTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.cluster.state_update.notification_time metric with initial data.
-func (m *metricElasticsearchNodeClusterStateUpdateNotificationTime) init() {
-	m.data.SetName("elasticsearch.node.cluster.state_update.notification_time")
-	m.data.SetDescription("The cumulative amount of time spent notifying listeners of a cluster state update since the node started.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeClusterStateUpdateNotificationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("status", clusterStateUpdateTypeAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeClusterStateUpdateNotificationTime) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeClusterStateUpdateNotificationTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeClusterStateUpdateNotificationTime(settings MetricSettings) metricElasticsearchNodeClusterStateUpdateNotificationTime {
-	m := metricElasticsearchNodeClusterStateUpdateNotificationTime{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricElasticsearchNodeDiskIoRead struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -2528,15 +2412,15 @@ func newMetricElasticsearchNodeHTTPConnections(settings MetricSettings) metricEl
 	return m
 }
 
-type metricElasticsearchNodeIngestCount struct {
+type metricElasticsearchNodeIngestDocuments struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills elasticsearch.node.ingest.count metric with initial data.
-func (m *metricElasticsearchNodeIngestCount) init() {
-	m.data.SetName("elasticsearch.node.ingest.count")
+// init fills elasticsearch.node.ingest.documents metric with initial data.
+func (m *metricElasticsearchNodeIngestDocuments) init() {
+	m.data.SetName("elasticsearch.node.ingest.documents")
 	m.data.SetDescription("Total number of documents ingested during the lifetime of this node.")
 	m.data.SetUnit("{documents}")
 	m.data.SetDataType(pmetric.MetricDataTypeSum)
@@ -2544,7 +2428,7 @@ func (m *metricElasticsearchNodeIngestCount) init() {
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricElasticsearchNodeIngestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricElasticsearchNodeIngestDocuments) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -2555,14 +2439,14 @@ func (m *metricElasticsearchNodeIngestCount) recordDataPoint(start pcommon.Times
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeIngestCount) updateCapacity() {
+func (m *metricElasticsearchNodeIngestDocuments) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeIngestCount) emit(metrics pmetric.MetricSlice) {
+func (m *metricElasticsearchNodeIngestDocuments) emit(metrics pmetric.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -2570,8 +2454,8 @@ func (m *metricElasticsearchNodeIngestCount) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricElasticsearchNodeIngestCount(settings MetricSettings) metricElasticsearchNodeIngestCount {
-	m := metricElasticsearchNodeIngestCount{settings: settings}
+func newMetricElasticsearchNodeIngestDocuments(settings MetricSettings) metricElasticsearchNodeIngestDocuments {
+	m := metricElasticsearchNodeIngestDocuments{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -2579,48 +2463,50 @@ func newMetricElasticsearchNodeIngestCount(settings MetricSettings) metricElasti
 	return m
 }
 
-type metricElasticsearchNodeIngestCurrent struct {
+type metricElasticsearchNodeIngestDocumentsCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills elasticsearch.node.ingest.current metric with initial data.
-func (m *metricElasticsearchNodeIngestCurrent) init() {
-	m.data.SetName("elasticsearch.node.ingest.current")
+// init fills elasticsearch.node.ingest.documents.current metric with initial data.
+func (m *metricElasticsearchNodeIngestDocumentsCurrent) init() {
+	m.data.SetName("elasticsearch.node.ingest.documents.current")
 	m.data.SetDescription("Total number of documents currently being ingested.")
 	m.data.SetUnit("{documents}")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricElasticsearchNodeIngestCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricElasticsearchNodeIngestDocumentsCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeIngestCurrent) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+func (m *metricElasticsearchNodeIngestDocumentsCurrent) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeIngestCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+func (m *metricElasticsearchNodeIngestDocumentsCurrent) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeIngestCurrent(settings MetricSettings) metricElasticsearchNodeIngestCurrent {
-	m := metricElasticsearchNodeIngestCurrent{settings: settings}
+func newMetricElasticsearchNodeIngestDocumentsCurrent(settings MetricSettings) metricElasticsearchNodeIngestDocumentsCurrent {
+	m := metricElasticsearchNodeIngestDocumentsCurrent{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -2628,15 +2514,15 @@ func newMetricElasticsearchNodeIngestCurrent(settings MetricSettings) metricElas
 	return m
 }
 
-type metricElasticsearchNodeIngestFailed struct {
+type metricElasticsearchNodeIngestOperationsFailed struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills elasticsearch.node.ingest.failed metric with initial data.
-func (m *metricElasticsearchNodeIngestFailed) init() {
-	m.data.SetName("elasticsearch.node.ingest.failed")
+// init fills elasticsearch.node.ingest.operations.failed metric with initial data.
+func (m *metricElasticsearchNodeIngestOperationsFailed) init() {
+	m.data.SetName("elasticsearch.node.ingest.operations.failed")
 	m.data.SetDescription("Total number of failed ingest operations during the lifetime of this node.")
 	m.data.SetUnit("{operation}")
 	m.data.SetDataType(pmetric.MetricDataTypeSum)
@@ -2644,7 +2530,7 @@ func (m *metricElasticsearchNodeIngestFailed) init() {
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricElasticsearchNodeIngestFailed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricElasticsearchNodeIngestOperationsFailed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -2655,14 +2541,14 @@ func (m *metricElasticsearchNodeIngestFailed) recordDataPoint(start pcommon.Time
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeIngestFailed) updateCapacity() {
+func (m *metricElasticsearchNodeIngestOperationsFailed) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeIngestFailed) emit(metrics pmetric.MetricSlice) {
+func (m *metricElasticsearchNodeIngestOperationsFailed) emit(metrics pmetric.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -2670,165 +2556,8 @@ func (m *metricElasticsearchNodeIngestFailed) emit(metrics pmetric.MetricSlice) 
 	}
 }
 
-func newMetricElasticsearchNodeIngestFailed(settings MetricSettings) metricElasticsearchNodeIngestFailed {
-	m := metricElasticsearchNodeIngestFailed{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeIngestPipelineCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.ingest.pipeline.count metric with initial data.
-func (m *metricElasticsearchNodeIngestPipelineCount) init() {
-	m.data.SetName("elasticsearch.node.ingest.pipeline.count")
-	m.data.SetDescription("Total number of documents ingested during the lifetime of this node.")
-	m.data.SetUnit("{documents}")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeIngestPipelineCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("name", ingestPipelineNameAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeIngestPipelineCount) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeIngestPipelineCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeIngestPipelineCount(settings MetricSettings) metricElasticsearchNodeIngestPipelineCount {
-	m := metricElasticsearchNodeIngestPipelineCount{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeIngestPipelineCurrent struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.ingest.pipeline.current metric with initial data.
-func (m *metricElasticsearchNodeIngestPipelineCurrent) init() {
-	m.data.SetName("elasticsearch.node.ingest.pipeline.current")
-	m.data.SetDescription("Total number of documents currently being ingested by a pipeline.")
-	m.data.SetUnit("{documents}")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeIngestPipelineCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("name", ingestPipelineNameAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeIngestPipelineCurrent) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeIngestPipelineCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeIngestPipelineCurrent(settings MetricSettings) metricElasticsearchNodeIngestPipelineCurrent {
-	m := metricElasticsearchNodeIngestPipelineCurrent{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricElasticsearchNodeIngestPipelineFailed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills elasticsearch.node.ingest.pipeline.failed metric with initial data.
-func (m *metricElasticsearchNodeIngestPipelineFailed) init() {
-	m.data.SetName("elasticsearch.node.ingest.pipeline.failed")
-	m.data.SetDescription("Total number of failed operations for the ingest pipeline.")
-	m.data.SetUnit("{operation}")
-	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricElasticsearchNodeIngestPipelineFailed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-	dp.Attributes().InsertString("name", ingestPipelineNameAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricElasticsearchNodeIngestPipelineFailed) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricElasticsearchNodeIngestPipelineFailed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricElasticsearchNodeIngestPipelineFailed(settings MetricSettings) metricElasticsearchNodeIngestPipelineFailed {
-	m := metricElasticsearchNodeIngestPipelineFailed{settings: settings}
+func newMetricElasticsearchNodeIngestOperationsFailed(settings MetricSettings) metricElasticsearchNodeIngestOperationsFailed {
+	m := metricElasticsearchNodeIngestOperationsFailed{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -2993,6 +2722,163 @@ func newMetricElasticsearchNodeOperationsTime(settings MetricSettings) metricEla
 	return m
 }
 
+type metricElasticsearchNodePipelineIngestDocumentsCurrent struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.pipeline.ingest.documents.current metric with initial data.
+func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) init() {
+	m.data.SetName("elasticsearch.node.pipeline.ingest.documents.current")
+	m.data.SetDescription("Total number of documents currently being ingested by a pipeline.")
+	m.data.SetUnit("{documents}")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("name", ingestPipelineNameAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodePipelineIngestDocumentsCurrent(settings MetricSettings) metricElasticsearchNodePipelineIngestDocumentsCurrent {
+	m := metricElasticsearchNodePipelineIngestDocumentsCurrent{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodePipelineIngestDocumentsPreprocessed struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.pipeline.ingest.documents.preprocessed metric with initial data.
+func (m *metricElasticsearchNodePipelineIngestDocumentsPreprocessed) init() {
+	m.data.SetName("elasticsearch.node.pipeline.ingest.documents.preprocessed")
+	m.data.SetDescription("Number of documents preprocessed by the ingest pipeline.")
+	m.data.SetUnit("{documents}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodePipelineIngestDocumentsPreprocessed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("name", ingestPipelineNameAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodePipelineIngestDocumentsPreprocessed) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodePipelineIngestDocumentsPreprocessed) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodePipelineIngestDocumentsPreprocessed(settings MetricSettings) metricElasticsearchNodePipelineIngestDocumentsPreprocessed {
+	m := metricElasticsearchNodePipelineIngestDocumentsPreprocessed{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricElasticsearchNodePipelineIngestOperationsFailed struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills elasticsearch.node.pipeline.ingest.operations.failed metric with initial data.
+func (m *metricElasticsearchNodePipelineIngestOperationsFailed) init() {
+	m.data.SetName("elasticsearch.node.pipeline.ingest.operations.failed")
+	m.data.SetDescription("Total number of failed operations for the ingest pipeline.")
+	m.data.SetUnit("{operation}")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricElasticsearchNodePipelineIngestOperationsFailed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().InsertString("name", ingestPipelineNameAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricElasticsearchNodePipelineIngestOperationsFailed) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricElasticsearchNodePipelineIngestOperationsFailed) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricElasticsearchNodePipelineIngestOperationsFailed(settings MetricSettings) metricElasticsearchNodePipelineIngestOperationsFailed {
+	m := metricElasticsearchNodePipelineIngestOperationsFailed{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricElasticsearchNodeScriptCacheEvictions struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -3005,7 +2891,7 @@ func (m *metricElasticsearchNodeScriptCacheEvictions) init() {
 	m.data.SetDescription("Total number of times the script cache has evicted old data.")
 	m.data.SetUnit("1")
 	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
@@ -3056,7 +2942,7 @@ func (m *metricElasticsearchNodeScriptCompilationLimitTriggered) init() {
 	m.data.SetDescription("Total number of times the script compilation circuit breaker has limited inline script compilations.")
 	m.data.SetUnit("1")
 	m.data.SetDataType(pmetric.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
@@ -4414,84 +4300,80 @@ func newMetricJvmThreadsCount(settings MetricSettings) metricJvmThreadsCount {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                                                        pcommon.Timestamp   // start time that will be applied to all recorded data points.
-	metricsCapacity                                                  int                 // maximum observed number of metrics per resource.
-	resourceCapacity                                                 int                 // maximum observed number of resource attributes.
-	metricsBuffer                                                    pmetric.Metrics     // accumulates metrics data before emitting.
-	buildInfo                                                        component.BuildInfo // contains version information
-	metricElasticsearchBreakerMemoryEstimated                        metricElasticsearchBreakerMemoryEstimated
-	metricElasticsearchBreakerMemoryLimit                            metricElasticsearchBreakerMemoryLimit
-	metricElasticsearchBreakerTripped                                metricElasticsearchBreakerTripped
-	metricElasticsearchClusterDataNodes                              metricElasticsearchClusterDataNodes
-	metricElasticsearchClusterHealth                                 metricElasticsearchClusterHealth
-	metricElasticsearchClusterNodes                                  metricElasticsearchClusterNodes
-	metricElasticsearchClusterShards                                 metricElasticsearchClusterShards
-	metricElasticsearchIndexingPressureMemoryCoordinating            metricElasticsearchIndexingPressureMemoryCoordinating
-	metricElasticsearchIndexingPressureMemoryLimit                   metricElasticsearchIndexingPressureMemoryLimit
-	metricElasticsearchIndexingPressureMemoryPrimary                 metricElasticsearchIndexingPressureMemoryPrimary
-	metricElasticsearchIndexingPressureMemoryReplica                 metricElasticsearchIndexingPressureMemoryReplica
-	metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections  metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections
-	metricElasticsearchIndexingPressureMemoryTotalReplicaRejections  metricElasticsearchIndexingPressureMemoryTotalReplicaRejections
-	metricElasticsearchNodeCacheEvictions                            metricElasticsearchNodeCacheEvictions
-	metricElasticsearchNodeCacheMemoryUsage                          metricElasticsearchNodeCacheMemoryUsage
-	metricElasticsearchNodeClusterConnections                        metricElasticsearchNodeClusterConnections
-	metricElasticsearchNodeClusterIo                                 metricElasticsearchNodeClusterIo
-	metricElasticsearchNodeClusterIoReceived                         metricElasticsearchNodeClusterIoReceived
-	metricElasticsearchNodeClusterIoSent                             metricElasticsearchNodeClusterIoSent
-	metricElasticsearchNodeClusterPublishedStatesCompatible          metricElasticsearchNodeClusterPublishedStatesCompatible
-	metricElasticsearchNodeClusterPublishedStatesFull                metricElasticsearchNodeClusterPublishedStatesFull
-	metricElasticsearchNodeClusterPublishedStatesIncompatible        metricElasticsearchNodeClusterPublishedStatesIncompatible
-	metricElasticsearchNodeClusterStateQueueCommitted                metricElasticsearchNodeClusterStateQueueCommitted
-	metricElasticsearchNodeClusterStateQueuePending                  metricElasticsearchNodeClusterStateQueuePending
-	metricElasticsearchNodeClusterStateUpdateCommitTime              metricElasticsearchNodeClusterStateUpdateCommitTime
-	metricElasticsearchNodeClusterStateUpdateCompletionTime          metricElasticsearchNodeClusterStateUpdateCompletionTime
-	metricElasticsearchNodeClusterStateUpdateComputationTime         metricElasticsearchNodeClusterStateUpdateComputationTime
-	metricElasticsearchNodeClusterStateUpdateContextConstructionTime metricElasticsearchNodeClusterStateUpdateContextConstructionTime
-	metricElasticsearchNodeClusterStateUpdateCount                   metricElasticsearchNodeClusterStateUpdateCount
-	metricElasticsearchNodeClusterStateUpdateMasterApplyTime         metricElasticsearchNodeClusterStateUpdateMasterApplyTime
-	metricElasticsearchNodeClusterStateUpdateNotificationTime        metricElasticsearchNodeClusterStateUpdateNotificationTime
-	metricElasticsearchNodeDiskIoRead                                metricElasticsearchNodeDiskIoRead
-	metricElasticsearchNodeDiskIoWrite                               metricElasticsearchNodeDiskIoWrite
-	metricElasticsearchNodeDocuments                                 metricElasticsearchNodeDocuments
-	metricElasticsearchNodeFsDiskAvailable                           metricElasticsearchNodeFsDiskAvailable
-	metricElasticsearchNodeHTTPConnections                           metricElasticsearchNodeHTTPConnections
-	metricElasticsearchNodeIngestCount                               metricElasticsearchNodeIngestCount
-	metricElasticsearchNodeIngestCurrent                             metricElasticsearchNodeIngestCurrent
-	metricElasticsearchNodeIngestFailed                              metricElasticsearchNodeIngestFailed
-	metricElasticsearchNodeIngestPipelineCount                       metricElasticsearchNodeIngestPipelineCount
-	metricElasticsearchNodeIngestPipelineCurrent                     metricElasticsearchNodeIngestPipelineCurrent
-	metricElasticsearchNodeIngestPipelineFailed                      metricElasticsearchNodeIngestPipelineFailed
-	metricElasticsearchNodeOpenFiles                                 metricElasticsearchNodeOpenFiles
-	metricElasticsearchNodeOperationsCompleted                       metricElasticsearchNodeOperationsCompleted
-	metricElasticsearchNodeOperationsTime                            metricElasticsearchNodeOperationsTime
-	metricElasticsearchNodeScriptCacheEvictions                      metricElasticsearchNodeScriptCacheEvictions
-	metricElasticsearchNodeScriptCompilationLimitTriggered           metricElasticsearchNodeScriptCompilationLimitTriggered
-	metricElasticsearchNodeScriptCompilations                        metricElasticsearchNodeScriptCompilations
-	metricElasticsearchNodeShardsDataSetSize                         metricElasticsearchNodeShardsDataSetSize
-	metricElasticsearchNodeShardsReservedSize                        metricElasticsearchNodeShardsReservedSize
-	metricElasticsearchNodeShardsSize                                metricElasticsearchNodeShardsSize
-	metricElasticsearchNodeThreadPoolTasksFinished                   metricElasticsearchNodeThreadPoolTasksFinished
-	metricElasticsearchNodeThreadPoolTasksQueued                     metricElasticsearchNodeThreadPoolTasksQueued
-	metricElasticsearchNodeThreadPoolThreads                         metricElasticsearchNodeThreadPoolThreads
-	metricElasticsearchNodeTranslogOperations                        metricElasticsearchNodeTranslogOperations
-	metricElasticsearchNodeTranslogSize                              metricElasticsearchNodeTranslogSize
-	metricElasticsearchNodeTranslogUncommittedSize                   metricElasticsearchNodeTranslogUncommittedSize
-	metricElasticsearchOsCPULoadAvg15m                               metricElasticsearchOsCPULoadAvg15m
-	metricElasticsearchOsCPULoadAvg1m                                metricElasticsearchOsCPULoadAvg1m
-	metricElasticsearchOsCPULoadAvg5m                                metricElasticsearchOsCPULoadAvg5m
-	metricElasticsearchOsCPUUsage                                    metricElasticsearchOsCPUUsage
-	metricElasticsearchOsMemory                                      metricElasticsearchOsMemory
-	metricJvmClassesLoaded                                           metricJvmClassesLoaded
-	metricJvmGcCollectionsCount                                      metricJvmGcCollectionsCount
-	metricJvmGcCollectionsElapsed                                    metricJvmGcCollectionsElapsed
-	metricJvmMemoryHeapCommitted                                     metricJvmMemoryHeapCommitted
-	metricJvmMemoryHeapMax                                           metricJvmMemoryHeapMax
-	metricJvmMemoryHeapUsed                                          metricJvmMemoryHeapUsed
-	metricJvmMemoryNonheapCommitted                                  metricJvmMemoryNonheapCommitted
-	metricJvmMemoryNonheapUsed                                       metricJvmMemoryNonheapUsed
-	metricJvmMemoryPoolMax                                           metricJvmMemoryPoolMax
-	metricJvmMemoryPoolUsed                                          metricJvmMemoryPoolUsed
-	metricJvmThreadsCount                                            metricJvmThreadsCount
+	startTime                                                       pcommon.Timestamp   // start time that will be applied to all recorded data points.
+	metricsCapacity                                                 int                 // maximum observed number of metrics per resource.
+	resourceCapacity                                                int                 // maximum observed number of resource attributes.
+	metricsBuffer                                                   pmetric.Metrics     // accumulates metrics data before emitting.
+	buildInfo                                                       component.BuildInfo // contains version information
+	metricElasticsearchBreakerMemoryEstimated                       metricElasticsearchBreakerMemoryEstimated
+	metricElasticsearchBreakerMemoryLimit                           metricElasticsearchBreakerMemoryLimit
+	metricElasticsearchBreakerTripped                               metricElasticsearchBreakerTripped
+	metricElasticsearchClusterDataNodes                             metricElasticsearchClusterDataNodes
+	metricElasticsearchClusterHealth                                metricElasticsearchClusterHealth
+	metricElasticsearchClusterNodes                                 metricElasticsearchClusterNodes
+	metricElasticsearchClusterPublishedStatesDifferences            metricElasticsearchClusterPublishedStatesDifferences
+	metricElasticsearchClusterPublishedStatesFull                   metricElasticsearchClusterPublishedStatesFull
+	metricElasticsearchClusterShards                                metricElasticsearchClusterShards
+	metricElasticsearchClusterStateQueue                            metricElasticsearchClusterStateQueue
+	metricElasticsearchClusterStateUpdateCommitTime                 metricElasticsearchClusterStateUpdateCommitTime
+	metricElasticsearchClusterStateUpdateCompletionTime             metricElasticsearchClusterStateUpdateCompletionTime
+	metricElasticsearchClusterStateUpdateComputationTime            metricElasticsearchClusterStateUpdateComputationTime
+	metricElasticsearchClusterStateUpdateContextConstructionTime    metricElasticsearchClusterStateUpdateContextConstructionTime
+	metricElasticsearchClusterStateUpdateCount                      metricElasticsearchClusterStateUpdateCount
+	metricElasticsearchClusterStateUpdateMasterApplyTime            metricElasticsearchClusterStateUpdateMasterApplyTime
+	metricElasticsearchClusterStateUpdateNotificationTime           metricElasticsearchClusterStateUpdateNotificationTime
+	metricElasticsearchIndexingPressureMemoryLimit                  metricElasticsearchIndexingPressureMemoryLimit
+	metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections
+	metricElasticsearchIndexingPressureMemoryTotalReplicaRejections metricElasticsearchIndexingPressureMemoryTotalReplicaRejections
+	metricElasticsearchMemoryIndexingPressure                       metricElasticsearchMemoryIndexingPressure
+	metricElasticsearchNodeCacheEvictions                           metricElasticsearchNodeCacheEvictions
+	metricElasticsearchNodeCacheMemoryUsage                         metricElasticsearchNodeCacheMemoryUsage
+	metricElasticsearchNodeClusterConnections                       metricElasticsearchNodeClusterConnections
+	metricElasticsearchNodeClusterIo                                metricElasticsearchNodeClusterIo
+	metricElasticsearchNodeClusterIoReceived                        metricElasticsearchNodeClusterIoReceived
+	metricElasticsearchNodeClusterIoSent                            metricElasticsearchNodeClusterIoSent
+	metricElasticsearchNodeDiskIoRead                               metricElasticsearchNodeDiskIoRead
+	metricElasticsearchNodeDiskIoWrite                              metricElasticsearchNodeDiskIoWrite
+	metricElasticsearchNodeDocuments                                metricElasticsearchNodeDocuments
+	metricElasticsearchNodeFsDiskAvailable                          metricElasticsearchNodeFsDiskAvailable
+	metricElasticsearchNodeHTTPConnections                          metricElasticsearchNodeHTTPConnections
+	metricElasticsearchNodeIngestDocuments                          metricElasticsearchNodeIngestDocuments
+	metricElasticsearchNodeIngestDocumentsCurrent                   metricElasticsearchNodeIngestDocumentsCurrent
+	metricElasticsearchNodeIngestOperationsFailed                   metricElasticsearchNodeIngestOperationsFailed
+	metricElasticsearchNodeOpenFiles                                metricElasticsearchNodeOpenFiles
+	metricElasticsearchNodeOperationsCompleted                      metricElasticsearchNodeOperationsCompleted
+	metricElasticsearchNodeOperationsTime                           metricElasticsearchNodeOperationsTime
+	metricElasticsearchNodePipelineIngestDocumentsCurrent           metricElasticsearchNodePipelineIngestDocumentsCurrent
+	metricElasticsearchNodePipelineIngestDocumentsPreprocessed      metricElasticsearchNodePipelineIngestDocumentsPreprocessed
+	metricElasticsearchNodePipelineIngestOperationsFailed           metricElasticsearchNodePipelineIngestOperationsFailed
+	metricElasticsearchNodeScriptCacheEvictions                     metricElasticsearchNodeScriptCacheEvictions
+	metricElasticsearchNodeScriptCompilationLimitTriggered          metricElasticsearchNodeScriptCompilationLimitTriggered
+	metricElasticsearchNodeScriptCompilations                       metricElasticsearchNodeScriptCompilations
+	metricElasticsearchNodeShardsDataSetSize                        metricElasticsearchNodeShardsDataSetSize
+	metricElasticsearchNodeShardsReservedSize                       metricElasticsearchNodeShardsReservedSize
+	metricElasticsearchNodeShardsSize                               metricElasticsearchNodeShardsSize
+	metricElasticsearchNodeThreadPoolTasksFinished                  metricElasticsearchNodeThreadPoolTasksFinished
+	metricElasticsearchNodeThreadPoolTasksQueued                    metricElasticsearchNodeThreadPoolTasksQueued
+	metricElasticsearchNodeThreadPoolThreads                        metricElasticsearchNodeThreadPoolThreads
+	metricElasticsearchNodeTranslogOperations                       metricElasticsearchNodeTranslogOperations
+	metricElasticsearchNodeTranslogSize                             metricElasticsearchNodeTranslogSize
+	metricElasticsearchNodeTranslogUncommittedSize                  metricElasticsearchNodeTranslogUncommittedSize
+	metricElasticsearchOsCPULoadAvg15m                              metricElasticsearchOsCPULoadAvg15m
+	metricElasticsearchOsCPULoadAvg1m                               metricElasticsearchOsCPULoadAvg1m
+	metricElasticsearchOsCPULoadAvg5m                               metricElasticsearchOsCPULoadAvg5m
+	metricElasticsearchOsCPUUsage                                   metricElasticsearchOsCPUUsage
+	metricElasticsearchOsMemory                                     metricElasticsearchOsMemory
+	metricJvmClassesLoaded                                          metricJvmClassesLoaded
+	metricJvmGcCollectionsCount                                     metricJvmGcCollectionsCount
+	metricJvmGcCollectionsElapsed                                   metricJvmGcCollectionsElapsed
+	metricJvmMemoryHeapCommitted                                    metricJvmMemoryHeapCommitted
+	metricJvmMemoryHeapMax                                          metricJvmMemoryHeapMax
+	metricJvmMemoryHeapUsed                                         metricJvmMemoryHeapUsed
+	metricJvmMemoryNonheapCommitted                                 metricJvmMemoryNonheapCommitted
+	metricJvmMemoryNonheapUsed                                      metricJvmMemoryNonheapUsed
+	metricJvmMemoryPoolMax                                          metricJvmMemoryPoolMax
+	metricJvmMemoryPoolUsed                                         metricJvmMemoryPoolUsed
+	metricJvmThreadsCount                                           metricJvmThreadsCount
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -4509,79 +4391,75 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		startTime:     pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer: pmetric.NewMetrics(),
 		buildInfo:     buildInfo,
-		metricElasticsearchBreakerMemoryEstimated:                        newMetricElasticsearchBreakerMemoryEstimated(settings.ElasticsearchBreakerMemoryEstimated),
-		metricElasticsearchBreakerMemoryLimit:                            newMetricElasticsearchBreakerMemoryLimit(settings.ElasticsearchBreakerMemoryLimit),
-		metricElasticsearchBreakerTripped:                                newMetricElasticsearchBreakerTripped(settings.ElasticsearchBreakerTripped),
-		metricElasticsearchClusterDataNodes:                              newMetricElasticsearchClusterDataNodes(settings.ElasticsearchClusterDataNodes),
-		metricElasticsearchClusterHealth:                                 newMetricElasticsearchClusterHealth(settings.ElasticsearchClusterHealth),
-		metricElasticsearchClusterNodes:                                  newMetricElasticsearchClusterNodes(settings.ElasticsearchClusterNodes),
-		metricElasticsearchClusterShards:                                 newMetricElasticsearchClusterShards(settings.ElasticsearchClusterShards),
-		metricElasticsearchIndexingPressureMemoryCoordinating:            newMetricElasticsearchIndexingPressureMemoryCoordinating(settings.ElasticsearchIndexingPressureMemoryCoordinating),
-		metricElasticsearchIndexingPressureMemoryLimit:                   newMetricElasticsearchIndexingPressureMemoryLimit(settings.ElasticsearchIndexingPressureMemoryLimit),
-		metricElasticsearchIndexingPressureMemoryPrimary:                 newMetricElasticsearchIndexingPressureMemoryPrimary(settings.ElasticsearchIndexingPressureMemoryPrimary),
-		metricElasticsearchIndexingPressureMemoryReplica:                 newMetricElasticsearchIndexingPressureMemoryReplica(settings.ElasticsearchIndexingPressureMemoryReplica),
-		metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections:  newMetricElasticsearchIndexingPressureMemoryTotalPrimaryRejections(settings.ElasticsearchIndexingPressureMemoryTotalPrimaryRejections),
-		metricElasticsearchIndexingPressureMemoryTotalReplicaRejections:  newMetricElasticsearchIndexingPressureMemoryTotalReplicaRejections(settings.ElasticsearchIndexingPressureMemoryTotalReplicaRejections),
-		metricElasticsearchNodeCacheEvictions:                            newMetricElasticsearchNodeCacheEvictions(settings.ElasticsearchNodeCacheEvictions),
-		metricElasticsearchNodeCacheMemoryUsage:                          newMetricElasticsearchNodeCacheMemoryUsage(settings.ElasticsearchNodeCacheMemoryUsage),
-		metricElasticsearchNodeClusterConnections:                        newMetricElasticsearchNodeClusterConnections(settings.ElasticsearchNodeClusterConnections),
-		metricElasticsearchNodeClusterIo:                                 newMetricElasticsearchNodeClusterIo(settings.ElasticsearchNodeClusterIo),
-		metricElasticsearchNodeClusterIoReceived:                         newMetricElasticsearchNodeClusterIoReceived(settings.ElasticsearchNodeClusterIoReceived),
-		metricElasticsearchNodeClusterIoSent:                             newMetricElasticsearchNodeClusterIoSent(settings.ElasticsearchNodeClusterIoSent),
-		metricElasticsearchNodeClusterPublishedStatesCompatible:          newMetricElasticsearchNodeClusterPublishedStatesCompatible(settings.ElasticsearchNodeClusterPublishedStatesCompatible),
-		metricElasticsearchNodeClusterPublishedStatesFull:                newMetricElasticsearchNodeClusterPublishedStatesFull(settings.ElasticsearchNodeClusterPublishedStatesFull),
-		metricElasticsearchNodeClusterPublishedStatesIncompatible:        newMetricElasticsearchNodeClusterPublishedStatesIncompatible(settings.ElasticsearchNodeClusterPublishedStatesIncompatible),
-		metricElasticsearchNodeClusterStateQueueCommitted:                newMetricElasticsearchNodeClusterStateQueueCommitted(settings.ElasticsearchNodeClusterStateQueueCommitted),
-		metricElasticsearchNodeClusterStateQueuePending:                  newMetricElasticsearchNodeClusterStateQueuePending(settings.ElasticsearchNodeClusterStateQueuePending),
-		metricElasticsearchNodeClusterStateUpdateCommitTime:              newMetricElasticsearchNodeClusterStateUpdateCommitTime(settings.ElasticsearchNodeClusterStateUpdateCommitTime),
-		metricElasticsearchNodeClusterStateUpdateCompletionTime:          newMetricElasticsearchNodeClusterStateUpdateCompletionTime(settings.ElasticsearchNodeClusterStateUpdateCompletionTime),
-		metricElasticsearchNodeClusterStateUpdateComputationTime:         newMetricElasticsearchNodeClusterStateUpdateComputationTime(settings.ElasticsearchNodeClusterStateUpdateComputationTime),
-		metricElasticsearchNodeClusterStateUpdateContextConstructionTime: newMetricElasticsearchNodeClusterStateUpdateContextConstructionTime(settings.ElasticsearchNodeClusterStateUpdateContextConstructionTime),
-		metricElasticsearchNodeClusterStateUpdateCount:                   newMetricElasticsearchNodeClusterStateUpdateCount(settings.ElasticsearchNodeClusterStateUpdateCount),
-		metricElasticsearchNodeClusterStateUpdateMasterApplyTime:         newMetricElasticsearchNodeClusterStateUpdateMasterApplyTime(settings.ElasticsearchNodeClusterStateUpdateMasterApplyTime),
-		metricElasticsearchNodeClusterStateUpdateNotificationTime:        newMetricElasticsearchNodeClusterStateUpdateNotificationTime(settings.ElasticsearchNodeClusterStateUpdateNotificationTime),
-		metricElasticsearchNodeDiskIoRead:                                newMetricElasticsearchNodeDiskIoRead(settings.ElasticsearchNodeDiskIoRead),
-		metricElasticsearchNodeDiskIoWrite:                               newMetricElasticsearchNodeDiskIoWrite(settings.ElasticsearchNodeDiskIoWrite),
-		metricElasticsearchNodeDocuments:                                 newMetricElasticsearchNodeDocuments(settings.ElasticsearchNodeDocuments),
-		metricElasticsearchNodeFsDiskAvailable:                           newMetricElasticsearchNodeFsDiskAvailable(settings.ElasticsearchNodeFsDiskAvailable),
-		metricElasticsearchNodeHTTPConnections:                           newMetricElasticsearchNodeHTTPConnections(settings.ElasticsearchNodeHTTPConnections),
-		metricElasticsearchNodeIngestCount:                               newMetricElasticsearchNodeIngestCount(settings.ElasticsearchNodeIngestCount),
-		metricElasticsearchNodeIngestCurrent:                             newMetricElasticsearchNodeIngestCurrent(settings.ElasticsearchNodeIngestCurrent),
-		metricElasticsearchNodeIngestFailed:                              newMetricElasticsearchNodeIngestFailed(settings.ElasticsearchNodeIngestFailed),
-		metricElasticsearchNodeIngestPipelineCount:                       newMetricElasticsearchNodeIngestPipelineCount(settings.ElasticsearchNodeIngestPipelineCount),
-		metricElasticsearchNodeIngestPipelineCurrent:                     newMetricElasticsearchNodeIngestPipelineCurrent(settings.ElasticsearchNodeIngestPipelineCurrent),
-		metricElasticsearchNodeIngestPipelineFailed:                      newMetricElasticsearchNodeIngestPipelineFailed(settings.ElasticsearchNodeIngestPipelineFailed),
-		metricElasticsearchNodeOpenFiles:                                 newMetricElasticsearchNodeOpenFiles(settings.ElasticsearchNodeOpenFiles),
-		metricElasticsearchNodeOperationsCompleted:                       newMetricElasticsearchNodeOperationsCompleted(settings.ElasticsearchNodeOperationsCompleted),
-		metricElasticsearchNodeOperationsTime:                            newMetricElasticsearchNodeOperationsTime(settings.ElasticsearchNodeOperationsTime),
-		metricElasticsearchNodeScriptCacheEvictions:                      newMetricElasticsearchNodeScriptCacheEvictions(settings.ElasticsearchNodeScriptCacheEvictions),
-		metricElasticsearchNodeScriptCompilationLimitTriggered:           newMetricElasticsearchNodeScriptCompilationLimitTriggered(settings.ElasticsearchNodeScriptCompilationLimitTriggered),
-		metricElasticsearchNodeScriptCompilations:                        newMetricElasticsearchNodeScriptCompilations(settings.ElasticsearchNodeScriptCompilations),
-		metricElasticsearchNodeShardsDataSetSize:                         newMetricElasticsearchNodeShardsDataSetSize(settings.ElasticsearchNodeShardsDataSetSize),
-		metricElasticsearchNodeShardsReservedSize:                        newMetricElasticsearchNodeShardsReservedSize(settings.ElasticsearchNodeShardsReservedSize),
-		metricElasticsearchNodeShardsSize:                                newMetricElasticsearchNodeShardsSize(settings.ElasticsearchNodeShardsSize),
-		metricElasticsearchNodeThreadPoolTasksFinished:                   newMetricElasticsearchNodeThreadPoolTasksFinished(settings.ElasticsearchNodeThreadPoolTasksFinished),
-		metricElasticsearchNodeThreadPoolTasksQueued:                     newMetricElasticsearchNodeThreadPoolTasksQueued(settings.ElasticsearchNodeThreadPoolTasksQueued),
-		metricElasticsearchNodeThreadPoolThreads:                         newMetricElasticsearchNodeThreadPoolThreads(settings.ElasticsearchNodeThreadPoolThreads),
-		metricElasticsearchNodeTranslogOperations:                        newMetricElasticsearchNodeTranslogOperations(settings.ElasticsearchNodeTranslogOperations),
-		metricElasticsearchNodeTranslogSize:                              newMetricElasticsearchNodeTranslogSize(settings.ElasticsearchNodeTranslogSize),
-		metricElasticsearchNodeTranslogUncommittedSize:                   newMetricElasticsearchNodeTranslogUncommittedSize(settings.ElasticsearchNodeTranslogUncommittedSize),
-		metricElasticsearchOsCPULoadAvg15m:                               newMetricElasticsearchOsCPULoadAvg15m(settings.ElasticsearchOsCPULoadAvg15m),
-		metricElasticsearchOsCPULoadAvg1m:                                newMetricElasticsearchOsCPULoadAvg1m(settings.ElasticsearchOsCPULoadAvg1m),
-		metricElasticsearchOsCPULoadAvg5m:                                newMetricElasticsearchOsCPULoadAvg5m(settings.ElasticsearchOsCPULoadAvg5m),
-		metricElasticsearchOsCPUUsage:                                    newMetricElasticsearchOsCPUUsage(settings.ElasticsearchOsCPUUsage),
-		metricElasticsearchOsMemory:                                      newMetricElasticsearchOsMemory(settings.ElasticsearchOsMemory),
-		metricJvmClassesLoaded:                                           newMetricJvmClassesLoaded(settings.JvmClassesLoaded),
-		metricJvmGcCollectionsCount:                                      newMetricJvmGcCollectionsCount(settings.JvmGcCollectionsCount),
-		metricJvmGcCollectionsElapsed:                                    newMetricJvmGcCollectionsElapsed(settings.JvmGcCollectionsElapsed),
-		metricJvmMemoryHeapCommitted:                                     newMetricJvmMemoryHeapCommitted(settings.JvmMemoryHeapCommitted),
-		metricJvmMemoryHeapMax:                                           newMetricJvmMemoryHeapMax(settings.JvmMemoryHeapMax),
-		metricJvmMemoryHeapUsed:                                          newMetricJvmMemoryHeapUsed(settings.JvmMemoryHeapUsed),
-		metricJvmMemoryNonheapCommitted:                                  newMetricJvmMemoryNonheapCommitted(settings.JvmMemoryNonheapCommitted),
-		metricJvmMemoryNonheapUsed:                                       newMetricJvmMemoryNonheapUsed(settings.JvmMemoryNonheapUsed),
-		metricJvmMemoryPoolMax:                                           newMetricJvmMemoryPoolMax(settings.JvmMemoryPoolMax),
-		metricJvmMemoryPoolUsed:                                          newMetricJvmMemoryPoolUsed(settings.JvmMemoryPoolUsed),
-		metricJvmThreadsCount:                                            newMetricJvmThreadsCount(settings.JvmThreadsCount),
+		metricElasticsearchBreakerMemoryEstimated:                       newMetricElasticsearchBreakerMemoryEstimated(settings.ElasticsearchBreakerMemoryEstimated),
+		metricElasticsearchBreakerMemoryLimit:                           newMetricElasticsearchBreakerMemoryLimit(settings.ElasticsearchBreakerMemoryLimit),
+		metricElasticsearchBreakerTripped:                               newMetricElasticsearchBreakerTripped(settings.ElasticsearchBreakerTripped),
+		metricElasticsearchClusterDataNodes:                             newMetricElasticsearchClusterDataNodes(settings.ElasticsearchClusterDataNodes),
+		metricElasticsearchClusterHealth:                                newMetricElasticsearchClusterHealth(settings.ElasticsearchClusterHealth),
+		metricElasticsearchClusterNodes:                                 newMetricElasticsearchClusterNodes(settings.ElasticsearchClusterNodes),
+		metricElasticsearchClusterPublishedStatesDifferences:            newMetricElasticsearchClusterPublishedStatesDifferences(settings.ElasticsearchClusterPublishedStatesDifferences),
+		metricElasticsearchClusterPublishedStatesFull:                   newMetricElasticsearchClusterPublishedStatesFull(settings.ElasticsearchClusterPublishedStatesFull),
+		metricElasticsearchClusterShards:                                newMetricElasticsearchClusterShards(settings.ElasticsearchClusterShards),
+		metricElasticsearchClusterStateQueue:                            newMetricElasticsearchClusterStateQueue(settings.ElasticsearchClusterStateQueue),
+		metricElasticsearchClusterStateUpdateCommitTime:                 newMetricElasticsearchClusterStateUpdateCommitTime(settings.ElasticsearchClusterStateUpdateCommitTime),
+		metricElasticsearchClusterStateUpdateCompletionTime:             newMetricElasticsearchClusterStateUpdateCompletionTime(settings.ElasticsearchClusterStateUpdateCompletionTime),
+		metricElasticsearchClusterStateUpdateComputationTime:            newMetricElasticsearchClusterStateUpdateComputationTime(settings.ElasticsearchClusterStateUpdateComputationTime),
+		metricElasticsearchClusterStateUpdateContextConstructionTime:    newMetricElasticsearchClusterStateUpdateContextConstructionTime(settings.ElasticsearchClusterStateUpdateContextConstructionTime),
+		metricElasticsearchClusterStateUpdateCount:                      newMetricElasticsearchClusterStateUpdateCount(settings.ElasticsearchClusterStateUpdateCount),
+		metricElasticsearchClusterStateUpdateMasterApplyTime:            newMetricElasticsearchClusterStateUpdateMasterApplyTime(settings.ElasticsearchClusterStateUpdateMasterApplyTime),
+		metricElasticsearchClusterStateUpdateNotificationTime:           newMetricElasticsearchClusterStateUpdateNotificationTime(settings.ElasticsearchClusterStateUpdateNotificationTime),
+		metricElasticsearchIndexingPressureMemoryLimit:                  newMetricElasticsearchIndexingPressureMemoryLimit(settings.ElasticsearchIndexingPressureMemoryLimit),
+		metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections: newMetricElasticsearchIndexingPressureMemoryTotalPrimaryRejections(settings.ElasticsearchIndexingPressureMemoryTotalPrimaryRejections),
+		metricElasticsearchIndexingPressureMemoryTotalReplicaRejections: newMetricElasticsearchIndexingPressureMemoryTotalReplicaRejections(settings.ElasticsearchIndexingPressureMemoryTotalReplicaRejections),
+		metricElasticsearchMemoryIndexingPressure:                       newMetricElasticsearchMemoryIndexingPressure(settings.ElasticsearchMemoryIndexingPressure),
+		metricElasticsearchNodeCacheEvictions:                           newMetricElasticsearchNodeCacheEvictions(settings.ElasticsearchNodeCacheEvictions),
+		metricElasticsearchNodeCacheMemoryUsage:                         newMetricElasticsearchNodeCacheMemoryUsage(settings.ElasticsearchNodeCacheMemoryUsage),
+		metricElasticsearchNodeClusterConnections:                       newMetricElasticsearchNodeClusterConnections(settings.ElasticsearchNodeClusterConnections),
+		metricElasticsearchNodeClusterIo:                                newMetricElasticsearchNodeClusterIo(settings.ElasticsearchNodeClusterIo),
+		metricElasticsearchNodeClusterIoReceived:                        newMetricElasticsearchNodeClusterIoReceived(settings.ElasticsearchNodeClusterIoReceived),
+		metricElasticsearchNodeClusterIoSent:                            newMetricElasticsearchNodeClusterIoSent(settings.ElasticsearchNodeClusterIoSent),
+		metricElasticsearchNodeDiskIoRead:                               newMetricElasticsearchNodeDiskIoRead(settings.ElasticsearchNodeDiskIoRead),
+		metricElasticsearchNodeDiskIoWrite:                              newMetricElasticsearchNodeDiskIoWrite(settings.ElasticsearchNodeDiskIoWrite),
+		metricElasticsearchNodeDocuments:                                newMetricElasticsearchNodeDocuments(settings.ElasticsearchNodeDocuments),
+		metricElasticsearchNodeFsDiskAvailable:                          newMetricElasticsearchNodeFsDiskAvailable(settings.ElasticsearchNodeFsDiskAvailable),
+		metricElasticsearchNodeHTTPConnections:                          newMetricElasticsearchNodeHTTPConnections(settings.ElasticsearchNodeHTTPConnections),
+		metricElasticsearchNodeIngestDocuments:                          newMetricElasticsearchNodeIngestDocuments(settings.ElasticsearchNodeIngestDocuments),
+		metricElasticsearchNodeIngestDocumentsCurrent:                   newMetricElasticsearchNodeIngestDocumentsCurrent(settings.ElasticsearchNodeIngestDocumentsCurrent),
+		metricElasticsearchNodeIngestOperationsFailed:                   newMetricElasticsearchNodeIngestOperationsFailed(settings.ElasticsearchNodeIngestOperationsFailed),
+		metricElasticsearchNodeOpenFiles:                                newMetricElasticsearchNodeOpenFiles(settings.ElasticsearchNodeOpenFiles),
+		metricElasticsearchNodeOperationsCompleted:                      newMetricElasticsearchNodeOperationsCompleted(settings.ElasticsearchNodeOperationsCompleted),
+		metricElasticsearchNodeOperationsTime:                           newMetricElasticsearchNodeOperationsTime(settings.ElasticsearchNodeOperationsTime),
+		metricElasticsearchNodePipelineIngestDocumentsCurrent:           newMetricElasticsearchNodePipelineIngestDocumentsCurrent(settings.ElasticsearchNodePipelineIngestDocumentsCurrent),
+		metricElasticsearchNodePipelineIngestDocumentsPreprocessed:      newMetricElasticsearchNodePipelineIngestDocumentsPreprocessed(settings.ElasticsearchNodePipelineIngestDocumentsPreprocessed),
+		metricElasticsearchNodePipelineIngestOperationsFailed:           newMetricElasticsearchNodePipelineIngestOperationsFailed(settings.ElasticsearchNodePipelineIngestOperationsFailed),
+		metricElasticsearchNodeScriptCacheEvictions:                     newMetricElasticsearchNodeScriptCacheEvictions(settings.ElasticsearchNodeScriptCacheEvictions),
+		metricElasticsearchNodeScriptCompilationLimitTriggered:          newMetricElasticsearchNodeScriptCompilationLimitTriggered(settings.ElasticsearchNodeScriptCompilationLimitTriggered),
+		metricElasticsearchNodeScriptCompilations:                       newMetricElasticsearchNodeScriptCompilations(settings.ElasticsearchNodeScriptCompilations),
+		metricElasticsearchNodeShardsDataSetSize:                        newMetricElasticsearchNodeShardsDataSetSize(settings.ElasticsearchNodeShardsDataSetSize),
+		metricElasticsearchNodeShardsReservedSize:                       newMetricElasticsearchNodeShardsReservedSize(settings.ElasticsearchNodeShardsReservedSize),
+		metricElasticsearchNodeShardsSize:                               newMetricElasticsearchNodeShardsSize(settings.ElasticsearchNodeShardsSize),
+		metricElasticsearchNodeThreadPoolTasksFinished:                  newMetricElasticsearchNodeThreadPoolTasksFinished(settings.ElasticsearchNodeThreadPoolTasksFinished),
+		metricElasticsearchNodeThreadPoolTasksQueued:                    newMetricElasticsearchNodeThreadPoolTasksQueued(settings.ElasticsearchNodeThreadPoolTasksQueued),
+		metricElasticsearchNodeThreadPoolThreads:                        newMetricElasticsearchNodeThreadPoolThreads(settings.ElasticsearchNodeThreadPoolThreads),
+		metricElasticsearchNodeTranslogOperations:                       newMetricElasticsearchNodeTranslogOperations(settings.ElasticsearchNodeTranslogOperations),
+		metricElasticsearchNodeTranslogSize:                             newMetricElasticsearchNodeTranslogSize(settings.ElasticsearchNodeTranslogSize),
+		metricElasticsearchNodeTranslogUncommittedSize:                  newMetricElasticsearchNodeTranslogUncommittedSize(settings.ElasticsearchNodeTranslogUncommittedSize),
+		metricElasticsearchOsCPULoadAvg15m:                              newMetricElasticsearchOsCPULoadAvg15m(settings.ElasticsearchOsCPULoadAvg15m),
+		metricElasticsearchOsCPULoadAvg1m:                               newMetricElasticsearchOsCPULoadAvg1m(settings.ElasticsearchOsCPULoadAvg1m),
+		metricElasticsearchOsCPULoadAvg5m:                               newMetricElasticsearchOsCPULoadAvg5m(settings.ElasticsearchOsCPULoadAvg5m),
+		metricElasticsearchOsCPUUsage:                                   newMetricElasticsearchOsCPUUsage(settings.ElasticsearchOsCPUUsage),
+		metricElasticsearchOsMemory:                                     newMetricElasticsearchOsMemory(settings.ElasticsearchOsMemory),
+		metricJvmClassesLoaded:                                          newMetricJvmClassesLoaded(settings.JvmClassesLoaded),
+		metricJvmGcCollectionsCount:                                     newMetricJvmGcCollectionsCount(settings.JvmGcCollectionsCount),
+		metricJvmGcCollectionsElapsed:                                   newMetricJvmGcCollectionsElapsed(settings.JvmGcCollectionsElapsed),
+		metricJvmMemoryHeapCommitted:                                    newMetricJvmMemoryHeapCommitted(settings.JvmMemoryHeapCommitted),
+		metricJvmMemoryHeapMax:                                          newMetricJvmMemoryHeapMax(settings.JvmMemoryHeapMax),
+		metricJvmMemoryHeapUsed:                                         newMetricJvmMemoryHeapUsed(settings.JvmMemoryHeapUsed),
+		metricJvmMemoryNonheapCommitted:                                 newMetricJvmMemoryNonheapCommitted(settings.JvmMemoryNonheapCommitted),
+		metricJvmMemoryNonheapUsed:                                      newMetricJvmMemoryNonheapUsed(settings.JvmMemoryNonheapUsed),
+		metricJvmMemoryPoolMax:                                          newMetricJvmMemoryPoolMax(settings.JvmMemoryPoolMax),
+		metricJvmMemoryPoolUsed:                                         newMetricJvmMemoryPoolUsed(settings.JvmMemoryPoolUsed),
+		metricJvmThreadsCount:                                           newMetricJvmThreadsCount(settings.JvmThreadsCount),
 	}
 	for _, op := range options {
 		op(mb)
@@ -4654,45 +4532,41 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricElasticsearchClusterDataNodes.emit(ils.Metrics())
 	mb.metricElasticsearchClusterHealth.emit(ils.Metrics())
 	mb.metricElasticsearchClusterNodes.emit(ils.Metrics())
+	mb.metricElasticsearchClusterPublishedStatesDifferences.emit(ils.Metrics())
+	mb.metricElasticsearchClusterPublishedStatesFull.emit(ils.Metrics())
 	mb.metricElasticsearchClusterShards.emit(ils.Metrics())
-	mb.metricElasticsearchIndexingPressureMemoryCoordinating.emit(ils.Metrics())
+	mb.metricElasticsearchClusterStateQueue.emit(ils.Metrics())
+	mb.metricElasticsearchClusterStateUpdateCommitTime.emit(ils.Metrics())
+	mb.metricElasticsearchClusterStateUpdateCompletionTime.emit(ils.Metrics())
+	mb.metricElasticsearchClusterStateUpdateComputationTime.emit(ils.Metrics())
+	mb.metricElasticsearchClusterStateUpdateContextConstructionTime.emit(ils.Metrics())
+	mb.metricElasticsearchClusterStateUpdateCount.emit(ils.Metrics())
+	mb.metricElasticsearchClusterStateUpdateMasterApplyTime.emit(ils.Metrics())
+	mb.metricElasticsearchClusterStateUpdateNotificationTime.emit(ils.Metrics())
 	mb.metricElasticsearchIndexingPressureMemoryLimit.emit(ils.Metrics())
-	mb.metricElasticsearchIndexingPressureMemoryPrimary.emit(ils.Metrics())
-	mb.metricElasticsearchIndexingPressureMemoryReplica.emit(ils.Metrics())
 	mb.metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections.emit(ils.Metrics())
 	mb.metricElasticsearchIndexingPressureMemoryTotalReplicaRejections.emit(ils.Metrics())
+	mb.metricElasticsearchMemoryIndexingPressure.emit(ils.Metrics())
 	mb.metricElasticsearchNodeCacheEvictions.emit(ils.Metrics())
 	mb.metricElasticsearchNodeCacheMemoryUsage.emit(ils.Metrics())
 	mb.metricElasticsearchNodeClusterConnections.emit(ils.Metrics())
 	mb.metricElasticsearchNodeClusterIo.emit(ils.Metrics())
 	mb.metricElasticsearchNodeClusterIoReceived.emit(ils.Metrics())
 	mb.metricElasticsearchNodeClusterIoSent.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterPublishedStatesCompatible.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterPublishedStatesFull.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterPublishedStatesIncompatible.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterStateQueueCommitted.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterStateQueuePending.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterStateUpdateCommitTime.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterStateUpdateCompletionTime.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterStateUpdateComputationTime.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterStateUpdateContextConstructionTime.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterStateUpdateCount.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterStateUpdateMasterApplyTime.emit(ils.Metrics())
-	mb.metricElasticsearchNodeClusterStateUpdateNotificationTime.emit(ils.Metrics())
 	mb.metricElasticsearchNodeDiskIoRead.emit(ils.Metrics())
 	mb.metricElasticsearchNodeDiskIoWrite.emit(ils.Metrics())
 	mb.metricElasticsearchNodeDocuments.emit(ils.Metrics())
 	mb.metricElasticsearchNodeFsDiskAvailable.emit(ils.Metrics())
 	mb.metricElasticsearchNodeHTTPConnections.emit(ils.Metrics())
-	mb.metricElasticsearchNodeIngestCount.emit(ils.Metrics())
-	mb.metricElasticsearchNodeIngestCurrent.emit(ils.Metrics())
-	mb.metricElasticsearchNodeIngestFailed.emit(ils.Metrics())
-	mb.metricElasticsearchNodeIngestPipelineCount.emit(ils.Metrics())
-	mb.metricElasticsearchNodeIngestPipelineCurrent.emit(ils.Metrics())
-	mb.metricElasticsearchNodeIngestPipelineFailed.emit(ils.Metrics())
+	mb.metricElasticsearchNodeIngestDocuments.emit(ils.Metrics())
+	mb.metricElasticsearchNodeIngestDocumentsCurrent.emit(ils.Metrics())
+	mb.metricElasticsearchNodeIngestOperationsFailed.emit(ils.Metrics())
 	mb.metricElasticsearchNodeOpenFiles.emit(ils.Metrics())
 	mb.metricElasticsearchNodeOperationsCompleted.emit(ils.Metrics())
 	mb.metricElasticsearchNodeOperationsTime.emit(ils.Metrics())
+	mb.metricElasticsearchNodePipelineIngestDocumentsCurrent.emit(ils.Metrics())
+	mb.metricElasticsearchNodePipelineIngestDocumentsPreprocessed.emit(ils.Metrics())
+	mb.metricElasticsearchNodePipelineIngestOperationsFailed.emit(ils.Metrics())
 	mb.metricElasticsearchNodeScriptCacheEvictions.emit(ils.Metrics())
 	mb.metricElasticsearchNodeScriptCompilationLimitTriggered.emit(ils.Metrics())
 	mb.metricElasticsearchNodeScriptCompilations.emit(ils.Metrics())
@@ -4770,29 +4644,64 @@ func (mb *MetricsBuilder) RecordElasticsearchClusterNodesDataPoint(ts pcommon.Ti
 	mb.metricElasticsearchClusterNodes.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordElasticsearchClusterPublishedStatesDifferencesDataPoint adds a data point to elasticsearch.cluster.published_states.differences metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterPublishedStatesDifferencesDataPoint(ts pcommon.Timestamp, val int64, clusterPublishedDifferenceStateAttributeValue AttributeClusterPublishedDifferenceState) {
+	mb.metricElasticsearchClusterPublishedStatesDifferences.recordDataPoint(mb.startTime, ts, val, clusterPublishedDifferenceStateAttributeValue.String())
+}
+
+// RecordElasticsearchClusterPublishedStatesFullDataPoint adds a data point to elasticsearch.cluster.published_states.full metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterPublishedStatesFullDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchClusterPublishedStatesFull.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordElasticsearchClusterShardsDataPoint adds a data point to elasticsearch.cluster.shards metric.
 func (mb *MetricsBuilder) RecordElasticsearchClusterShardsDataPoint(ts pcommon.Timestamp, val int64, shardStateAttributeValue AttributeShardState) {
 	mb.metricElasticsearchClusterShards.recordDataPoint(mb.startTime, ts, val, shardStateAttributeValue.String())
 }
 
-// RecordElasticsearchIndexingPressureMemoryCoordinatingDataPoint adds a data point to elasticsearch.indexing_pressure.memory.coordinating metric.
-func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryCoordinatingDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchIndexingPressureMemoryCoordinating.recordDataPoint(mb.startTime, ts, val)
+// RecordElasticsearchClusterStateQueueDataPoint adds a data point to elasticsearch.cluster.state_queue metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterStateQueueDataPoint(ts pcommon.Timestamp, val int64, clusterStateQueueStateAttributeValue AttributeClusterStateQueueState) {
+	mb.metricElasticsearchClusterStateQueue.recordDataPoint(mb.startTime, ts, val, clusterStateQueueStateAttributeValue.String())
+}
+
+// RecordElasticsearchClusterStateUpdateCommitTimeDataPoint adds a data point to elasticsearch.cluster.state_update.commit_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterStateUpdateCommitTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchClusterStateUpdateCommitTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchClusterStateUpdateCompletionTimeDataPoint adds a data point to elasticsearch.cluster.state_update.completion_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterStateUpdateCompletionTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchClusterStateUpdateCompletionTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchClusterStateUpdateComputationTimeDataPoint adds a data point to elasticsearch.cluster.state_update.computation_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterStateUpdateComputationTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchClusterStateUpdateComputationTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchClusterStateUpdateContextConstructionTimeDataPoint adds a data point to elasticsearch.cluster.state_update.context_construction_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterStateUpdateContextConstructionTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchClusterStateUpdateContextConstructionTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchClusterStateUpdateCountDataPoint adds a data point to elasticsearch.cluster.state_update.count metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterStateUpdateCountDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchClusterStateUpdateCount.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchClusterStateUpdateMasterApplyTimeDataPoint adds a data point to elasticsearch.cluster.state_update.master_apply_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterStateUpdateMasterApplyTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchClusterStateUpdateMasterApplyTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
+}
+
+// RecordElasticsearchClusterStateUpdateNotificationTimeDataPoint adds a data point to elasticsearch.cluster.state_update.notification_time metric.
+func (mb *MetricsBuilder) RecordElasticsearchClusterStateUpdateNotificationTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
+	mb.metricElasticsearchClusterStateUpdateNotificationTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
 }
 
 // RecordElasticsearchIndexingPressureMemoryLimitDataPoint adds a data point to elasticsearch.indexing_pressure.memory.limit metric.
 func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryLimitDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricElasticsearchIndexingPressureMemoryLimit.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordElasticsearchIndexingPressureMemoryPrimaryDataPoint adds a data point to elasticsearch.indexing_pressure.memory.primary metric.
-func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryPrimaryDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchIndexingPressureMemoryPrimary.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordElasticsearchIndexingPressureMemoryReplicaDataPoint adds a data point to elasticsearch.indexing_pressure.memory.replica metric.
-func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryReplicaDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchIndexingPressureMemoryReplica.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordElasticsearchIndexingPressureMemoryTotalPrimaryRejectionsDataPoint adds a data point to elasticsearch.indexing_pressure.memory.total.primary_rejections metric.
@@ -4803,6 +4712,11 @@ func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryTotalPrimaryR
 // RecordElasticsearchIndexingPressureMemoryTotalReplicaRejectionsDataPoint adds a data point to elasticsearch.indexing_pressure.memory.total.replica_rejections metric.
 func (mb *MetricsBuilder) RecordElasticsearchIndexingPressureMemoryTotalReplicaRejectionsDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricElasticsearchIndexingPressureMemoryTotalReplicaRejections.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordElasticsearchMemoryIndexingPressureDataPoint adds a data point to elasticsearch.memory.indexing_pressure metric.
+func (mb *MetricsBuilder) RecordElasticsearchMemoryIndexingPressureDataPoint(ts pcommon.Timestamp, val int64, indexingPressureStageAttributeValue AttributeIndexingPressureStage) {
+	mb.metricElasticsearchMemoryIndexingPressure.recordDataPoint(mb.startTime, ts, val, indexingPressureStageAttributeValue.String())
 }
 
 // RecordElasticsearchNodeCacheEvictionsDataPoint adds a data point to elasticsearch.node.cache.evictions metric.
@@ -4835,66 +4749,6 @@ func (mb *MetricsBuilder) RecordElasticsearchNodeClusterIoSentDataPoint(ts pcomm
 	mb.metricElasticsearchNodeClusterIoSent.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordElasticsearchNodeClusterPublishedStatesCompatibleDataPoint adds a data point to elasticsearch.node.cluster.published_states.compatible metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterPublishedStatesCompatibleDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchNodeClusterPublishedStatesCompatible.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordElasticsearchNodeClusterPublishedStatesFullDataPoint adds a data point to elasticsearch.node.cluster.published_states.full metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterPublishedStatesFullDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchNodeClusterPublishedStatesFull.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordElasticsearchNodeClusterPublishedStatesIncompatibleDataPoint adds a data point to elasticsearch.node.cluster.published_states.incompatible metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterPublishedStatesIncompatibleDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchNodeClusterPublishedStatesIncompatible.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordElasticsearchNodeClusterStateQueueCommittedDataPoint adds a data point to elasticsearch.node.cluster.state_queue.committed metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateQueueCommittedDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchNodeClusterStateQueueCommitted.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordElasticsearchNodeClusterStateQueuePendingDataPoint adds a data point to elasticsearch.node.cluster.state_queue.pending metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateQueuePendingDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchNodeClusterStateQueuePending.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordElasticsearchNodeClusterStateUpdateCommitTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.commit_time metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateCommitTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
-	mb.metricElasticsearchNodeClusterStateUpdateCommitTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
-}
-
-// RecordElasticsearchNodeClusterStateUpdateCompletionTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.completion_time metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateCompletionTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
-	mb.metricElasticsearchNodeClusterStateUpdateCompletionTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
-}
-
-// RecordElasticsearchNodeClusterStateUpdateComputationTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.computation_time metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateComputationTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
-	mb.metricElasticsearchNodeClusterStateUpdateComputationTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
-}
-
-// RecordElasticsearchNodeClusterStateUpdateContextConstructionTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.context_construction_time metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateContextConstructionTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
-	mb.metricElasticsearchNodeClusterStateUpdateContextConstructionTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
-}
-
-// RecordElasticsearchNodeClusterStateUpdateCountDataPoint adds a data point to elasticsearch.node.cluster.state_update.count metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateCountDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
-	mb.metricElasticsearchNodeClusterStateUpdateCount.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
-}
-
-// RecordElasticsearchNodeClusterStateUpdateMasterApplyTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.master_apply_time metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateMasterApplyTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
-	mb.metricElasticsearchNodeClusterStateUpdateMasterApplyTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
-}
-
-// RecordElasticsearchNodeClusterStateUpdateNotificationTimeDataPoint adds a data point to elasticsearch.node.cluster.state_update.notification_time metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeClusterStateUpdateNotificationTimeDataPoint(ts pcommon.Timestamp, val int64, clusterStateUpdateTypeAttributeValue AttributeClusterStateUpdateType) {
-	mb.metricElasticsearchNodeClusterStateUpdateNotificationTime.recordDataPoint(mb.startTime, ts, val, clusterStateUpdateTypeAttributeValue.String())
-}
-
 // RecordElasticsearchNodeDiskIoReadDataPoint adds a data point to elasticsearch.node.disk.io.read metric.
 func (mb *MetricsBuilder) RecordElasticsearchNodeDiskIoReadDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricElasticsearchNodeDiskIoRead.recordDataPoint(mb.startTime, ts, val)
@@ -4920,34 +4774,19 @@ func (mb *MetricsBuilder) RecordElasticsearchNodeHTTPConnectionsDataPoint(ts pco
 	mb.metricElasticsearchNodeHTTPConnections.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordElasticsearchNodeIngestCountDataPoint adds a data point to elasticsearch.node.ingest.count metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeIngestCountDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchNodeIngestCount.recordDataPoint(mb.startTime, ts, val)
+// RecordElasticsearchNodeIngestDocumentsDataPoint adds a data point to elasticsearch.node.ingest.documents metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeIngestDocumentsDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeIngestDocuments.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordElasticsearchNodeIngestCurrentDataPoint adds a data point to elasticsearch.node.ingest.current metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeIngestCurrentDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchNodeIngestCurrent.recordDataPoint(mb.startTime, ts, val)
+// RecordElasticsearchNodeIngestDocumentsCurrentDataPoint adds a data point to elasticsearch.node.ingest.documents.current metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeIngestDocumentsCurrentDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeIngestDocumentsCurrent.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordElasticsearchNodeIngestFailedDataPoint adds a data point to elasticsearch.node.ingest.failed metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeIngestFailedDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricElasticsearchNodeIngestFailed.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordElasticsearchNodeIngestPipelineCountDataPoint adds a data point to elasticsearch.node.ingest.pipeline.count metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeIngestPipelineCountDataPoint(ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
-	mb.metricElasticsearchNodeIngestPipelineCount.recordDataPoint(mb.startTime, ts, val, ingestPipelineNameAttributeValue)
-}
-
-// RecordElasticsearchNodeIngestPipelineCurrentDataPoint adds a data point to elasticsearch.node.ingest.pipeline.current metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeIngestPipelineCurrentDataPoint(ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
-	mb.metricElasticsearchNodeIngestPipelineCurrent.recordDataPoint(mb.startTime, ts, val, ingestPipelineNameAttributeValue)
-}
-
-// RecordElasticsearchNodeIngestPipelineFailedDataPoint adds a data point to elasticsearch.node.ingest.pipeline.failed metric.
-func (mb *MetricsBuilder) RecordElasticsearchNodeIngestPipelineFailedDataPoint(ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
-	mb.metricElasticsearchNodeIngestPipelineFailed.recordDataPoint(mb.startTime, ts, val, ingestPipelineNameAttributeValue)
+// RecordElasticsearchNodeIngestOperationsFailedDataPoint adds a data point to elasticsearch.node.ingest.operations.failed metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodeIngestOperationsFailedDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricElasticsearchNodeIngestOperationsFailed.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordElasticsearchNodeOpenFilesDataPoint adds a data point to elasticsearch.node.open_files metric.
@@ -4963,6 +4802,21 @@ func (mb *MetricsBuilder) RecordElasticsearchNodeOperationsCompletedDataPoint(ts
 // RecordElasticsearchNodeOperationsTimeDataPoint adds a data point to elasticsearch.node.operations.time metric.
 func (mb *MetricsBuilder) RecordElasticsearchNodeOperationsTimeDataPoint(ts pcommon.Timestamp, val int64, operationAttributeValue AttributeOperation) {
 	mb.metricElasticsearchNodeOperationsTime.recordDataPoint(mb.startTime, ts, val, operationAttributeValue.String())
+}
+
+// RecordElasticsearchNodePipelineIngestDocumentsCurrentDataPoint adds a data point to elasticsearch.node.pipeline.ingest.documents.current metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodePipelineIngestDocumentsCurrentDataPoint(ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	mb.metricElasticsearchNodePipelineIngestDocumentsCurrent.recordDataPoint(mb.startTime, ts, val, ingestPipelineNameAttributeValue)
+}
+
+// RecordElasticsearchNodePipelineIngestDocumentsPreprocessedDataPoint adds a data point to elasticsearch.node.pipeline.ingest.documents.preprocessed metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodePipelineIngestDocumentsPreprocessedDataPoint(ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	mb.metricElasticsearchNodePipelineIngestDocumentsPreprocessed.recordDataPoint(mb.startTime, ts, val, ingestPipelineNameAttributeValue)
+}
+
+// RecordElasticsearchNodePipelineIngestOperationsFailedDataPoint adds a data point to elasticsearch.node.pipeline.ingest.operations.failed metric.
+func (mb *MetricsBuilder) RecordElasticsearchNodePipelineIngestOperationsFailedDataPoint(ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
+	mb.metricElasticsearchNodePipelineIngestOperationsFailed.recordDataPoint(mb.startTime, ts, val, ingestPipelineNameAttributeValue)
 }
 
 // RecordElasticsearchNodeScriptCacheEvictionsDataPoint adds a data point to elasticsearch.node.script.cache_evictions metric.

--- a/receiver/elasticsearchreceiver/internal/model/nodestats.go
+++ b/receiver/elasticsearchreceiver/internal/model/nodestats.go
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 package model // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver/internal/model"
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver/internal/metadata"
+)
 
 // NodeStats represents a response from elasticsearch's /_nodes/stats endpoint.
 // The struct is not exhaustive; It does not provide all values returned by elasticsearch,
@@ -34,6 +37,101 @@ type NodeStatsNodesInfo struct {
 	CircuitBreakerInfo    map[string]CircuitBreakerStats `json:"breakers"`
 	FS                    FSStats                        `json:"fs"`
 	OS                    OSStats                        `json:"os"`
+	IndexingPressure      IndexingPressure               `json:"indexing_pressure"`
+	Discovery             Discovery                      `json:"discovery"`
+	Ingest                Ingest                         `json:"ingest"`
+	Script                Script                         `json:"script"`
+}
+
+type Script struct {
+	Compilations              int64 `json:"compilations"`
+	CacheEvictions            int64 `json:"cache_evictions"`
+	CompilationLimitTriggered int64 `json:"compilation_limit_triggered"`
+}
+
+type Ingest struct {
+	Total     IngestTotalStats                    `json:"total"`
+	Pipelines map[string]IngestPipelineTotalStats `json:"pipelines"`
+}
+
+type IngestTotalStats struct {
+	Count        int64 `json:"count"`
+	TimeInMillis int64 `json:"time_in_millis"`
+	Current      int64 `json:"current"`
+	Failed       int64 `json:"failed"`
+}
+
+type IngestPipelineTotalStats struct {
+	IngestTotalStats
+}
+
+type Discovery struct {
+	ClusterStateQueue       DiscoveryClusterStateQueue                                                       `json:"cluster_state_queue"`
+	SerializedClusterStates map[string]DiscoverySerializedClusterStatesStats                                 `json:"serialized_cluster_states"`
+	PublishedClusterStates  DiscoveryPublishedClusterStates                                                  `json:"published_cluster_states"`
+	ClusterStateUpdate      map[metadata.AttributeClusterStateUpdateType]DiscoveryClusterStateUpdateStatsAll `json:"cluster_state_update"`
+}
+
+type DiscoveryClusterStateQueue struct {
+	Total     int64 `json:"total"`
+	Pending   int64 `json:"pending"`
+	Committed int64 `json:"committed"`
+}
+
+type DiscoverySerializedClusterStatesStats struct {
+	Count                int64 `json:"count"`
+	UncompressedSizeInBy int64 `json:"uncompressed_size_in_bytes"`
+	CompressedSizeInBy   int64 `json:"compressed_size_in_bytes"`
+}
+
+type DiscoveryPublishedClusterStates struct {
+	FullStates        int64 `json:"full_states"`
+	IncompatibleDiffs int64 `json:"incompatible_diffs"`
+	CompatibleDiffs   int64 `json:"compatible_diffs"`
+}
+
+type DiscoveryClusterStateUpdateStatsBase struct {
+	Count                 int64 `json:"count"`
+	ComputationTimeMillis int64 `json:"computation_time_millis"`
+	PublicationTimeMillis int64 `json:"publication_time_millis"`
+}
+
+type DiscoveryClusterStateUpdateStatsAll struct {
+	DiscoveryClusterStateUpdateStatsBase
+
+	ContextConstructionTimeMillis int64 `json:"context_construction_time_millis"`
+	CommitTimeMillis              int64 `json:"commit_time_millis"`
+	CompletionTimeMillis          int64 `json:"completion_time_millis"`
+	MasterApplyTimeMillis         int64 `json:"master_apply_time_millis"`
+	NotificationTimeMillis        int64 `json:"notification_time_millis"`
+}
+
+type IndexingPressure struct {
+	Memory IndexingPressureMemory `json:"memory"`
+}
+
+type IndexingPressureMemory struct {
+	Current   IndexingPressureMemoryCurrentStats `json:"current"`
+	Total     IndexingPressureMemoryTotalStats   `json:"total"`
+	LimitInBy int64                              `json:"limit_in_bytes"`
+}
+
+type IndexingPressureMemoryCurrentStats struct {
+	IndexingPressureMemoryStats
+}
+
+type IndexingPressureMemoryTotalStats struct {
+	IndexingPressureMemoryStats
+	PrimaryRejections int64 `json:"primary_rejections"`
+	ReplicaRejections int64 `json:"replica_rejections"`
+}
+
+type IndexingPressureMemoryStats struct {
+	CombinedCoordinatingAndPrimaryInBy int64 `json:"combined_coordinating_and_primary_in_bytes"`
+	CoordinatingInBy                   int64 `json:"coordinating_in_bytes"`
+	PrimaryInBy                        int64 `json:"primary_in_bytes"`
+	ReplicaInBy                        int64 `json:"replica_in_bytes"`
+	AllInBy                            int64 `json:"all_in_bytes"`
 }
 
 type OSStats struct {

--- a/receiver/elasticsearchreceiver/internal/model/nodestats.go
+++ b/receiver/elasticsearchreceiver/internal/model/nodestats.go
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 package model // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver/internal/model"
-import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver/internal/metadata"
-)
 
 // NodeStats represents a response from elasticsearch's /_nodes/stats endpoint.
 // The struct is not exhaustive; It does not provide all values returned by elasticsearch,
@@ -66,10 +63,10 @@ type IngestPipelineTotalStats struct {
 }
 
 type Discovery struct {
-	ClusterStateQueue       DiscoveryClusterStateQueue                                                       `json:"cluster_state_queue"`
-	SerializedClusterStates map[string]DiscoverySerializedClusterStatesStats                                 `json:"serialized_cluster_states"`
-	PublishedClusterStates  DiscoveryPublishedClusterStates                                                  `json:"published_cluster_states"`
-	ClusterStateUpdate      map[metadata.AttributeClusterStateUpdateType]DiscoveryClusterStateUpdateStatsAll `json:"cluster_state_update"`
+	ClusterStateQueue       DiscoveryClusterStateQueue                       `json:"cluster_state_queue"`
+	SerializedClusterStates map[string]DiscoverySerializedClusterStatesStats `json:"serialized_cluster_states"`
+	PublishedClusterStates  DiscoveryPublishedClusterStates                  `json:"published_cluster_states"`
+	ClusterStateUpdate      map[string]DiscoveryClusterStateUpdateStatsAll   `json:"cluster_state_update"`
 }
 
 type DiscoveryClusterStateQueue struct {

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -90,6 +90,22 @@ attributes:
     enum:
       - free
       - used
+  indexing_memory_state:
+    value: state
+    description: State of the indexing memory
+    enum:
+      - current
+      - total
+  cluster_state_update_type:
+    value: status
+    description: Type of cluster state update
+    enum:
+      - unchanged
+      - success
+      - failure
+  ingest_pipeline_name:
+    value: name
+    description: Name of the ingest pipeline.
 metrics:
   # these metrics are from /_nodes/stats, and are node level metrics
   elasticsearch.breaker.memory.estimated:
@@ -483,9 +499,228 @@ metrics:
   elasticsearch.os.memory:
     description: Amount of physical memory.
     unit: By
+    gauge:
+      value_type: int
+    attributes: [memory_state]
+    enabled: true
+  elasticsearch.indexing_pressure.memory.coordinating:
+    description: Memory consumed, in bytes, by indexing requests in the coordinating stage.
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.indexing_pressure.memory.primary:
+    description: Memory consumed, in bytes, by indexing requests in the primary stage.
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.indexing_pressure.memory.replica:
+    description: Memory consumed, in bytes, by indexing requests in the primary stage.
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.indexing_pressure.memory.total.primary_rejections:
+    description: Cumulative number of indexing requests rejected in the primary stage.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.indexing_pressure.memory.total.replica_rejections:
+    description: Number of indexing requests rejected in the replica stage.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.indexing_pressure.memory.limit:
+    description: Configured memory limit, in bytes, for the indexing requests.
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.cluster.state_queue.pending:
+    description: Number of pending cluster states in queue.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.cluster.state_queue.committed:
+    description: Number of pending cluster states in queue.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.cluster.published_states.full:
+    description: Number of published cluster states.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.cluster.published_states.incompatible:
+    description: Number of incompatible differences between published cluster states.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.cluster.published_states.compatible:
+    description: Number of compatible differences between published cluster states.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.cluster.state_update.count:
+    description: The number of cluster state update attempts that changed the cluster state since the node started.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ cluster_state_update_type ]
+    enabled: true
+  elasticsearch.node.cluster.state_update.computation_time:
+    description: The cumulative amount of time spent computing cluster state updates since the node started.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ cluster_state_update_type ]
+    enabled: true
+  elasticsearch.node.cluster.state_update.context_construction_time:
+    description: The cumulative amount of time spent constructing a publication context since the node started.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ cluster_state_update_type ]
+    enabled: true
+  elasticsearch.node.cluster.state_update.commit_time:
+    description: The cumulative amount of time spent waiting for a cluster state update to commit.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ cluster_state_update_type ]
+    enabled: true
+  elasticsearch.node.cluster.state_update.completion_time:
+    description: The cumulative amount of time spent waiting for a cluster state update to complete.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ cluster_state_update_type ]
+    enabled: true
+  elasticsearch.node.cluster.state_update.master_apply_time:
+    description: The cumulative amount of time spent applying cluster state updates on the elected master since the node started.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ cluster_state_update_type ]
+    enabled: true
+  elasticsearch.node.cluster.state_update.notification_time:
+    description: The cumulative amount of time spent notifying listeners of a cluster state update since the node started.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ cluster_state_update_type ]
+    enabled: true
+  elasticsearch.node.ingest.count:
+    description: Total number of documents ingested during the lifetime of this node.
+    unit: "{documents}"
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.ingest.current:
+    description: Total number of documents currently being ingested.
+    unit: "{documents}"
+    gauge:
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.ingest.failed:
+    description: Total number of failed ingest operations during the lifetime of this node.
+    unit: "{operation}"
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.ingest.pipeline.count:
+    description: Total number of documents ingested during the lifetime of this node.
+    unit: "{documents}"
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ingest_pipeline_name ]
+    enabled: true
+  elasticsearch.node.ingest.pipeline.failed:
+    description: Total number of failed operations for the ingest pipeline.
+    unit: "{operation}"
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ingest_pipeline_name ]
+    enabled: true
+  elasticsearch.node.ingest.pipeline.current:
+    description: Total number of documents currently being ingested by a pipeline.
+    unit: "{documents}"
+    gauge:
+      value_type: int
+    attributes: [ ingest_pipeline_name ]
+    enabled: true
+  elasticsearch.node.script.compilations:
+    description: Total number of inline script compilations performed by the node.
+    unit: "{compilations}"
     sum:
       monotonic: false
       aggregation: cumulative
       value_type: int
-    attributes: [memory_state]
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.script.cache_evictions:
+    description: Total number of times the script cache has evicted old data.
+    unit: 1
+    sum:
+      monotonic: false
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.script.compilation_limit_triggered:
+    description: Total number of times the script compilation circuit breaker has limited inline script compilations.
+    unit: 1
+    sum:
+      monotonic: false
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ]
     enabled: true

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -694,7 +694,9 @@ metrics:
   elasticsearch.node.pipeline.ingest.documents.current:
     description: Total number of documents currently being ingested by a pipeline.
     unit: "{documents}"
-    gauge:
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
     attributes: [ ingest_pipeline_name ]
     enabled: true

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -115,13 +115,19 @@ attributes:
       - coordinating
       - primary
       - replica
+  cluster_state_update_state:
+    value: state
+    description: State of cluster state update
   cluster_state_update_type:
-    value: status
+    value: type
     description: Type of cluster state update
     enum:
-      - unchanged
-      - success
-      - failure
+      - computation
+      - context_construction
+      - commit
+      - completion
+      - master_apply
+      - notification
   ingest_pipeline_name:
     value: name
     description: Name of the ingest pipeline.
@@ -590,61 +596,16 @@ metrics:
       monotonic: true
       aggregation: cumulative
       value_type: int
-    attributes: [ cluster_state_update_type ]
+    attributes: [ cluster_state_update_state ]
     enabled: true
-  elasticsearch.cluster.state_update.computation_time:
-    description: The cumulative amount of time spent computing cluster state updates since the node started.
-    unit: 1
+  elasticsearch.cluster.state_update.time:
+    description: The cumulative amount of time updating the cluster state since the node started.
+    unit: ms
     sum:
       monotonic: true
       aggregation: cumulative
       value_type: int
-    attributes: [ cluster_state_update_type ]
-    enabled: true
-  elasticsearch.cluster.state_update.context_construction_time:
-    description: The cumulative amount of time spent constructing a publication context since the node started.
-    unit: 1
-    sum:
-      monotonic: true
-      aggregation: cumulative
-      value_type: int
-    attributes: [ cluster_state_update_type ]
-    enabled: true
-  elasticsearch.cluster.state_update.commit_time:
-    description: The cumulative amount of time spent waiting for a cluster state update to commit.
-    unit: 1
-    sum:
-      monotonic: true
-      aggregation: cumulative
-      value_type: int
-    attributes: [ cluster_state_update_type ]
-    enabled: true
-  elasticsearch.cluster.state_update.completion_time:
-    description: The cumulative amount of time spent waiting for a cluster state update to complete.
-    unit: 1
-    sum:
-      monotonic: true
-      aggregation: cumulative
-      value_type: int
-    attributes: [ cluster_state_update_type ]
-    enabled: true
-  elasticsearch.cluster.state_update.master_apply_time:
-    description: The cumulative amount of time spent applying cluster state updates on the elected master since the node started.
-    unit: 1
-    sum:
-      monotonic: true
-      aggregation: cumulative
-      value_type: int
-    attributes: [ cluster_state_update_type ]
-    enabled: true
-  elasticsearch.cluster.state_update.notification_time:
-    description: The cumulative amount of time spent notifying listeners of a cluster state update since the node started.
-    unit: 1
-    sum:
-      monotonic: true
-      aggregation: cumulative
-      value_type: int
-    attributes: [ cluster_state_update_type ]
+    attributes: [ cluster_state_update_state, cluster_state_update_type ]
     enabled: true
   elasticsearch.node.ingest.documents:
     description: Total number of documents ingested during the lifetime of this node.

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -96,6 +96,25 @@ attributes:
     enum:
       - current
       - total
+  cluster_published_difference_state:
+    value: state
+    description: State of the published differences
+    enum:
+      - incompatible
+      - compatible
+  cluster_state_queue_state:
+    value: state
+    description: State of the published differences
+    enum:
+      - pending
+      - committed
+  indexing_pressure_stage:
+    value: stage
+    description: Stage of the indexing pressure
+    enum:
+      - coordinating
+      - primary
+      - replica
   cluster_state_update_type:
     value: status
     description: Type of cluster state update
@@ -503,26 +522,14 @@ metrics:
       value_type: int
     attributes: [memory_state]
     enabled: true
-  elasticsearch.indexing_pressure.memory.coordinating:
-    description: Memory consumed, in bytes, by indexing requests in the coordinating stage.
+  elasticsearch.memory.indexing_pressure:
+    description: Memory consumed, in bytes, by indexing requests in the specified stage.
     unit: By
-    gauge:
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-    attributes: []
-    enabled: true
-  elasticsearch.indexing_pressure.memory.primary:
-    description: Memory consumed, in bytes, by indexing requests in the primary stage.
-    unit: By
-    gauge:
-      value_type: int
-    attributes: []
-    enabled: true
-  elasticsearch.indexing_pressure.memory.replica:
-    description: Memory consumed, in bytes, by indexing requests in the primary stage.
-    unit: By
-    gauge:
-      value_type: int
-    attributes: []
+    attributes: [  indexing_pressure_stage ]
     enabled: true
   elasticsearch.indexing_pressure.memory.total.primary_rejections:
     description: Cumulative number of indexing requests rejected in the primary stage.
@@ -549,42 +556,34 @@ metrics:
       value_type: int
     attributes: [ ]
     enabled: true
-  elasticsearch.node.cluster.state_queue.pending:
-    description: Number of pending cluster states in queue.
+  elasticsearch.cluster.state_queue:
+    description: Number of cluster states in queue.
     unit: 1
-    gauge:
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-    attributes: [ ]
+    attributes: [ cluster_state_queue_state ]
     enabled: true
-  elasticsearch.node.cluster.state_queue.committed:
-    description: Number of pending cluster states in queue.
-    unit: 1
-    gauge:
-      value_type: int
-    attributes: [ ]
-    enabled: true
-  elasticsearch.node.cluster.published_states.full:
+  elasticsearch.cluster.published_states.full:
     description: Number of published cluster states.
     unit: 1
-    gauge:
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
-  elasticsearch.node.cluster.published_states.incompatible:
-    description: Number of incompatible differences between published cluster states.
+  elasticsearch.cluster.published_states.differences:
+    description: Number of differences between published cluster states.
     unit: 1
-    gauge:
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-    attributes: [ ]
+    attributes: [ cluster_published_difference_state ]
     enabled: true
-  elasticsearch.node.cluster.published_states.compatible:
-    description: Number of compatible differences between published cluster states.
-    unit: 1
-    gauge:
-      value_type: int
-    attributes: [ ]
-    enabled: true
-  elasticsearch.node.cluster.state_update.count:
+  elasticsearch.cluster.state_update.count:
     description: The number of cluster state update attempts that changed the cluster state since the node started.
     unit: 1
     sum:
@@ -593,7 +592,7 @@ metrics:
       value_type: int
     attributes: [ cluster_state_update_type ]
     enabled: true
-  elasticsearch.node.cluster.state_update.computation_time:
+  elasticsearch.cluster.state_update.computation_time:
     description: The cumulative amount of time spent computing cluster state updates since the node started.
     unit: 1
     sum:
@@ -602,7 +601,7 @@ metrics:
       value_type: int
     attributes: [ cluster_state_update_type ]
     enabled: true
-  elasticsearch.node.cluster.state_update.context_construction_time:
+  elasticsearch.cluster.state_update.context_construction_time:
     description: The cumulative amount of time spent constructing a publication context since the node started.
     unit: 1
     sum:
@@ -611,7 +610,7 @@ metrics:
       value_type: int
     attributes: [ cluster_state_update_type ]
     enabled: true
-  elasticsearch.node.cluster.state_update.commit_time:
+  elasticsearch.cluster.state_update.commit_time:
     description: The cumulative amount of time spent waiting for a cluster state update to commit.
     unit: 1
     sum:
@@ -620,7 +619,7 @@ metrics:
       value_type: int
     attributes: [ cluster_state_update_type ]
     enabled: true
-  elasticsearch.node.cluster.state_update.completion_time:
+  elasticsearch.cluster.state_update.completion_time:
     description: The cumulative amount of time spent waiting for a cluster state update to complete.
     unit: 1
     sum:
@@ -629,7 +628,7 @@ metrics:
       value_type: int
     attributes: [ cluster_state_update_type ]
     enabled: true
-  elasticsearch.node.cluster.state_update.master_apply_time:
+  elasticsearch.cluster.state_update.master_apply_time:
     description: The cumulative amount of time spent applying cluster state updates on the elected master since the node started.
     unit: 1
     sum:
@@ -638,7 +637,7 @@ metrics:
       value_type: int
     attributes: [ cluster_state_update_type ]
     enabled: true
-  elasticsearch.node.cluster.state_update.notification_time:
+  elasticsearch.cluster.state_update.notification_time:
     description: The cumulative amount of time spent notifying listeners of a cluster state update since the node started.
     unit: 1
     sum:
@@ -647,7 +646,7 @@ metrics:
       value_type: int
     attributes: [ cluster_state_update_type ]
     enabled: true
-  elasticsearch.node.ingest.count:
+  elasticsearch.node.ingest.documents:
     description: Total number of documents ingested during the lifetime of this node.
     unit: "{documents}"
     sum:
@@ -656,14 +655,16 @@ metrics:
       value_type: int
     attributes: [ ]
     enabled: true
-  elasticsearch.node.ingest.current:
+  elasticsearch.node.ingest.documents.current:
     description: Total number of documents currently being ingested.
     unit: "{documents}"
-    gauge:
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
-  elasticsearch.node.ingest.failed:
+  elasticsearch.node.ingest.operations.failed:
     description: Total number of failed ingest operations during the lifetime of this node.
     unit: "{operation}"
     sum:
@@ -672,16 +673,16 @@ metrics:
       value_type: int
     attributes: [ ]
     enabled: true
-  elasticsearch.node.ingest.pipeline.count:
-    description: Total number of documents ingested during the lifetime of this node.
+  elasticsearch.node.pipeline.ingest.documents.preprocessed:
+    description: Number of documents preprocessed by the ingest pipeline.
     unit: "{documents}"
     sum:
-      monotonic: true
+      monotonic: false
       aggregation: cumulative
       value_type: int
     attributes: [ ingest_pipeline_name ]
     enabled: true
-  elasticsearch.node.ingest.pipeline.failed:
+  elasticsearch.node.pipeline.ingest.operations.failed:
     description: Total number of failed operations for the ingest pipeline.
     unit: "{operation}"
     sum:
@@ -690,7 +691,7 @@ metrics:
       value_type: int
     attributes: [ ingest_pipeline_name ]
     enabled: true
-  elasticsearch.node.ingest.pipeline.current:
+  elasticsearch.node.pipeline.ingest.documents.current:
     description: Total number of documents currently being ingested by a pipeline.
     unit: "{documents}"
     gauge:
@@ -710,7 +711,7 @@ metrics:
     description: Total number of times the script cache has evicted old data.
     unit: 1
     sum:
-      monotonic: false
+      monotonic: true
       aggregation: cumulative
       value_type: int
     attributes: [ ]
@@ -719,7 +720,7 @@ metrics:
     description: Total number of times the script compilation circuit breaker has limited inline script compilations.
     unit: 1
     sum:
-      monotonic: false
+      monotonic: true
       aggregation: cumulative
       value_type: int
     attributes: [ ]

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -226,40 +226,40 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordJvmThreadsCountDataPoint(now, info.JVMInfo.JVMThreadInfo.Count)
 
 		r.mb.RecordElasticsearchIndexingPressureMemoryLimitDataPoint(now, info.IndexingPressure.Memory.LimitInBy)
-		r.mb.RecordElasticsearchIndexingPressureMemoryPrimaryDataPoint(now, info.IndexingPressure.Memory.Current.PrimaryInBy)
-		r.mb.RecordElasticsearchIndexingPressureMemoryCoordinatingDataPoint(now, info.IndexingPressure.Memory.Current.CoordinatingInBy)
-		r.mb.RecordElasticsearchIndexingPressureMemoryReplicaDataPoint(now, info.IndexingPressure.Memory.Current.ReplicaInBy)
+		r.mb.RecordElasticsearchMemoryIndexingPressureDataPoint(now, info.IndexingPressure.Memory.Current.PrimaryInBy, metadata.AttributeIndexingPressureStagePrimary)
+		r.mb.RecordElasticsearchMemoryIndexingPressureDataPoint(now, info.IndexingPressure.Memory.Current.CoordinatingInBy, metadata.AttributeIndexingPressureStageCoordinating)
+		r.mb.RecordElasticsearchMemoryIndexingPressureDataPoint(now, info.IndexingPressure.Memory.Current.ReplicaInBy, metadata.AttributeIndexingPressureStageReplica)
 		r.mb.RecordElasticsearchIndexingPressureMemoryTotalPrimaryRejectionsDataPoint(now, info.IndexingPressure.Memory.Total.PrimaryRejections)
 		r.mb.RecordElasticsearchIndexingPressureMemoryTotalReplicaRejectionsDataPoint(now, info.IndexingPressure.Memory.Total.ReplicaRejections)
 
-		r.mb.RecordElasticsearchNodeClusterStateQueueCommittedDataPoint(now, info.Discovery.ClusterStateQueue.Committed)
-		r.mb.RecordElasticsearchNodeClusterStateQueuePendingDataPoint(now, info.Discovery.ClusterStateQueue.Pending)
+		r.mb.RecordElasticsearchClusterStateQueueDataPoint(now, info.Discovery.ClusterStateQueue.Committed, metadata.AttributeClusterStateQueueStateCommitted)
+		r.mb.RecordElasticsearchClusterStateQueueDataPoint(now, info.Discovery.ClusterStateQueue.Committed, metadata.AttributeClusterStateQueueStatePending)
 
-		r.mb.RecordElasticsearchNodeClusterPublishedStatesCompatibleDataPoint(now, info.Discovery.PublishedClusterStates.CompatibleDiffs)
-		r.mb.RecordElasticsearchNodeClusterPublishedStatesIncompatibleDataPoint(now, info.Discovery.PublishedClusterStates.IncompatibleDiffs)
-		r.mb.RecordElasticsearchNodeClusterPublishedStatesFullDataPoint(now, info.Discovery.PublishedClusterStates.FullStates)
+		r.mb.RecordElasticsearchClusterPublishedStatesFullDataPoint(now, info.Discovery.PublishedClusterStates.FullStates)
+		r.mb.RecordElasticsearchClusterPublishedStatesDifferencesDataPoint(now, info.Discovery.PublishedClusterStates.CompatibleDiffs, metadata.AttributeClusterPublishedDifferenceStateCompatible)
+		r.mb.RecordElasticsearchClusterPublishedStatesDifferencesDataPoint(now, info.Discovery.PublishedClusterStates.IncompatibleDiffs, metadata.AttributeClusterPublishedDifferenceStateIncompatible)
 
 		for csuName, csuInfo := range info.Discovery.ClusterStateUpdate {
-			r.mb.RecordElasticsearchNodeClusterStateUpdateCountDataPoint(now, csuInfo.Count, csuName)
-			r.mb.RecordElasticsearchNodeClusterStateUpdateComputationTimeDataPoint(now, csuInfo.ComputationTimeMillis, csuName)
-			r.mb.RecordElasticsearchNodeClusterStateUpdateNotificationTimeDataPoint(now, csuInfo.NotificationTimeMillis, csuName)
+			r.mb.RecordElasticsearchClusterStateUpdateCountDataPoint(now, csuInfo.Count, csuName)
+			r.mb.RecordElasticsearchClusterStateUpdateComputationTimeDataPoint(now, csuInfo.ComputationTimeMillis, csuName)
+			r.mb.RecordElasticsearchClusterStateUpdateNotificationTimeDataPoint(now, csuInfo.NotificationTimeMillis, csuName)
 
 			if csuName != metadata.AttributeClusterStateUpdateTypeUnchanged {
-				r.mb.RecordElasticsearchNodeClusterStateUpdateContextConstructionTimeDataPoint(now, csuInfo.ContextConstructionTimeMillis, csuName)
-				r.mb.RecordElasticsearchNodeClusterStateUpdateCommitTimeDataPoint(now, csuInfo.CommitTimeMillis, csuName)
-				r.mb.RecordElasticsearchNodeClusterStateUpdateCompletionTimeDataPoint(now, csuInfo.CompletionTimeMillis, csuName)
-				r.mb.RecordElasticsearchNodeClusterStateUpdateMasterApplyTimeDataPoint(now, csuInfo.MasterApplyTimeMillis, csuName)
+				r.mb.RecordElasticsearchClusterStateUpdateContextConstructionTimeDataPoint(now, csuInfo.ContextConstructionTimeMillis, csuName)
+				r.mb.RecordElasticsearchClusterStateUpdateCommitTimeDataPoint(now, csuInfo.CommitTimeMillis, csuName)
+				r.mb.RecordElasticsearchClusterStateUpdateCompletionTimeDataPoint(now, csuInfo.CompletionTimeMillis, csuName)
+				r.mb.RecordElasticsearchClusterStateUpdateMasterApplyTimeDataPoint(now, csuInfo.MasterApplyTimeMillis, csuName)
 			}
 		}
 
-		r.mb.RecordElasticsearchNodeIngestCountDataPoint(now, info.Ingest.Total.Count)
-		r.mb.RecordElasticsearchNodeIngestCurrentDataPoint(now, info.Ingest.Total.Current)
-		r.mb.RecordElasticsearchNodeIngestFailedDataPoint(now, info.Ingest.Total.Failed)
+		r.mb.RecordElasticsearchNodeIngestDocumentsDataPoint(now, info.Ingest.Total.Count)
+		r.mb.RecordElasticsearchNodeIngestDocumentsCurrentDataPoint(now, info.Ingest.Total.Current)
+		r.mb.RecordElasticsearchNodeIngestOperationsFailedDataPoint(now, info.Ingest.Total.Failed)
 
 		for ipName, ipInfo := range info.Ingest.Pipelines {
-			r.mb.RecordElasticsearchNodeIngestPipelineCountDataPoint(now, ipInfo.Count, ipName)
-			r.mb.RecordElasticsearchNodeIngestPipelineFailedDataPoint(now, ipInfo.Failed, ipName)
-			r.mb.RecordElasticsearchNodeIngestPipelineCurrentDataPoint(now, ipInfo.Current, ipName)
+			r.mb.RecordElasticsearchNodePipelineIngestDocumentsPreprocessedDataPoint(now, ipInfo.Count, ipName)
+			r.mb.RecordElasticsearchNodePipelineIngestOperationsFailedDataPoint(now, ipInfo.Failed, ipName)
+			r.mb.RecordElasticsearchNodePipelineIngestDocumentsCurrentDataPoint(now, ipInfo.Current, ipName)
 		}
 
 		r.mb.RecordElasticsearchNodeScriptCacheEvictionsDataPoint(now, info.Script.CacheEvictions)

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -239,17 +239,14 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordElasticsearchClusterPublishedStatesDifferencesDataPoint(now, info.Discovery.PublishedClusterStates.CompatibleDiffs, metadata.AttributeClusterPublishedDifferenceStateCompatible)
 		r.mb.RecordElasticsearchClusterPublishedStatesDifferencesDataPoint(now, info.Discovery.PublishedClusterStates.IncompatibleDiffs, metadata.AttributeClusterPublishedDifferenceStateIncompatible)
 
-		for csuName, csuInfo := range info.Discovery.ClusterStateUpdate {
-			r.mb.RecordElasticsearchClusterStateUpdateCountDataPoint(now, csuInfo.Count, csuName)
-			r.mb.RecordElasticsearchClusterStateUpdateComputationTimeDataPoint(now, csuInfo.ComputationTimeMillis, csuName)
-			r.mb.RecordElasticsearchClusterStateUpdateNotificationTimeDataPoint(now, csuInfo.NotificationTimeMillis, csuName)
-
-			if csuName != metadata.AttributeClusterStateUpdateTypeUnchanged {
-				r.mb.RecordElasticsearchClusterStateUpdateContextConstructionTimeDataPoint(now, csuInfo.ContextConstructionTimeMillis, csuName)
-				r.mb.RecordElasticsearchClusterStateUpdateCommitTimeDataPoint(now, csuInfo.CommitTimeMillis, csuName)
-				r.mb.RecordElasticsearchClusterStateUpdateCompletionTimeDataPoint(now, csuInfo.CompletionTimeMillis, csuName)
-				r.mb.RecordElasticsearchClusterStateUpdateMasterApplyTimeDataPoint(now, csuInfo.MasterApplyTimeMillis, csuName)
-			}
+		for cusState, csuInfo := range info.Discovery.ClusterStateUpdate {
+			r.mb.RecordElasticsearchClusterStateUpdateCountDataPoint(now, csuInfo.Count, cusState)
+			r.mb.RecordElasticsearchClusterStateUpdateTimeDataPoint(now, csuInfo.ComputationTimeMillis, cusState, metadata.AttributeClusterStateUpdateTypeComputation)
+			r.mb.RecordElasticsearchClusterStateUpdateTimeDataPoint(now, csuInfo.NotificationTimeMillis, cusState, metadata.AttributeClusterStateUpdateTypeNotification)
+			r.mb.RecordElasticsearchClusterStateUpdateTimeDataPoint(now, csuInfo.ContextConstructionTimeMillis, cusState, metadata.AttributeClusterStateUpdateTypeContextConstruction)
+			r.mb.RecordElasticsearchClusterStateUpdateTimeDataPoint(now, csuInfo.CommitTimeMillis, cusState, metadata.AttributeClusterStateUpdateTypeCommit)
+			r.mb.RecordElasticsearchClusterStateUpdateTimeDataPoint(now, csuInfo.CompletionTimeMillis, cusState, metadata.AttributeClusterStateUpdateTypeCompletion)
+			r.mb.RecordElasticsearchClusterStateUpdateTimeDataPoint(now, csuInfo.MasterApplyTimeMillis, cusState, metadata.AttributeClusterStateUpdateTypeMasterApply)
 		}
 
 		r.mb.RecordElasticsearchNodeIngestDocumentsDataPoint(now, info.Ingest.Total.Count)

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -225,6 +225,47 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 
 		r.mb.RecordJvmThreadsCountDataPoint(now, info.JVMInfo.JVMThreadInfo.Count)
 
+		r.mb.RecordElasticsearchIndexingPressureMemoryLimitDataPoint(now, info.IndexingPressure.Memory.LimitInBy)
+		r.mb.RecordElasticsearchIndexingPressureMemoryPrimaryDataPoint(now, info.IndexingPressure.Memory.Current.PrimaryInBy)
+		r.mb.RecordElasticsearchIndexingPressureMemoryCoordinatingDataPoint(now, info.IndexingPressure.Memory.Current.CoordinatingInBy)
+		r.mb.RecordElasticsearchIndexingPressureMemoryReplicaDataPoint(now, info.IndexingPressure.Memory.Current.ReplicaInBy)
+		r.mb.RecordElasticsearchIndexingPressureMemoryTotalPrimaryRejectionsDataPoint(now, info.IndexingPressure.Memory.Total.PrimaryRejections)
+		r.mb.RecordElasticsearchIndexingPressureMemoryTotalReplicaRejectionsDataPoint(now, info.IndexingPressure.Memory.Total.ReplicaRejections)
+
+		r.mb.RecordElasticsearchNodeClusterStateQueueCommittedDataPoint(now, info.Discovery.ClusterStateQueue.Committed)
+		r.mb.RecordElasticsearchNodeClusterStateQueuePendingDataPoint(now, info.Discovery.ClusterStateQueue.Pending)
+
+		r.mb.RecordElasticsearchNodeClusterPublishedStatesCompatibleDataPoint(now, info.Discovery.PublishedClusterStates.CompatibleDiffs)
+		r.mb.RecordElasticsearchNodeClusterPublishedStatesIncompatibleDataPoint(now, info.Discovery.PublishedClusterStates.IncompatibleDiffs)
+		r.mb.RecordElasticsearchNodeClusterPublishedStatesFullDataPoint(now, info.Discovery.PublishedClusterStates.FullStates)
+
+		for csuName, csuInfo := range info.Discovery.ClusterStateUpdate {
+			r.mb.RecordElasticsearchNodeClusterStateUpdateCountDataPoint(now, csuInfo.Count, csuName)
+			r.mb.RecordElasticsearchNodeClusterStateUpdateComputationTimeDataPoint(now, csuInfo.ComputationTimeMillis, csuName)
+			r.mb.RecordElasticsearchNodeClusterStateUpdateNotificationTimeDataPoint(now, csuInfo.NotificationTimeMillis, csuName)
+
+			if csuName != metadata.AttributeClusterStateUpdateTypeUnchanged {
+				r.mb.RecordElasticsearchNodeClusterStateUpdateContextConstructionTimeDataPoint(now, csuInfo.ContextConstructionTimeMillis, csuName)
+				r.mb.RecordElasticsearchNodeClusterStateUpdateCommitTimeDataPoint(now, csuInfo.CommitTimeMillis, csuName)
+				r.mb.RecordElasticsearchNodeClusterStateUpdateCompletionTimeDataPoint(now, csuInfo.CompletionTimeMillis, csuName)
+				r.mb.RecordElasticsearchNodeClusterStateUpdateMasterApplyTimeDataPoint(now, csuInfo.MasterApplyTimeMillis, csuName)
+			}
+		}
+
+		r.mb.RecordElasticsearchNodeIngestCountDataPoint(now, info.Ingest.Total.Count)
+		r.mb.RecordElasticsearchNodeIngestCurrentDataPoint(now, info.Ingest.Total.Current)
+		r.mb.RecordElasticsearchNodeIngestFailedDataPoint(now, info.Ingest.Total.Failed)
+
+		for ipName, ipInfo := range info.Ingest.Pipelines {
+			r.mb.RecordElasticsearchNodeIngestPipelineCountDataPoint(now, ipInfo.Count, ipName)
+			r.mb.RecordElasticsearchNodeIngestPipelineFailedDataPoint(now, ipInfo.Failed, ipName)
+			r.mb.RecordElasticsearchNodeIngestPipelineCurrentDataPoint(now, ipInfo.Current, ipName)
+		}
+
+		r.mb.RecordElasticsearchNodeScriptCacheEvictionsDataPoint(now, info.Script.CacheEvictions)
+		r.mb.RecordElasticsearchNodeScriptCompilationsDataPoint(now, info.Script.Compilations)
+		r.mb.RecordElasticsearchNodeScriptCompilationLimitTriggeredDataPoint(now, info.Script.CompilationLimitTriggered)
+
 		r.mb.EmitForResource(metadata.WithElasticsearchClusterName(nodeStats.ClusterName),
 			metadata.WithElasticsearchNodeName(info.Name))
 	}

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
@@ -25,58 +25,6 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "fielddata"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "in_flight_requests"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "model_inference"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
                               "asInt": "305152000",
                               "attributes": [
                                  {
@@ -86,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -99,8 +47,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "fielddata"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "in_flight_requests"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "model_inference"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -114,58 +114,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "214748364",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "fielddata"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "536870912",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "in_flight_requests"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "268435456",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "model_inference"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "536870912",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
                               "asInt": "510027366",
                               "attributes": [
                                  {
@@ -175,8 +123,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "322122547",
@@ -188,8 +136,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "214748364",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "fielddata"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "536870912",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "in_flight_requests"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "268435456",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "model_inference"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "536870912",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -207,64 +207,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "fielddata"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "in_flight_requests"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "model_inference"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
                                        "stringValue": "parent"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -276,8 +224,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "fielddata"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "in_flight_requests"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "model_inference"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -300,8 +300,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -313,8 +313,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -328,8 +328,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -351,8 +351,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -364,12 +364,415 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
                      "unit": "1"
+                  },
+                  {
+                     "description": "The number of cluster state update attempts that changed the cluster state since the node started.",
+                     "name": "elasticsearch.cluster.state_update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "7",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The cumulative amount of time updating the cluster state since the node started.",
+                     "name": "elasticsearch.cluster.state_update.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "7",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "40",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "17",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "113",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "117",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "484",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
                   },
                   {
                      "description": "Configured memory limit, in bytes, for the indexing requests.",
@@ -377,8 +780,8 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -393,8 +796,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -409,8 +812,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -433,8 +836,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -446,8 +849,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -459,8 +862,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -482,8 +885,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "938",
@@ -495,8 +898,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -519,8 +922,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "394",
@@ -532,8 +935,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -547,8 +950,8 @@
                         "dataPoints": [
                            {
                               "asInt": "100",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -570,8 +973,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "157732",
@@ -583,8 +986,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -599,8 +1002,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1617780",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -614,8 +1017,8 @@
                         "dataPoints": [
                            {
                               "asInt": "602016",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -637,8 +1040,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "200",
@@ -650,8 +1053,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -665,8 +1068,8 @@
                         "dataPoints": [
                            {
                               "asInt": "12293464064",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -680,8 +1083,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -695,8 +1098,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -711,8 +1114,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -726,8 +1129,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -742,8 +1145,8 @@
                         "dataPoints": [
                            {
                               "asInt": "270",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -765,8 +1168,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "400",
@@ -778,8 +1181,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "600",
@@ -791,8 +1194,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "124",
@@ -804,8 +1207,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "234",
@@ -817,8 +1220,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "235",
@@ -830,8 +1233,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "5234",
@@ -843,8 +1246,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "5234",
@@ -856,8 +1259,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "958",
@@ -869,8 +1272,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "345",
@@ -882,8 +1285,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -895,8 +1298,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -919,8 +1322,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "500",
@@ -932,8 +1335,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "500",
@@ -945,8 +1348,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "2354",
@@ -958,8 +1361,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "256",
@@ -971,8 +1374,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "5234",
@@ -984,8 +1387,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "2342",
@@ -997,8 +1400,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "25345",
@@ -1010,8 +1413,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "544",
@@ -1023,8 +1426,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "995",
@@ -1036,8 +1439,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "664",
@@ -1049,8 +1452,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -1073,8 +1476,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -1086,8 +1489,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1109,8 +1512,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -1122,8 +1525,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1145,8 +1548,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "0",
@@ -1158,8 +1561,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -1174,8 +1577,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -1190,8 +1593,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -1206,8 +1609,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1221,8 +1624,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1236,8 +1639,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1251,8 +1654,8 @@
                         "dataPoints": [
                            {
                               "asInt": "300",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1280,8 +1683,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "4",
@@ -1299,8 +1702,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -1323,8 +1726,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1352,8 +1755,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "-2",
@@ -1371,8 +1774,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1386,8 +1789,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -1402,8 +1805,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1417,8 +1820,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1430,8 +1833,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1444,8 +1847,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1458,8 +1861,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1472,8 +1875,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1494,8 +1897,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "294109184",
@@ -1507,8 +1910,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1521,8 +1924,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20695",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1545,8 +1948,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "10",
@@ -1558,8 +1961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -1582,8 +1985,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "5",
@@ -1595,8 +1998,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ],
                         "isMonotonic": true
@@ -1609,8 +2012,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1623,8 +2026,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1637,8 +2040,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305152000",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1651,8 +2054,8 @@
                         "dataPoints": [
                            {
                               "asInt": "131792896",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1665,8 +2068,8 @@
                         "dataPoints": [
                            {
                               "asInt": "128825192",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1687,8 +2090,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "736870912",
@@ -1700,8 +2103,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "536870912",
@@ -1713,8 +2116,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1735,8 +2138,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "10485760",
@@ -1748,8 +2151,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            },
                            {
                               "asInt": "76562432",
@@ -1761,8 +2164,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },
@@ -1775,8 +2178,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1661327548460643000",
-                              "timeUnixNano": "1661327548472169000"
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
                            }
                         ]
                      },

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
@@ -1,12 +1,24 @@
 {
    "resourceMetrics": [
       {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "elasticsearch.cluster.name",
+                  "value": {
+                     "stringValue": "docker-cluster"
+                  }
+               },
+               {
+                  "key": "elasticsearch.node.name",
+                  "value": {
+                     "stringValue": "917e13e55eed"
+                  }
+               }
+            ]
+         },
          "scopeMetrics": [
             {
-               "scope": {
-                  "name": "otelcol/elasticsearchreceiver",
-                  "version": "latest"
-               },
                "metrics": [
                   {
                      "description": "Estimated memory used for the operation.",
@@ -22,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -35,8 +47,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -48,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -61,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -74,8 +86,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "305152000",
@@ -87,8 +99,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -97,6 +109,7 @@
                   },
                   {
                      "description": "Memory limit for the circuit breaker.",
+                     "name": "elasticsearch.breaker.memory.limit",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -110,8 +123,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "214748364",
@@ -123,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "536870912",
@@ -136,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "268435456",
@@ -149,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "536870912",
@@ -162,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "510027366",
@@ -175,17 +188,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
-                        ],
-                        "isMonotonic": false
+                        ]
                      },
-                     "name": "elasticsearch.breaker.memory.limit",
                      "unit": "By"
                   },
                   {
                      "description": "Total number of times the circuit breaker has been triggered and prevented an out of memory error.",
+                     "name": "elasticsearch.breaker.tripped",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -199,8 +211,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -212,8 +224,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -225,8 +237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -238,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -251,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -264,13 +276,100 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "name": "elasticsearch.breaker.tripped",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the coordinating stage.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.coordinating",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Configured memory limit, in bytes, for the indexing requests.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "53687091",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.limit",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.primary",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.replica",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Cumulative number of indexing requests rejected in the primary stage.",
+                     "name": "elasticsearch.indexing_pressure.memory.total.primary_rejections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of indexing requests rejected in the replica stage.",
+                     "name": "elasticsearch.indexing_pressure.memory.total.replica_rejections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
                      "unit": "1"
                   },
                   {
@@ -289,8 +388,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "938",
@@ -302,8 +401,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ],
                         "isMonotonic": true
@@ -326,8 +425,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "394",
@@ -339,8 +438,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -354,8 +453,8 @@
                         "dataPoints": [
                            {
                               "asInt": "100",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -377,8 +476,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "157732",
@@ -390,11 +489,111 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ],
                         "isMonotonic": true
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Number of compatible differences between published cluster states.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.published_states.compatible",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of published cluster states.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.published_states.full",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of incompatible differences between published cluster states.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.published_states.incompatible",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of pending cluster states in queue.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.state_queue.committed",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of pending cluster states in queue.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.state_queue.pending",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The total number of kilobytes read across all file stores for this node.",
+                     "name": "elasticsearch.node.disk.io.read",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1617780",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The total number of kilobytes written across all file stores for this node.",
+                     "name": "elasticsearch.node.disk.io.write",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "602016",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
                      },
                      "unit": "By"
                   },
@@ -414,8 +613,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "200",
@@ -427,8 +626,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -442,38 +641,8 @@
                         "dataPoints": [
                            {
                               "asInt": "12293464064",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "The total number of kilobytes read across all file stores for this node.",
-                     "name": "elasticsearch.node.disk.io.read",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "1617780",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "The total number of kilobytes written across all file stores for this node.",
-                     "name": "elasticsearch.node.disk.io.write",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "602016",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -487,12 +656,167 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
                      "unit": "{connections}"
+                  },
+                  {
+                     "description": "Total number of documents ingested during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.ingest.current",
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed ingest operations during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
+                  },
+                  {
+                     "description": "Total number of documents ingested during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.pipeline.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested by a pipeline.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.ingest.pipeline.current",
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed operations for the ingest pipeline.",
+                     "name": "elasticsearch.node.ingest.pipeline.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
                   },
                   {
                      "description": "The number of open file descriptors held by the node.",
@@ -502,8 +826,8 @@
                         "dataPoints": [
                            {
                               "asInt": "270",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -525,8 +849,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "400",
@@ -538,8 +862,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "600",
@@ -551,8 +875,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "124",
@@ -564,8 +888,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "234",
@@ -577,8 +901,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "235",
@@ -590,8 +914,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "5234",
@@ -603,8 +927,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "5234",
@@ -616,8 +940,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "958",
@@ -629,8 +953,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "345",
@@ -642,8 +966,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "0",
@@ -655,8 +979,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ],
                         "isMonotonic": true
@@ -679,8 +1003,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "500",
@@ -692,8 +1016,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "500",
@@ -705,8 +1029,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "2354",
@@ -718,8 +1042,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "256",
@@ -731,8 +1055,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "5234",
@@ -744,8 +1068,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "2342",
@@ -757,8 +1081,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "25345",
@@ -770,8 +1094,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "544",
@@ -783,8 +1107,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "995",
@@ -796,8 +1120,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "664",
@@ -809,8 +1133,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ],
                         "isMonotonic": true
@@ -818,19 +1142,49 @@
                      "unit": "ms"
                   },
                   {
-                     "description": "The size of the shards assigned to this node.",
-                     "name": "elasticsearch.node.shards.size",
+                     "description": "Total number of times the script cache has evicted old data.",
+                     "name": "elasticsearch.node.script.cache_evictions",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "300",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Total number of times the script compilation circuit breaker has limited inline script compilations.",
+                     "name": "elasticsearch.node.script.compilation_limit_triggered",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Total number of inline script compilations performed by the node.",
+                     "name": "elasticsearch.node.script.compilations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "unit": "{compilations}"
                   },
                   {
                      "description": "Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.",
@@ -840,8 +1194,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -855,149 +1209,25 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "Number of transaction log operations.",
-                     "name": "elasticsearch.node.translog.operations",
+                     "description": "The size of the shards assigned to this node.",
+                     "name": "elasticsearch.node.shards.size",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "{operations}"
-                  },
-                  {
-                     "description": "Size of the transaction log.",
-                     "name": "elasticsearch.node.translog.size",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "asInt": "300",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Size of uncommitted transaction log operations.",
-                     "name": "elasticsearch.node.translog.uncommitted.size",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Recent CPU usage for the whole system, or -1 if not supported.",
-                     "name": "elasticsearch.os.cpu.usage",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "3",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "%"
-                  },
-                  {
-                     "description": "One-minute load average on the system (field is not present if one-minute load average is not available).",
-                     "name": "elasticsearch.os.cpu.load_avg.1m",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asDouble": "0.0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Five-minute load average on the system (field is not present if five-minute load average is not available).",
-                     "name": "elasticsearch.os.cpu.load_avg.5m",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asDouble": "0.02",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).",
-                     "name": "elasticsearch.os.cpu.load_avg.15m",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asDouble": "0.02",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Amount of physical memory.",
-                     "name": "elasticsearch.os.memory",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "294109184",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "free"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "779632640",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "used"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ],
-                        "isMonotonic": false
                      },
                      "unit": "By"
                   },
@@ -1023,8 +1253,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "4",
@@ -1042,8 +1272,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ],
                         "isMonotonic": true
@@ -1066,8 +1296,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -1095,8 +1325,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "-2",
@@ -1114,12 +1344,149 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
                      "unit": "{threads}"
+                  },
+                  {
+                     "description": "Number of transaction log operations.",
+                     "name": "elasticsearch.node.translog.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "Size of the transaction log.",
+                     "name": "elasticsearch.node.translog.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Size of uncommitted transaction log operations.",
+                     "name": "elasticsearch.node.translog.uncommitted.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0.02,
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.15m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "One-minute load average on the system (field is not present if one-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0,
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.1m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Five-minute load average on the system (field is not present if five-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0.02,
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.5m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Recent CPU usage for the whole system, or -1 if not supported.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.usage",
+                     "unit": "%"
+                  },
+                  {
+                     "description": "Amount of physical memory.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "779632640",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "used"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           },
+                           {
+                              "asInt": "294109184",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "free"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.memory",
+                     "unit": "By"
                   },
                   {
                      "description": "The number of loaded classes",
@@ -1127,8 +1494,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20695",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -1151,8 +1518,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "10",
@@ -1164,8 +1531,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ],
                         "isMonotonic": true
@@ -1188,8 +1555,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "5",
@@ -1201,8 +1568,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ],
                         "isMonotonic": true
@@ -1215,8 +1582,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -1229,8 +1596,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -1243,8 +1610,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305152000",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -1257,8 +1624,8 @@
                         "dataPoints": [
                            {
                               "asInt": "131792896",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -1271,8 +1638,8 @@
                         "dataPoints": [
                            {
                               "asInt": "128825192",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -1293,8 +1660,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "736870912",
@@ -1306,8 +1673,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "536870912",
@@ -1319,8 +1686,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -1341,8 +1708,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "10485760",
@@ -1354,8 +1721,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            },
                            {
                               "asInt": "76562432",
@@ -1367,8 +1734,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
@@ -1381,33 +1748,21 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135376193210000",
+                              "timeUnixNano": "1661135376204250000"
                            }
                         ]
                      },
                      "name": "jvm.threads.count",
                      "unit": "1"
                   }
-               ]
-            }
-         ],
-         "resource": {
-            "attributes": [
-               {
-                  "key": "elasticsearch.cluster.name",
-                  "value": {
-                     "stringValue": "docker-cluster"
-                  }
-               },
-               {
-                  "key": "elasticsearch.node.name",
-                  "value": {
-                     "stringValue": "917e13e55eed"
-                  }
+               ],
+               "scope": {
+                  "name": "otelcol/elasticsearchreceiver",
+                  "version": "latest"
                }
-            ]
-         }
+            }
+         ]
       }
    ]
 }

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
@@ -30,25 +30,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
                                        "stringValue": "fielddata"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "0",
@@ -60,8 +47,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "0",
@@ -73,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "0",
@@ -86,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "305152000",
@@ -99,8 +86,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -114,19 +114,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "322122547",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           },
-                           {
                               "asInt": "214748364",
                               "attributes": [
                                  {
@@ -136,8 +123,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "536870912",
@@ -149,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "268435456",
@@ -162,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "536870912",
@@ -175,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "510027366",
@@ -188,8 +175,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
+                              "asInt": "322122547",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -207,25 +207,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
                                        "stringValue": "fielddata"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "0",
@@ -237,8 +224,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "0",
@@ -250,8 +237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "0",
@@ -263,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "0",
@@ -276,8 +263,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -285,18 +285,91 @@
                      "unit": "1"
                   },
                   {
-                     "description": "Memory consumed, in bytes, by indexing requests in the coordinating stage.",
-                     "gauge": {
+                     "description": "Number of differences between published cluster states.",
+                     "name": "elasticsearch.cluster.published_states.differences",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "compatible"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "incompatible"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
-                     "name": "elasticsearch.indexing_pressure.memory.coordinating",
-                     "unit": "By"
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of published cluster states.",
+                     "name": "elasticsearch.cluster.published_states.full",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of cluster states in queue.",
+                     "name": "elasticsearch.cluster.state_queue",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "committed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "pending"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
                   },
                   {
                      "description": "Configured memory limit, in bytes, for the indexing requests.",
@@ -304,40 +377,12 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
                      "name": "elasticsearch.indexing_pressure.memory.limit",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.indexing_pressure.memory.primary",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.indexing_pressure.memory.replica",
                      "unit": "By"
                   },
                   {
@@ -348,8 +393,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -364,13 +409,62 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "1"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the specified stage.",
+                     "name": "elasticsearch.memory.indexing_pressure",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "primary"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "coordinating"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "replica"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
                   },
                   {
                      "description": "The number of evictions from the cache.",
@@ -388,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "938",
@@ -401,8 +495,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -425,8 +519,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "394",
@@ -438,8 +532,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -453,8 +547,8 @@
                         "dataPoints": [
                            {
                               "asInt": "100",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -476,8 +570,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "157732",
@@ -489,83 +583,13 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
-                  },
-                  {
-                     "description": "Number of compatible differences between published cluster states.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.published_states.compatible",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of published cluster states.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "2",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.published_states.full",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of incompatible differences between published cluster states.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.published_states.incompatible",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of pending cluster states in queue.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.state_queue.committed",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of pending cluster states in queue.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.state_queue.pending",
-                     "unit": "1"
                   },
                   {
                      "description": "The total number of kilobytes read across all file stores for this node.",
@@ -575,8 +599,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1617780",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -590,8 +614,8 @@
                         "dataPoints": [
                            {
                               "asInt": "602016",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -613,8 +637,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "200",
@@ -626,8 +650,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -641,8 +665,8 @@
                         "dataPoints": [
                            {
                               "asInt": "12293464064",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -656,8 +680,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -665,14 +689,14 @@
                   },
                   {
                      "description": "Total number of documents ingested during the lifetime of this node.",
-                     "name": "elasticsearch.node.ingest.count",
+                     "name": "elasticsearch.node.ingest.documents",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -681,137 +705,29 @@
                   },
                   {
                      "description": "Total number of documents currently being ingested.",
-                     "gauge": {
+                     "name": "elasticsearch.node.ingest.documents.current",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
-                     "name": "elasticsearch.node.ingest.current",
                      "unit": "{documents}"
                   },
                   {
                      "description": "Total number of failed ingest operations during the lifetime of this node.",
-                     "name": "elasticsearch.node.ingest.failed",
+                     "name": "elasticsearch.node.ingest.operations.failed",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "{operation}"
-                  },
-                  {
-                     "description": "Total number of documents ingested during the lifetime of this node.",
-                     "name": "elasticsearch.node.ingest.pipeline.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_6"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_7"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "Total number of documents currently being ingested by a pipeline.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_6"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_7"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.ingest.pipeline.current",
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "Total number of failed operations for the ingest pipeline.",
-                     "name": "elasticsearch.node.ingest.pipeline.failed",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_6"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_7"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -826,8 +742,8 @@
                         "dataPoints": [
                            {
                               "asInt": "270",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -849,8 +765,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "400",
@@ -862,8 +778,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "600",
@@ -875,8 +791,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "124",
@@ -888,8 +804,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "234",
@@ -901,8 +817,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "235",
@@ -914,8 +830,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "5234",
@@ -927,8 +843,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "5234",
@@ -940,8 +856,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "958",
@@ -953,8 +869,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "345",
@@ -966,8 +882,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "0",
@@ -979,8 +895,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -1003,8 +919,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "500",
@@ -1016,8 +932,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "500",
@@ -1029,8 +945,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "2354",
@@ -1042,8 +958,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "256",
@@ -1055,8 +971,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "5234",
@@ -1068,8 +984,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "2342",
@@ -1081,8 +997,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "25345",
@@ -1094,8 +1010,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "544",
@@ -1107,8 +1023,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "995",
@@ -1120,8 +1036,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "664",
@@ -1133,13 +1049,122 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "ms"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested by a pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.documents.current",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Number of documents preprocessed by the ingest pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.documents.preprocessed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed operations for the ingest pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.operations.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
                   },
                   {
                      "description": "Total number of times the script cache has evicted old data.",
@@ -1149,10 +1174,11 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
-                        ]
+                        ],
+                        "isMonotonic": true
                      },
                      "unit": "1"
                   },
@@ -1164,10 +1190,11 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
-                        ]
+                        ],
+                        "isMonotonic": true
                      },
                      "unit": "1"
                   },
@@ -1179,8 +1206,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1194,8 +1221,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1209,8 +1236,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1224,8 +1251,8 @@
                         "dataPoints": [
                            {
                               "asInt": "300",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1253,8 +1280,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "4",
@@ -1272,8 +1299,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -1296,8 +1323,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1325,8 +1352,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "-2",
@@ -1344,8 +1371,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1359,8 +1386,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -1375,8 +1402,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1390,8 +1417,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1403,8 +1430,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1417,8 +1444,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1431,8 +1458,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1445,8 +1472,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1467,8 +1494,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "294109184",
@@ -1480,8 +1507,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1494,8 +1521,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20695",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1518,8 +1545,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "10",
@@ -1531,8 +1558,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -1555,8 +1582,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "5",
@@ -1568,8 +1595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ],
                         "isMonotonic": true
@@ -1582,8 +1609,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1596,8 +1623,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1610,8 +1637,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305152000",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1624,8 +1651,8 @@
                         "dataPoints": [
                            {
                               "asInt": "131792896",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1638,8 +1665,8 @@
                         "dataPoints": [
                            {
                               "asInt": "128825192",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1660,8 +1687,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "736870912",
@@ -1673,8 +1700,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "536870912",
@@ -1686,8 +1713,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1708,8 +1735,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "10485760",
@@ -1721,8 +1748,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            },
                            {
                               "asInt": "76562432",
@@ -1734,8 +1761,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },
@@ -1748,8 +1775,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1661135376193210000",
-                              "timeUnixNano": "1661135376204250000"
+                              "startTimeUnixNano": "1661327548460643000",
+                              "timeUnixNano": "1661327548472169000"
                            }
                         ]
                      },

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -30,12 +30,25 @@
                                  {
                                     "key": "name",
                                     "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
                                        "stringValue": "fielddata"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -47,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -60,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -73,8 +86,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "305152000",
@@ -86,21 +99,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -114,6 +114,19 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "322122547",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
                               "asInt": "214748364",
                               "attributes": [
                                  {
@@ -123,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "536870912",
@@ -136,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "268435456",
@@ -149,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "536870912",
@@ -162,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "510027366",
@@ -175,21 +188,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
-                           },
-                           {
-                              "asInt": "322122547",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -207,12 +207,25 @@
                                  {
                                     "key": "name",
                                     "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
                                        "stringValue": "fielddata"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -224,8 +237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -237,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -250,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -263,21 +276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -300,8 +300,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -313,8 +313,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -328,8 +328,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -351,8 +351,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -364,12 +364,415 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
                      "unit": "1"
+                  },
+                  {
+                     "description": "The number of cluster state update attempts that changed the cluster state since the node started.",
+                     "name": "elasticsearch.cluster.state_update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "7",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The cumulative amount of time updating the cluster state since the node started.",
+                     "name": "elasticsearch.cluster.state_update.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "7",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "40",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "17",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "113",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "117",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "484",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
                   },
                   {
                      "description": "Configured memory limit, in bytes, for the indexing requests.",
@@ -377,8 +780,8 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -393,8 +796,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -409,8 +812,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -433,8 +836,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -446,8 +849,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -459,8 +862,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -482,8 +885,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "938",
@@ -495,8 +898,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -519,8 +922,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "394",
@@ -532,8 +935,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -547,8 +950,8 @@
                         "dataPoints": [
                            {
                               "asInt": "100",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -570,8 +973,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "157732",
@@ -583,8 +986,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -599,8 +1002,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1617780",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -614,8 +1017,8 @@
                         "dataPoints": [
                            {
                               "asInt": "602016",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -637,8 +1040,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "200",
@@ -650,8 +1053,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -665,8 +1068,8 @@
                         "dataPoints": [
                            {
                               "asInt": "12293464064",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -680,8 +1083,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -695,8 +1098,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -711,8 +1114,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -726,8 +1129,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -742,8 +1145,8 @@
                         "dataPoints": [
                            {
                               "asInt": "270",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -765,8 +1168,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "400",
@@ -778,8 +1181,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "600",
@@ -791,8 +1194,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "124",
@@ -804,8 +1207,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "234",
@@ -817,8 +1220,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "235",
@@ -830,8 +1233,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "5234",
@@ -843,8 +1246,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "5234",
@@ -856,8 +1259,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "958",
@@ -869,8 +1272,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "345",
@@ -882,8 +1285,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -895,8 +1298,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -919,8 +1322,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "500",
@@ -932,8 +1335,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "500",
@@ -945,8 +1348,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "2354",
@@ -958,8 +1361,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "256",
@@ -971,8 +1374,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "5234",
@@ -984,8 +1387,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "2342",
@@ -997,8 +1400,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "25345",
@@ -1010,8 +1413,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "544",
@@ -1023,8 +1426,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "995",
@@ -1036,8 +1439,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "664",
@@ -1049,8 +1452,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -1069,12 +1472,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_6"
+                                       "stringValue": "xpack_monitoring_7"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -1082,12 +1485,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_7"
+                                       "stringValue": "xpack_monitoring_6"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1105,12 +1508,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_6"
+                                       "stringValue": "xpack_monitoring_7"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -1118,12 +1521,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_7"
+                                       "stringValue": "xpack_monitoring_6"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1141,12 +1544,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_6"
+                                       "stringValue": "xpack_monitoring_7"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -1154,12 +1557,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_7"
+                                       "stringValue": "xpack_monitoring_6"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -1174,8 +1577,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -1190,8 +1593,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -1206,8 +1609,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1221,8 +1624,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1236,8 +1639,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1251,8 +1654,8 @@
                         "dataPoints": [
                            {
                               "asInt": "300",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1280,8 +1683,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "4",
@@ -1299,8 +1702,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -1323,8 +1726,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1352,8 +1755,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "-2",
@@ -1371,8 +1774,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1386,8 +1789,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -1402,8 +1805,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1417,8 +1820,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1430,8 +1833,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1444,8 +1847,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1458,8 +1861,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1472,8 +1875,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1494,8 +1897,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "294109184",
@@ -1507,8 +1910,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1521,8 +1924,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20695",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1545,8 +1948,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "10",
@@ -1558,8 +1961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -1582,8 +1985,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "5",
@@ -1595,8 +1998,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ],
                         "isMonotonic": true
@@ -1609,8 +2012,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1623,8 +2026,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1637,8 +2040,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305152000",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1651,8 +2054,8 @@
                         "dataPoints": [
                            {
                               "asInt": "131792896",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1665,8 +2068,8 @@
                         "dataPoints": [
                            {
                               "asInt": "128825192",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1687,8 +2090,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "736870912",
@@ -1700,8 +2103,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "536870912",
@@ -1713,8 +2116,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1735,8 +2138,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "10485760",
@@ -1748,8 +2151,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "76562432",
@@ -1761,8 +2164,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1775,8 +2178,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1813,8 +2216,8 @@
                         "dataPoints": [
                            {
                               "asInt": "25",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1836,8 +2239,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "1",
@@ -1849,8 +2252,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "0",
@@ -1862,8 +2265,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1877,8 +2280,8 @@
                         "dataPoints": [
                            {
                               "asInt": "46",
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
@@ -1900,8 +2303,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "2",
@@ -1913,8 +2316,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "10",
@@ -1926,8 +2329,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            },
                            {
                               "asInt": "3",
@@ -1939,8 +2342,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327492459812000",
-                              "timeUnixNano": "1661327492473099000"
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -1,12 +1,24 @@
 {
    "resourceMetrics": [
       {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "elasticsearch.cluster.name",
+                  "value": {
+                     "stringValue": "docker-cluster"
+                  }
+               },
+               {
+                  "key": "elasticsearch.node.name",
+                  "value": {
+                     "stringValue": "917e13e55eed"
+                  }
+               }
+            ]
+         },
          "scopeMetrics": [
             {
-               "scope": {
-                  "name": "otelcol/elasticsearchreceiver",
-                  "version": "latest"
-               },
                "metrics": [
                   {
                      "description": "Estimated memory used for the operation.",
@@ -18,51 +30,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "fielddata"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "in_flight_requests"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
                                        "stringValue": "model_inference"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "0",
@@ -74,8 +47,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "305152000",
@@ -87,21 +60,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.breaker.memory.estimated",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Memory limit for the circuit breaker.",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
                            {
-                              "asInt": "322122547",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -110,11 +73,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
-                              "asInt": "214748364",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -123,11 +86,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
-                              "asInt": "536870912",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -136,9 +99,20 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.breaker.memory.estimated",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Memory limit for the circuit breaker.",
+                     "name": "elasticsearch.breaker.memory.limit",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
                            {
                               "asInt": "268435456",
                               "attributes": [
@@ -149,8 +123,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "536870912",
@@ -162,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "510027366",
@@ -175,22 +149,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ],
-                        "isMonotonic": false
-                     },
-                     "name": "elasticsearch.breaker.memory.limit",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Total number of times the circuit breaker has been triggered and prevented an out of memory error.",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
                            {
-                              "asInt": "0",
+                              "asInt": "322122547",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -199,11 +162,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "214748364",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -212,11 +175,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "536870912",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -225,9 +188,19 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Total number of times the circuit breaker has been triggered and prevented an out of memory error.",
+                     "name": "elasticsearch.breaker.tripped",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
                            {
                               "asInt": "0",
                               "attributes": [
@@ -238,8 +211,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "0",
@@ -251,8 +224,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "0",
@@ -264,13 +237,139 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "fielddata"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "in_flight_requests"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "name": "elasticsearch.breaker.tripped",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the coordinating stage.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.coordinating",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Configured memory limit, in bytes, for the indexing requests.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "53687091",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.limit",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.primary",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.replica",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Cumulative number of indexing requests rejected in the primary stage.",
+                     "name": "elasticsearch.indexing_pressure.memory.total.primary_rejections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of indexing requests rejected in the replica stage.",
+                     "name": "elasticsearch.indexing_pressure.memory.total.replica_rejections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
                      "unit": "1"
                   },
                   {
@@ -289,8 +388,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "938",
@@ -302,8 +401,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ],
                         "isMonotonic": true
@@ -326,8 +425,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "394",
@@ -339,8 +438,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -354,8 +453,8 @@
                         "dataPoints": [
                            {
                               "asInt": "100",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -377,8 +476,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "157732",
@@ -390,11 +489,111 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ],
                         "isMonotonic": true
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Number of compatible differences between published cluster states.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.published_states.compatible",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of published cluster states.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.published_states.full",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of incompatible differences between published cluster states.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.published_states.incompatible",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of pending cluster states in queue.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.state_queue.committed",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of pending cluster states in queue.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.state_queue.pending",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The total number of kilobytes read across all file stores for this node.",
+                     "name": "elasticsearch.node.disk.io.read",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1617780",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The total number of kilobytes written across all file stores for this node.",
+                     "name": "elasticsearch.node.disk.io.write",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "602016",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
                      },
                      "unit": "By"
                   },
@@ -414,8 +613,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "200",
@@ -427,8 +626,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -442,38 +641,8 @@
                         "dataPoints": [
                            {
                               "asInt": "12293464064",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "The total number of kilobytes read across all file stores for this node.",
-                     "name": "elasticsearch.node.disk.io.read",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "1617780",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "The total number of kilobytes written across all file stores for this node.",
-                     "name": "elasticsearch.node.disk.io.write",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "602016",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -487,12 +656,167 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
                      "unit": "{connections}"
+                  },
+                  {
+                     "description": "Total number of documents ingested during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.ingest.current",
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed ingest operations during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
+                  },
+                  {
+                     "description": "Total number of documents ingested during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.pipeline.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested by a pipeline.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.ingest.pipeline.current",
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed operations for the ingest pipeline.",
+                     "name": "elasticsearch.node.ingest.pipeline.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
                   },
                   {
                      "description": "The number of open file descriptors held by the node.",
@@ -502,8 +826,8 @@
                         "dataPoints": [
                            {
                               "asInt": "270",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -525,8 +849,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "400",
@@ -538,8 +862,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "600",
@@ -551,8 +875,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "124",
@@ -564,8 +888,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "234",
@@ -577,8 +901,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "235",
@@ -590,8 +914,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "5234",
@@ -603,8 +927,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "5234",
@@ -616,8 +940,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "958",
@@ -629,8 +953,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "345",
@@ -642,8 +966,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "0",
@@ -655,8 +979,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ],
                         "isMonotonic": true
@@ -679,8 +1003,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "500",
@@ -692,8 +1016,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "500",
@@ -705,8 +1029,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "2354",
@@ -718,8 +1042,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "256",
@@ -731,8 +1055,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "5234",
@@ -744,8 +1068,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "2342",
@@ -757,8 +1081,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "25345",
@@ -770,8 +1094,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "544",
@@ -783,8 +1107,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "995",
@@ -796,8 +1120,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "664",
@@ -809,8 +1133,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ],
                         "isMonotonic": true
@@ -818,19 +1142,49 @@
                      "unit": "ms"
                   },
                   {
-                     "description": "The size of the shards assigned to this node.",
-                     "name": "elasticsearch.node.shards.size",
+                     "description": "Total number of times the script cache has evicted old data.",
+                     "name": "elasticsearch.node.script.cache_evictions",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "300",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Total number of times the script compilation circuit breaker has limited inline script compilations.",
+                     "name": "elasticsearch.node.script.compilation_limit_triggered",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Total number of inline script compilations performed by the node.",
+                     "name": "elasticsearch.node.script.compilations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "unit": "{compilations}"
                   },
                   {
                      "description": "Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.",
@@ -840,8 +1194,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -855,149 +1209,25 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "Number of transaction log operations.",
-                     "name": "elasticsearch.node.translog.operations",
+                     "description": "The size of the shards assigned to this node.",
+                     "name": "elasticsearch.node.shards.size",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "{operations}"
-                  },
-                  {
-                     "description": "Size of the transaction log.",
-                     "name": "elasticsearch.node.translog.size",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "asInt": "300",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Size of uncommitted transaction log operations.",
-                     "name": "elasticsearch.node.translog.uncommitted.size",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Recent CPU usage for the whole system, or -1 if not supported.",
-                     "name": "elasticsearch.os.cpu.usage",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "3",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "%"
-                  },
-                  {
-                     "description": "One-minute load average on the system (field is not present if one-minute load average is not available).",
-                     "name": "elasticsearch.os.cpu.load_avg.1m",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asDouble": "0.0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Five-minute load average on the system (field is not present if five-minute load average is not available).",
-                     "name": "elasticsearch.os.cpu.load_avg.5m",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asDouble": "0.02",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).",
-                     "name": "elasticsearch.os.cpu.load_avg.15m",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asDouble": "0.02",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Amount of physical memory.",
-                     "name": "elasticsearch.os.memory",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "294109184",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "free"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "779632640",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "used"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ],
-                        "isMonotonic": false
                      },
                      "unit": "By"
                   },
@@ -1023,8 +1253,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "4",
@@ -1042,8 +1272,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ],
                         "isMonotonic": true
@@ -1066,8 +1296,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1095,8 +1325,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "-2",
@@ -1114,12 +1344,149 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
                      "unit": "{threads}"
+                  },
+                  {
+                     "description": "Number of transaction log operations.",
+                     "name": "elasticsearch.node.translog.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "Size of the transaction log.",
+                     "name": "elasticsearch.node.translog.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Size of uncommitted transaction log operations.",
+                     "name": "elasticsearch.node.translog.uncommitted.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0.02,
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.15m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "One-minute load average on the system (field is not present if one-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0,
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.1m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Five-minute load average on the system (field is not present if five-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0.02,
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.5m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Recent CPU usage for the whole system, or -1 if not supported.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.usage",
+                     "unit": "%"
+                  },
+                  {
+                     "description": "Amount of physical memory.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "779632640",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "used"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
+                           {
+                              "asInt": "294109184",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "free"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.memory",
+                     "unit": "By"
                   },
                   {
                      "description": "The number of loaded classes",
@@ -1127,8 +1494,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20695",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1151,8 +1518,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "10",
@@ -1164,8 +1531,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ],
                         "isMonotonic": true
@@ -1188,8 +1555,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "5",
@@ -1201,8 +1568,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ],
                         "isMonotonic": true
@@ -1215,8 +1582,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1229,8 +1596,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1243,8 +1610,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305152000",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1257,8 +1624,8 @@
                         "dataPoints": [
                            {
                               "asInt": "131792896",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1271,8 +1638,8 @@
                         "dataPoints": [
                            {
                               "asInt": "128825192",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1293,8 +1660,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "736870912",
@@ -1306,8 +1673,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "536870912",
@@ -1319,8 +1686,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1341,8 +1708,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "10485760",
@@ -1354,8 +1721,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "76562432",
@@ -1367,8 +1734,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1381,17 +1748,23 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
                      "name": "jvm.threads.count",
                      "unit": "1"
                   }
-               ]
+               ],
+               "scope": {
+                  "name": "otelcol/elasticsearchreceiver",
+                  "version": "latest"
+               }
             }
-         ],
+         ]
+      },
+      {
          "resource": {
             "attributes": [
                {
@@ -1399,23 +1772,11 @@
                   "value": {
                      "stringValue": "docker-cluster"
                   }
-               },
-               {
-                  "key": "elasticsearch.node.name",
-                  "value": {
-                     "stringValue": "917e13e55eed"
-                  }
                }
             ]
-         }
-      },
-      {
+         },
          "scopeMetrics": [
             {
-               "scope": {
-                  "name": "otelcol/elasticsearchreceiver",
-                  "version": "latest"
-               },
                "metrics": [
                   {
                      "description": "The number of data nodes in the cluster.",
@@ -1425,12 +1786,61 @@
                         "dataPoints": [
                            {
                               "asInt": "25",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
                      "unit": "{nodes}"
+                  },
+                  {
+                     "description": "The health status of the cluster.",
+                     "name": "elasticsearch.cluster.health",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "green"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "yellow"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "red"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
+                           }
+                        ]
+                     },
+                     "unit": "{status}"
                   },
                   {
                      "description": "The total number of nodes in the cluster.",
@@ -1440,8 +1850,8 @@
                         "dataPoints": [
                            {
                               "asInt": "46",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
@@ -1463,8 +1873,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "2",
@@ -1476,8 +1886,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "10",
@@ -1489,8 +1899,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            },
                            {
                               "asInt": "3",
@@ -1502,75 +1912,20 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135165333568000",
+                              "timeUnixNano": "1661135165344879000"
                            }
                         ]
                      },
                      "unit": "{shards}"
-                  },
-                  {
-                     "description": "The health status of the cluster.",
-                     "name": "elasticsearch.cluster.health",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "status",
-                                    "value": {
-                                       "stringValue": "green"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "status",
-                                    "value": {
-                                       "stringValue": "yellow"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "status",
-                                    "value": {
-                                       "stringValue": "red"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "{status}"
                   }
-               ]
-            }
-         ],
-         "resource": {
-            "attributes": [
-               {
-                  "key": "elasticsearch.cluster.name",
-                  "value": {
-                     "stringValue": "docker-cluster"
-                  }
+               ],
+               "scope": {
+                  "name": "otelcol/elasticsearchreceiver",
+                  "version": "latest"
                }
-            ]
-         }
+            }
+         ]
       }
    ]
 }

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -30,64 +30,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "model_inference"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "305152000",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "parent"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
                                        "stringValue": "fielddata"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "0",
@@ -99,8 +47,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "model_inference"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "305152000",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "parent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -114,58 +114,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "268435456",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "model_inference"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "536870912",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "510027366",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "parent"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "322122547",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
                               "asInt": "214748364",
                               "attributes": [
                                  {
@@ -175,8 +123,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "536870912",
@@ -188,8 +136,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "268435456",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "model_inference"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "536870912",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "510027366",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "parent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "322122547",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -207,64 +207,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "model_inference"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "parent"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
                                        "stringValue": "fielddata"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "0",
@@ -276,8 +224,60 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "model_inference"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "parent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -285,18 +285,91 @@
                      "unit": "1"
                   },
                   {
-                     "description": "Memory consumed, in bytes, by indexing requests in the coordinating stage.",
-                     "gauge": {
+                     "description": "Number of differences between published cluster states.",
+                     "name": "elasticsearch.cluster.published_states.differences",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "compatible"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "incompatible"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
-                     "name": "elasticsearch.indexing_pressure.memory.coordinating",
-                     "unit": "By"
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of published cluster states.",
+                     "name": "elasticsearch.cluster.published_states.full",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of cluster states in queue.",
+                     "name": "elasticsearch.cluster.state_queue",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "committed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "pending"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
                   },
                   {
                      "description": "Configured memory limit, in bytes, for the indexing requests.",
@@ -304,40 +377,12 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
                      "name": "elasticsearch.indexing_pressure.memory.limit",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.indexing_pressure.memory.primary",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.indexing_pressure.memory.replica",
                      "unit": "By"
                   },
                   {
@@ -348,8 +393,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -364,13 +409,62 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "1"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the specified stage.",
+                     "name": "elasticsearch.memory.indexing_pressure",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "primary"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "coordinating"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "replica"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
                   },
                   {
                      "description": "The number of evictions from the cache.",
@@ -388,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "938",
@@ -401,8 +495,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -425,8 +519,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "394",
@@ -438,8 +532,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -453,8 +547,8 @@
                         "dataPoints": [
                            {
                               "asInt": "100",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -476,8 +570,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "157732",
@@ -489,83 +583,13 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
-                  },
-                  {
-                     "description": "Number of compatible differences between published cluster states.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.published_states.compatible",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of published cluster states.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "2",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.published_states.full",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of incompatible differences between published cluster states.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.published_states.incompatible",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of pending cluster states in queue.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.state_queue.committed",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of pending cluster states in queue.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.state_queue.pending",
-                     "unit": "1"
                   },
                   {
                      "description": "The total number of kilobytes read across all file stores for this node.",
@@ -575,8 +599,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1617780",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -590,8 +614,8 @@
                         "dataPoints": [
                            {
                               "asInt": "602016",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -613,8 +637,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "200",
@@ -626,8 +650,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -641,8 +665,8 @@
                         "dataPoints": [
                            {
                               "asInt": "12293464064",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -656,8 +680,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -665,14 +689,14 @@
                   },
                   {
                      "description": "Total number of documents ingested during the lifetime of this node.",
-                     "name": "elasticsearch.node.ingest.count",
+                     "name": "elasticsearch.node.ingest.documents",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -681,137 +705,29 @@
                   },
                   {
                      "description": "Total number of documents currently being ingested.",
-                     "gauge": {
+                     "name": "elasticsearch.node.ingest.documents.current",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
-                     "name": "elasticsearch.node.ingest.current",
                      "unit": "{documents}"
                   },
                   {
                      "description": "Total number of failed ingest operations during the lifetime of this node.",
-                     "name": "elasticsearch.node.ingest.failed",
+                     "name": "elasticsearch.node.ingest.operations.failed",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "{operation}"
-                  },
-                  {
-                     "description": "Total number of documents ingested during the lifetime of this node.",
-                     "name": "elasticsearch.node.ingest.pipeline.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_6"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_7"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "Total number of documents currently being ingested by a pipeline.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_6"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_7"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.ingest.pipeline.current",
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "Total number of failed operations for the ingest pipeline.",
-                     "name": "elasticsearch.node.ingest.pipeline.failed",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_6"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_7"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -826,8 +742,8 @@
                         "dataPoints": [
                            {
                               "asInt": "270",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -849,8 +765,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "400",
@@ -862,8 +778,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "600",
@@ -875,8 +791,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "124",
@@ -888,8 +804,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "234",
@@ -901,8 +817,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "235",
@@ -914,8 +830,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "5234",
@@ -927,8 +843,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "5234",
@@ -940,8 +856,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "958",
@@ -953,8 +869,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "345",
@@ -966,8 +882,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "0",
@@ -979,8 +895,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -1003,8 +919,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "500",
@@ -1016,8 +932,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "500",
@@ -1029,8 +945,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "2354",
@@ -1042,8 +958,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "256",
@@ -1055,8 +971,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "5234",
@@ -1068,8 +984,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "2342",
@@ -1081,8 +997,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "25345",
@@ -1094,8 +1010,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "544",
@@ -1107,8 +1023,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "995",
@@ -1120,8 +1036,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "664",
@@ -1133,13 +1049,122 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "ms"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested by a pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.documents.current",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Number of documents preprocessed by the ingest pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.documents.preprocessed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed operations for the ingest pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.operations.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
                   },
                   {
                      "description": "Total number of times the script cache has evicted old data.",
@@ -1149,10 +1174,11 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
-                        ]
+                        ],
+                        "isMonotonic": true
                      },
                      "unit": "1"
                   },
@@ -1164,10 +1190,11 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
-                        ]
+                        ],
+                        "isMonotonic": true
                      },
                      "unit": "1"
                   },
@@ -1179,8 +1206,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1194,8 +1221,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1209,8 +1236,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1224,8 +1251,8 @@
                         "dataPoints": [
                            {
                               "asInt": "300",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1253,8 +1280,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "4",
@@ -1272,8 +1299,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -1296,8 +1323,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1325,8 +1352,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "-2",
@@ -1344,8 +1371,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1359,8 +1386,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -1375,8 +1402,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1390,8 +1417,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1403,8 +1430,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1417,8 +1444,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1431,8 +1458,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1445,8 +1472,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1467,8 +1494,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "294109184",
@@ -1480,8 +1507,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1494,8 +1521,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20695",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1518,8 +1545,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "10",
@@ -1531,8 +1558,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -1555,8 +1582,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "5",
@@ -1568,8 +1595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ],
                         "isMonotonic": true
@@ -1582,8 +1609,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1596,8 +1623,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1610,8 +1637,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305152000",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1624,8 +1651,8 @@
                         "dataPoints": [
                            {
                               "asInt": "131792896",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1638,8 +1665,8 @@
                         "dataPoints": [
                            {
                               "asInt": "128825192",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1660,8 +1687,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "736870912",
@@ -1673,8 +1700,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "536870912",
@@ -1686,8 +1713,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1708,8 +1735,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "10485760",
@@ -1721,8 +1748,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "76562432",
@@ -1734,8 +1761,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1748,8 +1775,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1786,8 +1813,8 @@
                         "dataPoints": [
                            {
                               "asInt": "25",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1809,8 +1836,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "1",
@@ -1822,8 +1849,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "0",
@@ -1835,8 +1862,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1850,8 +1877,8 @@
                         "dataPoints": [
                            {
                               "asInt": "46",
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },
@@ -1873,8 +1900,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "2",
@@ -1886,8 +1913,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "10",
@@ -1899,8 +1926,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            },
                            {
                               "asInt": "3",
@@ -1912,8 +1939,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135165333568000",
-                              "timeUnixNano": "1661135165344879000"
+                              "startTimeUnixNano": "1661327492459812000",
+                              "timeUnixNano": "1661327492473099000"
                            }
                         ]
                      },

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/fullWithoutDirection.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/fullWithoutDirection.json
@@ -25,6 +25,19 @@
                      "gauge": {
                         "dataPoints": [
                            {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
                               "asInt": "305152000",
                               "attributes": [
                                  {
@@ -34,8 +47,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -47,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -60,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -73,8 +86,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -86,21 +99,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -114,6 +114,19 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "536870912",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
                               "asInt": "510027366",
                               "attributes": [
                                  {
@@ -123,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "322122547",
@@ -136,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "214748364",
@@ -149,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "536870912",
@@ -162,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "268435456",
@@ -175,21 +188,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
-                           },
-                           {
-                              "asInt": "536870912",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -207,12 +207,25 @@
                                  {
                                     "key": "name",
                                     "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
                                        "stringValue": "parent"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -224,8 +237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -237,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -250,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -263,21 +276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -300,8 +300,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -313,8 +313,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -328,8 +328,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -351,8 +351,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -364,12 +364,415 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
                      "unit": "1"
+                  },
+                  {
+                     "description": "The number of cluster state update attempts that changed the cluster state since the node started.",
+                     "name": "elasticsearch.cluster.state_update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "7",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The cumulative amount of time updating the cluster state since the node started.",
+                     "name": "elasticsearch.cluster.state_update.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "7",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "40",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "17",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "113",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "117",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "484",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
                   },
                   {
                      "description": "Configured memory limit, in bytes, for the indexing requests.",
@@ -377,8 +780,8 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -393,8 +796,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -409,8 +812,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -433,8 +836,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -446,8 +849,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -459,8 +862,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -482,8 +885,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "938",
@@ -495,8 +898,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -519,8 +922,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "394",
@@ -532,8 +935,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -547,8 +950,8 @@
                         "dataPoints": [
                            {
                               "asInt": "100",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -562,8 +965,8 @@
                         "dataPoints": [
                            {
                               "asInt": "129384",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -578,8 +981,8 @@
                         "dataPoints": [
                            {
                               "asInt": "157732",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -594,8 +997,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1617780",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -609,8 +1012,8 @@
                         "dataPoints": [
                            {
                               "asInt": "602016",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -632,8 +1035,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "200",
@@ -645,8 +1048,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -660,8 +1063,8 @@
                         "dataPoints": [
                            {
                               "asInt": "12293464064",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -675,8 +1078,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -690,8 +1093,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -706,8 +1109,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -721,8 +1124,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -737,8 +1140,8 @@
                         "dataPoints": [
                            {
                               "asInt": "270",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -760,8 +1163,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "400",
@@ -773,8 +1176,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "600",
@@ -786,8 +1189,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "124",
@@ -799,8 +1202,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "234",
@@ -812,8 +1215,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "235",
@@ -825,8 +1228,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "5234",
@@ -838,8 +1241,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "5234",
@@ -851,8 +1254,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "958",
@@ -864,8 +1267,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "345",
@@ -877,8 +1280,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -890,8 +1293,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -914,8 +1317,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "500",
@@ -927,8 +1330,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "500",
@@ -940,8 +1343,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "2354",
@@ -953,8 +1356,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "256",
@@ -966,8 +1369,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "5234",
@@ -979,8 +1382,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "2342",
@@ -992,8 +1395,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "25345",
@@ -1005,8 +1408,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "544",
@@ -1018,8 +1421,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "995",
@@ -1031,8 +1434,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "664",
@@ -1044,8 +1447,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -1068,8 +1471,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -1081,8 +1484,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1104,8 +1507,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -1117,8 +1520,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1140,8 +1543,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -1153,8 +1556,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -1169,8 +1572,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -1185,8 +1588,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -1201,8 +1604,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1216,8 +1619,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1231,8 +1634,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1246,8 +1649,8 @@
                         "dataPoints": [
                            {
                               "asInt": "300",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1275,8 +1678,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "4",
@@ -1294,8 +1697,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -1318,8 +1721,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1347,8 +1750,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "-2",
@@ -1366,8 +1769,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1381,8 +1784,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -1397,8 +1800,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1412,8 +1815,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1425,8 +1828,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1439,8 +1842,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1453,8 +1856,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1467,8 +1870,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1489,8 +1892,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "294109184",
@@ -1502,8 +1905,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1516,8 +1919,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20695",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1540,8 +1943,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "10",
@@ -1553,8 +1956,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -1577,8 +1980,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "5",
@@ -1590,8 +1993,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ],
                         "isMonotonic": true
@@ -1604,8 +2007,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1618,8 +2021,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1632,8 +2035,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305152000",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1646,8 +2049,8 @@
                         "dataPoints": [
                            {
                               "asInt": "131792896",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1660,8 +2063,8 @@
                         "dataPoints": [
                            {
                               "asInt": "128825192",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1682,8 +2085,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "736870912",
@@ -1695,8 +2098,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "536870912",
@@ -1708,8 +2111,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1730,8 +2133,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "10485760",
@@ -1743,8 +2146,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "76562432",
@@ -1756,8 +2159,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1770,8 +2173,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1808,8 +2211,8 @@
                         "dataPoints": [
                            {
                               "asInt": "25",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1831,8 +2234,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "1",
@@ -1844,8 +2247,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "0",
@@ -1857,8 +2260,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1872,8 +2275,8 @@
                         "dataPoints": [
                            {
                               "asInt": "46",
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },
@@ -1895,8 +2298,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "2",
@@ -1908,8 +2311,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "10",
@@ -1921,8 +2324,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            },
                            {
                               "asInt": "3",
@@ -1934,8 +2337,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661327518980688000",
-                              "timeUnixNano": "1661327518992890000"
+                              "startTimeUnixNano": "1661810968939578000",
+                              "timeUnixNano": "1661810968941018000"
                            }
                         ]
                      },

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/fullWithoutDirection.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/fullWithoutDirection.json
@@ -25,6 +25,19 @@
                      "gauge": {
                         "dataPoints": [
                            {
+                              "asInt": "305152000",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "parent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
                               "asInt": "0",
                               "attributes": [
                                  {
@@ -34,8 +47,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -47,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -60,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -73,8 +86,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -86,21 +99,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           },
-                           {
-                              "asInt": "305152000",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "parent"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -114,6 +114,19 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "510027366",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "parent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
                               "asInt": "322122547",
                               "attributes": [
                                  {
@@ -123,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "214748364",
@@ -136,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "536870912",
@@ -149,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "268435456",
@@ -162,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "536870912",
@@ -175,21 +188,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           },
-                           {
-                              "asInt": "510027366",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "parent"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -207,12 +207,25 @@
                                  {
                                     "key": "name",
                                     "value": {
+                                       "stringValue": "parent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
                                        "stringValue": "request"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -224,8 +237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -237,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -250,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -263,21 +276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "parent"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -285,18 +285,91 @@
                      "unit": "1"
                   },
                   {
-                     "description": "Memory consumed, in bytes, by indexing requests in the coordinating stage.",
-                     "gauge": {
+                     "description": "Number of differences between published cluster states.",
+                     "name": "elasticsearch.cluster.published_states.differences",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "compatible"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "incompatible"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
-                     "name": "elasticsearch.indexing_pressure.memory.coordinating",
-                     "unit": "By"
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of published cluster states.",
+                     "name": "elasticsearch.cluster.published_states.full",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of cluster states in queue.",
+                     "name": "elasticsearch.cluster.state_queue",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "committed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "pending"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
                   },
                   {
                      "description": "Configured memory limit, in bytes, for the indexing requests.",
@@ -304,40 +377,12 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
                      "name": "elasticsearch.indexing_pressure.memory.limit",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.indexing_pressure.memory.primary",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.indexing_pressure.memory.replica",
                      "unit": "By"
                   },
                   {
@@ -348,8 +393,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -364,13 +409,62 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "1"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the specified stage.",
+                     "name": "elasticsearch.memory.indexing_pressure",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "primary"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "coordinating"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "replica"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
                   },
                   {
                      "description": "The number of evictions from the cache.",
@@ -388,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "938",
@@ -401,8 +495,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -425,8 +519,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "394",
@@ -438,8 +532,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -453,8 +547,8 @@
                         "dataPoints": [
                            {
                               "asInt": "100",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -468,8 +562,8 @@
                         "dataPoints": [
                            {
                               "asInt": "129384",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -484,83 +578,13 @@
                         "dataPoints": [
                            {
                               "asInt": "157732",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "By"
-                  },
-                  {
-                     "description": "Number of compatible differences between published cluster states.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.published_states.compatible",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of published cluster states.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "2",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.published_states.full",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of incompatible differences between published cluster states.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.published_states.incompatible",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of pending cluster states in queue.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.state_queue.committed",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of pending cluster states in queue.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.cluster.state_queue.pending",
-                     "unit": "1"
                   },
                   {
                      "description": "The total number of kilobytes read across all file stores for this node.",
@@ -570,8 +594,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1617780",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -585,8 +609,8 @@
                         "dataPoints": [
                            {
                               "asInt": "602016",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -608,8 +632,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "200",
@@ -621,8 +645,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -636,8 +660,8 @@
                         "dataPoints": [
                            {
                               "asInt": "12293464064",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -651,8 +675,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -660,14 +684,14 @@
                   },
                   {
                      "description": "Total number of documents ingested during the lifetime of this node.",
-                     "name": "elasticsearch.node.ingest.count",
+                     "name": "elasticsearch.node.ingest.documents",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -676,137 +700,29 @@
                   },
                   {
                      "description": "Total number of documents currently being ingested.",
-                     "gauge": {
+                     "name": "elasticsearch.node.ingest.documents.current",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
-                     "name": "elasticsearch.node.ingest.current",
                      "unit": "{documents}"
                   },
                   {
                      "description": "Total number of failed ingest operations during the lifetime of this node.",
-                     "name": "elasticsearch.node.ingest.failed",
+                     "name": "elasticsearch.node.ingest.operations.failed",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "{operation}"
-                  },
-                  {
-                     "description": "Total number of documents ingested during the lifetime of this node.",
-                     "name": "elasticsearch.node.ingest.pipeline.count",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_6"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_7"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "Total number of documents currently being ingested by a pipeline.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_6"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_7"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           }
-                        ]
-                     },
-                     "name": "elasticsearch.node.ingest.pipeline.current",
-                     "unit": "{documents}"
-                  },
-                  {
-                     "description": "Total number of failed operations for the ingest pipeline.",
-                     "name": "elasticsearch.node.ingest.pipeline.failed",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_6"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "xpack_monitoring_7"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -821,8 +737,8 @@
                         "dataPoints": [
                            {
                               "asInt": "270",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -844,8 +760,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "400",
@@ -857,8 +773,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "600",
@@ -870,8 +786,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "124",
@@ -883,8 +799,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "234",
@@ -896,8 +812,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "235",
@@ -909,8 +825,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "5234",
@@ -922,8 +838,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "5234",
@@ -935,8 +851,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "958",
@@ -948,8 +864,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "345",
@@ -961,8 +877,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -974,8 +890,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -998,8 +914,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "500",
@@ -1011,8 +927,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "500",
@@ -1024,8 +940,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "2354",
@@ -1037,8 +953,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "256",
@@ -1050,8 +966,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "5234",
@@ -1063,8 +979,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "2342",
@@ -1076,8 +992,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "25345",
@@ -1089,8 +1005,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "544",
@@ -1102,8 +1018,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "995",
@@ -1115,8 +1031,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "664",
@@ -1128,13 +1044,122 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
                      },
                      "unit": "ms"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested by a pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.documents.current",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Number of documents preprocessed by the ingest pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.documents.preprocessed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed operations for the ingest pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.operations.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
                   },
                   {
                      "description": "Total number of times the script cache has evicted old data.",
@@ -1144,10 +1169,11 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
-                        ]
+                        ],
+                        "isMonotonic": true
                      },
                      "unit": "1"
                   },
@@ -1159,10 +1185,11 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
-                        ]
+                        ],
+                        "isMonotonic": true
                      },
                      "unit": "1"
                   },
@@ -1174,8 +1201,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1189,8 +1216,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1204,8 +1231,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1219,8 +1246,8 @@
                         "dataPoints": [
                            {
                               "asInt": "300",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1248,8 +1275,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "4",
@@ -1267,8 +1294,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -1291,8 +1318,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1320,8 +1347,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "-2",
@@ -1339,8 +1366,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1354,8 +1381,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -1370,8 +1397,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1385,8 +1412,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1398,8 +1425,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1412,8 +1439,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1426,8 +1453,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0.02,
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1440,8 +1467,8 @@
                         "dataPoints": [
                            {
                               "asInt": "3",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1462,8 +1489,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "294109184",
@@ -1475,8 +1502,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1489,8 +1516,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20695",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1513,8 +1540,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "10",
@@ -1526,8 +1553,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -1550,8 +1577,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "5",
@@ -1563,8 +1590,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ],
                         "isMonotonic": true
@@ -1577,8 +1604,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1591,8 +1618,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1605,8 +1632,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305152000",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1619,8 +1646,8 @@
                         "dataPoints": [
                            {
                               "asInt": "131792896",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1633,8 +1660,8 @@
                         "dataPoints": [
                            {
                               "asInt": "128825192",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1655,8 +1682,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "736870912",
@@ -1668,8 +1695,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "536870912",
@@ -1681,8 +1708,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1703,8 +1730,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "10485760",
@@ -1716,8 +1743,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "76562432",
@@ -1729,8 +1756,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1743,8 +1770,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1781,8 +1808,8 @@
                         "dataPoints": [
                            {
                               "asInt": "25",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1804,8 +1831,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "1",
@@ -1817,8 +1844,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "0",
@@ -1830,8 +1857,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1845,8 +1872,8 @@
                         "dataPoints": [
                            {
                               "asInt": "46",
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },
@@ -1868,8 +1895,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "2",
@@ -1881,8 +1908,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "10",
@@ -1894,8 +1921,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            },
                            {
                               "asInt": "3",
@@ -1907,8 +1934,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1661135407586280000",
-                              "timeUnixNano": "1661135407597820000"
+                              "startTimeUnixNano": "1661327518980688000",
+                              "timeUnixNano": "1661327518992890000"
                            }
                         ]
                      },

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/fullWithoutDirection.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/fullWithoutDirection.json
@@ -1,12 +1,24 @@
 {
    "resourceMetrics": [
       {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "elasticsearch.cluster.name",
+                  "value": {
+                     "stringValue": "docker-cluster"
+                  }
+               },
+               {
+                  "key": "elasticsearch.node.name",
+                  "value": {
+                     "stringValue": "917e13e55eed"
+                  }
+               }
+            ]
+         },
          "scopeMetrics": [
             {
-               "scope": {
-                  "name": "otelcol/elasticsearchreceiver",
-                  "version": "latest"
-               },
                "metrics": [
                   {
                      "description": "Estimated memory used for the operation.",
@@ -22,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -35,8 +47,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -48,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -61,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -74,8 +86,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "305152000",
@@ -87,8 +99,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -97,6 +109,7 @@
                   },
                   {
                      "description": "Memory limit for the circuit breaker.",
+                     "name": "elasticsearch.breaker.memory.limit",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -110,8 +123,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "214748364",
@@ -123,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "536870912",
@@ -136,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "268435456",
@@ -149,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "536870912",
@@ -162,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "510027366",
@@ -175,17 +188,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
-                        ],
-                        "isMonotonic": false
+                        ]
                      },
-                     "name": "elasticsearch.breaker.memory.limit",
                      "unit": "By"
                   },
                   {
                      "description": "Total number of times the circuit breaker has been triggered and prevented an out of memory error.",
+                     "name": "elasticsearch.breaker.tripped",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
@@ -199,8 +211,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -212,8 +224,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -225,8 +237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -238,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -251,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -264,13 +276,100 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "name": "elasticsearch.breaker.tripped",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the coordinating stage.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.coordinating",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Configured memory limit, in bytes, for the indexing requests.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "53687091",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.limit",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.primary",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the primary stage.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.replica",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Cumulative number of indexing requests rejected in the primary stage.",
+                     "name": "elasticsearch.indexing_pressure.memory.total.primary_rejections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of indexing requests rejected in the replica stage.",
+                     "name": "elasticsearch.indexing_pressure.memory.total.replica_rejections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
                      "unit": "1"
                   },
                   {
@@ -289,8 +388,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "938",
@@ -302,8 +401,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ],
                         "isMonotonic": true
@@ -326,8 +425,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "394",
@@ -339,8 +438,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -354,8 +453,8 @@
                         "dataPoints": [
                            {
                               "asInt": "100",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -369,8 +468,8 @@
                         "dataPoints": [
                            {
                               "asInt": "129384",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ],
                         "isMonotonic": true
@@ -385,11 +484,111 @@
                         "dataPoints": [
                            {
                               "asInt": "157732",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ],
                         "isMonotonic": true
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Number of compatible differences between published cluster states.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.published_states.compatible",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of published cluster states.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.published_states.full",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of incompatible differences between published cluster states.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.published_states.incompatible",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of pending cluster states in queue.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.state_queue.committed",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of pending cluster states in queue.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.cluster.state_queue.pending",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The total number of kilobytes read across all file stores for this node.",
+                     "name": "elasticsearch.node.disk.io.read",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1617780",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The total number of kilobytes written across all file stores for this node.",
+                     "name": "elasticsearch.node.disk.io.write",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "602016",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
                      },
                      "unit": "By"
                   },
@@ -409,8 +608,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "200",
@@ -422,8 +621,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -437,38 +636,8 @@
                         "dataPoints": [
                            {
                               "asInt": "12293464064",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "The total number of kilobytes read across all file stores for this node.",
-                     "name": "elasticsearch.node.disk.io.read",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "1617780",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "The total number of kilobytes written across all file stores for this node.",
-                     "name": "elasticsearch.node.disk.io.write",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "602016",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -482,12 +651,167 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
                      "unit": "{connections}"
+                  },
+                  {
+                     "description": "Total number of documents ingested during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.ingest.current",
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed ingest operations during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
+                  },
+                  {
+                     "description": "Total number of documents ingested during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.pipeline.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested by a pipeline.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.ingest.pipeline.current",
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed operations for the ingest pipeline.",
+                     "name": "elasticsearch.node.ingest.pipeline.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
                   },
                   {
                      "description": "The number of open file descriptors held by the node.",
@@ -497,8 +821,8 @@
                         "dataPoints": [
                            {
                               "asInt": "270",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -520,8 +844,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "400",
@@ -533,8 +857,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "600",
@@ -546,8 +870,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "124",
@@ -559,8 +883,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "234",
@@ -572,8 +896,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "235",
@@ -585,8 +909,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "5234",
@@ -598,8 +922,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "5234",
@@ -611,8 +935,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "958",
@@ -624,8 +948,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "345",
@@ -637,8 +961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "0",
@@ -650,8 +974,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ],
                         "isMonotonic": true
@@ -674,8 +998,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "500",
@@ -687,8 +1011,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "500",
@@ -700,8 +1024,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "2354",
@@ -713,8 +1037,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "256",
@@ -726,8 +1050,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "5234",
@@ -739,8 +1063,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "2342",
@@ -752,8 +1076,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "25345",
@@ -765,8 +1089,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "544",
@@ -778,8 +1102,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "995",
@@ -791,8 +1115,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "664",
@@ -804,8 +1128,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ],
                         "isMonotonic": true
@@ -813,19 +1137,49 @@
                      "unit": "ms"
                   },
                   {
-                     "description": "The size of the shards assigned to this node.",
-                     "name": "elasticsearch.node.shards.size",
+                     "description": "Total number of times the script cache has evicted old data.",
+                     "name": "elasticsearch.node.script.cache_evictions",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "300",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Total number of times the script compilation circuit breaker has limited inline script compilations.",
+                     "name": "elasticsearch.node.script.compilation_limit_triggered",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Total number of inline script compilations performed by the node.",
+                     "name": "elasticsearch.node.script.compilations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "unit": "{compilations}"
                   },
                   {
                      "description": "Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.",
@@ -835,8 +1189,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -850,149 +1204,25 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
                      "unit": "By"
                   },
                   {
-                     "description": "Number of transaction log operations.",
-                     "name": "elasticsearch.node.translog.operations",
+                     "description": "The size of the shards assigned to this node.",
+                     "name": "elasticsearch.node.shards.size",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "{operations}"
-                  },
-                  {
-                     "description": "Size of the transaction log.",
-                     "name": "elasticsearch.node.translog.size",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "asInt": "300",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Size of uncommitted transaction log operations.",
-                     "name": "elasticsearch.node.translog.uncommitted.size",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Recent CPU usage for the whole system, or -1 if not supported.",
-                     "name": "elasticsearch.os.cpu.usage",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "3",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "%"
-                  },
-                  {
-                     "description": "One-minute load average on the system (field is not present if one-minute load average is not available).",
-                     "name": "elasticsearch.os.cpu.load_avg.1m",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asDouble": "0.0",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Five-minute load average on the system (field is not present if five-minute load average is not available).",
-                     "name": "elasticsearch.os.cpu.load_avg.5m",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asDouble": "0.02",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).",
-                     "name": "elasticsearch.os.cpu.load_avg.15m",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asDouble": "0.02",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Amount of physical memory.",
-                     "name": "elasticsearch.os.memory",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "294109184",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "free"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "779632640",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "used"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ],
-                        "isMonotonic": false
                      },
                      "unit": "By"
                   },
@@ -1018,8 +1248,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "4",
@@ -1037,8 +1267,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ],
                         "isMonotonic": true
@@ -1061,8 +1291,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1090,8 +1320,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "-2",
@@ -1109,12 +1339,149 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
                      "unit": "{threads}"
+                  },
+                  {
+                     "description": "Number of transaction log operations.",
+                     "name": "elasticsearch.node.translog.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "Size of the transaction log.",
+                     "name": "elasticsearch.node.translog.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Size of uncommitted transaction log operations.",
+                     "name": "elasticsearch.node.translog.uncommitted.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0.02,
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.15m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "One-minute load average on the system (field is not present if one-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0,
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.1m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Five-minute load average on the system (field is not present if five-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0.02,
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.5m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Recent CPU usage for the whole system, or -1 if not supported.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.usage",
+                     "unit": "%"
+                  },
+                  {
+                     "description": "Amount of physical memory.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "779632640",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "used"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           },
+                           {
+                              "asInt": "294109184",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "free"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.memory",
+                     "unit": "By"
                   },
                   {
                      "description": "The number of loaded classes",
@@ -1122,8 +1489,8 @@
                         "dataPoints": [
                            {
                               "asInt": "20695",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1146,8 +1513,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "10",
@@ -1159,8 +1526,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ],
                         "isMonotonic": true
@@ -1183,8 +1550,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "5",
@@ -1196,8 +1563,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ],
                         "isMonotonic": true
@@ -1210,8 +1577,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1224,8 +1591,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1238,8 +1605,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305152000",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1252,8 +1619,8 @@
                         "dataPoints": [
                            {
                               "asInt": "131792896",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1266,8 +1633,8 @@
                         "dataPoints": [
                            {
                               "asInt": "128825192",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1288,8 +1655,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "736870912",
@@ -1301,8 +1668,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "536870912",
@@ -1314,8 +1681,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1336,8 +1703,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "10485760",
@@ -1349,8 +1716,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "76562432",
@@ -1362,8 +1729,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1376,17 +1743,23 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
                      "name": "jvm.threads.count",
                      "unit": "1"
                   }
-               ]
+               ],
+               "scope": {
+                  "name": "otelcol/elasticsearchreceiver",
+                  "version": "latest"
+               }
             }
-         ],
+         ]
+      },
+      {
          "resource": {
             "attributes": [
                {
@@ -1394,23 +1767,11 @@
                   "value": {
                      "stringValue": "docker-cluster"
                   }
-               },
-               {
-                  "key": "elasticsearch.node.name",
-                  "value": {
-                     "stringValue": "917e13e55eed"
-                  }
                }
             ]
-         }
-      },
-      {
+         },
          "scopeMetrics": [
             {
-               "scope": {
-                  "name": "otelcol/elasticsearchreceiver",
-                  "version": "latest"
-               },
                "metrics": [
                   {
                      "description": "The number of data nodes in the cluster.",
@@ -1420,12 +1781,61 @@
                         "dataPoints": [
                            {
                               "asInt": "25",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
                      "unit": "{nodes}"
+                  },
+                  {
+                     "description": "The health status of the cluster.",
+                     "name": "elasticsearch.cluster.health",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "green"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "yellow"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "red"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
+                           }
+                        ]
+                     },
+                     "unit": "{status}"
                   },
                   {
                      "description": "The total number of nodes in the cluster.",
@@ -1435,8 +1845,8 @@
                         "dataPoints": [
                            {
                               "asInt": "46",
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
@@ -1458,8 +1868,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "2",
@@ -1471,8 +1881,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "10",
@@ -1484,8 +1894,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            },
                            {
                               "asInt": "3",
@@ -1497,75 +1907,20 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
+                              "startTimeUnixNano": "1661135407586280000",
+                              "timeUnixNano": "1661135407597820000"
                            }
                         ]
                      },
                      "unit": "{shards}"
-                  },
-                  {
-                     "description": "The health status of the cluster.",
-                     "name": "elasticsearch.cluster.health",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "status",
-                                    "value": {
-                                       "stringValue": "green"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "status",
-                                    "value": {
-                                       "stringValue": "yellow"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "status",
-                                    "value": {
-                                       "stringValue": "red"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1642218266053041000",
-                              "timeUnixNano": "1642218266053039000"
-                           }
-                        ]
-                     },
-                     "unit": "{status}"
                   }
-               ]
-            }
-         ],
-         "resource": {
-            "attributes": [
-               {
-                  "key": "elasticsearch.cluster.name",
-                  "value": {
-                     "stringValue": "docker-cluster"
-                  }
+               ],
+               "scope": {
+                  "name": "otelcol/elasticsearchreceiver",
+                  "version": "latest"
                }
-            ]
-         }
+            }
+         ]
       }
    ]
 }

--- a/receiver/elasticsearchreceiver/testdata/sample_payloads/nodes_linux.json
+++ b/receiver/elasticsearchreceiver/testdata/sample_payloads/nodes_linux.json
@@ -430,6 +430,33 @@
           "full_states": 2,
           "incompatible_diffs": 0,
           "compatible_diffs": 1
+        },
+        "cluster_state_update": {
+          "unchanged": {
+            "count": 4,
+            "computation_time_millis": 7,
+            "notification_time_millis": 1
+          },
+          "success": {
+            "count": 7,
+            "computation_time_millis": 40,
+            "publication_time_millis": 627,
+            "context_construction_time_millis": 17,
+            "commit_time_millis": 113,
+            "completion_time_millis": 117,
+            "master_apply_time_millis": 484,
+            "notification_time_millis": 2
+          },
+          "failure": {
+            "count": 0,
+            "computation_time_millis": 0,
+            "publication_time_millis": 0,
+            "context_construction_time_millis": 0,
+            "commit_time_millis": 0,
+            "completion_time_millis": 0,
+            "master_apply_time_millis": 0,
+            "notification_time_millis": 0
+          }
         }
       },
       "ingest": {

--- a/unreleased/add-more-es-receiver-metrics.yaml
+++ b/unreleased/add-more-es-receiver-metrics.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add additional metrics
+
+# One or more tracking issues related to the change
+issues: [13115]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Add additional metrics for indexing_pressure, published_states, state_queue, ingest, script.


### PR DESCRIPTION
Fixes #13115 

**Description:** 

Adding more elasticsearch receiver metrics for indexing_pressure, published_states, state_queue, ingest, script.