### PR TITLE
[pkg/telemetryquerylanguage] remove unnecessary calls to clean attributes

### DIFF
--- a/pkg/telemetryquerylanguage/contexts/tqllogs/logs.go
+++ b/pkg/telemetryquerylanguage/contexts/tqllogs/logs.go
@@ -158,7 +158,6 @@ func accessResource() tql.StandardGetSetter {
 		},
 		Setter: func(ctx tql.TransformContext, val interface{}) {
 			if newRes, ok := val.(pcommon.Resource); ok {
-				ctx.GetResource().Attributes().Clear()
 				newRes.CopyTo(ctx.GetResource())
 			}
 		},
@@ -172,7 +171,6 @@ func accessResourceAttributes() tql.StandardGetSetter {
 		},
 		Setter: func(ctx tql.TransformContext, val interface{}) {
 			if attrs, ok := val.(pcommon.Map); ok {
-				ctx.GetResource().Attributes().Clear()
 				attrs.CopyTo(ctx.GetResource().Attributes())
 			}
 		},
@@ -299,7 +297,6 @@ func accessAttributes() tql.StandardGetSetter {
 		},
 		Setter: func(ctx tql.TransformContext, val interface{}) {
 			if attrs, ok := val.(pcommon.Map); ok {
-				ctx.GetItem().(plog.LogRecord).Attributes().Clear()
 				attrs.CopyTo(ctx.GetItem().(plog.LogRecord).Attributes())
 			}
 		},

--- a/pkg/telemetryquerylanguage/contexts/tqlmetrics/metrics.go
+++ b/pkg/telemetryquerylanguage/contexts/tqlmetrics/metrics.go
@@ -188,7 +188,6 @@ func accessResource() tql.StandardGetSetter {
 		},
 		Setter: func(ctx tql.TransformContext, val interface{}) {
 			if newRes, ok := val.(pcommon.Resource); ok {
-				ctx.GetResource().Attributes().Clear()
 				newRes.CopyTo(ctx.GetResource())
 			}
 		},
@@ -202,7 +201,6 @@ func accessResourceAttributes() tql.StandardGetSetter {
 		},
 		Setter: func(ctx tql.TransformContext, val interface{}) {
 			if attrs, ok := val.(pcommon.Map); ok {
-				ctx.GetResource().Attributes().Clear()
 				attrs.CopyTo(ctx.GetResource().Attributes())
 			}
 		},
@@ -394,22 +392,18 @@ func accessAttributes() tql.StandardGetSetter {
 			switch ctx.GetItem().(type) {
 			case pmetric.NumberDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
-					ctx.GetItem().(pmetric.NumberDataPoint).Attributes().Clear()
 					attrs.CopyTo(ctx.GetItem().(pmetric.NumberDataPoint).Attributes())
 				}
 			case pmetric.HistogramDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
-					ctx.GetItem().(pmetric.HistogramDataPoint).Attributes().Clear()
 					attrs.CopyTo(ctx.GetItem().(pmetric.HistogramDataPoint).Attributes())
 				}
 			case pmetric.ExponentialHistogramDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Attributes().Clear()
 					attrs.CopyTo(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Attributes())
 				}
 			case pmetric.SummaryDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
-					ctx.GetItem().(pmetric.SummaryDataPoint).Attributes().Clear()
 					attrs.CopyTo(ctx.GetItem().(pmetric.SummaryDataPoint).Attributes())
 				}
 			}

--- a/pkg/telemetryquerylanguage/contexts/tqltraces/traces.go
+++ b/pkg/telemetryquerylanguage/contexts/tqltraces/traces.go
@@ -167,7 +167,6 @@ func accessResource() tql.StandardGetSetter {
 		},
 		Setter: func(ctx tql.TransformContext, val interface{}) {
 			if newRes, ok := val.(pcommon.Resource); ok {
-				ctx.GetResource().Attributes().Clear()
 				newRes.CopyTo(ctx.GetResource())
 			}
 		},
@@ -181,7 +180,6 @@ func accessResourceAttributes() tql.StandardGetSetter {
 		},
 		Setter: func(ctx tql.TransformContext, val interface{}) {
 			if attrs, ok := val.(pcommon.Map); ok {
-				ctx.GetResource().Attributes().Clear()
 				attrs.CopyTo(ctx.GetResource().Attributes())
 			}
 		},
@@ -399,7 +397,6 @@ func accessAttributes() tql.StandardGetSetter {
 		},
 		Setter: func(ctx tql.TransformContext, val interface{}) {
 			if attrs, ok := val.(pcommon.Map); ok {
-				ctx.GetItem().(ptrace.Span).Attributes().Clear()
 				attrs.CopyTo(ctx.GetItem().(ptrace.Span).Attributes())
 			}
 		},


### PR DESCRIPTION
Also, in pdata, we do try to reuse memory if possible on the destination, so cleaning removes this optimization.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
