### PR TITLE
[processor/routingprocessor] Add support for using TQL expressions as routing conditions.

### DIFF
--- a/processor/routingprocessor/README.md
+++ b/processor/routingprocessor/README.md
@@ -1,5 +1,11 @@
 # Routing processor
 
+| Status                   |                       |
+|--------------------------|-----------------------|
+| Stability                | [beta]                |
+| Supported pipeline types | traces, metrics, logs |
+| Distributions            | [contrib]             |
+
 Routes logs, metrics or traces to specific exporters.
 
 This processor will either read a header from the incoming HTTP request (gRPC or plain HTTP), or it will read a resource attribute, and direct the trace information to specific exporters based on the value read.
@@ -9,6 +15,8 @@ Similarly, exporters defined as part of the pipeline are not authoritative: if y
 All exporters defined as part of this processor *must also* be defined as part of the pipeline's exporters.
 
 Given that this processor depends on information provided by the client via HTTP headers or resource attributes, caution must be taken when processors that aggregate data like `batch` or `groupbytrace` are used as part of the pipeline.
+
+## Configuration
 
 The following settings are required:
 
@@ -43,10 +51,62 @@ exporters:
     endpoint: localhost:24250
 ```
 
+### Tech Preview: Telemetry Query Language expressions as routing conditions
+
+Alternatively, it is possible to use subset of the [Telemetry Query Language (TQL)](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language)
+expressions as routing conditions.
+
+To configure the routing processor with [TQL] routing conditions use the following options:
+
+- `table (required)`: the routing table for this processor.
+- `table.expression (required)`: the routing condition provided as the [TQL] expression.
+- `table.exporters (required)`: the list of exporters to use when the routing condition is met.
+- `default_exporters (optional)`: contains the list of exporters to use when a record
+does not meet any of specified conditions.
+
+```yaml
+
+processors:
+  routing:
+    default_exporters:
+    - jaeger
+    table:
+      - expression: route() where resource.attributes["X-Tenant"] == "value"
+        exporters: [jaeger/1]
+      - expression: delete_key(resource.attributes, "X-Tenant") where IsMatch(resource.attributes["X-Tenant"], ".*cme") == true
+        exporters: [jaeger/2]
+
+exporters:
+  jaeger:
+    endpoint: localhost:14250
+  jaeger/1:
+    endpoint: localhost:24250
+  jaeger/2:
+    endpoint: localhost:34250
+```
+
+It is also possible to use both the conventional routing items configuration and
+the routing items with [TQL] conditions.
+
+#### Limitations:
+
+- [TQL] expressions can be applied only to resource attributes.
+- Currently, it is not possible to specify the boolean expression without function
+invocation as the routing condition. It is required to provide the NOOP `route()`
+or any other supported function as part of the routing expression, see
+[#13545](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545)
+for more information.
+- Supported [TQL] functions:
+  - [IsMatch](../../pkg/telemetryquerylanguage/functions/tqlcommon/README.md#IsMatch)
+  - [delete_key](../../pkg/telemetryquerylanguage/functions/tqlotel/README.md#delete_key)
+  - [delete_matching_keys](../../pkg/telemetryquerylanguage/functions/tqlotel/README.md#delete_matching_keys)
+
 The full list of settings exposed for this processor are documented [here](./config.go) with detailed sample configuration files:
 
 - [logs](./testdata/config_logs.yaml)
 - [metrics](./testdata/config_metrics.yaml)
 - [traces](./testdata/config_traces.yaml)
 
+[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [context_docs]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/README.md
+[TQL]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language

--- a/processor/routingprocessor/README.md
+++ b/processor/routingprocessor/README.md
@@ -53,8 +53,7 @@ exporters:
 
 ### Tech Preview: Telemetry Query Language expressions as routing conditions
 
-Alternatively, it is possible to use subset of the [Telemetry Query Language (TQL)](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language)
-expressions as routing conditions.
+Alternatively, it is possible to use subset of the [Telemetry Query Language (TQL)](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language) expressions as routing conditions.
 
 To configure the routing processor with [TQL] routing conditions use the following options:
 
@@ -71,31 +70,26 @@ processors:
     default_exporters:
     - jaeger
     table:
-      - expression: route() where resource.attributes["X-Tenant"] == "value"
-        exporters: [jaeger/1]
-      - expression: delete_key(resource.attributes, "X-Tenant") where IsMatch(resource.attributes["X-Tenant"], ".*cme") == true
-        exporters: [jaeger/2]
+      - expression: route() where resource.attributes["X-Tenant"] == "acme"
+        exporters: [jaeger/acme]
+      - expression: delete_key(resource.attributes, "X-Tenant") where IsMatch(resource.attributes["X-Tenant"], ".*corp") == true
+        exporters: [jaeger/ecorp]
 
 exporters:
   jaeger:
     endpoint: localhost:14250
-  jaeger/1:
+  jaeger/acme:
     endpoint: localhost:24250
-  jaeger/2:
+  jaeger/ecorp:
     endpoint: localhost:34250
 ```
 
-It is also possible to use both the conventional routing items configuration and
-the routing items with [TQL] conditions.
+It is also possible to use both the conventional routing items configuration and the routing items with [TQL] conditions.
 
 #### Limitations:
 
 - [TQL] expressions can be applied only to resource attributes.
