### PR TITLE
Fix use of net/http serve funtions without timeout support

### DIFF
--- a/internal/aws/xray/testdata/sampleserver/sample.go
+++ b/internal/aws/xray/testdata/sampleserver/sample.go
@@ -23,16 +23,20 @@ import (
 
 func main() {
 	// https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-go-handler.html
-	http.Handle("/", xray.Handler(
+	mux := http.NewServeMux()
+	mux.Handle("/", xray.Handler(
 		xray.NewFixedSegmentNamer("SampleServer"), http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte("Hello!"))
 			},
 		),
 	))
-
+	server := &http.Server{
+		Addr:    ":8000",
+		Handler: mux,
+	}
 	go func() {
-		if err := http.ListenAndServe(":8000", nil); err != nil {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			panic(err)
 		}
 	}()


### PR DESCRIPTION
This is a new rule added in golangci 1.49.0 (will update to that soon):

`G114: Use of net/http serve function that has no support for setting timeouts (gosec)`

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
