### PR TITLE
receiver/prometheus: fix total data points calculation, remove unused dropped data points

### DIFF
--- a/receiver/prometheusreceiver/internal/otlp_metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricsbuilder_test.go
@@ -43,8 +43,7 @@ func runBuilderStartTimeTests(t *testing.T, tests []buildTestData,
 					pt.t = st
 					assert.NoError(t, b.AddDataPoint(pt.lb, pt.t, pt.v))
 				}
-				_, _, err := b.Build(pmetric.NewMetricSlice())
-				assert.NoError(t, err)
+				assert.NoError(t, b.appendMetrics(pmetric.NewMetricSlice()))
 				assert.EqualValues(t, b.startTime, expectedBuilderStartTime)
 				st += interval
 			}
@@ -499,8 +498,7 @@ func runBuilderTests(t *testing.T, tests []buildTestData) {
 					assert.NoError(t, b.AddDataPoint(pt.lb, pt.t, pt.v))
 				}
 				metrics := pmetric.NewMetricSlice()
-				_, _, err := b.Build(metrics)
-				assert.NoError(t, err)
+				assert.NoError(t, b.appendMetrics(metrics))
 				assertEquivalentMetrics(t, wants[i], metrics)
 				st += interval
 			}
@@ -1222,7 +1220,7 @@ func Test_OTLPMetricBuilder_baddata(t *testing.T) {
 			return
 		}
 
-		if _, _, err := b.Build(pmetric.NewMetricSlice()); !errors.Is(err, errNoDataToBuild) {
+		if err := b.appendMetrics(pmetric.NewMetricSlice()); !errors.Is(err, errNoDataToBuild) {
 			t.Error("expecting errNoDataToBuild error, but get nil")
 		}
 	})

--- a/unreleased/fix-data-point-metric-prometeus.yaml
+++ b/unreleased/fix-data-point-metric-prometeus.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix num data point for metrics recorded in prometheusreceiver"
+
+# One or more tracking issues related to the change
+issues: [13705]
+


### PR DESCRIPTION
As per the current implementation the number of timeseries and dropped timeseries was wrong, since they were cumulative and not reset every export. The only user of these values is the obsreport which accepts only number of points in the current data (delta) not cumulative.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