-- Currently, it is not possible to specify the boolean expression without function
-invocation as the routing condition. It is required to provide the NOOP `route()`
-or any other supported function as part of the routing expression, see
-[#13545](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545)
-for more information.
+- Currently, it is not possible to specify the boolean expression without function invocation as the routing condition. It is required to provide the NOOP `route()` or any other supported function as part of the routing expression, see [#13545](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545) for more information.
 - Supported [TQL] functions:
   - [IsMatch](../../pkg/telemetryquerylanguage/functions/tqlcommon/README.md#IsMatch)
   - [delete_key](../../pkg/telemetryquerylanguage/functions/tqlotel/README.md#delete_key)

--- a/processor/routingprocessor/README.md
+++ b/processor/routingprocessor/README.md
@@ -51,14 +51,14 @@ exporters:
     endpoint: localhost:24250
 ```
 
-### Tech Preview: Telemetry Query Language expressions as routing conditions
+### Tech Preview: OpenTelemetry Transformation Language expressions as routing conditions
 
-Alternatively, it is possible to use subset of the [Telemetry Query Language (TQL)](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language) expressions as routing conditions.
+Alternatively, it is possible to use subset of the [OpenTelemetry Transformation Language (OTTL)](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language) expressions as routing conditions.
 
-To configure the routing processor with [TQL] routing conditions use the following options:
+To configure the routing processor with [OTTL] routing conditions use the following options:
 
 - `table (required)`: the routing table for this processor.
-- `table.expression (required)`: the routing condition provided as the [TQL] expression.
+- `table.expression (required)`: the routing condition provided as the [OTTL] expression.
 - `table.exporters (required)`: the list of exporters to use when the routing condition is met.
 - `default_exporters (optional)`: contains the list of exporters to use when a record
 does not meet any of specified conditions.
@@ -87,13 +87,13 @@ exporters:
 A signal may get matched by routing conditions of more than one routing table entry. In this case, the signal will be routed to all exporters of matching routes.
 Respectively, if none of the routing conditions met, then a signal is routed to default exporters.
 
-It is also possible to use both the conventional routing items configuration and the routing items with [TQL] conditions.
+It is also possible to use both the conventional routing items configuration and the routing items with [OTTL] conditions.
 
 #### Limitations:
 
-- [TQL] expressions can be applied only to resource attributes.
+- [OTTL] expressions can be applied only to resource attributes.
 - Currently, it is not possible to specify the boolean expression without function invocation as the routing condition. It is required to provide the NOOP `route()` or any other supported function as part of the routing expression, see [#13545](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545) for more information.
-- Supported [TQL] functions:
+- Supported [OTTL] functions:
   - [IsMatch](../../pkg/telemetryquerylanguage/functions/tqlcommon/README.md#IsMatch)
   - [delete_key](../../pkg/telemetryquerylanguage/functions/tqlotel/README.md#delete_key)
   - [delete_matching_keys](../../pkg/telemetryquerylanguage/functions/tqlotel/README.md#delete_matching_keys)
@@ -106,4 +106,4 @@ The full list of settings exposed for this processor are documented [here](./con
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [context_docs]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/README.md
-[TQL]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language
+[OTTL]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language

--- a/processor/routingprocessor/README.md
+++ b/processor/routingprocessor/README.md
@@ -84,6 +84,9 @@ exporters:
     endpoint: localhost:34250
 ```
 
+A signal may get matched by routing conditions of more than one routing table entry. In this case, the signal will be routed to all exporters of matching routes.
+Respectively, if none of the routing conditions met, then a signal is routed to default exporters.
+
 It is also possible to use both the conventional routing items configuration and the routing items with [TQL] conditions.
 
 #### Limitations:

--- a/processor/routingprocessor/config.go
+++ b/processor/routingprocessor/config.go
@@ -116,7 +116,7 @@ type RoutingTableItem struct {
 	// Required when 'Expression' isn't provided.
 	Value string `mapstructure:"value"`
 
-	// Expression is a TQL expression on which signals routing is based.
+	// Expression is a OTTL expression on which signals routing is based.
 	// Required when 'Value' isn't provided.
 	Expression string `mapstructure:"expression"`
 
@@ -127,8 +127,8 @@ type RoutingTableItem struct {
 	Exporters []string `mapstructure:"exporters"`
 }
 
-// rewriteRoutingItemsToTQL translates the attributes-based routing into TQL
-func rewriteRoutingEntriesToTQL(cfg *Config) *Config {
+// rewriteRoutingEntriesToOTTL translates the attributes-based routing into OTTL
+func rewriteRoutingEntriesToOTTL(cfg *Config) *Config {
 	if cfg.AttributeSource != resourceAttributeSource {
 		return cfg
 	}

--- a/processor/routingprocessor/config.go
+++ b/processor/routingprocessor/config.go
@@ -17,6 +17,7 @@ package routingprocessor // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"go.opentelemetry.io/collector/config"
 )
@@ -64,21 +65,25 @@ type Config struct {
 
 // Validate checks if the processor configuration is valid.
 func (c *Config) Validate() error {
+	// validate that there's at least one item in the table
+	if len(c.Table) == 0 {
+		return fmt.Errorf("invalid routing table: %w", errNoTableItems)
+	}
+
 	// validate that every route has a value for the routing attribute and has
 	// at least one exporter
 	for _, item := range c.Table {
-		if len(item.Value) == 0 {
+		if len(item.Value) == 0 && len(item.Expression) == 0 {
 			return fmt.Errorf("invalid (empty) route : %w", errEmptyRoute)
+		}
+
+		if len(item.Value) != 0 && len(item.Expression) != 0 {
+			return fmt.Errorf("both expression and value provided")
 		}
 
 		if len(item.Exporters) == 0 {
 			return fmt.Errorf("invalid route %s: %w", item.Value, errNoExporters)
 		}
-	}
-
-	// validate that there's at least one item in the table
-	if len(c.Table) == 0 {
-		return fmt.Errorf("invalid routing table: %w", errNoTableItems)
 	}
 
 	// we also need a "FromAttribute" value
@@ -107,12 +112,56 @@ const (
 
 // RoutingTableItem specifies how data should be routed to the different exporters
 type RoutingTableItem struct {
-	// Value represents a possible value for the field specified under FromAttribute. Required.
+	// Value represents a possible value for the field specified under FromAttribute.
 	Value string `mapstructure:"value"`
+
+	// Expression is a TQL condition / query on which signals routing is based.
+	Expression string `mapstructure:"expression"`
 
 	// Exporters contains the list of exporters to use when the value from the FromAttribute field matches this table item.
 	// When no exporters are specified, the ones specified under DefaultExporters are used, if any.
 	// The routing processor will fail upon the first failure from these exporters.
 	// Optional.
 	Exporters []string `mapstructure:"exporters"`
+}
+
+// rewriteRoutingItemsToTQL rewrites routing table entries based on resource
+// attributes routing to TQL.
+func rewriteRoutingEntriesToTQL(cfg *Config) Config {
+	if cfg.AttributeSource != resourceAttributeSource {
+		return *cfg
+	}
+	table := make([]RoutingTableItem, 0)
+	for _, e := range cfg.Table {
+		if e.Expression != "" {
+			table = append(table, e)
+			continue
+		}
+		var s strings.Builder
+		if cfg.DropRoutingResourceAttribute {
+			s.WriteString(
+				fmt.Sprintf(
+					"delete_key(resource.attributes, \"%s\")",
+					cfg.FromAttribute,
+				),
+			)
+		} else {
+			s.WriteString("route()")
+		}
+		s.WriteString(
+			fmt.Sprintf(
+				" where resource.attributes[\"%s\"] == \"%s\"",
+				cfg.FromAttribute,
+				e.Value,
+			),
+		)
+		table = append(table, RoutingTableItem{
+			Expression: s.String(),
+			Exporters:  e.Exporters,
+		})
+	}
+	return Config{
+		DefaultExporters: cfg.DefaultExporters,
+		Table:            table,
+	}
 }

--- a/processor/routingprocessor/config_test.go
+++ b/processor/routingprocessor/config_test.go
@@ -105,3 +105,199 @@ func TestLoadConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config config.Processor
+		error  string
+	}{
+		{
+			name: "both expression and value specified",
+			config: &Config{
+				FromAttribute:   "attr",
+				AttributeSource: resourceAttributeSource,
+				Table: []RoutingTableItem{
+					{
+						Exporters:  []string{"otlp"},
+						Value:      "value",
+						Expression: `route() where resource.attributes["attr"] == "value"`,
+					},
+				},
+			},
+			error: "both expression and value provided",
+		},
+		{
+			name: "neither expression or value provided",
+			config: &Config{
+				FromAttribute:   "attr",
+				AttributeSource: resourceAttributeSource,
+				Table: []RoutingTableItem{
+					{
+						Exporters: []string{"otlp"},
+					},
+				},
+			},
+			error: "invalid (empty) route : empty routing attribute provided",
+		},
+		{
+			name: "drop routing attribute with context as routing attribute source",
+			config: &Config{
+				FromAttribute:                "attr",
+				AttributeSource:              contextAttributeSource,
+				DropRoutingResourceAttribute: true,
+				Table: []RoutingTableItem{
+					{
+						Exporters: []string{"otlp"},
+						Value:     "test",
+					},
+				},
+			},
+			error: "using a different attribute source than 'attribute' and drop_resource_routing_attribute is set to true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.EqualError(t, tt.config.Validate(), tt.error)
+		})
+	}
+}
+
+func TestRewriteLegacyConfigToTQL(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+		want   Config
+	}{
+		{
+			name: "rewrite routing by resource attribute",
+			config: Config{
+				FromAttribute:   "attr",
+				AttributeSource: resourceAttributeSource,
+				Table: []RoutingTableItem{
+					{
+						Exporters: []string{"otlp"},
+						Value:     "value",
+					},
+				},
+			},
+			want: Config{
+				Table: []RoutingTableItem{
+					{
+						Exporters:  []string{"otlp"},
+						Expression: `route() where resource.attributes["attr"] == "value"`,
+					},
+				},
+			},
+		},
+		{
+			name: "rewrite routing by resource attribute multiple entries",
+			config: Config{
+				FromAttribute:   "attr",
+				AttributeSource: resourceAttributeSource,
+				Table: []RoutingTableItem{
+					{
+						Exporters: []string{"otlp"},
+						Value:     "value",
+					},
+					{
+						Exporters: []string{"otlp/2"},
+						Value:     "value2",
+					},
+				},
+			},
+			want: Config{
+				Table: []RoutingTableItem{
+					{
+						Exporters:  []string{"otlp"},
+						Expression: `route() where resource.attributes["attr"] == "value"`,
+					},
+					{
+						Exporters:  []string{"otlp/2"},
+						Expression: `route() where resource.attributes["attr"] == "value2"`,
+					},
+				},
+			},
+		},
+		{
+			name: "rewrite routing by resource attribute with dropping routing key",
+			config: Config{
+				FromAttribute:                "attr",
+				AttributeSource:              resourceAttributeSource,
+				DropRoutingResourceAttribute: true,
+				Table: []RoutingTableItem{
+					{
+						Exporters: []string{"otlp"},
+						Value:     "value",
+					},
+				},
+			},
+			want: Config{
+				Table: []RoutingTableItem{
+					{
+						Exporters:  []string{"otlp"},
+						Expression: `delete_key(resource.attributes, "attr") where resource.attributes["attr"] == "value"`,
+					},
+				},
+			},
+		},
+		{
+			name: "rewrite routing with context as attribute source",
+			config: Config{
+				FromAttribute:   "attr",
+				AttributeSource: contextAttributeSource,
+				Table: []RoutingTableItem{
+					{
+						Exporters: []string{"otlp"},
+						Value:     "value",
+					},
+				},
+			},
+			want: Config{
+				FromAttribute:   "attr",
+				AttributeSource: contextAttributeSource,
+				Table: []RoutingTableItem{
+					{
+						Exporters: []string{"otlp"},
+						Value:     "value",
+					},
+				},
+			},
+		},
+		{
+			name: "rewrite routing by resource attribute with mixed tql entries",
+			config: Config{
+				FromAttribute:   "attr",
+				AttributeSource: resourceAttributeSource,
+				Table: []RoutingTableItem{
+					{
+						Exporters: []string{"otlp"},
+						Value:     "value",
+					},
+					{
+						Exporters:  []string{"otlp/2"},
+						Expression: `route() where resource.attributes["attr"] == "value2"`,
+					},
+				},
+			},
+			want: Config{
+				Table: []RoutingTableItem{
+					{
+						Exporters:  []string{"otlp"},
+						Expression: `route() where resource.attributes["attr"] == "value"`,
+					},
+					{
+						Exporters:  []string{"otlp/2"},
+						Expression: `route() where resource.attributes["attr"] == "value2"`,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rewriteRoutingEntriesToTQL(&tt.config))
+		})
+	}
+}

--- a/processor/routingprocessor/config_test.go
+++ b/processor/routingprocessor/config_test.go
@@ -164,7 +164,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
-func TestRewriteLegacyConfigToTQL(t *testing.T) {
+func TestRewriteLegacyConfigToOTTL(t *testing.T) {
 	tests := []struct {
 		name   string
 		config Config
@@ -266,7 +266,7 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 			},
 		},
 		{
-			name: "rewrite routing by resource attribute with mixed tql entries",
+			name: "rewrite routing by resource attribute with mixed routing entries",
 			config: Config{
 				FromAttribute:   "attr",
 				AttributeSource: resourceAttributeSource,
@@ -297,7 +297,7 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, *rewriteRoutingEntriesToTQL(&tt.config))
+			assert.Equal(t, tt.want, *rewriteRoutingEntriesToOTTL(&tt.config))
 		})
 	}
 }

--- a/processor/routingprocessor/config_test.go
+++ b/processor/routingprocessor/config_test.go
@@ -120,12 +120,12 @@ func TestValidateConfig(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters:  []string{"otlp"},
-						Value:      "value",
-						Expression: `route() where resource.attributes["attr"] == "value"`,
+						Value:      "acme",
+						Expression: `route() where resource.attributes["attr"] == "acme"`,
 					},
 				},
 			},
-			error: "both expression and value provided",
+			error: "invalid route: both expression (route() where resource.attributes[\"attr\"] == \"acme\") and value (acme) provided",
 		},
 		{
 			name: "neither expression or value provided",
@@ -178,7 +178,7 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters: []string{"otlp"},
-						Value:     "value",
+						Value:     "acme",
 					},
 				},
 			},
