### PR TITLE
[receiver/dockerstats] Change memory gauges to sums

### DIFF
--- a/receiver/dockerstatsreceiver/documentation.md
+++ b/receiver/dockerstatsreceiver/documentation.md
@@ -65,44 +65,44 @@ These are the metrics available for this scraper.
 | **container.cpu.usage.system** | System CPU usage. | ns | Sum(Int) | <ul> </ul> |
 | **container.cpu.usage.total** | Total CPU time consumed. | ns | Sum(Int) | <ul> </ul> |
 | **container.cpu.usage.usermode** | Time spent by tasks of the cgroup in user mode (Linux).  Time spent by all container processes in user mode (Windows). | ns | Sum(Int) | <ul> </ul> |
-| **container.memory.active_anon** | The amount of anonymous memory that has been identified as active by the kernel. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.active_file** | Cache memory that has been identified as active by the kernel. [More docs](https://docs.docker.com/config/containers/runmetrics/) | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.cache** | The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.dirty** | Bytes that are waiting to get written back to the disk, from this cgroup. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.hierarchical_memory_limit** | The maximum amount of physical memory that can be used by the processes of this control group. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.hierarchical_memsw_limit** | The maximum amount of RAM + swap that can be used by the processes of this control group. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.inactive_anon** | The amount of anonymous memory that has been identified as inactive by the kernel. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.inactive_file** | Cache memory that has been identified as inactive by the kernel. [More docs](https://docs.docker.com/config/containers/runmetrics/) | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.mapped_file** | Indicates the amount of memory mapped by the processes in the control group. | By | Gauge(Int) | <ul> </ul> |
+| **container.memory.active_anon** | The amount of anonymous memory that has been identified as active by the kernel. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.active_file** | Cache memory that has been identified as active by the kernel. [More docs](https://docs.docker.com/config/containers/runmetrics/) | By | Sum(Int) | <ul> </ul> |
+| **container.memory.cache** | The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.dirty** | Bytes that are waiting to get written back to the disk, from this cgroup. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.hierarchical_memory_limit** | The maximum amount of physical memory that can be used by the processes of this control group. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.hierarchical_memsw_limit** | The maximum amount of RAM + swap that can be used by the processes of this control group. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.inactive_anon** | The amount of anonymous memory that has been identified as inactive by the kernel. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.inactive_file** | Cache memory that has been identified as inactive by the kernel. [More docs](https://docs.docker.com/config/containers/runmetrics/) | By | Sum(Int) | <ul> </ul> |
+| **container.memory.mapped_file** | Indicates the amount of memory mapped by the processes in the control group. | By | Sum(Int) | <ul> </ul> |
 | **container.memory.percent** | Percentage of memory used. | 1 | Gauge(Double) | <ul> </ul> |
 | **container.memory.pgfault** | Indicate the number of times that a process of the cgroup triggered a page fault. | {faults} | Sum(Int) | <ul> </ul> |
 | **container.memory.pgmajfault** | Indicate the number of times that a process of the cgroup triggered a major fault. | {faults} | Sum(Int) | <ul> </ul> |
 | **container.memory.pgpgin** | Number of pages read from disk by the cgroup. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt). | {operations} | Sum(Int) | <ul> </ul> |
 | **container.memory.pgpgout** | Number of pages written to disk by the cgroup. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt). | {operations} | Sum(Int) | <ul> </ul> |
-| **container.memory.rss** | The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.rss_huge** | Number of bytes of anonymous transparent hugepages in this cgroup. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.swap** | The amount of swap currently used by the processes in this cgroup. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_active_anon** | The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_active_file** | Cache memory that has been identified as active by the kernel. Includes descendant cgroups. [More docs](https://docs.docker.com/config/containers/runmetrics/). | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_cache** | Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_dirty** | Bytes that are waiting to get written back to the disk, from this cgroup and descendants. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_inactive_anon** | The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_inactive_file** | Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups. [More docs](https://docs.docker.com/config/containers/runmetrics/). | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_mapped_file** | Indicates the amount of memory mapped by the processes in the control group and descendant groups. | By | Gauge(Int) | <ul> </ul> |
+| **container.memory.rss** | The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.rss_huge** | Number of bytes of anonymous transparent hugepages in this cgroup. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.swap** | The amount of swap currently used by the processes in this cgroup. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_active_anon** | The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_active_file** | Cache memory that has been identified as active by the kernel. Includes descendant cgroups. [More docs](https://docs.docker.com/config/containers/runmetrics/). | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_cache** | Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_dirty** | Bytes that are waiting to get written back to the disk, from this cgroup and descendants. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_inactive_anon** | The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_inactive_file** | Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups. [More docs](https://docs.docker.com/config/containers/runmetrics/). | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_mapped_file** | Indicates the amount of memory mapped by the processes in the control group and descendant groups. | By | Sum(Int) | <ul> </ul> |
 | **container.memory.total_pgfault** | Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a page fault. | {faults} | Sum(Int) | <ul> </ul> |
 | **container.memory.total_pgmajfault** | Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a major fault. | {faults} | Sum(Int) | <ul> </ul> |
 | **container.memory.total_pgpgin** | Number of pages read from disk by the cgroup and descendant groups. | {operations} | Sum(Int) | <ul> </ul> |
 | **container.memory.total_pgpgout** | Number of pages written to disk by the cgroup and descendant groups. | {operations} | Sum(Int) | <ul> </ul> |
-| **container.memory.total_rss** | The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_rss_huge** | Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_swap** | The amount of swap currently used by the processes in this cgroup and descendant groups. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_unevictable** | The amount of memory that cannot be reclaimed. Includes descendant cgroups. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.total_writeback** | Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.unevictable** | The amount of memory that cannot be reclaimed. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.usage.limit** | Memory limit of the container. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.usage.max** | Maximum memory usage. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.usage.total** | Memory usage of the container. This excludes the total cache. | By | Gauge(Int) | <ul> </ul> |
-| **container.memory.writeback** | Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup. | By | Gauge(Int) | <ul> </ul> |
+| **container.memory.total_rss** | The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_rss_huge** | Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_swap** | The amount of swap currently used by the processes in this cgroup and descendant groups. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_unevictable** | The amount of memory that cannot be reclaimed. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.total_writeback** | Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.unevictable** | The amount of memory that cannot be reclaimed. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.usage.limit** | Memory limit of the container. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.usage.max** | Maximum memory usage. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.usage.total** | Memory usage of the container. This excludes the total cache. | By | Sum(Int) | <ul> </ul> |
+| **container.memory.writeback** | Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup. | By | Sum(Int) | <ul> </ul> |
 | **container.network.io.usage.rx_bytes** | Bytes received by the container. | By | Sum(Int) | <ul> <li>interface</li> </ul> |
 | **container.network.io.usage.rx_dropped** | Incoming packets dropped. | {packets} | Sum(Int) | <ul> <li>interface</li> </ul> |
 | **container.network.io.usage.rx_errors** | Received errors. | {errors} | Sum(Int) | <ul> <li>interface</li> </ul> |

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -3499,14 +3499,16 @@ func (m *metricContainerMemoryActiveAnon) init() {
 	m.data.SetName("container.memory.active_anon")
 	m.data.SetDescription("The amount of anonymous memory that has been identified as active by the kernel.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryActiveAnon) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -3514,14 +3516,14 @@ func (m *metricContainerMemoryActiveAnon) recordDataPoint(start pcommon.Timestam
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryActiveAnon) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryActiveAnon) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -3548,14 +3550,16 @@ func (m *metricContainerMemoryActiveFile) init() {
 	m.data.SetName("container.memory.active_file")
 	m.data.SetDescription("Cache memory that has been identified as active by the kernel.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryActiveFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -3563,14 +3567,14 @@ func (m *metricContainerMemoryActiveFile) recordDataPoint(start pcommon.Timestam
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryActiveFile) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryActiveFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -3597,14 +3601,16 @@ func (m *metricContainerMemoryCache) init() {
 	m.data.SetName("container.memory.cache")
 	m.data.SetDescription("The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryCache) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -3612,14 +3618,14 @@ func (m *metricContainerMemoryCache) recordDataPoint(start pcommon.Timestamp, ts
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryCache) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryCache) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -3646,14 +3652,16 @@ func (m *metricContainerMemoryDirty) init() {
 	m.data.SetName("container.memory.dirty")
 	m.data.SetDescription("Bytes that are waiting to get written back to the disk, from this cgroup.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryDirty) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -3661,14 +3669,14 @@ func (m *metricContainerMemoryDirty) recordDataPoint(start pcommon.Timestamp, ts
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryDirty) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryDirty) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -3695,14 +3703,16 @@ func (m *metricContainerMemoryHierarchicalMemoryLimit) init() {
 	m.data.SetName("container.memory.hierarchical_memory_limit")
 	m.data.SetDescription("The maximum amount of physical memory that can be used by the processes of this control group.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryHierarchicalMemoryLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -3710,14 +3720,14 @@ func (m *metricContainerMemoryHierarchicalMemoryLimit) recordDataPoint(start pco
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryHierarchicalMemoryLimit) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryHierarchicalMemoryLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -3744,14 +3754,16 @@ func (m *metricContainerMemoryHierarchicalMemswLimit) init() {
 	m.data.SetName("container.memory.hierarchical_memsw_limit")
 	m.data.SetDescription("The maximum amount of RAM + swap that can be used by the processes of this control group.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryHierarchicalMemswLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -3759,14 +3771,14 @@ func (m *metricContainerMemoryHierarchicalMemswLimit) recordDataPoint(start pcom
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryHierarchicalMemswLimit) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryHierarchicalMemswLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -3793,14 +3805,16 @@ func (m *metricContainerMemoryInactiveAnon) init() {
 	m.data.SetName("container.memory.inactive_anon")
 	m.data.SetDescription("The amount of anonymous memory that has been identified as inactive by the kernel.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryInactiveAnon) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -3808,14 +3822,14 @@ func (m *metricContainerMemoryInactiveAnon) recordDataPoint(start pcommon.Timest
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryInactiveAnon) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryInactiveAnon) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -3842,14 +3856,16 @@ func (m *metricContainerMemoryInactiveFile) init() {
 	m.data.SetName("container.memory.inactive_file")
 	m.data.SetDescription("Cache memory that has been identified as inactive by the kernel.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryInactiveFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -3857,14 +3873,14 @@ func (m *metricContainerMemoryInactiveFile) recordDataPoint(start pcommon.Timest
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryInactiveFile) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryInactiveFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -3891,14 +3907,16 @@ func (m *metricContainerMemoryMappedFile) init() {
 	m.data.SetName("container.memory.mapped_file")
 	m.data.SetDescription("Indicates the amount of memory mapped by the processes in the control group.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryMappedFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -3906,14 +3924,14 @@ func (m *metricContainerMemoryMappedFile) recordDataPoint(start pcommon.Timestam
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryMappedFile) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryMappedFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4193,14 +4211,16 @@ func (m *metricContainerMemoryRss) init() {
 	m.data.SetName("container.memory.rss")
 	m.data.SetDescription("The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryRss) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4208,14 +4228,14 @@ func (m *metricContainerMemoryRss) recordDataPoint(start pcommon.Timestamp, ts p
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryRss) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryRss) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4242,14 +4262,16 @@ func (m *metricContainerMemoryRssHuge) init() {
 	m.data.SetName("container.memory.rss_huge")
 	m.data.SetDescription("Number of bytes of anonymous transparent hugepages in this cgroup.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryRssHuge) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4257,14 +4279,14 @@ func (m *metricContainerMemoryRssHuge) recordDataPoint(start pcommon.Timestamp, 
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryRssHuge) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryRssHuge) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4291,14 +4313,16 @@ func (m *metricContainerMemorySwap) init() {
 	m.data.SetName("container.memory.swap")
 	m.data.SetDescription("The amount of swap currently used by the processes in this cgroup.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemorySwap) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4306,14 +4330,14 @@ func (m *metricContainerMemorySwap) recordDataPoint(start pcommon.Timestamp, ts 
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemorySwap) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemorySwap) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4340,14 +4364,16 @@ func (m *metricContainerMemoryTotalActiveAnon) init() {
 	m.data.SetName("container.memory.total_active_anon")
 	m.data.SetDescription("The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalActiveAnon) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4355,14 +4381,14 @@ func (m *metricContainerMemoryTotalActiveAnon) recordDataPoint(start pcommon.Tim
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalActiveAnon) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalActiveAnon) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4389,14 +4415,16 @@ func (m *metricContainerMemoryTotalActiveFile) init() {
 	m.data.SetName("container.memory.total_active_file")
 	m.data.SetDescription("Cache memory that has been identified as active by the kernel. Includes descendant cgroups.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalActiveFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4404,14 +4432,14 @@ func (m *metricContainerMemoryTotalActiveFile) recordDataPoint(start pcommon.Tim
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalActiveFile) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalActiveFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4438,14 +4466,16 @@ func (m *metricContainerMemoryTotalCache) init() {
 	m.data.SetName("container.memory.total_cache")
 	m.data.SetDescription("Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalCache) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4453,14 +4483,14 @@ func (m *metricContainerMemoryTotalCache) recordDataPoint(start pcommon.Timestam
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalCache) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalCache) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4487,14 +4517,16 @@ func (m *metricContainerMemoryTotalDirty) init() {
 	m.data.SetName("container.memory.total_dirty")
 	m.data.SetDescription("Bytes that are waiting to get written back to the disk, from this cgroup and descendants.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalDirty) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4502,14 +4534,14 @@ func (m *metricContainerMemoryTotalDirty) recordDataPoint(start pcommon.Timestam
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalDirty) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalDirty) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4536,14 +4568,16 @@ func (m *metricContainerMemoryTotalInactiveAnon) init() {
 	m.data.SetName("container.memory.total_inactive_anon")
 	m.data.SetDescription("The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalInactiveAnon) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4551,14 +4585,14 @@ func (m *metricContainerMemoryTotalInactiveAnon) recordDataPoint(start pcommon.T
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalInactiveAnon) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalInactiveAnon) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4585,14 +4619,16 @@ func (m *metricContainerMemoryTotalInactiveFile) init() {
 	m.data.SetName("container.memory.total_inactive_file")
 	m.data.SetDescription("Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalInactiveFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4600,14 +4636,14 @@ func (m *metricContainerMemoryTotalInactiveFile) recordDataPoint(start pcommon.T
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalInactiveFile) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalInactiveFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4634,14 +4670,16 @@ func (m *metricContainerMemoryTotalMappedFile) init() {
 	m.data.SetName("container.memory.total_mapped_file")
 	m.data.SetDescription("Indicates the amount of memory mapped by the processes in the control group and descendant groups.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalMappedFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4649,14 +4687,14 @@ func (m *metricContainerMemoryTotalMappedFile) recordDataPoint(start pcommon.Tim
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalMappedFile) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalMappedFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4887,14 +4925,16 @@ func (m *metricContainerMemoryTotalRss) init() {
 	m.data.SetName("container.memory.total_rss")
 	m.data.SetDescription("The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalRss) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4902,14 +4942,14 @@ func (m *metricContainerMemoryTotalRss) recordDataPoint(start pcommon.Timestamp,
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalRss) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalRss) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4936,14 +4976,16 @@ func (m *metricContainerMemoryTotalRssHuge) init() {
 	m.data.SetName("container.memory.total_rss_huge")
 	m.data.SetDescription("Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalRssHuge) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -4951,14 +4993,14 @@ func (m *metricContainerMemoryTotalRssHuge) recordDataPoint(start pcommon.Timest
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalRssHuge) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalRssHuge) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -4985,14 +5027,16 @@ func (m *metricContainerMemoryTotalSwap) init() {
 	m.data.SetName("container.memory.total_swap")
 	m.data.SetDescription("The amount of swap currently used by the processes in this cgroup and descendant groups.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalSwap) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -5000,14 +5044,14 @@ func (m *metricContainerMemoryTotalSwap) recordDataPoint(start pcommon.Timestamp
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalSwap) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalSwap) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -5034,14 +5078,16 @@ func (m *metricContainerMemoryTotalUnevictable) init() {
 	m.data.SetName("container.memory.total_unevictable")
 	m.data.SetDescription("The amount of memory that cannot be reclaimed. Includes descendant cgroups.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalUnevictable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -5049,14 +5095,14 @@ func (m *metricContainerMemoryTotalUnevictable) recordDataPoint(start pcommon.Ti
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalUnevictable) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalUnevictable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -5083,14 +5129,16 @@ func (m *metricContainerMemoryTotalWriteback) init() {
 	m.data.SetName("container.memory.total_writeback")
 	m.data.SetDescription("Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryTotalWriteback) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -5098,14 +5146,14 @@ func (m *metricContainerMemoryTotalWriteback) recordDataPoint(start pcommon.Time
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryTotalWriteback) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalWriteback) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -5132,14 +5180,16 @@ func (m *metricContainerMemoryUnevictable) init() {
 	m.data.SetName("container.memory.unevictable")
 	m.data.SetDescription("The amount of memory that cannot be reclaimed.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryUnevictable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -5147,14 +5197,14 @@ func (m *metricContainerMemoryUnevictable) recordDataPoint(start pcommon.Timesta
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryUnevictable) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryUnevictable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -5181,14 +5231,16 @@ func (m *metricContainerMemoryUsageLimit) init() {
 	m.data.SetName("container.memory.usage.limit")
 	m.data.SetDescription("Memory limit of the container.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryUsageLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -5196,14 +5248,14 @@ func (m *metricContainerMemoryUsageLimit) recordDataPoint(start pcommon.Timestam
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryUsageLimit) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryUsageLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -5230,14 +5282,16 @@ func (m *metricContainerMemoryUsageMax) init() {
 	m.data.SetName("container.memory.usage.max")
 	m.data.SetDescription("Maximum memory usage.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -5245,14 +5299,14 @@ func (m *metricContainerMemoryUsageMax) recordDataPoint(start pcommon.Timestamp,
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryUsageMax) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -5279,14 +5333,16 @@ func (m *metricContainerMemoryUsageTotal) init() {
 	m.data.SetName("container.memory.usage.total")
 	m.data.SetDescription("Memory usage of the container. This excludes the total cache.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryUsageTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -5294,14 +5350,14 @@ func (m *metricContainerMemoryUsageTotal) recordDataPoint(start pcommon.Timestam
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryUsageTotal) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryUsageTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -5328,14 +5384,16 @@ func (m *metricContainerMemoryWriteback) init() {
 	m.data.SetName("container.memory.writeback")
 	m.data.SetDescription("Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup.")
 	m.data.SetUnit("By")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricContainerMemoryWriteback) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
@@ -5343,14 +5401,14 @@ func (m *metricContainerMemoryWriteback) recordDataPoint(start pcommon.Timestamp
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricContainerMemoryWriteback) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryWriteback) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -119,20 +119,26 @@ metrics:
     enabled: true
     description: "Memory limit of the container."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.usage.total:
     enabled: true
     description: "Memory usage of the container. This excludes the total cache."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.usage.max:
     enabled: true
     description: "Maximum memory usage."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.percent:
     enabled: true
     description: "Percentage of memory used."
@@ -143,38 +149,50 @@ metrics:
     enabled: true
     description: "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.rss:
     enabled: true
     description: "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.rss_huge:
     enabled: true
     description: "Number of bytes of anonymous transparent hugepages in this cgroup."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.dirty:
     enabled: true
     description: "Bytes that are waiting to get written back to the disk, from this cgroup."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.writeback:
     enabled: true
     description: "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.mapped_file:
     enabled: true
     description: "Indicates the amount of memory mapped by the processes in the control group."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.pgpgin:
     enabled: true
     description: "Number of pages read from disk by the cgroup."
@@ -197,8 +215,10 @@ metrics:
     enabled: true
     description: "The amount of swap currently used by the processes in this cgroup."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.pgfault:
     enabled: true
     description: "Indicate the number of times that a process of the cgroup triggered a page fault."
@@ -219,82 +239,108 @@ metrics:
     enabled: true
     description: "The amount of anonymous memory that has been identified as inactive by the kernel."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.active_anon:
     enabled: true
     description: "The amount of anonymous memory that has been identified as active by the kernel."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.inactive_file:
     enabled: true
     description: "Cache memory that has been identified as inactive by the kernel."
     extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)"
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.active_file:
     enabled: true
     description: "Cache memory that has been identified as active by the kernel."
     extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)"
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.unevictable:
     enabled: true
     description: "The amount of memory that cannot be reclaimed."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.hierarchical_memory_limit:
     enabled: true
     description: "The maximum amount of physical memory that can be used by the processes of this control group."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.hierarchical_memsw_limit:
     enabled: true
     description: "The maximum amount of RAM + swap that can be used by the processes of this control group."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_cache:
     enabled: true
     description: "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_rss:
     enabled: true
     description: "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_rss_huge:
     enabled: true
     description: "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_dirty:
     enabled: true
     description: "Bytes that are waiting to get written back to the disk, from this cgroup and descendants."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_writeback:
     enabled: true
     description: "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_mapped_file:
     enabled: true
     description: "Indicates the amount of memory mapped by the processes in the control group and descendant groups."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_pgpgin:
     enabled: true
     description: "Number of pages read from disk by the cgroup and descendant groups."
@@ -315,8 +361,10 @@ metrics:
     enabled: true
     description: "The amount of swap currently used by the processes in this cgroup and descendant groups."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_pgfault:
     enabled: true
     description: "Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a page fault."
@@ -337,34 +385,44 @@ metrics:
     enabled: true
     description: "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_active_anon:
     enabled: true
     description: "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_inactive_file:
     enabled: true
     description: "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups."
     extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_active_file:
     enabled: true
     description: "Cache memory that has been identified as active by the kernel. Includes descendant cgroups."
     extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
   container.memory.total_unevictable:
     enabled: true
     description: "The amount of memory that cannot be reclaimed. Includes descendant cgroups."
     unit: By
-    gauge:
+    sum:
       value_type: int
+      aggregation: cumulative
+      monotonic: false
 
 
   # BlockIO

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.json
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.json
@@ -626,7 +626,8 @@
             },
             {
               "description": "Memory limit of the container.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "10449559552",
@@ -639,7 +640,8 @@
             },
             {
               "description": "Memory usage of the container. This excludes the total cache.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "454656",
@@ -665,7 +667,8 @@
             },
             {
               "description": "Maximum memory usage.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "3932160",
@@ -678,7 +681,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -691,7 +695,8 @@
             },
             {
               "description": "Cache memory that has been identified as active by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "270336",
@@ -704,7 +709,8 @@
             },
             {
               "description": "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "2433024",
@@ -717,7 +723,8 @@
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -730,7 +737,8 @@
             },
             {
               "description": "The maximum amount of physical memory that can be used by the processes of this control group.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "9223372036854772000",
@@ -743,7 +751,8 @@
             },
             {
               "description": "The maximum amount of RAM + swap that can be used by the processes of this control group.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "9223372036854772000",
@@ -756,7 +765,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -769,7 +779,8 @@
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "2162688",
@@ -782,7 +793,8 @@
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "1486848",
@@ -855,7 +867,8 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -868,7 +881,8 @@
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -881,7 +895,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -894,7 +909,8 @@
             },
             {
               "description": "Cache memory that has been identified as active by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "270336",
@@ -907,7 +923,8 @@
             },
             {
               "description": "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "2433024",
@@ -920,7 +937,8 @@
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup and descendants.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -933,7 +951,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -946,7 +965,8 @@
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "2162688",
@@ -959,7 +979,8 @@
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group and descendant groups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "1486848",
@@ -1032,7 +1053,8 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -1045,7 +1067,8 @@
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -1058,7 +1081,8 @@
             },
             {
               "description": "The amount of memory that cannot be reclaimed. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -1071,7 +1095,8 @@
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -1084,7 +1109,8 @@
             },
             {
               "description": "The amount of memory that cannot be reclaimed.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -1097,7 +1123,8 @@
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.json
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.json
@@ -626,6 +626,7 @@
             },
             {
               "description": "Memory limit of the container.",
+              "name": "container.memory.usage.limit",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -635,11 +636,11 @@
                   }
                 ]
               },
-              "name": "container.memory.usage.limit",
               "unit": "By"
             },
             {
               "description": "Memory usage of the container. This excludes the total cache.",
+              "name": "container.memory.usage.total",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -649,7 +650,6 @@
                   }
                 ]
               },
-              "name": "container.memory.usage.total",
               "unit": "By"
             },
             {
@@ -667,6 +667,7 @@
             },
             {
               "description": "Maximum memory usage.",
+              "name": "container.memory.usage.max",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -676,11 +677,11 @@
                   }
                 ]
               },
-              "name": "container.memory.usage.max",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel.",
+              "name": "container.memory.active_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -690,11 +691,11 @@
                   }
                 ]
               },
-              "name": "container.memory.active_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as active by the kernel.",
+              "name": "container.memory.active_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -704,11 +705,11 @@
                   }
                 ]
               },
