### PR TITLE
[exporter/datadogexporter] Do not validate key if the result will not be checked

### DIFF
--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -101,8 +101,10 @@ func newMetricsExporter(ctx context.Context, params component.ExporterCreateSett
 	client.ExtraHeader["User-Agent"] = utils.UserAgent(params.BuildInfo)
 	client.HttpClient = utils.NewHTTPClient(cfg.TimeoutSettings, cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify)
 
-	if err := utils.ValidateAPIKey(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
-		return nil, err
+	if cfg.API.FailOnInvalidKey {
+		if err := utils.ValidateAPIKey(params.Logger, client); err != nil {
+			return nil, err
+		}
 	}
 
 	tr, err := translatorFromConfig(params.Logger, cfg, sourceProvider)

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -54,8 +54,10 @@ type traceExporter struct {
 func newTracesExporter(ctx context.Context, params component.ExporterCreateSettings, cfg *Config, onceMetadata *sync.Once, sourceProvider source.Provider) (*traceExporter, error) {
 	// client to send running metric to the backend & perform API key validation
 	client := utils.CreateClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
-	if err := utils.ValidateAPIKey(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
-		return nil, err
+	if cfg.API.FailOnInvalidKey {
+		if err := utils.ValidateAPIKey(params.Logger, client); err != nil {
+			return nil, err
+		}
 	}
 	acfg := traceconfig.New()
 	src, err := sourceProvider.Source(ctx)


### PR DESCRIPTION
**Description:** <Describe what has changed.>

The API Key validation is being run and then, if the `fail_on_invalid_key` option is set, the result is thrown away. This PR prevents the validation from running at all if the error would be ignored. With both traces and metrics enabled, this can speed up the startup of the exporter by up to 1 second.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>