@@ -186,7 +186,7 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters:  []string{"otlp"},
-						Expression: `route() where resource.attributes["attr"] == "value"`,
+						Expression: `route() where resource.attributes["attr"] == "acme"`,
 					},
 				},
 			},
@@ -199,11 +199,11 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters: []string{"otlp"},
-						Value:     "value",
+						Value:     "acme",
 					},
 					{
 						Exporters: []string{"otlp/2"},
-						Value:     "value2",
+						Value:     "ecorp",
 					},
 				},
 			},
@@ -211,11 +211,11 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters:  []string{"otlp"},
-						Expression: `route() where resource.attributes["attr"] == "value"`,
+						Expression: `route() where resource.attributes["attr"] == "acme"`,
 					},
 					{
 						Exporters:  []string{"otlp/2"},
-						Expression: `route() where resource.attributes["attr"] == "value2"`,
+						Expression: `route() where resource.attributes["attr"] == "ecorp"`,
 					},
 				},
 			},
@@ -229,7 +229,7 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters: []string{"otlp"},
-						Value:     "value",
+						Value:     "acme",
 					},
 				},
 			},
@@ -237,7 +237,7 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters:  []string{"otlp"},
-						Expression: `delete_key(resource.attributes, "attr") where resource.attributes["attr"] == "value"`,
+						Expression: `delete_key(resource.attributes, "attr") where resource.attributes["attr"] == "acme"`,
 					},
 				},
 			},
