### PR TITLE
 [exporter/loadbalancing] Fix inconsistent handling of endpoints without port

### DIFF
--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -205,7 +205,7 @@ func TestRemoveExtraExporters(t *testing.T) {
 
 	// verify
 	assert.Len(t, p.exporters, 1)
-	assert.Contains(t, p.exporters, endpointWithPort("endpoint-1"))
+	assert.NotContains(t, p.exporters, endpointWithPort("endpoint-2"))
 }
 
 func TestAddMissingExporters(t *testing.T) {

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -190,12 +190,14 @@ func TestOnBackendChanges(t *testing.T) {
 func TestRemoveExtraExporters(t *testing.T) {
 	// prepare
 	cfg := simpleConfig()
-	p, err := newLoadBalancer(componenttest.NewNopExporterCreateSettings(), cfg, nil)
+	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		return newNopMockExporter(), nil
+	}
+	p, err := newLoadBalancer(componenttest.NewNopExporterCreateSettings(), cfg, componentFactory)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
-	p.exporters["endpoint-1"] = newNopMockExporter()
-	p.exporters["endpoint-2"] = newNopMockExporter()
+	p.addMissingExporters(context.Background(), []string{"endpoint-1", "endpoint-2"})
 	resolved := []string{"endpoint-1"}
 
 	// test
@@ -203,7 +205,7 @@ func TestRemoveExtraExporters(t *testing.T) {
 
 	// verify
 	assert.Len(t, p.exporters, 1)
-	assert.NotContains(t, p.exporters, "endpoint-2")
+	assert.Contains(t, p.exporters, endpointWithPort("endpoint-1"))
 }
 
 func TestAddMissingExporters(t *testing.T) {
@@ -262,7 +264,7 @@ func TestFailedToAddMissingExporters(t *testing.T) {
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
-	p.exporters["endpoint-1"] = newNopMockExporter()
+	p.exporters["endpoint-1:4317"] = newNopMockExporter()
 	resolved := []string{"endpoint-1", "endpoint-2"}
 
 	// test
@@ -270,7 +272,7 @@ func TestFailedToAddMissingExporters(t *testing.T) {
 
 	// verify
 	assert.Len(t, p.exporters, 1)
-	assert.NotContains(t, p.exporters, "endpoint-2")
+	assert.Contains(t, p.exporters, "endpoint-1:4317")
 }
 
 func TestEndpointFound(t *testing.T) {
@@ -334,10 +336,11 @@ func TestFailedExporterInRing(t *testing.T) {
 	// this is a case that we are not even sure that might happen, so, this test case is here to document
 	// this behavior. As the solution would require more locks/syncs/checks, we should probably wait to see
 	// if this is really a problem in the real world
-	delete(p.exporters, "endpoint-2")
+	resEndpoint := "endpoint-2"
+	delete(p.exporters, endpointWithPort(resEndpoint))
 
 	// sanity check
-	require.Contains(t, p.res.(*staticResolver).endpoints, "endpoint-2")
+	require.Contains(t, p.res.(*staticResolver).endpoints, resEndpoint)
 
 	// test
 	// this trace ID will reach the endpoint-2 -- see the consistent hashing tests for more info

--- a/unreleased/fix-missing-port-load-balancer.yaml
+++ b/unreleased/fix-missing-port-load-balancer.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: loadbalancingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed the case in loadbalancingexporter where a DNS resolver is defined without an explicit Port.
+
+# One or more tracking issues related to the change
+issues: [10321]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
Fixes the problem where a dns-resolver is defined without a `Port` element. This SHOULD result in the default port (4317) being used, but leads to some problems. See linked issue.

The gist of the fix is to ensure that the strings in the lb.exporters map always have the port, and are always looked up with the port. Some of the unit-tests (logs and traces) can no longer happen as written and have been removed.

A deeper fix would likely require more refactoring, since the host (with or without port) is also used in the `items` ring.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10321

**Testing:**
Unit tests performed.
Ran test-config from the linked issue, which worked.

**Documentation:**
No documentation added or changed.