### PR TITLE
[Prometheus receiver] Reduce memory usage

### DIFF
--- a/receiver/prometheusreceiver/internal/otlp_metricfamily.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily.go
@@ -246,13 +246,10 @@ func (mg *metricGroup) toNumberDataPoint(orderedLabelKeys []string, dest pmetric
 
 func populateAttributes(orderedKeys []string, ls labels.Labels, dest pcommon.Map) {
 	dest.EnsureCapacity(len(orderedKeys))
-	for _, key := range orderedKeys {
-		val := ls.Get(key)
-		if val == "" {
-			// empty label values should be omitted
-			continue
+	for i := 0; i < len(orderedKeys); i++ {
+		if val := ls.Get(orderedKeys[i]); val != "" {
+			dest.InsertString(orderedKeys[i], val)
 		}
-		dest.InsertString(key, val)
 	}
 }
 

--- a/unreleased/msg_fix-string-copies.yaml
+++ b/unreleased/msg_fix-string-copies.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiever
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reducing required memory usage
+
+# One or more tracking issues related to the change
+issues: [5958]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** 
This PR will use the strings directly from the array instead of creating an implicit copy of it (thus doubling memory usage).

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/5958

**Testing:** 
Ensuring that it passes the original testing.

I have a playground that shows at least the strings being consumed from `range` are different from those being stored inside the original array.
https://go.dev/play/p/wQcmYpkI5Ir

**Documentation:** <Describe the documentation added.>