### PR TITLE
[pkg/stanza] Do not directly embed input operator configs

### DIFF
--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -135,7 +135,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "filelog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["filelog"].CreateDefaultConfig().(*filelogreceiver.FileLogConfig)
-				cfg.Include = []string{filepath.Join(t.TempDir(), "*")}
+				cfg.InputConfig.Include = []string{filepath.Join(t.TempDir(), "*")}
 				return cfg
 			},
 		},
@@ -321,9 +321,9 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "syslog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["syslog"].CreateDefaultConfig().(*syslogreceiver.SysLogConfig)
-				cfg.TCP = &tcpop.NewConfig().BaseConfig
-				cfg.TCP.ListenAddress = "0.0.0.0:0"
-				cfg.Protocol = "rfc5424"
+				cfg.InputConfig.TCP = &tcpop.NewConfig().BaseConfig
+				cfg.InputConfig.TCP.ListenAddress = "0.0.0.0:0"
+				cfg.InputConfig.Protocol = "rfc5424"
 				return cfg
 			},
 		},
@@ -331,7 +331,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "tcplog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["tcplog"].CreateDefaultConfig().(*tcplogreceiver.TCPLogConfig)
-				cfg.ListenAddress = "0.0.0.0:0"
+				cfg.InputConfig.ListenAddress = "0.0.0.0:0"
 				return cfg
 			},
 		},
@@ -339,7 +339,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "udplog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["udplog"].CreateDefaultConfig().(*udplogreceiver.UDPLogConfig)
-				cfg.ListenAddress = "0.0.0.0:0"
+				cfg.InputConfig.ListenAddress = "0.0.0.0:0"
 				return cfg
 			},
 		},

--- a/receiver/filelogreceiver/filelog.go
+++ b/receiver/filelogreceiver/filelog.go
@@ -53,7 +53,7 @@ func createDefaultConfig() *FileLogConfig {
 			Operators:        adapter.OperatorConfigs{},
 			Converter:        adapter.ConverterConfig{},
 		},
-		Config: *file.NewConfig(),
+		InputConfig: *file.NewConfig(),
 	}
 }
 
@@ -64,12 +64,12 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 
 // FileLogConfig defines configuration for the filelog receiver
 type FileLogConfig struct {
-	file.Config        `mapstructure:",squash"`
+	InputConfig        file.Config `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`
 }
 
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*FileLogConfig)
-	return &operator.Config{Builder: &logConfig.Config}, nil
+	return &operator.Config{Builder: &logConfig.InputConfig}, nil
 }

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -65,7 +65,7 @@ func TestCreateWithInvalidInputConfig(t *testing.T) {
 	t.Parallel()
 
 	cfg := testdataConfigYaml()
-	cfg.StartAt = "middle"
+	cfg.InputConfig.StartAt = "middle"
 
 	_, err := NewFactory().CreateLogsReceiver(
 		context.Background(),
@@ -275,7 +275,7 @@ func testdataConfigYaml() *FileLogConfig {
 				FlushInterval: 100 * time.Millisecond,
 			},
 		},
-		Config: func() file.Config {
+		InputConfig: func() file.Config {
 			c := file.NewConfig()
 			c.Include = []string{"testdata/simple.log"}
 			c.StartAt = "beginning"
@@ -300,7 +300,7 @@ func rotationTestConfig(tempDir string) *FileLogConfig {
 			},
 			Converter: adapter.ConverterConfig{},
 		},
-		Config: func() file.Config {
+		InputConfig: func() file.Config {
 			c := file.NewConfig()
 			c.Include = []string{fmt.Sprintf("%s/*", tempDir)}
 			c.StartAt = "beginning"

--- a/receiver/journaldreceiver/journald.go
+++ b/receiver/journaldreceiver/journald.go
@@ -52,7 +52,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: *journald.NewConfig(),
+		InputConfig: *journald.NewConfig(),
 	}
 }
 
@@ -64,11 +64,11 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 // JournaldConfig defines configuration for the journald receiver
 type JournaldConfig struct {
 	adapter.BaseConfig `mapstructure:",squash"`
-	journald.Config    `mapstructure:",squash"`
+	InputConfig        journald.Config `mapstructure:",squash"`
 }
 
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*JournaldConfig)
-	return &operator.Config{Builder: &logConfig.Config}, nil
+	return &operator.Config{Builder: &logConfig.InputConfig}, nil
 }