@@ -250,7 +250,7 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters: []string{"otlp"},
-						Value:     "value",
+						Value:     "acme",
 					},
 				},
 			},
@@ -260,7 +260,7 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters: []string{"otlp"},
-						Value:     "value",
+						Value:     "acme",
 					},
 				},
 			},
@@ -273,11 +273,11 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters: []string{"otlp"},
-						Value:     "value",
+						Value:     "acme",
 					},
 					{
 						Exporters:  []string{"otlp/2"},
-						Expression: `route() where resource.attributes["attr"] == "value2"`,
+						Expression: `route() where resource.attributes["attr"] == "ecorp"`,
 					},
 				},
 			},
@@ -285,11 +285,11 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 				Table: []RoutingTableItem{
 					{
 						Exporters:  []string{"otlp"},
-						Expression: `route() where resource.attributes["attr"] == "value"`,
+						Expression: `route() where resource.attributes["attr"] == "acme"`,
 					},
 					{
 						Exporters:  []string{"otlp/2"},
-						Expression: `route() where resource.attributes["attr"] == "value2"`,
+						Expression: `route() where resource.attributes["attr"] == "ecorp"`,
 					},
 				},
 			},
@@ -297,7 +297,7 @@ func TestRewriteLegacyConfigToTQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, rewriteRoutingEntriesToTQL(&tt.config))
+			assert.Equal(t, tt.want, *rewriteRoutingEntriesToTQL(&tt.config))
 		})
 	}
 }

--- a/processor/routingprocessor/extract.go
+++ b/processor/routingprocessor/extract.go
@@ -18,37 +18,25 @@ import (
 	"context"
 	"strings"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
 )
 
 // extractor is responsible for extracting configured attributes from the processed data.
-// Currently it can be extract the attributes from context or resource attributes.
+// Currently it can be extract the attributes from context.
 type extractor struct {
 	fromAttr string
 	logger   *zap.Logger
 }
 
 // newExtractor creates new extractor which can extract attributes from logs,
-// metrics and traces from from requested attribute source and from the provided
+// metrics and traces from requested attribute source and from the provided
 // attribute name.
 func newExtractor(fromAttr string, logger *zap.Logger) extractor {
 	return extractor{
 		fromAttr: fromAttr,
 		logger:   logger,
 	}
-}
-
-// extractAttrFromResource extract string value from the requested resource attribute.
-func (e extractor) extractAttrFromResource(r pcommon.Resource) string {
-	firstResourceAttributes := r.Attributes()
-	routingAttribute, found := firstResourceAttributes.Get(e.fromAttr)
-	if !found {
-		return ""
-	}
-
-	return routingAttribute.AsString()
 }
 
 func (e extractor) extractFromContext(ctx context.Context) string {

--- a/processor/routingprocessor/extract.go
+++ b/processor/routingprocessor/extract.go
@@ -23,7 +23,7 @@ import (
 )
 
 // extractor is responsible for extracting configured attributes from the processed data.
-// Currently it can be extract the attributes from context.
+// Currently, it can only extract the attributes from context.
 type extractor struct {
 	fromAttr string
 	logger   *zap.Logger

--- a/processor/routingprocessor/extract_test.go
+++ b/processor/routingprocessor/extract_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
 )
@@ -76,49 +75,6 @@ func TestExtractorForTraces_FromContext(t *testing.T) {
 			assert.Equal(t,
 				tc.expectedValue,
 				e.extractFromContext(tc.ctxFunc()),
-			)
-		})
-	}
-}
-
-func TestExtractorForTraces_FromResourceAttribute(t *testing.T) {
-	testcases := []struct {
-		name          string
-		tracesFunc    func() ptrace.Traces
-		fromAttr      string
-		expectedValue string
-	}{
-		{
-			name: "value from resource attribute",
-			tracesFunc: func() ptrace.Traces {
-				traces := ptrace.NewTraces()
-				rSpans := traces.ResourceSpans().AppendEmpty()
-				rSpans.Resource().Attributes().PutString("k8s.namespace.name", "namespace-1")
-				return traces
-			},
-			fromAttr:      "k8s.namespace.name",
-			expectedValue: "namespace-1",
-		},
-		{
-			name: "value from resource attribute even when the same context attribute exists",
-			tracesFunc: func() ptrace.Traces {
-				traces := ptrace.NewTraces()
-				rSpans := traces.ResourceSpans().AppendEmpty()
-				rSpans.Resource().Attributes().PutString("k8s.namespace.name", "namespace-1")
-				return traces
-			},
-			fromAttr:      "k8s.namespace.name",
-			expectedValue: "namespace-1",
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			e := newExtractor(tc.fromAttr, zap.NewNop())
-
-			assert.Equal(t,
-				tc.expectedValue,
-				e.extractAttrFromResource(tc.tracesFunc().ResourceSpans().At(0).Resource()),
 			)
 		})
 	}