-              "name": "container.memory.active_file",
               "unit": "By"
             },
             {
               "description": "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device.",
+              "name": "container.memory.cache",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -718,11 +719,11 @@
                   }
                 ]
               },
-              "name": "container.memory.cache",
               "unit": "By"
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup.",
+              "name": "container.memory.dirty",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -732,11 +733,11 @@
                   }
                 ]
               },
-              "name": "container.memory.dirty",
               "unit": "By"
             },
             {
               "description": "The maximum amount of physical memory that can be used by the processes of this control group.",
+              "name": "container.memory.hierarchical_memory_limit",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -746,11 +747,11 @@
                   }
                 ]
               },
-              "name": "container.memory.hierarchical_memory_limit",
               "unit": "By"
             },
             {
               "description": "The maximum amount of RAM + swap that can be used by the processes of this control group.",
+              "name": "container.memory.hierarchical_memsw_limit",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -760,11 +761,11 @@
                   }
                 ]
               },
-              "name": "container.memory.hierarchical_memsw_limit",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel.",
+              "name": "container.memory.inactive_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -774,11 +775,11 @@
                   }
                 ]
               },
-              "name": "container.memory.inactive_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel.",
+              "name": "container.memory.inactive_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -788,11 +789,11 @@
                   }
                 ]
               },
