### PR TITLE
[receiver/splunkhec] Use Upsert* instead of Insert on empty map

### DIFF
--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -393,7 +393,7 @@ func (r *splunkReceiver) createResourceCustomizer(req *http.Request) func(resour
 		if strings.HasPrefix(accessToken, splunk.HECTokenHeader+" ") {
 			accessTokenValue := accessToken[len(splunk.HECTokenHeader)+1:]
 			return func(resource pcommon.Resource) {
-				resource.Attributes().InsertString(splunk.HecTokenLabel, accessTokenValue)
+				resource.Attributes().UpsertString(splunk.HecTokenLabel, accessTokenValue)
 			}
 		}
 	}


### PR DESCRIPTION
The resource customizer is always applied on empty resource, so it's safe to replace InsertString with UpsertString

Related issue: https://github.com/open-telemetry/opentelemetry-collector/issues/5998