### PR TITLE
[processor/k8sattributesprocessor] handle new pods

### DIFF
--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -523,7 +523,7 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 		// This should fix the case where scheduler has assigned the same attribtues (like IP address)
 		// to a new pod but update event for the old pod came in later.
 		if p, ok := c.Pods[id]; ok {
-			if p.StartTime != nil && !p.StartTime.Before(pod.Status.StartTime) {
+			if p.StartTime != nil && !p.StartTime.Before(pod.Status.StartTime) && !p.StartTime.Equal(pod.Status.StartTime) {
 				return
 			}
 		}

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -523,7 +523,7 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 		// This should fix the case where scheduler has assigned the same attribtues (like IP address)
 		// to a new pod but update event for the old pod came in later.
 		if p, ok := c.Pods[id]; ok {
-			if p.StartTime != nil && !p.StartTime.Before(pod.Status.StartTime) && !p.StartTime.Equal(pod.Status.StartTime) {
+			if pod.Status.StartTime.Before(p.StartTime) {
 				return
 			}
 		}

--- a/unreleased/fix-pod-replacement.yaml
+++ b/unreleased/fix-pod-replacement.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: k8sattributesprocessor now correctly adds attributes to new pods that start after the collector
+
+# One or more tracking issues related to the change
+issues:
+  - 13619
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Update start time check to ensure that new pods are included.

Without this fix, pods created after the opentelemetry collector
starts do not have their attributes set correctly

**Link to tracking Issue:** 

#13619 

**Testing:**

Ran this in kind before the fix and after the fix and validated that the pod info wasn't present following a restart before the fix but was present after the fix following a restart

**Documentation:**

No new documentation