-              "name": "container.memory.inactive_file",
               "unit": "By"
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group.",
+              "name": "container.memory.mapped_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -802,7 +803,6 @@
                   }
                 ]
               },
-              "name": "container.memory.mapped_file",
               "unit": "By"
             },
             {
@@ -867,6 +867,7 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps.",
+              "name": "container.memory.rss",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -876,11 +877,11 @@
                   }
                 ]
               },
-              "name": "container.memory.rss",
               "unit": "By"
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup.",
+              "name": "container.memory.rss_huge",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -890,11 +891,11 @@
                   }
                 ]
               },
-              "name": "container.memory.rss_huge",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_active_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -904,11 +905,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_active_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as active by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_active_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -918,11 +919,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_active_file",
               "unit": "By"
             },
             {
               "description": "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs.",
+              "name": "container.memory.total_cache",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -932,11 +933,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_cache",
               "unit": "By"
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup and descendants.",
+              "name": "container.memory.total_dirty",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -946,11 +947,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_dirty",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_inactive_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -960,11 +961,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_inactive_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_inactive_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -974,11 +975,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_inactive_file",
               "unit": "By"
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group and descendant groups.",
+              "name": "container.memory.total_mapped_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -988,7 +989,6 @@
                   }
                 ]
               },
-              "name": "container.memory.total_mapped_file",
               "unit": "By"
             },
             {
@@ -1053,6 +1053,7 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups.",
+              "name": "container.memory.total_rss",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1062,11 +1063,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_rss",
               "unit": "By"
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups.",
+              "name": "container.memory.total_rss_huge",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1076,11 +1077,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_rss_huge",
               "unit": "By"
             },
             {
               "description": "The amount of memory that cannot be reclaimed. Includes descendant cgroups.",
+              "name": "container.memory.total_unevictable",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1090,11 +1091,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_unevictable",
               "unit": "By"
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants.",
+              "name": "container.memory.total_writeback",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1104,11 +1105,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_writeback",
               "unit": "By"
             },
             {
               "description": "The amount of memory that cannot be reclaimed.",
+              "name": "container.memory.unevictable",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1118,11 +1119,11 @@
                   }
                 ]
               },