--- a/receiver/journaldreceiver/journald_test.go
+++ b/receiver/journaldreceiver/journald_test.go
@@ -56,7 +56,7 @@ func TestDecodeInputConfigFailure(t *testing.T) {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: func() journald.Config {
+		InputConfig: func() journald.Config {
 			c := journald.NewConfig()
 			c.StartAt = "middle"
 			return *c
@@ -73,7 +73,7 @@ func testdataConfigYaml() *JournaldConfig {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: func() journald.Config {
+		InputConfig: func() journald.Config {
 			c := journald.NewConfig()
 			c.Units = []string{"ssh"}
 			c.Priority = "info"

--- a/receiver/syslogreceiver/syslog.go
+++ b/receiver/syslogreceiver/syslog.go
@@ -52,7 +52,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: *syslog.NewConfig(),
+		InputConfig: *syslog.NewConfig(),
 	}
 }
 
@@ -63,14 +63,14 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 
 // SysLogConfig defines configuration for the syslog receiver
 type SysLogConfig struct {
-	syslog.Config      `mapstructure:",squash"`
+	InputConfig        syslog.Config `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`
 }
 
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*SysLogConfig)
-	return &operator.Config{Builder: &logConfig.Config}, nil
+	return &operator.Config{Builder: &logConfig.InputConfig}, nil
 }
 
 func (cfg *SysLogConfig) Unmarshal(componentParser *confmap.Conf) error {
@@ -80,9 +80,9 @@ func (cfg *SysLogConfig) Unmarshal(componentParser *confmap.Conf) error {
 	}
 
 	if componentParser.IsSet("tcp") {
-		cfg.TCP = &tcp.NewConfig().BaseConfig
+		cfg.InputConfig.TCP = &tcp.NewConfig().BaseConfig
 	} else if componentParser.IsSet("udp") {
-		cfg.UDP = &udp.NewConfig().BaseConfig
+		cfg.InputConfig.UDP = &udp.NewConfig().BaseConfig
 	}
 
 	return componentParser.UnmarshalExact(cfg)

--- a/receiver/syslogreceiver/syslog_test.go
+++ b/receiver/syslogreceiver/syslog_test.go
@@ -54,7 +54,7 @@ func testSyslog(t *testing.T, cfg *SysLogConfig) {
 	require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
 
 	var conn net.Conn
-	if cfg.Config.TCP != nil {
+	if cfg.InputConfig.TCP != nil {
 		conn, err = net.Dial("tcp", "0.0.0.0:29018")
 		require.NoError(t, err)
 	} else {
@@ -110,7 +110,7 @@ func testdataConfigYaml() *SysLogConfig {
 				WorkerCount:   1,
 			},
 		},
-		Config: func() syslog.Config {
+		InputConfig: func() syslog.Config {
 			c := syslog.NewConfig()
 			c.TCP = &tcp.NewConfig().BaseConfig
 			c.TCP.ListenAddress = "0.0.0.0:29018"
@@ -130,7 +130,7 @@ func testdataUDPConfig() *SysLogConfig {
 				WorkerCount:   1,
 			},
 		},
-		Config: func() syslog.Config {
+		InputConfig: func() syslog.Config {
 			c := syslog.NewConfig()
 			c.UDP = &udp.NewConfig().BaseConfig
 			c.UDP.ListenAddress = "0.0.0.0:29018"
@@ -148,7 +148,7 @@ func TestDecodeInputConfigFailure(t *testing.T) {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: func() syslog.Config {
+		InputConfig: func() syslog.Config {
 			c := syslog.NewConfig()
 			c.TCP = &tcp.NewConfig().BaseConfig
 			c.Protocol = "fake"

--- a/receiver/tcplogreceiver/tcp.go
+++ b/receiver/tcplogreceiver/tcp.go
@@ -49,7 +49,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: *tcp.NewConfig(),
+		InputConfig: *tcp.NewConfig(),
 	}
 }
 
@@ -60,12 +60,12 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 
 // TCPLogConfig defines configuration for the tcp receiver
 type TCPLogConfig struct {
-	tcp.Config         `mapstructure:",squash"`
+	InputConfig        tcp.Config `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`
 }
 
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*TCPLogConfig)
-	return &operator.Config{Builder: &logConfig.Config}, nil
+	return &operator.Config{Builder: &logConfig.InputConfig}, nil
 }

--- a/receiver/tcplogreceiver/tcp_test.go
+++ b/receiver/tcplogreceiver/tcp_test.go
@@ -95,7 +95,7 @@ func testdataConfigYaml() *TCPLogConfig {
 				WorkerCount: 1,
 			},
 		},
-		Config: func() tcp.Config {
+		InputConfig: func() tcp.Config {
 			c := tcp.NewConfig()
 			c.ListenAddress = "0.0.0.0:29018"
 			return *c
@@ -110,7 +110,7 @@ func TestDecodeInputConfigFailure(t *testing.T) {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: func() tcp.Config {
+		InputConfig: func() tcp.Config {
 			c := tcp.NewConfig()
 			c.Encoding.Encoding = "fake"
 			return *c

--- a/receiver/udplogreceiver/udp.go
+++ b/receiver/udplogreceiver/udp.go
@@ -49,7 +49,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: *udp.NewConfig(),
+		InputConfig: *udp.NewConfig(),
 	}
 }
 
@@ -60,12 +60,12 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 
 // UDPLogConfig defines configuration for the udp receiver
 type UDPLogConfig struct {
-	udp.Config         `mapstructure:",squash"`
+	InputConfig        udp.Config `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`
 }
 
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*UDPLogConfig)
-	return &operator.Config{Builder: &logConfig.Config}, nil
+	return &operator.Config{Builder: &logConfig.InputConfig}, nil
 }

--- a/receiver/udplogreceiver/udp_test.go
+++ b/receiver/udplogreceiver/udp_test.go
@@ -96,7 +96,7 @@ func testdataConfigYaml() *UDPLogConfig {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID("udplog")),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: func() udp.Config {
+		InputConfig: func() udp.Config {
 			c := udp.NewConfig()
 			c.ListenAddress = "0.0.0.0:29018"
 			return *c
@@ -112,7 +112,7 @@ func TestDecodeInputConfigFailure(t *testing.T) {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID("udplog")),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: func() udp.Config {
+		InputConfig: func() udp.Config {
 			c := udp.NewConfig()
 			c.Encoding.Encoding = "fake"
 			return *c

--- a/receiver/windowseventlogreceiver/receiver_windows.go
+++ b/receiver/windowseventlogreceiver/receiver_windows.go
@@ -53,7 +53,7 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 			Operators:        adapter.OperatorConfigs{},
 			Converter:        adapter.ConverterConfig{},
 		},
-		Config: *windows.NewConfig(),
+		InputConfig: *windows.NewConfig(),
 	}
 }
 
@@ -65,11 +65,11 @@ func (f ReceiverType) BaseConfig(cfg config.Receiver) adapter.BaseConfig {
 // DecodeInputConfig unmarshals the input operator
 func (f ReceiverType) DecodeInputConfig(cfg config.Receiver) (*operator.Config, error) {
 	logConfig := cfg.(*WindowsLogConfig)
-	return &operator.Config{Builder: &logConfig.Config}, nil
+	return &operator.Config{Builder: &logConfig.InputConfig}, nil
 }
 
 // WindowsLogConfig defines configuration for the windowseventlog receiver
 type WindowsLogConfig struct {
-	windows.Config     `mapstructure:",squash"`
+	InputConfig        windows.Config `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`
 }

--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -63,7 +63,7 @@ func TestCreateWithInvalidInputConfig(t *testing.T) {
 
 	cfg := &WindowsLogConfig{
 		BaseConfig: adapter.BaseConfig{},
-		Config: func() windows.Config {
+		InputConfig: func() windows.Config {
 			c := windows.NewConfig()
 			c.StartAt = "middle"
 			return *c
@@ -141,7 +141,7 @@ func createTestConfig() *WindowsLogConfig {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        adapter.OperatorConfigs{},
 		},
-		Config: func() windows.Config {
+		InputConfig: func() windows.Config {
 			c := windows.NewConfig()
 			c.Channel = "application"
 			c.StartAt = "end"


### PR DESCRIPTION
Direct embedding is causing issues in some cases where the embedded
structs have receiver functions of with conflicting signatures
compared to those higher up. This change just assigns a field name
to the pkg/stanza input operator configs, when used in other components.