### PR TITLE
receiver/prometheus: Remove temporary maps to dedup and remove unuseful labels

### DIFF
--- a/receiver/prometheusreceiver/internal/otlp_metricfamily.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily.go
@@ -31,14 +31,12 @@ import (
 type metricFamily struct {
 	mtype pmetric.MetricDataType
 	// isMonotonic only applies to sums
-	isMonotonic      bool
-	groups           map[string]*metricGroup
-	name             string
-	mc               MetadataCache
-	labelKeys        map[string]bool
-	labelKeysOrdered []string
-	metadata         *scrape.MetricMetadata
-	groupOrders      []*metricGroup
+	isMonotonic bool
+	groups      map[uint64]*metricGroup
+	name        string
+	mc          MetadataCache
+	metadata    *scrape.MetricMetadata
+	groupOrders []*metricGroup
 }
 
 // metricGroup, represents a single metric of a metric family. for example a histogram metric is usually represent by
@@ -64,32 +62,12 @@ func newMetricFamily(metricName string, mc MetadataCache, logger *zap.Logger) *m
 	}
 
 	return &metricFamily{
-		mtype:            mtype,
-		isMonotonic:      isMonotonic,
-		groups:           make(map[string]*metricGroup),
-		name:             familyName,
-		mc:               mc,
-		labelKeys:        make(map[string]bool),
-		labelKeysOrdered: make([]string, 0),
-		metadata:         metadata,
-	}
-}
-
-// updateLabelKeys is used to store all the label keys of a same metric family in observed order. since prometheus
-// receiver removes any label with empty value before feeding it to an appender, in order to figure out all the labels
-// from the same metric family we will need to keep track of what labels have ever been observed.
-func (mf *metricFamily) updateLabelKeys(ls labels.Labels) {
-	for _, l := range ls {
-		if isUsefulLabel(mf.mtype, l.Name) {
-			if _, ok := mf.labelKeys[l.Name]; !ok {
-				mf.labelKeys[l.Name] = true
-				// use insertion sort to maintain order
-				i := sort.SearchStrings(mf.labelKeysOrdered, l.Name)
-				mf.labelKeysOrdered = append(mf.labelKeysOrdered, "")
-				copy(mf.labelKeysOrdered[i+1:], mf.labelKeysOrdered[i:])
-				mf.labelKeysOrdered[i] = l.Name
-			}
-		}
+		mtype:       mtype,
+		isMonotonic: isMonotonic,
+		groups:      make(map[uint64]*metricGroup),
+		name:        familyName,
+		mc:          mc,
+		metadata:    metadata,
 	}
 }
 
@@ -105,9 +83,10 @@ func (mf *metricFamily) includesMetric(metricName string) bool {
 	return metricName == mf.name
 }
 
-func (mf *metricFamily) getGroupKey(ls labels.Labels) string {
-	mf.updateLabelKeys(ls)
-	return dpgSignature(mf.labelKeysOrdered, ls)
+func (mf *metricFamily) getGroupKey(ls labels.Labels) uint64 {
+	bytes := make([]byte, 0, 2048)
+	hash, _ := ls.HashWithoutLabels(bytes, getSortedNotUsefulLabels(mf.mtype)...)
+	return hash
 }
 
 func (mg *metricGroup) sortPoints() {
@@ -116,7 +95,7 @@ func (mg *metricGroup) sortPoints() {
 	})
 }
 