-              "name": "container.memory.unevictable",
               "unit": "By"
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup.",
+              "name": "container.memory.writeback",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1132,7 +1133,6 @@
                   }
                 ]
               },
-              "name": "container.memory.writeback",
               "unit": "By"
             },
             {

--- a/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.json
+++ b/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.json
@@ -542,6 +542,7 @@
             },
             {
               "description": "Memory limit of the container.",
+              "name": "container.memory.usage.limit",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -551,11 +552,11 @@
                   }
                 ]
               },
-              "name": "container.memory.usage.limit",
               "unit": "By"
             },
             {
               "description": "Memory usage of the container. This excludes the total cache.",
+              "name": "container.memory.usage.total",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -565,7 +566,6 @@
                   }
                 ]
               },
-              "name": "container.memory.usage.total",
               "unit": "By"
             },
             {
@@ -583,6 +583,7 @@
             },
             {
               "description": "Maximum memory usage.",
+              "name": "container.memory.usage.max",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -592,11 +593,11 @@
                   }
                 ]
               },
-              "name": "container.memory.usage.max",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel.",
+              "name": "container.memory.active_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -606,11 +607,11 @@
                   }
                 ]
               },
-              "name": "container.memory.active_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as active by the kernel.",
+              "name": "container.memory.active_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -620,11 +621,11 @@
                   }
                 ]
               },
