### PR TITLE
exporter/clickhouseexporter: fix cast FlagsStruct into uint32

### DIFF
--- a/exporter/clickhouseexporter/exporter.go
+++ b/exporter/clickhouseexporter/exporter.go
@@ -90,7 +90,7 @@ func (e *clickhouseExporter) pushLogsData(ctx context.Context, ld plog.Logs) err
 						r.Timestamp().AsTime(),
 						r.TraceID().HexString(),
 						r.SpanID().HexString(),
-						r.FlagsStruct(),
+						uint32(r.FlagsStruct()),
 						r.SeverityText(),
 						int32(r.SeverityNumber()),
 						serviceName,

--- a/unreleased/clickhouseexporter-type-cast-fix.yaml
+++ b/unreleased/clickhouseexporter-type-cast-fix.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: clickhouseexporter
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: cast FlagsStruct into uint32 in ExecContext to fix export failure
+
+# One or more tracking issues related to the change
+issues: [13843]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
cast `LogRecordFlags` into `uint32` before pass into `ExecContext` similar to `SeverityNumber` since the db statement is unable to convert `LogRecordFlags` into `uint32`.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13843

**Testing:** <Describe what testing was performed and which tests were added.>
I have tested locally and it works, but not exacatly sure how we want to automate this test with code. If anyone can give some direction it would be great.

**Documentation:** <Describe the documentation added.>