### PR TITLE
[receiver/elasticsearchreceiver] Fix elasticsearch metrics from By to KiBy

### DIFF
--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -30,8 +30,8 @@ These are the metrics available for this scraper.
 | **elasticsearch.node.cluster.io** | The number of bytes sent and received on the network for internal cluster communication. | By | Sum(Int) | <ul> <li>direction</li> </ul> |
 | **elasticsearch.node.cluster.io.received** | The number of bytes received on the network for internal cluster communication. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.cluster.io.sent** | The number of bytes sent on the network for internal cluster communication. | By | Sum(Int) | <ul> </ul> |
-| **elasticsearch.node.disk.io.read** | The total number of kilobytes read across all file stores for this node. | By | Sum(Int) | <ul> </ul> |
-| **elasticsearch.node.disk.io.write** | The total number of kilobytes written across all file stores for this node. | By | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.disk.io.read** | The total number of kilobytes read across all file stores for this node. | KiBy | Sum(Int) | <ul> </ul> |
+| **elasticsearch.node.disk.io.write** | The total number of kilobytes written across all file stores for this node. | KiBy | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.documents** | The number of documents on the node. | {documents} | Sum(Int) | <ul> <li>document_state</li> </ul> |
 | **elasticsearch.node.fs.disk.available** | The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise. | By | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.fs.disk.free** | The amount of unallocated disk space across all file stores for this node. | By | Sum(Int) | <ul> </ul> |

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -1901,7 +1901,7 @@ type metricElasticsearchNodeDiskIoRead struct {
 func (m *metricElasticsearchNodeDiskIoRead) init() {
 	m.data.SetName("elasticsearch.node.disk.io.read")
 	m.data.SetDescription("The total number of kilobytes read across all file stores for this node.")
-	m.data.SetUnit("By")
+	m.data.SetUnit("KiBy")
 	m.data.SetDataType(pmetric.MetricDataTypeSum)
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -1952,7 +1952,7 @@ type metricElasticsearchNodeDiskIoWrite struct {
 func (m *metricElasticsearchNodeDiskIoWrite) init() {
 	m.data.SetName("elasticsearch.node.disk.io.write")
 	m.data.SetDescription("The total number of kilobytes written across all file stores for this node.")
-	m.data.SetUnit("By")
+	m.data.SetUnit("KiBy")
 	m.data.SetDataType(pmetric.MetricDataTypeSum)
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -203,9 +203,11 @@ metrics:
       value_type: int
     attributes: []
     enabled: true
-  # The calculation for node.disk.io.read is actually in KiBy(1024 bytes), not Kby (1000 bytes)
-  # Source: https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java#L287
-  # The calculation uses uses IoStats package where blocks are equivalent to sectors that have the size of 512 bytes https://linux.die.net/man/1/iostat
+  # The calculation for node.disk.io.read is actually in KiBy(1024 bytes), not kBy (1000 bytes)
+  # The metric value calculation comes from sectors: https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java#L287
+  # The metric value is gathered by reading disk stats files from https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java#L117
+  # which come from a kernel https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
+  # Linux always considers sectors to be 512 bytes https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/linux/types.h#L125
   elasticsearch.node.disk.io.read:
     description: The total number of kilobytes read across all file stores for this node.
     unit: KiBy
@@ -215,9 +217,11 @@ metrics:
       value_type: int
     attributes: [ ]
     enabled: true
-  # The calculation for elasticsearch.node.disk.io.write is actually in KiBy(1024 bytes), not Kby (1000 bytes)
-  # Source: https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java#L293
-  # The calculation uses uses IoStats package where blocks are equivalent to sectors that have the size of 512 bytes https://linux.die.net/man/1/iostat
+  # The calculation for node.disk.io.write is actually in KiBy(1024 bytes), not kBy (1000 bytes)
+  # The metric value calculation comes from sectors: https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java#L293
+  # The metric value is gathered by reading disk stats files from https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java#L117
+  # which come from a kernel https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
+  # Linux always considers sectors to be 512 bytes https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/linux/types.h#L125
   elasticsearch.node.disk.io.write:
     description: The total number of kilobytes written across all file stores for this node.
     unit: KiBy

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -205,7 +205,7 @@ metrics:
     enabled: true
   elasticsearch.node.disk.io.read:
     description: The total number of kilobytes read across all file stores for this node.
-    unit: By
+    unit: KiBy
     sum:
       monotonic: false
       aggregation: cumulative
@@ -214,7 +214,7 @@ metrics:
     enabled: true
   elasticsearch.node.disk.io.write:
     description: The total number of kilobytes written across all file stores for this node.
-    unit: By
+    unit: KiBy
     sum:
       monotonic: false
       aggregation: cumulative

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -203,6 +203,9 @@ metrics:
       value_type: int
     attributes: []
     enabled: true
+  # The calculation for node.disk.io.read is actually in KiBy(1024 bytes), not Kby (1000 bytes)
+  # Source: https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java#L287
+  # The calculation uses uses IoStats package where blocks are equivalent to sectors that have the size of 512 bytes https://linux.die.net/man/1/iostat
   elasticsearch.node.disk.io.read:
     description: The total number of kilobytes read across all file stores for this node.
     unit: KiBy
@@ -212,6 +215,9 @@ metrics:
       value_type: int
     attributes: [ ]
     enabled: true
+  # The calculation for elasticsearch.node.disk.io.write is actually in KiBy(1024 bytes), not Kby (1000 bytes)
+  # Source: https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java#L293
+  # The calculation uses uses IoStats package where blocks are equivalent to sectors that have the size of 512 bytes https://linux.die.net/man/1/iostat
   elasticsearch.node.disk.io.write:
     description: The total number of kilobytes written across all file stores for this node.
     unit: KiBy

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
@@ -1007,7 +1007,7 @@
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "KiBy"
                   },
                   {
                      "description": "The total number of kilobytes written across all file stores for this node.",
@@ -1022,7 +1022,7 @@
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "KiBy"
                   },
                   {
                      "description": "The number of documents on the node.",

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -1007,7 +1007,7 @@
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "KiBy"
                   },
                   {
                      "description": "The total number of kilobytes written across all file stores for this node.",
@@ -1022,7 +1022,7 @@
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "KiBy"
                   },
                   {
                      "description": "The number of documents on the node.",

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/fullWithoutDirection.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/fullWithoutDirection.json
@@ -1002,7 +1002,7 @@
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "KiBy"
                   },
                   {
                      "description": "The total number of kilobytes written across all file stores for this node.",
@@ -1017,7 +1017,7 @@
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "KiBy"
                   },
                   {
                      "description": "The number of documents on the node.",

--- a/unreleased/elasticsearchreceiver-fix-diskio-units.yaml
+++ b/unreleased/elasticsearchreceiver-fix-diskio-units.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix elasticsearch.node.disk.io.read/write metrics from By to KiBy
+
+# One or more tracking issues related to the change
+issues: [13815]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Updates `elasticsearch.node.disk.io.read` and `elasticsearch.node.disk.io.write` units to kilobytes.

**Link to tracking Issue:** <Issue number if applicable>
#13815 

**Testing:** <Describe what testing was performed and which tests were added.>
- Unit tests

**Documentation:** <Describe the documentation added.>
Documentation has been updated via `make generate`