-              "name": "container.memory.active_file",
               "unit": "By"
             },
             {
               "description": "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device.",
+              "name": "container.memory.cache",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -634,11 +635,11 @@
                   }
                 ]
               },
-              "name": "container.memory.cache",
               "unit": "By"
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup.",
+              "name": "container.memory.dirty",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -648,11 +649,11 @@
                   }
                 ]
               },
-              "name": "container.memory.dirty",
               "unit": "By"
             },
             {
               "description": "The maximum amount of physical memory that can be used by the processes of this control group.",
+              "name": "container.memory.hierarchical_memory_limit",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -662,11 +663,11 @@
                   }
                 ]
               },
-              "name": "container.memory.hierarchical_memory_limit",
               "unit": "By"
             },
             {
               "description": "The maximum amount of RAM + swap that can be used by the processes of this control group.",
+              "name": "container.memory.hierarchical_memsw_limit",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -676,11 +677,11 @@
                   }
                 ]
               },
-              "name": "container.memory.hierarchical_memsw_limit",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel.",
+              "name": "container.memory.inactive_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -690,11 +691,11 @@
                   }
                 ]
               },
-              "name": "container.memory.inactive_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel.",
+              "name": "container.memory.inactive_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -704,11 +705,11 @@
                   }
                 ]
               },
