### PR TITLE
[receiver/vcenter] Refresh User Sessions

### DIFF
--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -47,7 +47,10 @@ func newVcenterClient(c *Config) *vcenterClient {
 // EnsureConnection will establish a connection to the vSphere SDK if not already established
 func (vc *vcenterClient) EnsureConnection(ctx context.Context) error {
 	if vc.moClient != nil {
-		return nil
+		sessionActive, _ := vc.moClient.SessionManager.SessionIsActive(ctx)
+		if sessionActive {
+			return nil
+		}
 	}
 
 	sdkURL, err := vc.cfg.SDKUrl()

--- a/receiver/vcenterreceiver/client_test.go
+++ b/receiver/vcenterreceiver/client_test.go
@@ -16,12 +16,16 @@ package vcenterreceiver // import github.com/open-telemetry/opentelemetry-collec
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25"
+	"go.opentelemetry.io/collector/config/configtls"
 )
 
 func TestGetClusters(t *testing.T) {
@@ -62,5 +66,35 @@ func TestGetVMs(t *testing.T) {
 		vms, err := client.VMs(ctx)
 		require.NoError(t, err)
 		require.NotEmpty(t, vms)
+	})
+}
+
+func TestSessionReestablish(t *testing.T) {
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		// finder := find.NewFinder(c)
+		sm := session.NewManager(c)
+
+		moClient := &govmomi.Client{
+			Client:         c,
+			SessionManager: sm,
+		}
+		pw, _ := simulator.DefaultLogin.Password()
+		client := vcenterClient{
+			vimDriver: c,
+			cfg: &Config{
+				Username: simulator.DefaultLogin.Username(),
+				Password: pw,
+				Endpoint: fmt.Sprintf("%s://%s", c.URL().Scheme, c.URL().Host),
+				TLSClientSetting: configtls.TLSClientSetting{
+					Insecure: true,
+				},
+			},
+			moClient: moClient,
+		}
+		err := sm.Logout(ctx)
+		require.NoError(t, err)
+
+		err = client.EnsureConnection(ctx)
+		require.NoError(t, err)
 	})
 }

--- a/receiver/vcenterreceiver/client_test.go
+++ b/receiver/vcenterreceiver/client_test.go
@@ -71,9 +71,7 @@ func TestGetVMs(t *testing.T) {
 
 func TestSessionReestablish(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		// finder := find.NewFinder(c)
 		sm := session.NewManager(c)
-
 		moClient := &govmomi.Client{
 			Client:         c,
 			SessionManager: sm,
@@ -94,10 +92,14 @@ func TestSessionReestablish(t *testing.T) {
 		err := sm.Logout(ctx)
 		require.NoError(t, err)
 
+		connected, err := client.moClient.SessionManager.SessionIsActive(ctx)
+		require.NoError(t, err)
+		require.False(t, connected)
+
 		err = client.EnsureConnection(ctx)
 		require.NoError(t, err)
 
-		connected, err := client.moClient.SessionManager.SessionIsActive(ctx)
+		connected, err = client.moClient.SessionManager.SessionIsActive(ctx)
 		require.NoError(t, err)
 		require.True(t, connected)
 	})

--- a/receiver/vcenterreceiver/client_test.go
+++ b/receiver/vcenterreceiver/client_test.go
@@ -96,5 +96,9 @@ func TestSessionReestablish(t *testing.T) {
 
 		err = client.EnsureConnection(ctx)
 		require.NoError(t, err)
+
+		connected, err := client.moClient.SessionManager.SessionIsActive(ctx)
+		require.NoError(t, err)
+		require.True(t, connected)
 	})
 }

--- a/unreleased/vcenter-refresh-sessions.yaml
+++ b/unreleased/vcenter-refresh-sessions.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Re-establish sessions when running with particular TLS settings.
+
+# One or more tracking issues related to the change
+issues: [13447]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**  Attempt to refresh user sessions when the monitoring user gets logged out.

Submitting in draft to run a couple long runs to validate.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** Potentially solves #13447 

**Testing:** Long form testing and unit testing using the simulator

**Documentation:** no new documentation