### PR TITLE
[CI] Use stopgap solution for hanging actions/cache bug

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -46,6 +46,10 @@ jobs:
             ~\go\pkg\mod
             ~\AppData\Local\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        env:
+          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+          # Cache downloads for this workflow consistently run in under 10 minutes
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 15
       - name: Run Unit tests
         run: make gotest GROUP=${{ matrix.group }}
   windows-unittest:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,6 +32,10 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+          # Cache downloads for this workflow consistently run in under 1 minute
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,6 +37,10 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: changelog-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        env:
+          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+          # Cache downloads for this workflow consistently run in under 1 minute
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
 
       - name: Ensure no changes to the CHANGELOG
         run: |

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -33,6 +33,10 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
           key: loadtest-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        env:
+          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+          # Cache downloads for this workflow consistently run in under 2 minutes
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
       - name: Install Dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -32,6 +32,10 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
           key: prometheus-${{ runner.os }}-go-${{ hashFiles('**/go.mod', '**/go.sum') }}
+        env:
+          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+          # Cache downloads for this workflow consistently run in under 1 minute
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
       - run: make otelcontribcol
         working-directory: opentelemetry-collector-contrib
       - name: Checkout compliance repo
@@ -39,7 +43,7 @@ jobs:
         with:
           repository: prometheus/compliance
           path: compliance
-          ref: f0482884578bac67b053e3eaa1ca7f783d146557 
+          ref: f0482884578bac67b053e3eaa1ca7f783d146557
       - name: Copy binary to compliance directory
         run: mkdir compliance/remote_write_sender/bin && cp opentelemetry-collector-contrib/bin/otelcontribcol_linux_amd64 compliance/remote_write_sender/bin/otelcol_linux_amd64
       - name: Run compliance tests


### PR DESCRIPTION
There is a [bug in azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js/issues/22321) affecting Github's actions `actions/cache` where downloads may hang indefinitely.
This has plagued our workflows [for months](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10289), causing many unnecessary
failures. The worst part is that, by default, a job will hang for
6 hours before finally being killed.

This PR uses a newly provided stopgap environment variable to ensure that,
when this bug occurs, the job will fail much faster. The goal here is to
provide earlier feedback to PR authors. [More info here](https://github.com/actions/cache/issues/810#issuecomment-1222550359).

Time limits are proposed based on observed download times on recently run
workflows.

Notably, this action runs much slower on Windows and with
more variability. 15 minutes is slightly less than double the longest run
I was able to find, so should be sufficiently long to avoid premature
failures. A 5m timeout is proposed for all other workflows, which appear to
run the cache download in about 40s-60s.