-              "name": "container.memory.inactive_file",
               "unit": "By"
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group.",
+              "name": "container.memory.mapped_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -718,7 +719,6 @@
                   }
                 ]
               },
-              "name": "container.memory.mapped_file",
               "unit": "By"
             },
             {
@@ -783,6 +783,7 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps.",
+              "name": "container.memory.rss",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -792,11 +793,11 @@
                   }
                 ]
               },
-              "name": "container.memory.rss",
               "unit": "By"
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup.",
+              "name": "container.memory.rss_huge",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -806,11 +807,11 @@
                   }
                 ]
               },
-              "name": "container.memory.rss_huge",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_active_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -820,11 +821,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_active_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as active by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_active_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -834,11 +835,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_active_file",
               "unit": "By"
             },
             {
               "description": "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs.",
+              "name": "container.memory.total_cache",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -848,11 +849,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_cache",
               "unit": "By"
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup and descendants.",
+              "name": "container.memory.total_dirty",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -862,11 +863,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_dirty",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_inactive_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -876,11 +877,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_inactive_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_inactive_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -890,11 +891,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_inactive_file",
               "unit": "By"
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group and descendant groups.",
+              "name": "container.memory.total_mapped_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -904,7 +905,6 @@
                   }
                 ]
               },
-              "name": "container.memory.total_mapped_file",
               "unit": "By"
             },
             {
@@ -969,6 +969,7 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups.",
+              "name": "container.memory.total_rss",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -978,11 +979,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_rss",
               "unit": "By"
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups.",
+              "name": "container.memory.total_rss_huge",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -992,11 +993,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_rss_huge",
               "unit": "By"
             },
             {
               "description": "The amount of memory that cannot be reclaimed. Includes descendant cgroups.",
+              "name": "container.memory.total_unevictable",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1006,11 +1007,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_unevictable",
               "unit": "By"
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants.",
+              "name": "container.memory.total_writeback",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1020,11 +1021,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_writeback",
               "unit": "By"
             },
             {
               "description": "The amount of memory that cannot be reclaimed.",
+              "name": "container.memory.unevictable",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1034,11 +1035,11 @@
                   }
                 ]
               },
