### PR TITLE
[receiver/signalfx] Replace usages of Insert to Upsert on empty maps

### DIFF
--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -254,7 +254,7 @@ func (r *sfxReceiver) handleDatapointReq(resp http.ResponseWriter, req *http.Req
 			for i := 0; i < md.ResourceMetrics().Len(); i++ {
 				rm := md.ResourceMetrics().At(i)
 				res := rm.Resource()
-				res.Attributes().InsertString(splunk.SFxAccessTokenLabel, accessToken)
+				res.Attributes().UpsertString(splunk.SFxAccessTokenLabel, accessToken)
 			}
 		}
 	}
@@ -297,7 +297,7 @@ func (r *sfxReceiver) handleEventReq(resp http.ResponseWriter, req *http.Request
 
 	if r.config.AccessTokenPassthrough {
 		if accessToken := req.Header.Get(splunk.SFxAccessTokenHeader); accessToken != "" {
-			rl.Resource().Attributes().InsertString(splunk.SFxAccessTokenLabel, accessToken)
+			rl.Resource().Attributes().UpsertString(splunk.SFxAccessTokenLabel, accessToken)
 		}
 	}
 


### PR DESCRIPTION
signalfx receiver doesn't create resource attributes from sfx datapoints or events. So it's save to use Map.Upsert instead of Map.Insert on empty maps

Related issue: https://github.com/open-telemetry/opentelemetry-collector/issues/5998
