### PR TITLE
[receiver/k8scluster] Move k8s clients creation to the starting phase

### DIFF
--- a/receiver/k8sclusterreceiver/config.go
+++ b/receiver/k8sclusterreceiver/config.go
@@ -15,11 +15,10 @@
 package k8sclusterreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
 
 import (
+	"fmt"
 	"time"
 
-	quotaclientset "github.com/openshift/client-go/quota/clientset/versioned"
 	"go.opentelemetry.io/collector/config"
-	k8s "k8s.io/client-go/kubernetes"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 )
@@ -43,26 +42,14 @@ type Config struct {
 
 	// Whether OpenShift supprot should be enabled or not.
 	Distribution string `mapstructure:"distribution"`
-
-	// For mocking.
-	makeClient               func(apiConf k8sconfig.APIConfig) (k8s.Interface, error)
-	makeOpenShiftQuotaClient func(apiConf k8sconfig.APIConfig) (quotaclientset.Interface, error)
 }
 
 func (cfg *Config) Validate() error {
+	switch cfg.Distribution {
+	case distributionOpenShift:
+	case distributionKubernetes:
+	default:
+		return fmt.Errorf("\"%s\" is not a supported distribution. Must be one of: \"openshift\", \"kubernetes\"", cfg.Distribution)
+	}
 	return cfg.APIConfig.Validate()
-}
-
-func (cfg *Config) getK8sClient() (k8s.Interface, error) {
-	if cfg.makeClient == nil {
-		cfg.makeClient = k8sconfig.MakeClient
-	}
-	return cfg.makeClient(cfg.APIConfig)
-}
-
-func (cfg *Config) getOpenShiftQuotaClient() (quotaclientset.Interface, error) {
-	if cfg.makeOpenShiftQuotaClient == nil {
-		cfg.makeOpenShiftQuotaClient = k8sconfig.MakeOpenShiftQuotaClient
-	}
-	return cfg.makeOpenShiftQuotaClient(cfg.APIConfig)
 }

--- a/receiver/k8sclusterreceiver/config_test.go
+++ b/receiver/k8sclusterreceiver/config_test.go
@@ -71,3 +71,25 @@ func TestLoadConfig(t *testing.T) {
 			},
 		})
 }
+
+func TestInvalidConfig(t *testing.T) {
+	// No APIConfig
+	cfg := &Config{
+		ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "all_settings")),
+		Distribution:       distributionKubernetes,
+		CollectionInterval: 30 * time.Second,
+	}
+	err := cfg.Validate()
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid authType for kubernetes: ", err.Error())
+
+	// Wrong distro
+	cfg = &Config{
+		ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "all_settings")),
+		Distribution:       "wrong",
+		CollectionInterval: 30 * time.Second,
+	}
+	err = cfg.Validate()
+	assert.NotNil(t, err)
+	assert.Equal(t, "\"wrong\" is not a supported distribution. Must be one of: \"openshift\", \"kubernetes\"", err.Error())
+}

--- a/unreleased/k8s-cluster-refactoring.yaml
+++ b/unreleased/k8s-cluster-refactoring.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: receiver/k8scluster
+note: Moving initialization of k8s client from receiver init to receiver start phase.
+issues: [12582]


### PR DESCRIPTION
This is mostly a refactoring PRs with no actual changes except for moving initialization of k8s client from receiver init to receiver start phase. This allows us to move all the k8s client creation logic and its mocks to the struct where they are actually being used them instead of keeping them in Config struct.