-              "name": "container.memory.unevictable",
               "unit": "By"
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup.",
+              "name": "container.memory.writeback",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1048,7 +1049,6 @@
                   }
                 ]
               },
-              "name": "container.memory.writeback",
               "unit": "By"
             },
             {
@@ -1785,6 +1785,7 @@
             },
             {
               "description": "Memory limit of the container.",
+              "name": "container.memory.usage.limit",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1794,11 +1795,11 @@
                   }
                 ]
               },
-              "name": "container.memory.usage.limit",
               "unit": "By"
             },
             {
               "description": "Memory usage of the container. This excludes the total cache.",
+              "name": "container.memory.usage.total",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1808,7 +1809,6 @@
                   }
                 ]
               },
-              "name": "container.memory.usage.total",
               "unit": "By"
             },
             {
@@ -1826,6 +1826,7 @@
             },
             {
               "description": "Maximum memory usage.",
+              "name": "container.memory.usage.max",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1835,11 +1836,11 @@
                   }
                 ]
               },
-              "name": "container.memory.usage.max",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel.",
+              "name": "container.memory.active_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1849,11 +1850,11 @@
                   }
                 ]
               },
-              "name": "container.memory.active_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as active by the kernel.",
+              "name": "container.memory.active_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1863,11 +1864,11 @@
                   }
                 ]
               },
-              "name": "container.memory.active_file",
               "unit": "By"
             },
             {
               "description": "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device.",
+              "name": "container.memory.cache",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1877,11 +1878,11 @@
                   }
                 ]
               },
-              "name": "container.memory.cache",
               "unit": "By"
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup.",
+              "name": "container.memory.dirty",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1891,11 +1892,11 @@
                   }
                 ]
               },
-              "name": "container.memory.dirty",
               "unit": "By"
             },
             {
               "description": "The maximum amount of physical memory that can be used by the processes of this control group.",
+              "name": "container.memory.hierarchical_memory_limit",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1905,11 +1906,11 @@
                   }
                 ]
               },
-              "name": "container.memory.hierarchical_memory_limit",
               "unit": "By"
             },
             {
               "description": "The maximum amount of RAM + swap that can be used by the processes of this control group.",
+              "name": "container.memory.hierarchical_memsw_limit",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1919,11 +1920,11 @@
                   }
                 ]
               },
-              "name": "container.memory.hierarchical_memsw_limit",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel.",
+              "name": "container.memory.inactive_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1933,11 +1934,11 @@
                   }
                 ]
               },
-              "name": "container.memory.inactive_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel.",
+              "name": "container.memory.inactive_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1947,11 +1948,11 @@
                   }
                 ]
               },
-              "name": "container.memory.inactive_file",
               "unit": "By"
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group.",
+              "name": "container.memory.mapped_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -1961,7 +1962,6 @@
                   }
                 ]
               },
-              "name": "container.memory.mapped_file",
               "unit": "By"
             },
             {
@@ -2026,6 +2026,7 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps.",
+              "name": "container.memory.rss",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2035,11 +2036,11 @@
                   }
                 ]
               },
-              "name": "container.memory.rss",
               "unit": "By"
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup.",
+              "name": "container.memory.rss_huge",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2049,11 +2050,11 @@
                   }
                 ]
               },
-              "name": "container.memory.rss_huge",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_active_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2063,11 +2064,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_active_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as active by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_active_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2077,11 +2078,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_active_file",
               "unit": "By"
             },
             {
               "description": "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs.",
+              "name": "container.memory.total_cache",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2091,11 +2092,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_cache",
               "unit": "By"
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup and descendants.",
+              "name": "container.memory.total_dirty",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2105,11 +2106,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_dirty",
               "unit": "By"
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_inactive_anon",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2119,11 +2120,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_inactive_anon",
               "unit": "By"
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
+              "name": "container.memory.total_inactive_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2133,11 +2134,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_inactive_file",
               "unit": "By"
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group and descendant groups.",
+              "name": "container.memory.total_mapped_file",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2147,7 +2148,6 @@
                   }
                 ]
               },
-              "name": "container.memory.total_mapped_file",
               "unit": "By"
             },
             {
@@ -2212,6 +2212,7 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups.",
+              "name": "container.memory.total_rss",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2221,11 +2222,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_rss",
               "unit": "By"
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups.",
+              "name": "container.memory.total_rss_huge",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2235,11 +2236,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_rss_huge",
               "unit": "By"
             },
             {
               "description": "The amount of memory that cannot be reclaimed. Includes descendant cgroups.",
+              "name": "container.memory.total_unevictable",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2249,11 +2250,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_unevictable",
               "unit": "By"
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants.",
+              "name": "container.memory.total_writeback",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2263,11 +2264,11 @@
                   }
                 ]
               },
-              "name": "container.memory.total_writeback",
               "unit": "By"
             },
             {
               "description": "The amount of memory that cannot be reclaimed.",
+              "name": "container.memory.unevictable",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2277,11 +2278,11 @@
                   }
                 ]
               },
-              "name": "container.memory.unevictable",
               "unit": "By"
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup.",
+              "name": "container.memory.writeback",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
@@ -2291,7 +2292,6 @@
                   }
                 ]
               },
