### PR TITLE
[exporter/dynatrace] Dynatrace support for Summary metric data type

### DIFF
--- a/exporter/dynatraceexporter/internal/serialization/serialization.go
+++ b/exporter/dynatraceexporter/internal/serialization/serialization.go
@@ -36,6 +36,8 @@ func SerializeMetric(logger *zap.Logger, prefix string, metric pmetric.Metric, d
 		metricLines = serializeGauge(logger, prefix, metric, defaultDimensions, staticDimensions, metricLines)
 	case pmetric.MetricDataTypeSum:
 		metricLines = serializeSum(logger, prefix, metric, defaultDimensions, staticDimensions, prev, metricLines)
+	case pmetric.MetricDataTypeSummary:
+		metricLines = serializeSummary(logger, prefix, metric, defaultDimensions, staticDimensions, metricLines)
 	case pmetric.MetricDataTypeHistogram:
 		metricLines = serializeHistogram(logger, prefix, metric, defaultDimensions, staticDimensions, metricLines)
 	default:

--- a/exporter/dynatraceexporter/internal/serialization/summary.go
+++ b/exporter/dynatraceexporter/internal/serialization/summary.go
@@ -43,7 +43,7 @@ func serializeSummary(logger *zap.Logger, prefix string, metric pmetric.Metric, 
 
 		if err != nil {
 			logger.Warn(
-				"Error serializing histogram data point",
+				"Error serializing summary data point",
 				zap.String("name", metric.Name()),
 				zap.Error(err),
 			)
@@ -57,10 +57,19 @@ func serializeSummary(logger *zap.Logger, prefix string, metric pmetric.Metric, 
 }
 
 func summaryDataPointToSummary(dp pmetric.SummaryDataPoint) (float64, float64, float64) {
-	var min, max float64
-	if quantileValues := dp.QuantileValues(); quantileValues.Len() > 0 {
-		min = quantileValues.At(0).Value()
-		max = quantileValues.At(quantileValues.Len() - 1).Value()
+	if dp.QuantileValues().Len() == 0 {
+		return 0, 0, dp.Sum()
+	}
+
+	min, max := dp.QuantileValues().At(0).Value(), dp.QuantileValues().At(0).Value()
+	for bi := 1; bi < dp.QuantileValues().Len(); bi++ {
+		value := dp.QuantileValues().At(bi).Value()
+		if value < min {
+			min = value
+		}
+		if value > max {
+			max = value
+		}
 	}
 	return min, max, dp.Sum()
 }

--- a/exporter/dynatraceexporter/internal/serialization/summary.go
+++ b/exporter/dynatraceexporter/internal/serialization/summary.go
@@ -1,4 +1,4 @@
-package serialization
+package serialization // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter/internal/serialization"
 
 import (
 	dtMetric "github.com/dynatrace-oss/dynatrace-metric-utils-go/metric"

--- a/exporter/dynatraceexporter/internal/serialization/summary.go
+++ b/exporter/dynatraceexporter/internal/serialization/summary.go
@@ -71,5 +71,14 @@ func summaryDataPointToSummary(dp pmetric.SummaryDataPoint) (float64, float64, f
 			max = value
 		}
 	}
+	if dp.Count() > 0 {
+		mean := dp.Sum() / float64(dp.Count())
+		if min > mean {
+			min = mean
+		}
+		if max < mean {
+			max = mean
+		}
+	}
 	return min, max, dp.Sum()
 }

--- a/exporter/dynatraceexporter/internal/serialization/summary.go
+++ b/exporter/dynatraceexporter/internal/serialization/summary.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package serialization // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter/internal/serialization"
 
 import (

--- a/exporter/dynatraceexporter/internal/serialization/summary.go
+++ b/exporter/dynatraceexporter/internal/serialization/summary.go
@@ -26,14 +26,14 @@ func serializeSummaryPoint(name, prefix string, dims dimensions.NormalizedDimens
 		return "", nil
 	}
 
-	min, max, sum := summaryDataPointToSummary(dp)
+	min, max := summaryDataPointToStats(dp)
 
 	dm, err := dtMetric.NewMetric(
 		name,
 		dtMetric.WithPrefix(prefix),
 		dtMetric.WithDimensions(dims),
 		dtMetric.WithTimestamp(dp.Timestamp().AsTime()),
-		dtMetric.WithFloatSummaryValue(min, max, sum, int64(dp.Count())),
+		dtMetric.WithFloatSummaryValue(min, max, dp.Sum(), int64(dp.Count())),
 	)
 
 	if err != nil {
@@ -70,9 +70,9 @@ func serializeSummary(logger *zap.Logger, prefix string, metric pmetric.Metric, 
 	return metricLines
 }
 
-func summaryDataPointToSummary(dp pmetric.SummaryDataPoint) (float64, float64, float64) {
+func summaryDataPointToStats(dp pmetric.SummaryDataPoint) (float64, float64) {
 	if dp.QuantileValues().Len() == 0 {
-		return 0, 0, dp.Sum()
+		return 0, 0
 	}
 
 	min, max := dp.QuantileValues().At(0).Value(), dp.QuantileValues().At(0).Value()
@@ -94,5 +94,5 @@ func summaryDataPointToSummary(dp pmetric.SummaryDataPoint) (float64, float64, f
 			max = mean
 		}
 	}
-	return min, max, dp.Sum()
+	return min, max
 }

--- a/exporter/dynatraceexporter/internal/serialization/summary.go
+++ b/exporter/dynatraceexporter/internal/serialization/summary.go
@@ -1,0 +1,66 @@
+package serialization
+
+import (
+	dtMetric "github.com/dynatrace-oss/dynatrace-metric-utils-go/metric"
+	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/dimensions"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+func serializeSummaryPoint(name, prefix string, dims dimensions.NormalizedDimensionList, dp pmetric.SummaryDataPoint) (string, error) {
+	if dp.Count() == 0 {
+		return "", nil
+	}
+
+	min, max, sum := summaryDataPointToSummary(dp)
+
+	dm, err := dtMetric.NewMetric(
+		name,
+		dtMetric.WithPrefix(prefix),
+		dtMetric.WithDimensions(dims),
+		dtMetric.WithTimestamp(dp.Timestamp().AsTime()),
+		dtMetric.WithFloatSummaryValue(min, max, sum, int64(dp.Count())),
+	)
+
+	if err != nil {
+		return "", err
+	}
+
+	return dm.Serialize()
+}
+
+func serializeSummary(logger *zap.Logger, prefix string, metric pmetric.Metric, defaultDimensions dimensions.NormalizedDimensionList, staticDimensions dimensions.NormalizedDimensionList, metricLines []string) []string {
+	summary := metric.Summary()
+
+	for i := 0; i < summary.DataPoints().Len(); i++ {
+		dp := summary.DataPoints().At(i)
+		line, err := serializeSummaryPoint(
+			metric.Name(),
+			prefix,
+			makeCombinedDimensions(defaultDimensions, dp.Attributes(), staticDimensions),
+			dp,
+		)
+
+		if err != nil {
+			logger.Warn(
+				"Error serializing histogram data point",
+				zap.String("name", metric.Name()),
+				zap.Error(err),
+			)
+		}
+
+		if line != "" {
+			metricLines = append(metricLines, line)
+		}
+	}
+	return metricLines
+}
+
+func summaryDataPointToSummary(dp pmetric.SummaryDataPoint) (float64, float64, float64) {
+	var min, max float64
+	if quantileValues := dp.QuantileValues(); quantileValues.Len() > 0 {
+		min = quantileValues.At(0).Value()
+		max = quantileValues.At(quantileValues.Len() - 1).Value()
+	}
+	return min, max, dp.Sum()
+}

--- a/exporter/dynatraceexporter/internal/serialization/summary_test.go
+++ b/exporter/dynatraceexporter/internal/serialization/summary_test.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package serialization
 
 import (

--- a/exporter/dynatraceexporter/internal/serialization/summary_test.go
+++ b/exporter/dynatraceexporter/internal/serialization/summary_test.go
@@ -1,0 +1,88 @@
+package serialization
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/dimensions"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func Test_serializeSummaryPoint(t *testing.T) {
+	summary := pmetric.NewSummaryDataPoint()
+	fillTestValueAtQuantileSlice(summary.QuantileValues(), []float64{1, 2, 3, 4, 5, 6, 7})
+	summary.SetCount(2)
+	summary.SetSum(9.5)
+	summary.SetTimestamp(pcommon.Timestamp(time.Date(2021, 07, 16, 12, 30, 0, 0, time.UTC).UnixNano()))
+
+	t.Run("delta with prefix and dimension", func(t *testing.T) {
+		got, err := serializeSummaryPoint("delta_summary", "prefix", dimensions.NewNormalizedDimensionList(dimensions.NewDimension("key", "value")), summary)
+		assert.NoError(t, err)
+		assert.Equal(t, "prefix.delta_summary,key=value gauge,min=1,max=7,sum=9.5,count=2 1626438600000", got)
+	})
+
+	t.Run("out of order quantile", func(t *testing.T) {
+		summaryOutOfOrderQuantile := pmetric.NewSummaryDataPoint()
+		fillTestValueAtQuantileSlice(summaryOutOfOrderQuantile.QuantileValues(), []float64{5, 3, 1, 8, 4, 2, 7, 6})
+		summaryOutOfOrderQuantile.SetCount(2)
+		summaryOutOfOrderQuantile.SetSum(9.5)
+		summaryOutOfOrderQuantile.SetTimestamp(pcommon.Timestamp(time.Date(2021, 07, 16, 12, 30, 0, 0, time.UTC).UnixNano()))
+
+		got, err := serializeSummaryPoint("delta_out_of_order_quantile", "prefix", dimensions.NewNormalizedDimensionList(dimensions.NewDimension("key", "value")), summaryOutOfOrderQuantile)
+		assert.NoError(t, err)
+		assert.Equal(t, "prefix.delta_out_of_order_quantile,key=value gauge,min=1,max=8,sum=9.5,count=2 1626438600000", got)
+	})
+
+	t.Run("empty quantile", func(t *testing.T) {
+		summaryEmptyQuantile := pmetric.NewSummaryDataPoint()
+		summaryEmptyQuantile.SetCount(2)
+		summaryEmptyQuantile.SetSum(9.5)
+		summaryEmptyQuantile.SetTimestamp(pcommon.Timestamp(time.Date(2021, 07, 16, 12, 30, 0, 0, time.UTC).UnixNano()))
+
+		got, err := serializeSummaryPoint("delta_empty_quantile", "prefix", dimensions.NewNormalizedDimensionList(dimensions.NewDimension("key", "value")), summaryEmptyQuantile)
+		assert.NoError(t, err)
+		assert.Equal(t, "prefix.delta_empty_quantile,key=value gauge,min=0,max=0,sum=9.5,count=2 1626438600000", got)
+	})
+}
+
+func Test_serializeSummary(t *testing.T) {
+	emptyDims := dimensions.NewNormalizedDimensionList()
+	metric := pmetric.NewMetric()
+	metric.SetDataType(pmetric.MetricDataTypeSummary)
+	metric.SetName("metric_name")
+	summary := metric.Summary()
+	dp := summary.DataPoints().AppendEmpty()
+	fillTestValueAtQuantileSlice(dp.QuantileValues(), []float64{1, 2, 3, 4, 5, 6, 7})
+	dp.SetCount(3)
+	dp.SetSum(8)
+
+	zapCore, observedLogs := observer.New(zap.WarnLevel)
+	logger := zap.New(zapCore)
+
+	lines := serializeSummary(logger, "", metric, emptyDims, emptyDims, []string{})
+
+	expectedLines := []string{
+		"metric_name gauge,min=1,max=7,sum=8,count=3",
+	}
+
+	assert.ElementsMatch(t, lines, expectedLines)
+
+	assert.Empty(t, observedLogs.All())
+}
+
+func fillTestValueAtQuantileSlice(tv pmetric.ValueAtQuantileSlice, values []float64) {
+	l := 7
+	tv.EnsureCapacity(len(values))
+	for i := 0; i < l; i++ {
+		fillTestValueAtQuantile(tv.AppendEmpty(), values[i])
+	}
+}
+
+func fillTestValueAtQuantile(tv pmetric.ValueAtQuantile, v float64) {
+	tv.SetQuantile(v)
+	tv.SetValue(v)
+}

--- a/unreleased/dynatrace-summary-metric.yaml
+++ b/unreleased/dynatrace-summary-metric.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: dynatraceexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Dynatrace support for Summary metric data type
+
+# One or more tracking issues related to the change
+issues: [13450]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Dynatrace support for Summary metric data type.

I created this because I need to use the StatsD receiver, and it don't support Histogram for timing, only Summary.

This was based on reading the source code of other exporters, I don't have a deep knowledge of metrics, so this must be reviewed for correctness.

By my understanding, the received data is already a summary, so the only work would be converting to the OpenTelemetry format.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Tested using the StatsD receiver sending to Dynatrace, it seems to report corrent timing.

**Documentation:** <Describe the documentation added.>