### PR TITLE
[processor/redaction] Update existing redaction attributes

### DIFF
--- a/unreleased/redaction-run-twice.yaml
+++ b/unreleased/redaction-run-twice.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: processor/redaction
+note: Update redaction attributes in case if data sent through the processor more than once, not not ignore them.
+issues: [13854]


### PR DESCRIPTION
Update redaction attributes in case if data sent through the processor more than once. Existing attributes must be updated, not overridden or ignored. Currently, the attributes are not updated if they are already set.