### PR TITLE
Replace pcommon.Insert* usages with pcommon.Upsert*

### DIFF
--- a/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
+++ b/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
@@ -83,7 +83,7 @@ func convertLogRecord(lr plog.LogRecord, resourceAttrs pcommon.Map, logger *zap.
 	resourceAttrs.Range(func(k string, v pcommon.Value) bool {
 		// LogRecord attribute takes priority
 		if _, ok := attrs.Get(k); !ok {
-			resourceAttrsForDimensions.Insert(k, v)
+			v.CopyTo(resourceAttrsForDimensions.UpsertEmpty(k))
 		}
 		return true
 	})

--- a/exporter/sumologicexporter/filter.go
+++ b/exporter/sumologicexporter/filter.go
@@ -48,7 +48,7 @@ func (f *filter) filterIn(attributes pcommon.Map) fields {
 	attributes.Range(func(k string, v pcommon.Value) bool {
 		for _, regex := range f.regexes {
 			if regex.MatchString(k) {
-				returnValue.Insert(k, v)
+				v.CopyTo(returnValue.UpsertEmpty(k))
 				return true
 			}
 		}
@@ -68,7 +68,7 @@ func (f *filter) filterOut(attributes pcommon.Map) fields {
 				return true
 			}
 		}
-		returnValue.Insert(k, v)
+		v.CopyTo(returnValue.UpsertEmpty(k))
 		return true
 	})
 	returnValue.Sort()

--- a/pkg/translator/jaeger/jaegerproto_to_traces.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces.go
@@ -178,7 +178,7 @@ func translateHostnameAttr(attrs pcommon.Map) {
 	hostname, hostnameFound := attrs.Get("hostname")
 	_, convHostNameFound := attrs.Get(conventions.AttributeHostName)
 	if hostnameFound && !convHostNameFound {
-		attrs.Insert(conventions.AttributeHostName, hostname)
+		hostname.CopyTo(attrs.UpsertEmpty(conventions.AttributeHostName))
 		attrs.Remove("hostname")
 	}
 }
@@ -188,7 +188,7 @@ func translateJaegerVersionAttr(attrs pcommon.Map) {
 	jaegerVersion, jaegerVersionFound := attrs.Get("jaeger.version")
 	_, exporterVersionFound := attrs.Get(occonventions.AttributeExporterVersion)
 	if jaegerVersionFound && !exporterVersionFound {
-		attrs.InsertString(occonventions.AttributeExporterVersion, "Jaeger-"+jaegerVersion.StringVal())
+		attrs.UpsertString(occonventions.AttributeExporterVersion, "Jaeger-"+jaegerVersion.StringVal())
 		attrs.Remove("jaeger.version")
 	}
 }

--- a/processor/groupbyattrsprocessor/processor.go
+++ b/processor/groupbyattrsprocessor/processor.go
@@ -195,7 +195,7 @@ func (gap *groupByAttrsProcessor) extractGroupingAttributes(attrMap pcommon.Map)
 	for _, attrKey := range gap.groupByKeys {
 		attrVal, found := attrMap.Get(attrKey)
 		if found {
-			groupingAttributes.Insert(attrKey, attrVal)
+			attrVal.CopyTo(groupingAttributes.UpsertEmpty(attrKey))
 			foundMatch = true
 		}
 	}

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -268,8 +268,8 @@ func TestProcess(t *testing.T) {
 		{
 			query: []string{`set(attributes["test"], Concat("-", attributes["attr1"], attributes["attr2"])) where metric.name == Concat("", "operation", "A")`},
 			want: func(td pmetric.Metrics) {
-				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().InsertString("test", "test1-test2")
-				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().InsertString("test", "test1-test2")
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().UpsertString("test", "test1-test2")
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().UpsertString("test", "test1-test2")
 			},
 		},
 	}

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -168,27 +168,27 @@ func TestProcess(t *testing.T) {
 		{
 			query: `set(attributes["test"], Concat(": ", attributes["http.method"], attributes["http.url"]))`,
 			want: func(td ptrace.Traces) {
-				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().InsertString("test", "get: http://localhost/health")
-				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Attributes().InsertString("test", "get: http://localhost/health")
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().UpsertString("test", "get: http://localhost/health")
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Attributes().UpsertString("test", "get: http://localhost/health")
 			},
 		},
 		{
 			query: `set(attributes["test"], Concat("", attributes["http.method"], ": ", attributes["http.url"]))`,
 			want: func(td ptrace.Traces) {
-				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().InsertString("test", "get: http://localhost/health")
-				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Attributes().InsertString("test", "get: http://localhost/health")
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().UpsertString("test", "get: http://localhost/health")
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Attributes().UpsertString("test", "get: http://localhost/health")
 			},
 		},
 		{
 			query: `set(attributes["test"], Concat(": ", attributes["http.method"], attributes["http.url"])) where name == Concat("", "operation", "A")`,
 			want: func(td ptrace.Traces) {
-				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().InsertString("test", "get: http://localhost/health")
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().UpsertString("test", "get: http://localhost/health")
 			},
 		},
 		{
 			query: `set(attributes["kind"], Concat("", "kind", ": ", kind)) where kind == 1`,
 			want: func(td ptrace.Traces) {
-				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().InsertString("kind", "kind: 1")
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().UpsertString("kind", "kind: 1")
 			},
 		},
 	}

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -129,7 +129,7 @@ func (t *transaction) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e e
 				copyToLowerBytes(sid[:], b)
 				exemplar.SetSpanID(pcommon.NewSpanID(sid))
 			default:
-				exemplar.FilteredAttributes().Insert(lb.Name, pcommon.NewValueString(lb.Value))
+				exemplar.FilteredAttributes().UpsertString(lb.Name, lb.Value)
 			}
 		}
 		t.metricBuilder.families[familyName].groups[gk].exemplars[e.Value] = exemplar

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -145,7 +145,7 @@ func buildAttributes(dimensions map[string]interface{}) pcommon.Map {
 			// TODO: Log or metric for this odd ball?
 			continue
 		}
-		attributes.InsertString(key, fmt.Sprintf("%v", val))
+		attributes.UpsertString(key, fmt.Sprintf("%v", val))
 	}
 	return attributes
 }

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
@@ -172,13 +172,13 @@ func initializeMetricDps(metric pmetric.Metric, now pcommon.Timestamp, counterVa
 	}
 
 	dp := dps.AppendEmpty()
+	if counterValue.InstanceName != "" {
+		dp.Attributes().UpsertString(instanceLabelName, counterValue.InstanceName)
+	}
 	if attributes != nil {
 		for attKey, attVal := range attributes {
-			dp.Attributes().InsertString(attKey, attVal)
+			dp.Attributes().UpsertString(attKey, attVal)
 		}
-	}
-	if counterValue.InstanceName != "" {
-		dp.Attributes().InsertString(instanceLabelName, counterValue.InstanceName)
 	}
 
 	dp.SetTimestamp(now)


### PR DESCRIPTION
Replace a few usages of pcommon.Insert* with pcommon.Upsert* where no data expected under a key

Related issue: https://github.com/open-telemetry/opentelemetry-collector/issues/5998