### PR TITLE
[exporter/sumologic] Make the exporter to not mutate logs data

### DIFF
--- a/exporter/sumologicexporter/filter.go
+++ b/exporter/sumologicexporter/filter.go
@@ -41,19 +41,22 @@ func newFilter(flds []string) (filter, error) {
 	}, nil
 }
 
-// filterIn returns fields which match at least one of the filter regexes
-func (f *filter) filterIn(attributes pcommon.Map) fields {
+// mergeAndFilterIn merges provided attribute maps and returns fields which match at least one of the filter regexes.
+// Later attribute maps take precedence over former ones.
+func (f *filter) mergeAndFilterIn(attrMaps ...pcommon.Map) fields {
 	returnValue := pcommon.NewMap()
 
-	attributes.Range(func(k string, v pcommon.Value) bool {
-		for _, regex := range f.regexes {
-			if regex.MatchString(k) {
-				v.CopyTo(returnValue.UpsertEmpty(k))
-				return true
+	for _, attributes := range attrMaps {
+		attributes.Range(func(k string, v pcommon.Value) bool {
+			for _, regex := range f.regexes {
+				if regex.MatchString(k) {
+					v.CopyTo(returnValue.UpsertEmpty(k))
+					return true
+				}
 			}
-		}
-		return true
-	})
+			return true
+		})
+	}
 	returnValue.Sort()
 	return newFields(returnValue)
 }

--- a/exporter/sumologicexporter/filter_test.go
+++ b/exporter/sumologicexporter/filter_test.go
@@ -23,18 +23,21 @@ import (
 )
 
 func TestGetMetadata(t *testing.T) {
-	attributes := pcommon.NewMap()
-	attributes.UpsertString("key3", "value3")
-	attributes.UpsertString("key1", "value1")
-	attributes.UpsertString("key2", "value2")
-	attributes.UpsertString("additional_key2", "value2")
-	attributes.UpsertString("additional_key3", "value3")
+	attributes1 := pcommon.NewMap()
+	attributes1.UpsertString("key3", "to-be-overridden")
+	attributes1.UpsertString("key1", "value1")
+	attributes1.UpsertString("key2", "value2")
+	attributes1.UpsertString("additional_key2", "value2")
+	attributes1.UpsertString("additional_key3", "value3")
+	attributes2 := pcommon.NewMap()
+	attributes2.UpsertString("additional_key1", "value1")
+	attributes2.UpsertString("key3", "value3")
 
 	regexes := []string{"^key[12]", "^key3"}
 	f, err := newFilter(regexes)
 	require.NoError(t, err)
 
-	metadata := f.filterIn(attributes)
+	metadata := f.mergeAndFilterIn(attributes1, attributes2)
 	expected := fieldsFromMap(map[string]string{
 		"key1": "value1",
 		"key2": "value2",


### PR DESCRIPTION
The exporter unnecessary mutates log data just to temporarily copy resource attributes into log attributes. This change removes that redundant step which make the exporter not mutating anymore.
