### PR TITLE
[exporter/awsxrayexporter] fixed cloudwatch log group ARN parsing

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -15,8 +15,8 @@
 package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter/internal/translator"
 
 import (
-	"bytes"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -269,10 +269,12 @@ func getLogGroupMetadata(logGroups pcommon.Slice, isArn bool) []awsxray.LogGroup
 	return lgm
 }
 
+// Log group name will always be in the 7th position of the ARN
+// https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format
 func parseLogGroup(arn string) string {
-	i := bytes.LastIndexByte([]byte(arn), byte(':'))
-	if i != -1 {
-		return arn[i+1:]
+	parts := strings.SplitAfter(arn, ":")
+	if len(parts) >= 7 {
+		return strings.Trim(parts[6], ":")
 	}
 
 	return arn

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -272,9 +272,9 @@ func getLogGroupMetadata(logGroups pcommon.Slice, isArn bool) []awsxray.LogGroup
 // Log group name will always be in the 7th position of the ARN
 // https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format
 func parseLogGroup(arn string) string {
-	parts := strings.SplitAfter(arn, ":")
+	parts := strings.Split(arn, ":")
 	if len(parts) >= 7 {
-		return strings.Trim(parts[6], ":")
+		return parts[6]
 	}
 
 	return arn

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -397,7 +397,7 @@ func TestLogGroupsFromArns(t *testing.T) {
 		LogGroup: awsxray.String("group1"),
 		Arn:      awsxray.String(group1),
 	}
-	group2 := "arn:aws:logs:us-east-1:123456789123:log-group:group2"
+	group2 := "arn:aws:logs:us-east-1:123456789123:log-group:group2:*"
 	cwl2 := awsxray.LogGroupMetadata{
 		LogGroup: awsxray.String("group2"),
 		Arn:      awsxray.String(group2),

--- a/unreleased/fix-log-group-parser.yaml
+++ b/unreleased/fix-log-group-parser.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a bug in the logic for parsing CloudWatch Log Group ARNs 
+
+# One or more tracking issues related to the change
+issues: [13702]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fixed the Log group ARN parsing logic to account for another, valid log group ARN representation that includes a trailing `:*` on the ARN. Before this fix, the parser would incorrectly pick up the asterisk as the log group name.

Before, we used `bytes` for performance, but now that we're actually returning what we call `Split` on, I think it makes more sense to use `strings` instead.

**Link to tracking Issue:** <Issue number if applicable>
fixes #13702 
Full discussion on https://github.com/open-telemetry/opentelemetry-java/pull/4574

**Testing:** <Describe what testing was performed and which tests were added.>
Modified a unit test to cover this case.