-              "name": "container.memory.writeback",
               "unit": "By"
             },
             {

--- a/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.json
+++ b/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.json
@@ -542,7 +542,8 @@
             },
             {
               "description": "Memory limit of the container.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "2074079232",
@@ -555,7 +556,8 @@
             },
             {
               "description": "Memory usage of the container. This excludes the total cache.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "352256",
@@ -581,7 +583,8 @@
             },
             {
               "description": "Maximum memory usage.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "6172672",
@@ -594,7 +597,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "4096",
@@ -607,7 +611,8 @@
             },
             {
               "description": "Cache memory that has been identified as active by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "73728",
@@ -620,7 +625,8 @@
             },
             {
               "description": "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "73728",
@@ -633,7 +639,8 @@
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -646,7 +653,8 @@
             },
             {
               "description": "The maximum amount of physical memory that can be used by the processes of this control group.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "9223372036854772000",
@@ -659,7 +667,8 @@
             },
             {
               "description": "The maximum amount of RAM + swap that can be used by the processes of this control group.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "9223372036854772000",
@@ -672,7 +681,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "106496",
@@ -685,7 +695,8 @@
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -698,7 +709,8 @@
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -771,7 +783,8 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "110592",
@@ -784,7 +797,8 @@
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -797,7 +811,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "4096",
@@ -810,7 +825,8 @@
             },
             {
               "description": "Cache memory that has been identified as active by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "73728",
@@ -823,7 +839,8 @@
             },
             {
               "description": "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "73728",
@@ -836,7 +853,8 @@
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup and descendants.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -849,7 +867,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "106496",
@@ -862,7 +881,8 @@
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -875,7 +895,8 @@
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group and descendant groups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -948,7 +969,8 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "110592",
@@ -961,7 +983,8 @@
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -974,7 +997,8 @@
             },
             {
               "description": "The amount of memory that cannot be reclaimed. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -987,7 +1011,8 @@
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -1000,7 +1025,8 @@
             },
             {
               "description": "The amount of memory that cannot be reclaimed.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -1013,7 +1039,8 @@
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -1758,7 +1785,8 @@
             },
             {
               "description": "Memory limit of the container.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "2074079232",
@@ -1771,7 +1799,8 @@
             },
             {
               "description": "Memory usage of the container. This excludes the total cache.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "380928",
@@ -1797,7 +1826,8 @@
             },
             {
               "description": "Maximum memory usage.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "6201344",
@@ -1810,7 +1840,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "4096",
@@ -1823,7 +1854,8 @@
             },
             {
               "description": "Cache memory that has been identified as active by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "393216",
@@ -1836,7 +1868,8 @@
             },
             {
               "description": "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "921600",
@@ -1849,7 +1882,8 @@
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -1862,7 +1896,8 @@
             },
             {
               "description": "The maximum amount of physical memory that can be used by the processes of this control group.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "9223372036854772000",
@@ -1875,7 +1910,8 @@
             },
             {
               "description": "The maximum amount of RAM + swap that can be used by the processes of this control group.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "9223372036854772000",
@@ -1888,7 +1924,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "147456",
@@ -1901,7 +1938,8 @@
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "528384",
@@ -1914,7 +1952,8 @@
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "843776",
@@ -1987,7 +2026,8 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "151552",
@@ -2000,7 +2040,8 @@
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -2013,7 +2054,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "4096",
@@ -2026,7 +2068,8 @@
             },
             {
               "description": "Cache memory that has been identified as active by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "393216",
@@ -2039,7 +2082,8 @@
             },
             {
               "description": "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "921600",
@@ -2052,7 +2096,8 @@
             },
             {
               "description": "Bytes that are waiting to get written back to the disk, from this cgroup and descendants.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -2065,7 +2110,8 @@
             },
             {
               "description": "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "147456",
@@ -2078,7 +2124,8 @@
             },
             {
               "description": "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "528384",
@@ -2091,7 +2138,8 @@
             },
             {
               "description": "Indicates the amount of memory mapped by the processes in the control group and descendant groups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "843776",
@@ -2164,7 +2212,8 @@
             },
             {
               "description": "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "151552",
@@ -2177,7 +2226,8 @@
             },
             {
               "description": "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -2190,7 +2240,8 @@
             },
             {
               "description": "The amount of memory that cannot be reclaimed. Includes descendant cgroups.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -2203,7 +2254,8 @@
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -2216,7 +2268,8 @@
             },
             {
               "description": "The amount of memory that cannot be reclaimed.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",
@@ -2229,7 +2282,8 @@
             },
             {
               "description": "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup.",
-              "gauge": {
+              "sum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                 "dataPoints": [
                   {
                     "asInt": "0",

--- a/unreleased/dockerstats-memory-gauge-to-sum.yaml
+++ b/unreleased/dockerstats-memory-gauge-to-sum.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: dockerstatsreceiver
+note: Change relevant memory metrics from gauges to sums, so they are aligned with spec recommendations and can be aggregated.
+issues: [9794]


### PR DESCRIPTION
**Description:** 
This changes all the metrics that are measured in bytes, to non-monotonic, cumulative sums.

This allows the metrics to be more easily aggregated, and align with spec recommendations on when to use gauge vs sum. Sum should be used for data that can be aggregated, and that includes memory measurements. 

There's no code changes besides those generated by mdatagen. 

**Link to tracking Issue:** 

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9794

**Testing:**

Tests were updated to expect cumulative, non monotonic sums. 

**Documentation:** 

Docs were automatically updated by `go generate`. 