### PR TITLE
[processor/transform] Fix panic on gauge type

### DIFF
--- a/processor/transformprocessor/internal/metrics/processor.go
+++ b/processor/transformprocessor/internal/metrics/processor.go
@@ -54,7 +54,7 @@ func (p *Processor) ProcessMetrics(_ context.Context, td pmetric.Metrics) (pmetr
 				case pmetric.MetricDataTypeSum:
 					p.handleNumberDataPoints(metric.Sum().DataPoints(), metrics.At(k), metrics, smetrics.Scope(), rmetrics.Resource())
 				case pmetric.MetricDataTypeGauge:
-					p.handleNumberDataPoints(metric.Sum().DataPoints(), metrics.At(k), metrics, smetrics.Scope(), rmetrics.Resource())
+					p.handleNumberDataPoints(metric.Gauge().DataPoints(), metrics.At(k), metrics, smetrics.Scope(), rmetrics.Resource())
 				case pmetric.MetricDataTypeHistogram:
 					p.handleHistogramDataPoints(metric.Histogram().DataPoints(), metrics.At(k), metrics, smetrics.Scope(), rmetrics.Resource())
 				case pmetric.MetricDataTypeExponentialHistogram:

--- a/unreleased/transform-fix-panic-gauge-type.yaml
+++ b/unreleased/transform-fix-panic-gauge-type.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: transformprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes panic of transformprocessor handling Gauge types
+
+# One or more tracking issues related to the change
+issues: [13905]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** The transform processor was panicking on handling the gauge data type. Appears to be a typo in the switch statement.

**Link to tracking Issue:**  Resolves #13905 

**Testing:** did local testing against config in issue and scrape now no longer panics.

**Documentation:** changelog entry