### PR TITLE
[receiver/prometheus] Use Upsert* instead of Insert* on empty maps

### DIFF
--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -230,7 +230,7 @@ func populateAttributes(mType pmetric.MetricDataType, ls labels.Labels, dest pco
 			// empty label values should be omitted
 			continue
 		}
-		dest.InsertString(ls[i].Name, ls[i].Value)
+		dest.UpsertString(ls[i].Name, ls[i].Value)
 	}
 }
 


### PR DESCRIPTION
To evaluate https://github.com/open-telemetry/opentelemetry-collector/issues/5998.

The function is always applied on new datapoints, so it's safe to replace Insert with Upsert.