--- a/processor/routingprocessor/go.mod
+++ b/processor/routingprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/routi
 go 1.18
 
 require (
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.0
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.60.0
 	go.opentelemetry.io/collector/pdata v0.60.0
@@ -13,11 +14,13 @@ require (
 
 require (
 	cloud.google.com/go/compute v1.9.0 // indirect
+	github.com/alecthomas/participle/v2 v2.0.0-beta.5 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -39,6 +42,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
 	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
 	golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 // indirect
@@ -46,7 +50,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220804142021-4e6b2dfa6612 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
@@ -55,3 +58,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaege
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger => ../../pkg/translator/jaeger
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage => ../../pkg/telemetryquerylanguage

--- a/processor/routingprocessor/go.mod
+++ b/processor/routingprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/routi
 go 1.18
 
 require (
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.60.0
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.60.0
 	go.opentelemetry.io/collector/pdata v0.60.0

--- a/processor/routingprocessor/go.sum
+++ b/processor/routingprocessor/go.sum
@@ -35,6 +35,10 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/alecthomas/assert/v2 v2.0.3 h1:WKqJODfOiQG0nEJKFKzDIG3E29CN2/4zR9XGJzKIkbg=
+github.com/alecthomas/participle/v2 v2.0.0-beta.5 h1:y6dsSYVb1G5eK6mgmy+BgI3Mw35a3WghArZ/Hbebrjo=
+github.com/alecthomas/participle/v2 v2.0.0-beta.5/go.mod h1:RC764t6n4L8D8ITAJv0qdokritYSNR3wV5cVwmIEaMM=
+github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -113,6 +117,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -214,6 +220,7 @@ github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoI
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -242,7 +249,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -402,6 +408,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -696,7 +704,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/processor/routingprocessor/internal/common/functions.go
+++ b/processor/routingprocessor/internal/common/functions.go
@@ -1,0 +1,38 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor/internal/common"
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/functions/tqlcommon"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/functions/tqlotel"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql"
+)
+
+var registry = map[string]interface{}{
+	"IsMatch":              tqlcommon.IsMatch,
+	"delete_key":           tqlotel.DeleteKey,
+	"delete_matching_keys": tqlotel.DeleteMatchingKeys,
+	// noop function, it is required since the parsing of conditions is not implemented yet,
+	// see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545
+	"route": func(_ []string) (tql.ExprFunc, error) {
+		return func(ctx tql.TransformContext) interface{} {
+			return true
+		}, nil
+	},
+}
+
+func Functions() map[string]interface{} {
+	return registry
+}

--- a/processor/routingprocessor/internal/common/logger.go
+++ b/processor/routingprocessor/internal/common/logger.go
@@ -1,0 +1,64 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor/internal/common"
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql"
+)
+
+type TQLLogger struct {
+	logger *zap.Logger
+}
+
+func NewTQLLogger(logger *zap.Logger) TQLLogger {
+	return TQLLogger{
+		logger: logger,
+	}
+}
+
+// WithFields creates a new logger that will include the specified fields
+// in all subsequent logs in addition to fields attached to the context
+// of the parent logger. Note that fields are not deduplicated.
+func (tqll TQLLogger) WithFields(fields map[string]any) tql.Logger {
+	newFields := make([]zap.Field, len(fields))
+	i := 0
+
+	for k, v := range fields {
+		switch val := v.(type) {
+		// zap.Any will base64 encode byte slices, but we want them printed as hexadecimal.
+		case []byte:
+			newFields[i] = zap.String(k, fmt.Sprintf("%x", val))
+		default:
+			newFields[i] = zap.Any(k, val)
+		}
+		i++
+	}
+
+	return TQLLogger{
+		logger: tqll.logger.With(newFields...),
+	}
+}
+
+func (tqll TQLLogger) Info(msg string) {
+	tqll.logger.Info(msg)
+}
+
+func (tqll TQLLogger) Error(msg string) {
+	tqll.logger.Error(msg)
+}

--- a/processor/routingprocessor/internal/common/logger.go
+++ b/processor/routingprocessor/internal/common/logger.go
@@ -35,7 +35,7 @@ func NewTQLLogger(logger *zap.Logger) TQLLogger {
 // WithFields creates a new logger that will include the specified fields
 // in all subsequent logs in addition to fields attached to the context
 // of the parent logger. Note that fields are not deduplicated.
-func (tqll TQLLogger) WithFields(fields map[string]any) tql.Logger {
+func (t TQLLogger) WithFields(fields map[string]any) tql.Logger {
 	newFields := make([]zap.Field, len(fields))
 	i := 0
 
@@ -51,14 +51,14 @@ func (tqll TQLLogger) WithFields(fields map[string]any) tql.Logger {
 	}
 
 	return TQLLogger{
-		logger: tqll.logger.With(newFields...),
+		logger: t.logger.With(newFields...),
 	}
 }
 
-func (tqll TQLLogger) Info(msg string) {
-	tqll.logger.Info(msg)
+func (t TQLLogger) Info(msg string) {
+	t.logger.Info(msg)
 }
 
-func (tqll TQLLogger) Error(msg string) {
-	tqll.logger.Error(msg)
+func (t TQLLogger) Error(msg string) {
+	t.logger.Error(msg)
 }

--- a/processor/routingprocessor/internal/common/logger.go
+++ b/processor/routingprocessor/internal/common/logger.go
@@ -22,12 +22,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql"
 )
 
-type TQLLogger struct {
+type OTTLLogger struct {
 	logger *zap.Logger
 }
 
-func NewTQLLogger(logger *zap.Logger) TQLLogger {
-	return TQLLogger{
+func NewOTTLLogger(logger *zap.Logger) OTTLLogger {
+	return OTTLLogger{
 		logger: logger,
 	}
 }
@@ -35,7 +35,7 @@ func NewTQLLogger(logger *zap.Logger) TQLLogger {
 // WithFields creates a new logger that will include the specified fields
 // in all subsequent logs in addition to fields attached to the context
 // of the parent logger. Note that fields are not deduplicated.
-func (t TQLLogger) WithFields(fields map[string]any) tql.Logger {
+func (t OTTLLogger) WithFields(fields map[string]any) tql.Logger {
 	newFields := make([]zap.Field, len(fields))
 	i := 0
 
@@ -50,15 +50,15 @@ func (t TQLLogger) WithFields(fields map[string]any) tql.Logger {
 		i++
 	}
 
-	return TQLLogger{
+	return OTTLLogger{
 		logger: t.logger.With(newFields...),
 	}
 }
 
-func (t TQLLogger) Info(msg string) {
+func (t OTTLLogger) Info(msg string) {
 	t.logger.Info(msg)
 }
 
-func (t TQLLogger) Error(msg string) {
+func (t OTTLLogger) Error(msg string) {
 	t.logger.Error(msg)
 }

--- a/processor/routingprocessor/logs.go
+++ b/processor/routingprocessor/logs.go
@@ -39,7 +39,7 @@ type logProcessor struct {
 }
 
 func newLogProcessor(logger *zap.Logger, config config.Processor) *logProcessor {
-	cfg := rewriteRoutingEntriesToTQL(config.(*Config))
+	cfg := rewriteRoutingEntriesToOTTL(config.(*Config))
 
 	return &logProcessor{
 		logger: logger,

--- a/processor/routingprocessor/logs.go
+++ b/processor/routingprocessor/logs.go
@@ -32,7 +32,7 @@ var _ component.LogsProcessor = (*logProcessor)(nil)
 
 type logProcessor struct {
 	logger *zap.Logger
-	config Config
+	config *Config
 
 	extractor extractor
 	router    router[component.LogsExporter]

--- a/processor/routingprocessor/metrics.go
+++ b/processor/routingprocessor/metrics.go
@@ -20,30 +20,36 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/contexts/tqlmetrics"
 )
 
 var _ component.MetricsProcessor = (*metricsProcessor)(nil)
 
 type metricsProcessor struct {
 	logger *zap.Logger
-	config *Config
+	config Config
 
 	extractor extractor
 	router    router[component.MetricsExporter]
 }
 
-func newMetricProcessor(logger *zap.Logger, cfg config.Processor) *metricsProcessor {
-	oCfg := cfg.(*Config)
+func newMetricProcessor(logger *zap.Logger, config config.Processor) *metricsProcessor {
+	cfg := rewriteRoutingEntriesToTQL(config.(*Config))
 
 	return &metricsProcessor{
 		logger: logger,
-		config: oCfg,
-
-		extractor: newExtractor(oCfg.FromAttribute, logger),
-		router:    newRouter[component.MetricsExporter](*oCfg, logger),
+		config: cfg,
+		router: newRouter[component.MetricsExporter](
+			cfg.Table,
+			cfg.DefaultExporters,
+			logger,
+		),
+		extractor: newExtractor(cfg.FromAttribute, logger),
 	}
 }
 
@@ -56,56 +62,63 @@ func (p *metricsProcessor) Start(_ context.Context, host component.Host) error {
 }
 
 func (p *metricsProcessor) ConsumeMetrics(ctx context.Context, m pmetric.Metrics) error {
-	var errs error
-	switch p.config.AttributeSource {
-	case resourceAttributeSource:
-		errs = multierr.Append(errs, p.route(ctx, m))
-	case contextAttributeSource:
-		fallthrough
-	default:
-		errs = multierr.Append(errs, p.routeForContext(ctx, m))
+	if p.config.FromAttribute == "" {
+		err := p.route(ctx, m)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
-	// TODO: determine the proper action when errors happen
-	return errs
+	err := p.routeForContext(ctx, m)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (p *metricsProcessor) route(ctx context.Context, tm pmetric.Metrics) error {
-	// routingEntry is used to group pmetric.ResourceMetrics that are routed to
-	// the same set of exporters.
-	// This way we're not ending up with all the metrics split up which would cause
-	// higher CPU usage.
+	// groups is used to group pmetric.ResourceMetrics that are routed to
+	// the same set of exporters. This way we're not ending up with all the
+	// metrics split up which would cause higher CPU usage.
 	groups := map[string]struct {
 		exporters  []component.MetricsExporter
 		resMetrics pmetric.ResourceMetricsSlice
 	}{}
 
 	var errs error
-	resMetricsSlice := tm.ResourceMetrics()
-	for i := 0; i < resMetricsSlice.Len(); i++ {
-		resMetrics := resMetricsSlice.At(i)
 
-		attrValue := p.extractor.extractAttrFromResource(resMetrics.Resource())
-		exp := p.router.defaultExporters
-		// If we have an exporter list defined for that attribute value then use it.
-		if e, ok := p.router.exporters[attrValue]; ok {
-			exp = e
-			if p.config.DropRoutingResourceAttribute {
-				resMetrics.Resource().Attributes().Remove(p.config.FromAttribute)
+	for i := 0; i < tm.ResourceMetrics().Len(); i++ {
+		rmetrics := tm.ResourceMetrics().At(i)
+		mtx := tqlmetrics.NewTransformContext(
+			nil,
+			pmetric.Metric{},
+			pmetric.MetricSlice{},
+			pcommon.InstrumentationScope{},
+			rmetrics.Resource(),
+		)
+
+		for key, route := range p.router.routes {
+			exporters := p.router.defaultExporters
+			var gKey string
+			if route.expression.Condition(mtx) {
+				route.expression.Function(mtx)
+				exporters = route.exporters
+				gKey = key
 			}
-		}
 
-		if rEntry, ok := groups[attrValue]; ok {
-			resMetrics.MoveTo(rEntry.resMetrics.AppendEmpty())
-		} else {
-			newResMetrics := pmetric.NewResourceMetricsSlice()
-			resMetrics.MoveTo(newResMetrics.AppendEmpty())
+			if g, ok := groups[gKey]; ok {
+				rmetrics.MoveTo(g.resMetrics.AppendEmpty())
+			} else {
+				newResMetrics := pmetric.NewResourceMetricsSlice()
+				rmetrics.MoveTo(newResMetrics.AppendEmpty())
 
-			groups[attrValue] = struct {
-				exporters  []component.MetricsExporter
-				resMetrics pmetric.ResourceMetricsSlice
-			}{
-				exporters:  exp,
-				resMetrics: newResMetrics,
+				groups[gKey] = struct {
+					exporters  []component.MetricsExporter
+					resMetrics pmetric.ResourceMetricsSlice
+				}{
+					exporters:  exporters,
+					resMetrics: newResMetrics,
+				}
 			}
 		}
 	}
@@ -124,10 +137,7 @@ func (p *metricsProcessor) route(ctx context.Context, tm pmetric.Metrics) error 
 
 func (p *metricsProcessor) routeForContext(ctx context.Context, m pmetric.Metrics) error {
 	value := p.extractor.extractFromContext(ctx)
-	exporters, ok := p.router.exporters[value]
-	if !ok {
-		exporters = p.router.defaultExporters
-	}
+	exporters := p.router.getExporters(value)
 
 	var errs error
 	for _, e := range exporters {

--- a/processor/routingprocessor/metrics.go
+++ b/processor/routingprocessor/metrics.go
@@ -32,7 +32,7 @@ var _ component.MetricsProcessor = (*metricsProcessor)(nil)
 
 type metricsProcessor struct {
 	logger *zap.Logger
-	config Config
+	config *Config
 
 	extractor extractor
 	router    router[component.MetricsExporter]

--- a/processor/routingprocessor/metrics.go
+++ b/processor/routingprocessor/metrics.go
@@ -39,7 +39,7 @@ type metricsProcessor struct {
 }
 
 func newMetricProcessor(logger *zap.Logger, config config.Processor) *metricsProcessor {
-	cfg := rewriteRoutingEntriesToTQL(config.(*Config))
+	cfg := rewriteRoutingEntriesToOTTL(config.(*Config))
 
 	return &metricsProcessor{
 		logger: logger,

--- a/processor/routingprocessor/metrics_test.go
+++ b/processor/routingprocessor/metrics_test.go
@@ -332,7 +332,7 @@ func Benchmark_MetricsRouting_ResourceAttribute(b *testing.B) {
 	runBenchmark(b, cfg)
 }
 
-func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithTQL(t *testing.T) {
+func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithOTTL(t *testing.T) {
 	defaultExp := &mockMetricsExporter{}
 	firstExp := &mockMetricsExporter{}
 	secondExp := &mockMetricsExporter{}
@@ -351,8 +351,6 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithTQL(t *testing.T
 	}
 
 	exp := newMetricProcessor(zap.NewNop(), &Config{
-		FromAttribute:    "X-Tenant",
-		AttributeSource:  resourceAttributeSource,
 		DefaultExporters: []string{"otlp"},
 		Table: []RoutingTableItem{
 			{
@@ -365,39 +363,108 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithTQL(t *testing.T
 			},
 		},
 	})
+	require.NoError(t, exp.Start(context.Background(), host))
 
-	m := pmetric.NewMetrics()
+	t.Run("metric matched by no expressions", func(t *testing.T) {
+		defaultExp.Reset()
+		firstExp.Reset()
+		secondExp.Reset()
 
-	rm := m.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().UpsertDouble("value", 1.5)
-	metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	metric.SetEmptyGauge()
-	metric.SetName("cpu")
+		m := pmetric.NewMetrics()
 
-	rm = m.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().UpsertDouble("value", 3.5)
-	metric = rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	metric.SetEmptyGauge()
-	metric.SetName("cpu_system")
+		rm := m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 0.0)
+		metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu")
 
-	rm = m.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().UpsertDouble("value", 0.0)
-	metric = rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	metric.SetEmptyGauge()
-	metric.SetName("cpu_idle")
+		require.NoError(t, exp.ConsumeMetrics(context.Background(), m))
 
-	ctx := context.Background()
-	require.NoError(t, exp.Start(ctx, host))
-	require.NoError(t, exp.ConsumeMetrics(ctx, m))
+		assert.Len(t, defaultExp.AllMetrics(), 1)
+		assert.Len(t, firstExp.AllMetrics(), 0)
+		assert.Len(t, secondExp.AllMetrics(), 0)
+	})
 
-	// The numbers below stem from the fact that data is routed and grouped
-	// per resource attribute which is used for routing.
-	assert.Len(t, defaultExp.AllMetrics(), 1, "one metric should be routed to default exporter")
-	assert.Equal(t, defaultExp.AllMetrics()[0].MetricCount(), 2)
+	t.Run("metric matched by one of two expressions", func(t *testing.T) {
+		defaultExp.Reset()
+		firstExp.Reset()
+		secondExp.Reset()
 
-	// fist and second exporters should have received the same data
-	assert.Len(t, firstExp.AllMetrics(), 1, "one metric should be routed to non default exporter")
-	assert.Equal(t, firstExp.AllMetrics()[0].MetricCount(), 1)
+		m := pmetric.NewMetrics()
 
-	assert.Equal(t, firstExp.AllMetrics(), secondExp.AllMetrics())
+		rm := m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 2.7)
+		metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu")
+
+		require.NoError(t, exp.ConsumeMetrics(context.Background(), m))
+
+		assert.Len(t, defaultExp.AllMetrics(), 0)
+		assert.Len(t, firstExp.AllMetrics(), 1)
+		assert.Len(t, secondExp.AllMetrics(), 0)
+	})
+
+	t.Run("metric matched by all expressions", func(t *testing.T) {
+		defaultExp.Reset()
+		firstExp.Reset()
+		secondExp.Reset()
+
+		m := pmetric.NewMetrics()
+
+		rm := m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 5.0)
+		metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu")
+
+		rm = m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 3.1)
+		metric = rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu1")
+
+		require.NoError(t, exp.ConsumeMetrics(context.Background(), m))
+
+		assert.Len(t, defaultExp.AllMetrics(), 0)
+		assert.Len(t, firstExp.AllMetrics(), 1)
+		assert.Len(t, secondExp.AllMetrics(), 1)
+
+		assert.Equal(t, firstExp.AllMetrics()[0].MetricCount(), 2)
+		assert.Equal(t, secondExp.AllMetrics()[0].MetricCount(), 2)
+		assert.Equal(t, firstExp.AllMetrics(), secondExp.AllMetrics())
+	})
+
+	t.Run("one metric matched by all expressions, other matched by none", func(t *testing.T) {
+		defaultExp.Reset()
+		firstExp.Reset()
+		secondExp.Reset()
+
+		m := pmetric.NewMetrics()
+
+		rm := m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 5.0)
+		metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu")
+
+		rm = m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", -1.0)
+		metric = rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu1")
+
+		require.NoError(t, exp.ConsumeMetrics(context.Background(), m))
+
+		assert.Len(t, defaultExp.AllMetrics(), 1)
+		assert.Len(t, firstExp.AllMetrics(), 1)
+		assert.Len(t, secondExp.AllMetrics(), 1)
+
+		assert.Equal(t, firstExp.AllMetrics(), secondExp.AllMetrics())
+
+		rmetric := defaultExp.AllMetrics()[0].ResourceMetrics().At(0)
+		attr, ok := rmetric.Resource().Attributes().Get("value")
+		assert.True(t, ok, "routing attribute must exists")
+		assert.Equal(t, attr.DoubleVal(), float64(-1.0))
+	})
 }

--- a/processor/routingprocessor/router.go
+++ b/processor/routingprocessor/router.go
@@ -21,6 +21,10 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/contexts/tqllogs"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage/tql"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor/internal/common"
 )
 
 var errExporterNotFound = errors.New("exporter not found")
@@ -29,22 +33,42 @@ var errExporterNotFound = errors.New("exporter not found")
 // be instantiated with component.TracesExporter, component.MetricsExporter, and
 // component.LogsExporter type arguments.
 type router[E component.Exporter] struct {
-	config Config
 	logger *zap.Logger
+	tqlp   tql.Parser
+
+	defaultExporterIDs []string
+	table              []RoutingTableItem
 
 	defaultExporters []E
-	exporters        map[string][]E
+	routes           map[string]routingItem[E]
 }
 
 // newRouter creates a new router instance with its type parameter constrained
 // to component.Exporter.
-func newRouter[E component.Exporter](config Config, logger *zap.Logger) router[E] {
+func newRouter[E component.Exporter](
+	table []RoutingTableItem,
+	defaultExporterIDs []string,
+	logger *zap.Logger,
+) router[E] {
 	return router[E]{
 		logger: logger,
-		config: config,
+		tqlp: tql.NewParser(
+			common.Functions(),
+			tqllogs.ParsePath,
+			tqllogs.ParseEnum,
+			common.NewTQLLogger(logger),
+		),
 
-		exporters: make(map[string][]E),
+		table:              table,
+		defaultExporterIDs: defaultExporterIDs,
+
+		routes: make(map[string]routingItem[E]),
 	}
+}
+
+type routingItem[E component.Exporter] struct {
+	exporters  []E
+	expression tql.Query
 }
 
 func (r *router[E]) registerExporters(available map[config.ComponentID]component.Exporter) error {
@@ -55,11 +79,9 @@ func (r *router[E]) registerExporters(available map[config.ComponentID]component
 	}
 
 	// register exporters for each route
-	for _, entry := range r.config.Table {
-		err := r.registerRouteExporters(entry.Value, entry.Exporters, available)
-		if err != nil {
-			return err
-		}
+	err = r.registerRouteExporters(available)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -68,7 +90,7 @@ func (r *router[E]) registerExporters(available map[config.ComponentID]component
 // registerDefaultExporters registers the configured default exporters
 // using the provided available exporters map.
 func (r *router[E]) registerDefaultExporters(available map[config.ComponentID]component.Exporter) error {
-	for _, name := range r.config.DefaultExporters {
+	for _, name := range r.defaultExporterIDs {
 		e, err := r.extractExporter(name, available)
 		if errors.Is(err, errExporterNotFound) {
 			continue
@@ -84,25 +106,60 @@ func (r *router[E]) registerDefaultExporters(available map[config.ComponentID]co
 
 // registerRouteExporters registers route exporters using the provided
 // available exporters map to check if they were available.
-func (r *router[E]) registerRouteExporters(
-	route string,
-	exporters []string,
-	available map[config.ComponentID]component.Exporter,
-) error {
-	for _, name := range exporters {
-		e, err := r.extractExporter(name, available)
-		if errors.Is(err, errExporterNotFound) {
-			continue
-		}
+func (r *router[E]) registerRouteExporters(available map[config.ComponentID]component.Exporter) error {
+	for _, item := range r.table {
+		e, err := r.routingExpression(item)
 		if err != nil {
 			return err
 		}
-		r.exporters[route] = append(r.exporters[route], e)
-	}
 
+		route, ok := r.routes[key(item)]
+		if !ok {
+			route.expression = e
+		}
+
+		for _, name := range item.Exporters {
+			e, err := r.extractExporter(name, available)
+			if errors.Is(err, errExporterNotFound) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			route.exporters = append(route.exporters, e)
+		}
+		r.routes[key(item)] = route
+	}
 	return nil
 }
 
+// routingExpression builds a routing TQL expressions from provided
+// routing table entry configuration. If routing table entry configuration
+// does not contain a TQL expressions then nil is returned.
+func (r *router[E]) routingExpression(item RoutingTableItem) (tql.Query, error) {
+	var e tql.Query
+	if item.Expression != "" {
+		queries, err := r.tqlp.ParseQueries([]string{item.Expression})
+		if err != nil {
+			return e, err
+		}
+		if len(queries) != 1 {
+			return e, errors.New("more than one expression specified")
+		}
+		e = queries[0]
+	}
+	return e, nil
+}
+
+func key(entry RoutingTableItem) string {
+	if entry.Value != "" {
+		return entry.Value
+	}
+	return entry.Expression
+}
+
+// extractExporter returns an exporter for the given name (type/name) and type
+// argument if it exists in the list of available exporters.
 func (r *router[E]) extractExporter(name string, available map[config.ComponentID]component.Exporter) (E, error) {
 	var exporter E
 
@@ -131,4 +188,12 @@ func (r *router[E]) extractExporter(name string, available map[config.ComponentI
 			fmt.Errorf("the exporter %q isn't a %T exporter", id.String(), new(E))
 	}
 	return exporter, nil
+}
+
+func (r *router[E]) getExporters(key string) []E {
+	e, ok := r.routes[key]
+	if !ok {
+		return r.defaultExporters
+	}
+	return e.exporters
 }

--- a/processor/routingprocessor/traces.go
+++ b/processor/routingprocessor/traces.go
@@ -32,7 +32,7 @@ var _ component.TracesProcessor = (*tracesProcessor)(nil)
 
 type tracesProcessor struct {
 	logger *zap.Logger
-	config Config
+	config *Config
 
 	extractor extractor
 	router    router[component.TracesExporter]

--- a/processor/routingprocessor/traces.go
+++ b/processor/routingprocessor/traces.go
@@ -39,7 +39,7 @@ type tracesProcessor struct {
 }
 
 func newTracesProcessor(logger *zap.Logger, config config.Processor) *tracesProcessor {
-	cfg := rewriteRoutingEntriesToTQL(config.(*Config))
+	cfg := rewriteRoutingEntriesToOTTL(config.(*Config))
 
 	return &tracesProcessor{
 		logger: logger,

--- a/unreleased/tql-routing-processor.yaml
+++ b/unreleased/tql-routing-processor.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/routingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for using Telemetry Query Language expressions as routing conditions.
+
+# One or more tracking issues related to the change
+issues: [13158]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/unreleased/tql-routing-processor.yaml
+++ b/unreleased/tql-routing-processor.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: processor/routingprocessor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add support for using Telemetry Query Language expressions as routing conditions.
+note: Add support for using OpenTelemetry Transformation Language (OTTL) expressions as routing conditions.
 
 # One or more tracking issues related to the change
 issues: [13158]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Use [TQL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/telemetryquerylanguage) expressions in the routing table as routing conditions.

Follow up:
- Make it possible to use only boolean conditions as routing expressions without function invocations, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545
- TQL expressions can be applied only on resource attributes, if needed, it is possible to extend the scope. 

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13158

**Testing:** <Describe what testing was performed and which tests were added.>
- Unit tests. Existing tests also cover this functionality. 

**Documentation:** <Describe the documentation added.>
- Updated Readme 