### PR TITLE
[pkg/stanza] Consolidate confmap testing into a single file per operator

### DIFF
--- a/pkg/stanza/entry/field.go
+++ b/pkg/stanza/entry/field.go
@@ -63,6 +63,12 @@ func (f *Field) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return err
 }
 
+func (f *Field) UnmarshalText(text []byte) error {
+	field, err := NewField(string(text))
+	*f = field
+	return err
+}
+
 func NewField(s string) (Field, error) {
 	keys, err := fromJSONDot(s)
 	if err != nil {

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -387,7 +387,7 @@ func TestUnmarshal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, NewConfig())
+			tc.RunDeprecated(t, NewConfig())
 		})
 	}
 }

--- a/pkg/stanza/operator/config.go
+++ b/pkg/stanza/operator/config.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"go.opentelemetry.io/collector/confmap"
 	"go.uber.org/zap"
 )
 
@@ -102,4 +103,30 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // MarshalYAML will marshal a config to YAML.
 func (c Config) MarshalYAML() (interface{}, error) {
 	return c.Builder, nil
+}
+
+func (c *Config) Unmarshal(component *confmap.Conf) error {
+	if !component.IsSet("type") {
+		return fmt.Errorf("missing required field 'type'")
+	}
+
+	typeInterface := component.Get("type")
+
+	typeString, ok := typeInterface.(string)
+	if !ok {
+		return fmt.Errorf("non-string type %T for field 'type'", typeInterface)
+	}
+
+	builderFunc, ok := DefaultRegistry.Lookup(typeString)
+	if !ok {
+		return fmt.Errorf("unsupported type '%s'", typeString)
+	}
+
+	builder := builderFunc()
+	if err := component.UnmarshalExact(builder); err != nil {
+		return fmt.Errorf("unmarshal to %s: %w", typeString, err)
+	}
+
+	c.Builder = builder
+	return nil
 }