-func (mg *metricGroup) toDistributionPoint(orderedLabelKeys []string, dest pmetric.HistogramDataPointSlice) {
+func (mg *metricGroup) toDistributionPoint(dest pmetric.HistogramDataPointSlice) {
 	if !mg.hasCount || len(mg.complexValue) == 0 {
 		return
 	}
@@ -165,7 +144,7 @@ func (mg *metricGroup) toDistributionPoint(orderedLabelKeys []string, dest pmetr
 		point.SetStartTimestamp(tsNanos) // metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 	}
 	point.SetTimestamp(tsNanos)
-	populateAttributes(orderedLabelKeys, mg.ls, point.Attributes())
+	populateAttributes(pmetric.MetricDataTypeHistogram, mg.ls, point.Attributes())
 }
 
 func pdataTimestampFromMs(timeAtMs int64) pcommon.Timestamp {
@@ -173,7 +152,7 @@ func pdataTimestampFromMs(timeAtMs int64) pcommon.Timestamp {
 	return pcommon.NewTimestampFromTime(time.Unix(secs, ns))
 }
 
-func (mg *metricGroup) toSummaryPoint(orderedLabelKeys []string, dest pmetric.SummaryDataPointSlice) {
+func (mg *metricGroup) toSummaryPoint(dest pmetric.SummaryDataPointSlice) {
 	// expecting count to be provided, however, in the following two cases, they can be missed.
 	// 1. data is corrupted
 	// 2. ignored by startValue evaluation
@@ -214,10 +193,10 @@ func (mg *metricGroup) toSummaryPoint(orderedLabelKeys []string, dest pmetric.Su
 	if mg.family.isCumulativeType() {
 		point.SetStartTimestamp(tsNanos) // metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 	}
-	populateAttributes(orderedLabelKeys, mg.ls, point.Attributes())
+	populateAttributes(pmetric.MetricDataTypeSummary, mg.ls, point.Attributes())
 }
 
-func (mg *metricGroup) toNumberDataPoint(orderedLabelKeys []string, dest pmetric.NumberDataPointSlice) {
+func (mg *metricGroup) toNumberDataPoint(dest pmetric.NumberDataPointSlice) {
 	var startTsNanos pcommon.Timestamp
 	tsNanos := pdataTimestampFromMs(mg.ts)
 	// gauge/undefined types have no start time.
@@ -233,18 +212,25 @@ func (mg *metricGroup) toNumberDataPoint(orderedLabelKeys []string, dest pmetric
 	} else {
 		point.SetDoubleVal(mg.value)
 	}
-	populateAttributes(orderedLabelKeys, mg.ls, point.Attributes())
+	populateAttributes(pmetric.MetricDataTypeGauge, mg.ls, point.Attributes())
 }
 
-func populateAttributes(orderedKeys []string, ls labels.Labels, dest pcommon.Map) {
-	dest.EnsureCapacity(len(orderedKeys))
-	for _, key := range orderedKeys {
-		val := ls.Get(key)
-		if val == "" {
+func populateAttributes(mType pmetric.MetricDataType, ls labels.Labels, dest pcommon.Map) {
+	dest.EnsureCapacity(ls.Len())
+	names := getSortedNotUsefulLabels(mType)
+	j := 0
+	for i := range ls {
+		for j < len(names) && names[j] < ls[i].Name {
+			j++
+		}
+		if j < len(names) && ls[i].Name == names[j] {
+			continue
+		}
+		if ls[i].Value == "" {
 			// empty label values should be omitted
 			continue
 		}
-		dest.InsertString(key, val)
+		dest.InsertString(ls[i].Name, ls[i].Value)
 	}
 }
 
@@ -254,7 +240,7 @@ func (mf *metricFamily) isCumulativeType() bool {
 		mf.mtype == pmetric.MetricDataTypeSummary
 }
 
-func (mf *metricFamily) loadMetricGroupOrCreate(groupKey string, ls labels.Labels, ts int64) *metricGroup {
+func (mf *metricFamily) loadMetricGroupOrCreate(groupKey uint64, ls labels.Labels, ts int64) *metricGroup {
 	mg, ok := mf.groups[groupKey]
 	if !ok {
 		mg = &metricGroup{
@@ -317,7 +303,7 @@ func (mf *metricFamily) appendMetric(metrics pmetric.MetricSlice) {
 		histogram.SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 		hdpL := histogram.DataPoints()
 		for _, mg := range mf.groupOrders {
-			mg.toDistributionPoint(mf.labelKeysOrdered, hdpL)
+			mg.toDistributionPoint(hdpL)
 		}
 		pointCount = hdpL.Len()
 
@@ -325,7 +311,7 @@ func (mf *metricFamily) appendMetric(metrics pmetric.MetricSlice) {
 		summary := metric.Summary()
 		sdpL := summary.DataPoints()
 		for _, mg := range mf.groupOrders {
-			mg.toSummaryPoint(mf.labelKeysOrdered, sdpL)
+			mg.toSummaryPoint(sdpL)
 		}
 		pointCount = sdpL.Len()
 
@@ -335,7 +321,7 @@ func (mf *metricFamily) appendMetric(metrics pmetric.MetricSlice) {
 		sum.SetIsMonotonic(mf.isMonotonic)
 		sdpL := sum.DataPoints()
 		for _, mg := range mf.groupOrders {
-			mg.toNumberDataPoint(mf.labelKeysOrdered, sdpL)
+			mg.toNumberDataPoint(sdpL)
 		}
 		pointCount = sdpL.Len()
 
@@ -344,7 +330,7 @@ func (mf *metricFamily) appendMetric(metrics pmetric.MetricSlice) {
 		gauge := metric.Gauge()
 		gdpL := gauge.DataPoints()
 		for _, mg := range mf.groupOrders {
-			mg.toNumberDataPoint(mf.labelKeysOrdered, gdpL)
+			mg.toNumberDataPoint(gdpL)
 		}
 		pointCount = gdpL.Len()
 	}

--- a/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
@@ -197,9 +197,9 @@ func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, 1, len(mp.groups), "Expecting exactly 1 groupKey")
+			require.Len(t, mp.groups, 1)
 			groupKey := mp.getGroupKey(tt.labels.Copy())
-			require.NotNil(t, mp.groups[groupKey], "Expecting the groupKey to have a value given key:: "+groupKey)
+			require.NotNil(t, mp.groups[groupKey])
 
 			sl := pmetric.NewMetricSlice()
 			mp.appendMetric(sl)
@@ -436,13 +436,9 @@ func TestMetricGroupData_toSummaryUnitTest(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, 1, len(mp.groups), "Expecting exactly 1 groupKey")
-			// Get the lone group key.
-			groupKey := ""
-			for key := range mp.groups {
-				groupKey = key
-			}
-			require.NotNil(t, mp.groups[groupKey], "Expecting the groupKey to have a value given key:: "+groupKey)
+			require.Len(t, mp.groups, 1)
+			groupKey := mp.getGroupKey(tt.labelsScrapes[0].labels.Copy())
+			require.NotNil(t, mp.groups[groupKey])
 
 			sl := pmetric.NewMetricSlice()
 			mp.appendMetric(sl)
@@ -523,9 +519,9 @@ func TestMetricGroupData_toNumberDataUnitTest(t *testing.T) {
 				require.NoError(t, mp.Add(tv.metric, tt.labels.Copy(), tv.at, tv.value))
 			}
 
-			require.Equal(t, 1, len(mp.groups), "Expecting exactly 1 groupKey")
+			require.Len(t, mp.groups, 1)
 			groupKey := mp.getGroupKey(tt.labels.Copy())
-			require.NotNil(t, mp.groups[groupKey], "Expecting the groupKey to have a value given key:: "+groupKey)
+			require.NotNil(t, mp.groups[groupKey])
 
 			sl := pmetric.NewMetricSlice()
 			mp.appendMetric(sl)

--- a/receiver/prometheusreceiver/internal/otlp_transaction.go
+++ b/receiver/prometheusreceiver/internal/otlp_transaction.go
@@ -16,6 +16,7 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -82,6 +83,7 @@ func (t *transaction) Append(ref storage.SeriesRef, labels labels.Labels, atMs i
 
 	if len(t.externalLabels) != 0 {
 		labels = append(labels, t.externalLabels...)
+		sort.Sort(labels)
 	}
 
 	if t.isNew {

--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -16,10 +16,7 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"errors"
-	"strconv"
 	"strings"
-
-	"github.com/prometheus/prometheus/model/labels"
 )
 
 const (
@@ -46,31 +43,6 @@ var (
 	errNoJobInstance      = errors.New("job or instance cannot be found from labels")
 	errNoStartTimeMetrics = errors.New("process_start_time_seconds metric is missing")
 )
-
-// dpgSignature is used to create a key for data complexValue belong to a same group of a metric family
-func dpgSignature(orderedKnownLabelKeys []string, ls labels.Labels) string {
-	size := 0
-	for _, k := range orderedKnownLabelKeys {
-		v := ls.Get(k)
-		if v == "" {
-			continue
-		}
-		// 2 enclosing quotes + 1 equality sign = 3 extra chars.
-		// Note: if any character in the label value requires escaping,
-		// we'll need more space than that, which will lead to some
-		// extra allocation.
-		size += 3 + len(k) + len(v)
-	}
-	sign := make([]byte, 0, size)
-	for _, k := range orderedKnownLabelKeys {
-		v := ls.Get(k)
-		if v == "" {
-			continue
-		}
-		sign = strconv.AppendQuote(sign, k+"="+v)
-	}
-	return string(sign)
-}
 
 func normalizeMetricName(name string) string {
 	for _, s := range trimmableSuffixes {

--- a/unreleased/prometeus-receiver-remove-temp-maps.yaml
+++ b/unreleased/prometeus-receiver-remove-temp-maps.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove temporary maps to dedup and remove unuseful labels"
+
+# One or more tracking issues related to the change
+issues: [13705]
+


### PR DESCRIPTION
This PR also changes the map key for the metric family/group to uint64 to reduce memory usage by the prometheus receiver.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
