### PR TITLE
[exporter/sumologic] Mark exporter as mutating data

### DIFF
--- a/exporter/sumologicexporter/exporter.go
+++ b/exporter/sumologicexporter/exporter.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -83,6 +84,7 @@ func newLogsExporter(
 		// Disable exporterhelper Timeout, since we are using a custom mechanism
 		// within exporter itself
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 		exporterhelper.WithRetry(cfg.RetrySettings),
 		exporterhelper.WithQueue(cfg.QueueSettings),
 		exporterhelper.WithStart(se.start),
@@ -106,6 +108,7 @@ func newMetricsExporter(
 		// Disable exporterhelper Timeout, since we are using a custom mechanism
 		// within exporter itself
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 		exporterhelper.WithRetry(cfg.RetrySettings),
 		exporterhelper.WithQueue(cfg.QueueSettings),
 		exporterhelper.WithStart(se.start),

--- a/unreleased/mark-sumologic-as-mutating.yaml
+++ b/unreleased/mark-sumologic-as-mutating.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: exporter/sumologic
+note: Mark the exporter as mutating.
+issues: [13647]


### PR DESCRIPTION
The exporter mutates the logs data at least in https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/sumologicexporter/exporter.go#L171 and https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/sumologicexporter/exporter.go#L314

In order to avoid affecting other exporters configured alongside, the exporter should be marked as mutating data so all pdata is copied over.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13646