--- a/pkg/stanza/operator/helper/operatortest/operatortest.go
+++ b/pkg/stanza/operator/helper/operatortest/operatortest.go
@@ -27,13 +27,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
-// ConfigUnmarshalTest is used for testing golden configs
-type ConfigUnmarshalTest struct {
-	Name      string
-	Expect    interface{}
-	ExpectErr bool
-}
-
 func configFromFileViaYaml(file string, config interface{}) error {
 	bytes, err := os.ReadFile(file) // #nosec - configs load based on user specified directory
 	if err != nil {
@@ -71,7 +64,7 @@ func configFromFileViaMapstructure(file string, config interface{}) error {
 }
 
 // Run Unmarshalls yaml files and compares them against the expected.
-func (c ConfigUnmarshalTest) Run(t *testing.T, config interface{}) {
+func (c ConfigUnmarshalTest) RunDeprecated(t *testing.T, config interface{}) {
 	mapConfig := config
 	yamlConfig := config
 	yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", c.Name)), yamlConfig)

--- a/pkg/stanza/operator/helper/operatortest/operatortest_confmap.go
+++ b/pkg/stanza/operator/helper/operatortest/operatortest_confmap.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operatortest // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+)
+
+// ConfigUnmarshalTest is used for testing golden configs
+type ConfigUnmarshalTest struct {
+	Name      string
+	Expect    interface{}
+	ExpectErr bool
+}
+
+// Run Unmarshals yaml files and compares them against the expected.
+func (c ConfigUnmarshalTest) Run(t *testing.T, defaultConfig operator.Builder) {
+	cm, err := confmaptest.LoadConf(filepath.Join(".", "testdata", fmt.Sprintf("%s.yaml", c.Name)))
+	require.NoError(t, err)
+
+	cfg := newAnyOpConfig(defaultConfig)
+	err = config.UnmarshalReceiver(cm, cfg)
+
+	if c.ExpectErr {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
+		require.Equal(t, c.Expect, cfg.Operator.Builder)
+	}
+}
+
+type anyOpConfig struct {
+	config.ReceiverSettings `mapstructure:",squash"`
+	Operator                operator.Config `mapstructure:"operator"`
+}
+
+func newAnyOpConfig(opCfg operator.Builder) *anyOpConfig {
+	return &anyOpConfig{
+		ReceiverSettings: config.NewReceiverSettings(config.NewComponentID("any_op")),
+		Operator:         operator.Config{Builder: opCfg},
+	}
+}
+
+func (a *anyOpConfig) Unmarshal(component *confmap.Conf) error {
+	return a.Operator.Unmarshal(component)
+}

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -510,7 +510,7 @@ func TestUnmarshal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/parser/csv/config_test.go
+++ b/pkg/stanza/operator/parser/csv/config_test.go
@@ -80,7 +80,7 @@ func TestConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/parser/json/config_test.go
+++ b/pkg/stanza/operator/parser/json/config_test.go
@@ -14,6 +14,7 @@
 package json
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -22,83 +23,80 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	cases := []operatortest.ConfigUnmarshalTest{
-		{
-			Name:   "default",
-			Expect: NewConfig(),
+	operatortest.ConfigUnmarshalTests{
+		DefaultConfig: NewConfig(),
+		TestsFile:     filepath.Join(".", "testdata", "config.yaml"),
+		Tests: []operatortest.ConfigUnmarshalTest{
+			{
+				Name:   "default",
+				Expect: NewConfig(),
+			},
+			{
+				Name: "on_error_drop",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.OnError = "drop"
+					return cfg
+				}(),
+			},
+			{
+				Name: "parse_from_simple",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.ParseFrom = entry.NewBodyField("from")
+					return cfg
+				}(),
+			},
+			{
+				Name: "parse_to_simple",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.ParseTo = entry.NewBodyField("log")
+					return cfg
+				}(),
+			},
+			{
+				Name: "timestamp",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					parseField := entry.NewBodyField("timestamp_field")
+					newTime := helper.TimeParser{
+						LayoutType: "strptime",
+						Layout:     "%Y-%m-%d",
+						ParseFrom:  &parseField,
+					}
+					cfg.TimeParser = &newTime
+					return cfg
+				}(),
+			},
+			{
+				Name: "severity",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					parseField := entry.NewBodyField("severity_field")
+					severityParser := helper.NewSeverityConfig()
+					severityParser.ParseFrom = &parseField
+					mapping := map[interface{}]interface{}{
+						"critical": "5xx",
+						"error":    "4xx",
+						"info":     "3xx",
+						"debug":    "2xx",
+					}
+					severityParser.Mapping = mapping
+					cfg.Config = &severityParser
+					return cfg
+				}(),
+			},
+			{
+				Name: "scope_name",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					loggerNameParser := helper.NewScopeNameParser()
+					loggerNameParser.ParseFrom = entry.NewBodyField("logger_name_field")
+					cfg.ScopeNameParser = &loggerNameParser
+					return cfg
+				}(),
+			},
 		},
-		{
-			Name: "parse_from_simple",
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.ParseFrom = entry.NewBodyField("from")
-				return cfg
-			}(),
-		},
-		{
-			Name: "parse_to_simple",
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.ParseTo = entry.NewBodyField("log")
-				return cfg
-			}(),
-		},
-		{
-			Name: "on_error_drop",
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.OnError = "drop"
-				return cfg
-			}(),
-		},
-		{
-			Name: "timestamp",
-			Expect: func() *Config {
-				cfg := NewConfig()
-				parseField := entry.NewBodyField("timestamp_field")
-				newTime := helper.TimeParser{
-					LayoutType: "strptime",
-					Layout:     "%Y-%m-%d",
-					ParseFrom:  &parseField,
-				}
-				cfg.TimeParser = &newTime
-				return cfg
-			}(),
-		},
-		{
-			Name: "severity",
-			Expect: func() *Config {
-				cfg := NewConfig()
-				parseField := entry.NewBodyField("severity_field")
-				severityParser := helper.NewSeverityConfig()
-				severityParser.ParseFrom = &parseField
-				mapping := map[interface{}]interface{}{
-					"critical": "5xx",
-					"error":    "4xx",
-					"info":     "3xx",
-					"debug":    "2xx",
-				}
-				severityParser.Mapping = mapping
-				cfg.Config = &severityParser
-				return cfg
-			}(),
-		},
-		{
-			Name: "scope_name",
-			Expect: func() *Config {
-				cfg := NewConfig()
-				loggerNameParser := helper.NewScopeNameParser()
-				loggerNameParser.ParseFrom = entry.NewBodyField("logger_name_field")
-				cfg.ScopeNameParser = &loggerNameParser
-				return cfg
-			}(),
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, NewConfig())
-			tc.RunDeprecated(t, NewConfig())
-		})
-	}
+	}.Run(t)
 }

--- a/pkg/stanza/operator/parser/json/config_test.go
+++ b/pkg/stanza/operator/parser/json/config_test.go
@@ -25,12 +25,12 @@ func TestConfig(t *testing.T) {
 	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name:   "default",
-			Expect: defaultCfg(),
+			Expect: NewConfig(),
 		},
 		{
 			Name: "parse_from_simple",
 			Expect: func() *Config {
-				cfg := defaultCfg()
+				cfg := NewConfig()
 				cfg.ParseFrom = entry.NewBodyField("from")
 				return cfg
 			}(),
@@ -38,7 +38,7 @@ func TestConfig(t *testing.T) {
 		{
 			Name: "parse_to_simple",
 			Expect: func() *Config {
-				cfg := defaultCfg()
+				cfg := NewConfig()
 				cfg.ParseTo = entry.NewBodyField("log")
 				return cfg
 			}(),
@@ -46,7 +46,7 @@ func TestConfig(t *testing.T) {
 		{
 			Name: "on_error_drop",
 			Expect: func() *Config {
-				cfg := defaultCfg()
+				cfg := NewConfig()
 				cfg.OnError = "drop"
 				return cfg
 			}(),
@@ -54,7 +54,7 @@ func TestConfig(t *testing.T) {
 		{
 			Name: "timestamp",
 			Expect: func() *Config {
-				cfg := defaultCfg()
+				cfg := NewConfig()
 				parseField := entry.NewBodyField("timestamp_field")
 				newTime := helper.TimeParser{
 					LayoutType: "strptime",
@@ -68,7 +68,7 @@ func TestConfig(t *testing.T) {
 		{
 			Name: "severity",
 			Expect: func() *Config {
-				cfg := defaultCfg()
+				cfg := NewConfig()
 				parseField := entry.NewBodyField("severity_field")
 				severityParser := helper.NewSeverityConfig()
 				severityParser.ParseFrom = &parseField
@@ -86,7 +86,7 @@ func TestConfig(t *testing.T) {
 		{
 			Name: "scope_name",
 			Expect: func() *Config {
-				cfg := defaultCfg()
+				cfg := NewConfig()
 				loggerNameParser := helper.NewScopeNameParser()
 				loggerNameParser.ParseFrom = entry.NewBodyField("logger_name_field")
 				cfg.ScopeNameParser = &loggerNameParser
@@ -97,11 +97,8 @@ func TestConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.Run(t, NewConfig())
+			tc.RunDeprecated(t, NewConfig())
 		})
 	}
-}
-
-func defaultCfg() *Config {
-	return NewConfig()
 }

--- a/pkg/stanza/operator/parser/json/testdata/config.yaml
+++ b/pkg/stanza/operator/parser/json/testdata/config.yaml
@@ -1,0 +1,30 @@
+default:
+  type: json_parser
+on_error_drop:
+  type: json_parser
+  on_error: drop
+parse_from_simple:
+  type: json_parser
+  parse_from: body.from
+parse_to_simple:
+  type: json_parser
+  parse_to: body.log
+scope_name:
+  type: json_parser
+  scope_name:
+    parse_from: body.logger_name_field
+severity:
+  type: json_parser
+  severity:
+    parse_from: body.severity_field
+    mapping:
+      critical: 5xx
+      error: 4xx
+      info: 3xx
+      debug: 2xx
+timestamp:
+  type: json_parser
+  timestamp:
+    parse_from: body.timestamp_field
+    layout_type: strptime
+    layout: '%Y-%m-%d'

--- a/pkg/stanza/operator/parser/json/testdata/default.yaml
+++ b/pkg/stanza/operator/parser/json/testdata/default.yaml
@@ -1,1 +1,0 @@
-type: json_parser

--- a/pkg/stanza/operator/parser/json/testdata/on_error_drop.yaml
+++ b/pkg/stanza/operator/parser/json/testdata/on_error_drop.yaml
@@ -1,2 +1,0 @@
-type: json_parser
-on_error: drop

--- a/pkg/stanza/operator/parser/json/testdata/parse_from_simple.yaml
+++ b/pkg/stanza/operator/parser/json/testdata/parse_from_simple.yaml
@@ -1,2 +1,0 @@
-type: json_parser
-parse_from: body.from

--- a/pkg/stanza/operator/parser/json/testdata/parse_to_simple.yaml
+++ b/pkg/stanza/operator/parser/json/testdata/parse_to_simple.yaml
@@ -1,2 +1,0 @@
-type: json_parser
-parse_to: body.log

--- a/pkg/stanza/operator/parser/json/testdata/scope_name.yaml
+++ b/pkg/stanza/operator/parser/json/testdata/scope_name.yaml
@@ -1,3 +1,0 @@
-type: json_parser
-scope_name:
-  parse_from: body.logger_name_field

--- a/pkg/stanza/operator/parser/json/testdata/severity.yaml
+++ b/pkg/stanza/operator/parser/json/testdata/severity.yaml
@@ -1,8 +1,0 @@
-type: json_parser
-severity:
-  parse_from: body.severity_field
-  mapping:
-    critical: 5xx
-    error: 4xx
-    info: 3xx
-    debug: 2xx

--- a/pkg/stanza/operator/parser/json/testdata/timestamp.yaml
+++ b/pkg/stanza/operator/parser/json/testdata/timestamp.yaml
@@ -1,5 +1,0 @@
-type: json_parser
-timestamp:
-  parse_from: body.timestamp_field
-  layout_type: strptime
-  layout: '%Y-%m-%d'

--- a/pkg/stanza/operator/parser/keyvalue/config_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/config_test.go
@@ -103,7 +103,7 @@ func TestConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/parser/regex/config_test.go
+++ b/pkg/stanza/operator/parser/regex/config_test.go
@@ -115,7 +115,7 @@ func TestParserGoldenConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/parser/trace/config_test.go
+++ b/pkg/stanza/operator/parser/trace/config_test.go
@@ -75,7 +75,7 @@ func TestConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/parser/uri/config_test.go
+++ b/pkg/stanza/operator/parser/uri/config_test.go
@@ -87,7 +87,7 @@ func TestParserGoldenConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/transformer/add/config_test.go
+++ b/pkg/stanza/operator/transformer/add/config_test.go
@@ -150,7 +150,7 @@ func TestGoldenConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/transformer/copy/config_test.go
+++ b/pkg/stanza/operator/transformer/copy/config_test.go
@@ -80,7 +80,7 @@ func TestGoldenConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/transformer/move/config_test.go
+++ b/pkg/stanza/operator/transformer/move/config_test.go
@@ -162,7 +162,7 @@ func TestGoldenConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/transformer/recombine/config_test.go
+++ b/pkg/stanza/operator/transformer/recombine/config_test.go
@@ -84,7 +84,7 @@ func TestConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/transformer/remove/config_test.go
+++ b/pkg/stanza/operator/transformer/remove/config_test.go
@@ -98,7 +98,7 @@ func TestGoldenConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/transformer/retain/config_test.go
+++ b/pkg/stanza/operator/transformer/retain/config_test.go
@@ -100,7 +100,7 @@ func TestGoldenConfigs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }

--- a/pkg/stanza/operator/transformer/router/config_test.go
+++ b/pkg/stanza/operator/transformer/router/config_test.go
@@ -97,7 +97,7 @@ func TestRouterGoldenConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.Run(t, defaultCfg())
+			tc.RunDeprecated(t, defaultCfg())
 		})
 	}
 }


### PR DESCRIPTION
Extends from #13437

This change allows tests to be written within a single yaml file.