### PR TITLE
[receiver/elasticsearchreceiver] collect elasticsearch.cluster.state_update.* metrics

### DIFF
--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -46,6 +46,10 @@ The full list of settings exposed for this receiver are documented [here](./conf
 
 ## Metrics
 
+The following metric are available with versions:
+- `elasticsearch.cluster.state_update.count` >= [7.16.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.0.html)
+- `elasticsearch.cluster.state_update.time` >= [7.16.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.0.html)
+
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 
 ### Feature gate configurations

--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -82,7 +82,7 @@ func newElasticsearchClient(settings component.TelemetrySettings, c Config, h co
 // nodeStatsMetrics is a comma separated list of metrics that will be gathered from NodeStats.
 // The available metrics are documented here for Elasticsearch 7.9:
 // https://www.elastic.co/guide/en/elasticsearch/reference/7.9/cluster-nodes-stats.html#cluster-nodes-stats-api-path-params
-const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http,fs,indexing_pressure,ingest,indices,adaptive_selection"
+const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http,fs,indexing_pressure,ingest,indices,adaptive_selection,discovery"
 
 // nodeStatsIndexMetrics is a comma separated list of index metrics that will be gathered from NodeStats.
 const nodeStatsIndexMetrics = "store,docs,indexing,get,search,merge,refresh,flush,warmer,query_cache,fielddata"

--- a/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_16_3
+++ b/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_16_3
@@ -1,0 +1,7 @@
+FROM elasticsearch:7.16.3
+
+ENV discovery.type=single-node
+
+ENV ES_JAVA_OPTS='-Xms512m -Xmx512m'
+
+EXPOSE 9300

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
@@ -1,0 +1,4964 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "elasticsearch.cluster.name",
+                  "value": {
+                     "stringValue": "docker-cluster"
+                  }
+               },
+               {
+                  "key": "elasticsearch.node.name",
+                  "value": {
+                     "stringValue": "c35766bb4501"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "Estimated memory used for the operation.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "eql_sequence"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "11456",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "368658928",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "parent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "fielddata"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "in_flight_requests"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "model_inference"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.breaker.memory.estimated",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Memory limit for the circuit breaker.",
+                     "name": "elasticsearch.breaker.memory.limit",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "268435456",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "eql_sequence"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "536870912",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "510027366",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "parent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "322122547",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "214748364",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "fielddata"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "536870912",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "in_flight_requests"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "268435456",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "model_inference"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Total number of times the circuit breaker has been triggered and prevented an out of memory error.",
+                     "name": "elasticsearch.breaker.tripped",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "eql_sequence"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "parent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "fielddata"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "in_flight_requests"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "model_inference"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of differences between published cluster states.",
+                     "name": "elasticsearch.cluster.published_states.differences",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "compatible"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "incompatible"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of published cluster states.",
+                     "name": "elasticsearch.cluster.published_states.full",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of cluster states in queue.",
+                     "name": "elasticsearch.cluster.state_queue",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "committed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "pending"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Configured memory limit, in bytes, for the indexing requests.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "53687091",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.indexing_pressure.memory.limit",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Cumulative number of indexing requests rejected in the primary stage.",
+                     "name": "elasticsearch.indexing_pressure.memory.total.primary_rejections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of indexing requests rejected in the replica stage.",
+                     "name": "elasticsearch.indexing_pressure.memory.total.replica_rejections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Memory consumed, in bytes, by indexing requests in the specified stage.",
+                     "name": "elasticsearch.memory.indexing_pressure",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "primary"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "coordinating"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "stage",
+                                    "value": {
+                                       "stringValue": "replica"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of evictions from the cache.",
+                     "name": "elasticsearch.node.cache.evictions",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "fielddata"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{evictions}"
+                  },
+                  {
+                     "description": "The size in bytes of the cache.",
+                     "name": "elasticsearch.node.cache.memory.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "fielddata"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of open tcp connections for internal cluster communication.",
+                     "name": "elasticsearch.node.cluster.connections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "The number of bytes sent and received on the network for internal cluster communication.",
+                     "name": "elasticsearch.node.cluster.io",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "direction",
+                                    "value": {
+                                       "stringValue": "received"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "direction",
+                                    "value": {
+                                       "stringValue": "sent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The total number of kilobytes read across all file stores for this node.",
+                     "name": "elasticsearch.node.disk.io.read",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The total number of kilobytes written across all file stores for this node.",
+                     "name": "elasticsearch.node.disk.io.write",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of documents on the node.",
+                     "name": "elasticsearch.node.documents",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "41",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "deleted"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise.",
+                     "name": "elasticsearch.node.fs.disk.available",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "175102763008",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of unallocated disk space across all file stores for this node.",
+                     "name": "elasticsearch.node.fs.disk.free",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "186715807744",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of disk space across all file stores for this node.",
+                     "name": "elasticsearch.node.fs.disk.total",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "228220321792",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of HTTP connections to the node.",
+                     "name": "elasticsearch.node.http.connections",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "Total number of documents ingested during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.documents",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested.",
+                     "name": "elasticsearch.node.ingest.documents.current",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed ingest operations during the lifetime of this node.",
+                     "name": "elasticsearch.node.ingest.operations.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
+                  },
+                  {
+                     "description": "The number of open file descriptors held by the node.",
+                     "name": "elasticsearch.node.open_files",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "305",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{files}"
+                  },
+                  {
+                     "description": "The number of operations completed.",
+                     "name": "elasticsearch.node.operations.completed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "41",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "index"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "43",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "43",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "fetch"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "scroll"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "suggest"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "merge"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "15",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "10",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "Time spent on operations.",
+                     "name": "elasticsearch.node.operations.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1070",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "index"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "75",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "68",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "fetch"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "68",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "scroll"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "suggest"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "merge"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "392",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "224",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Total number of documents currently being ingested by a pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.documents.current",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Number of documents preprocessed by the ingest pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.documents.preprocessed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{documents}"
+                  },
+                  {
+                     "description": "Total number of failed operations for the ingest pipeline.",
+                     "name": "elasticsearch.node.pipeline.ingest.operations.failed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_7"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "xpack_monitoring_6"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operation}"
+                  },
+                  {
+                     "description": "Total number of times the script cache has evicted old data.",
+                     "name": "elasticsearch.node.script.cache_evictions",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Total number of times the script compilation circuit breaker has limited inline script compilations.",
+                     "name": "elasticsearch.node.script.compilation_limit_triggered",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Total number of inline script compilations performed by the node.",
+                     "name": "elasticsearch.node.script.compilations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{compilations}"
+                  },
+                  {
+                     "description": "Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.",
+                     "name": "elasticsearch.node.shards.data_set.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "40114789",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available.",
+                     "name": "elasticsearch.node.shards.reserved.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The size of the shards assigned to this node.",
+                     "name": "elasticsearch.node.shards.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "40114789",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of tasks finished by the thread pool.",
+                     "name": "elasticsearch.node.thread_pool.tasks.finished",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "86",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "78",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "13",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "11",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "378",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "47",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{tasks}"
+                  },
+                  {
+                     "description": "The number of queued tasks in the thread pool.",
+                     "name": "elasticsearch.node.thread_pool.tasks.queued",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{tasks}"
+                  },
+                  {
+                     "description": "The number of threads in the thread pool.",
+                     "name": "elasticsearch.node.thread_pool.threads",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "8",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{threads}"
+                  },
+                  {
+                     "description": "Number of transaction log operations.",
+                     "name": "elasticsearch.node.translog.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "Size of the transaction log.",
+                     "name": "elasticsearch.node.translog.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Size of uncommitted transaction log operations.",
+                     "name": "elasticsearch.node.translog.uncommitted.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0,
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.15m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "One-minute load average on the system (field is not present if one-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0,
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.1m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Five-minute load average on the system (field is not present if five-minute load average is not available).",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0,
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.load_avg.5m",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Recent CPU usage for the whole system, or -1 if not supported.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.cpu.usage",
+                     "unit": "%"
+                  },
+                  {
+                     "description": "Amount of physical memory.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "used"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "free"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.os.memory",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of loaded classes",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "23898",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.classes.loaded",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The total number of garbage collections that have occurred",
+                     "name": "jvm.gc.collections.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "16",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "young"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "old"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The approximate accumulated collection elapsed time",
+                     "name": "jvm.gc.collections.elapsed",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "269",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "young"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "old"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "The amount of memory that is guaranteed to be available for the heap",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "536870912",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.memory.heap.committed",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The maximum amount of memory can be used for the heap",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "536870912",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.memory.heap.max",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The current heap memory usage",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "368658928",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.memory.heap.used",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The amount of memory that is guaranteed to be available for non-heap purposes",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "150536192",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.memory.nonheap.committed",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The current non-heap memory usage",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "147381640",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.memory.nonheap.used",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The maximum amount of memory can be used for the memory pool",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "young"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "survivor"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "536870912",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "old"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.memory.pool.max",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The current memory pool memory usage",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "268435456",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "young"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "36090352",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "survivor"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "64133120",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "old"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.memory.pool.used",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The current number of threads",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "53",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.threads.count",
+                     "unit": "1"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/elasticsearchreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "elasticsearch.cluster.name",
+                  "value": {
+                     "stringValue": "docker-cluster"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "description": "The number of data nodes in the cluster.",
+                     "name": "elasticsearch.cluster.data_nodes",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{nodes}"
+                  },
+                  {
+                     "description": "The health status of the cluster.",
+                     "name": "elasticsearch.cluster.health",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "green"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "yellow"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "red"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{status}"
+                  },
+                  {
+                     "description": "The total number of nodes in the cluster.",
+                     "name": "elasticsearch.cluster.nodes",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{nodes}"
+                  },
+                  {
+                     "description": "The number of shards in the cluster.",
+                     "name": "elasticsearch.cluster.shards",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "initializing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "relocating"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unassigned"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563042715406000",
+                              "timeUnixNano": "1662563052715818000"
+                           }
+                        ]
+                     },
+                     "unit": "{shards}"
+                  }
+               ],
+               "scope": {
+                  "name": "otelcol/elasticsearchreceiver",
+                  "version": "latest"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
@@ -12,7 +12,7 @@
                {
                   "key": "elasticsearch.node.name",
                   "value": {
-                     "stringValue": "c35766bb4501"
+                     "stringValue": "3a5967785724"
                   }
                }
             ]
@@ -34,11 +34,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "11456",
+                              "asInt": "9288",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -47,11 +47,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "368658928",
+                              "asInt": "231696464",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -60,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -73,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -86,8 +86,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -99,8 +99,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -112,8 +112,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -136,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "536870912",
@@ -149,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "510027366",
@@ -162,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "322122547",
@@ -175,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "214748364",
@@ -188,8 +188,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "536870912",
@@ -201,8 +201,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "268435456",
@@ -214,8 +214,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -237,8 +237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -250,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -263,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -276,8 +276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -289,8 +289,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -302,8 +302,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -315,8 +315,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -330,7 +330,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "53",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -339,8 +339,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -352,8 +352,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -366,9 +366,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "asInt": "2",
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -390,8 +390,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -403,12 +403,415 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
                      "unit": "1"
+                  },
+                  {
+                     "description": "The number of cluster state update attempts that changed the cluster state since the node started.",
+                     "name": "elasticsearch.cluster.state_update.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "55",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "46",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The cumulative amount of time updating the cluster state since the node started.",
+                     "name": "elasticsearch.cluster.state_update.time",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "743",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "7",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "40",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "1016",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "1080",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "832",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "14",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
                   },
                   {
                      "description": "Configured memory limit, in bytes, for the indexing requests.",
@@ -416,8 +819,8 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -432,8 +835,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -448,8 +851,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -472,8 +875,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -485,8 +888,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -498,8 +901,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -521,8 +924,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -534,8 +937,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -558,8 +961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -571,8 +974,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -586,8 +989,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -609,8 +1012,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -622,8 +1025,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -638,8 +1041,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -653,8 +1056,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -676,8 +1079,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -689,8 +1092,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -703,9 +1106,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "175102763008",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "asInt": "175102779392",
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -718,9 +1121,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "186715807744",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "asInt": "186715824128",
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -734,8 +1137,8 @@
                         "dataPoints": [
                            {
                               "asInt": "228220321792",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -749,8 +1152,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -764,8 +1167,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -780,8 +1183,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -795,8 +1198,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -811,8 +1214,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -834,8 +1237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -847,8 +1250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -860,8 +1263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "43",
@@ -873,8 +1276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "43",
@@ -886,8 +1289,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "3",
@@ -899,8 +1302,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -912,8 +1315,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -925,11 +1328,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "15",
+                              "asInt": "14",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -938,8 +1341,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "3",
@@ -951,11 +1354,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "10",
+                              "asInt": "8",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -964,8 +1367,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -979,7 +1382,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1070",
+                              "asInt": "890",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -988,8 +1391,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -1001,8 +1404,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -1014,11 +1417,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "75",
+                              "asInt": "63",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1027,11 +1430,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "68",
+                              "asInt": "78",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1040,11 +1443,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "68",
+                              "asInt": "51",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1053,8 +1456,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -1066,8 +1469,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -1079,11 +1482,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "392",
+                              "asInt": "97",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1092,11 +1495,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "224",
+                              "asInt": "173",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1105,8 +1508,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "1",
@@ -1118,8 +1521,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -1138,12 +1541,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_7"
+                                       "stringValue": "xpack_monitoring_6"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -1151,12 +1554,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_6"
+                                       "stringValue": "xpack_monitoring_7"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -1174,12 +1577,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_7"
+                                       "stringValue": "xpack_monitoring_6"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -1187,12 +1590,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_6"
+                                       "stringValue": "xpack_monitoring_7"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -1210,12 +1613,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_7"
+                                       "stringValue": "xpack_monitoring_6"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -1223,12 +1626,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "xpack_monitoring_6"
+                                       "stringValue": "xpack_monitoring_7"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -1243,8 +1646,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -1259,8 +1662,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -1275,8 +1678,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -1289,9 +1692,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "40114789",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "asInt": "40107780",
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -1305,8 +1708,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -1319,9 +1722,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "40114789",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "asInt": "40107780",
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -1333,310 +1736,6 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "86",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
                            {
                               "asInt": "3",
                               "attributes": [
@@ -1653,8 +1752,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -1672,616 +1771,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "78",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "13",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "11",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "4",
@@ -2299,8 +1790,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2318,8 +1809,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2327,7 +1818,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "fetch_shard_started"
+                                       "stringValue": "security-token-key"
                                     }
                                  },
                                  {
@@ -2337,8 +1828,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2346,7 +1837,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "fetch_shard_started"
+                                       "stringValue": "security-token-key"
                                     }
                                  },
                                  {
@@ -2356,16 +1847,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "378",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "generic"
+                                       "stringValue": "snapshot"
                                     }
                                  },
                                  {
@@ -2375,8 +1866,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2384,7 +1875,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "generic"
+                                       "stringValue": "snapshot"
                                     }
                                  },
                                  {
@@ -2394,8 +1885,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2403,7 +1894,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "ml_job_comms"
+                                       "stringValue": "transform_indexing"
                                     }
                                  },
                                  {
@@ -2413,8 +1904,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2422,7 +1913,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "ml_job_comms"
+                                       "stringValue": "transform_indexing"
                                     }
                                  },
                                  {
@@ -2432,8 +1923,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2441,7 +1932,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search_throttled"
+                                       "stringValue": "auto_complete"
                                     }
                                  },
                                  {
@@ -2451,8 +1942,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2460,7 +1951,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search_throttled"
+                                       "stringValue": "auto_complete"
                                     }
                                  },
                                  {
@@ -2470,122 +1961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "47",
@@ -2603,8 +1980,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2622,8 +1999,1034 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "13",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "12",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "361",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "78",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "86",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -2642,324 +3045,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "flush"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2971,8 +3062,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2980,12 +3071,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "fetch_shard_started"
+                                       "stringValue": "security-token-key"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -2993,12 +3084,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "generic"
+                                       "stringValue": "snapshot"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -3006,12 +3097,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "ml_job_comms"
+                                       "stringValue": "transform_indexing"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -3019,51 +3110,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search_throttled"
+                                       "stringValue": "auto_complete"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -3075,8 +3127,359 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -3094,310 +3497,6 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "flush"
                                     }
                                  },
@@ -3408,8 +3507,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "1",
@@ -3427,616 +3526,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4054,8 +3545,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "4",
@@ -4073,8 +3564,388 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4092,8 +3963,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4111,8 +3982,464 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4130,8 +4457,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "8",
@@ -4149,8 +4476,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4158,7 +4485,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "ml_job_comms"
+                                       "stringValue": "system_critical_write"
                                     }
                                  },
                                  {
@@ -4168,8 +4495,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4177,7 +4504,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "ml_job_comms"
+                                       "stringValue": "system_critical_write"
                                     }
                                  },
                                  {
@@ -4187,8 +4514,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4196,7 +4523,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search_throttled"
+                                       "stringValue": "system_write"
                                     }
                                  },
                                  {
@@ -4206,16 +4533,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "4",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search_throttled"
+                                       "stringValue": "system_write"
                                     }
                                  },
                                  {
@@ -4225,8 +4552,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4234,7 +4561,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "system_critical_read"
+                                       "stringValue": "ccr"
                                     }
                                  },
                                  {
@@ -4244,8 +4571,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4253,7 +4580,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "system_critical_read"
+                                       "stringValue": "ccr"
                                     }
                                  },
                                  {
@@ -4263,8 +4590,84 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4282,8 +4685,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4301,8 +4704,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4310,7 +4713,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "force_merge"
+                                       "stringValue": "search"
                                     }
                                  },
                                  {
@@ -4320,8 +4723,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4329,7 +4732,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "force_merge"
+                                       "stringValue": "search"
                                     }
                                  },
                                  {
@@ -4339,16 +4742,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "management"
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
                                     }
                                  },
                                  {
@@ -4358,16 +4761,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "1",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "management"
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
                                     }
                                  },
                                  {
@@ -4377,8 +4780,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4392,8 +4795,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -4408,8 +4811,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4423,8 +4826,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4436,8 +4839,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4450,8 +4853,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4464,8 +4867,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4478,8 +4881,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4500,8 +4903,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4513,8 +4916,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4526,9 +4929,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "23898",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "asInt": "23891",
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4542,7 +4945,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "16",
+                              "asInt": "15",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4551,8 +4954,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4564,8 +4967,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -4579,7 +4982,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "269",
+                              "asInt": "218",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4588,8 +4991,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4601,8 +5004,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ],
                         "isMonotonic": true
@@ -4615,8 +5018,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4629,8 +5032,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4642,9 +5045,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "368658928",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "asInt": "231696464",
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4656,9 +5059,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "150536192",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "asInt": "150405120",
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4670,9 +5073,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "147381640",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "asInt": "147272120",
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4693,8 +5096,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4706,8 +5109,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "536870912",
@@ -4719,8 +5122,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4732,7 +5135,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "268435456",
+                              "asInt": "134217728",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4741,11 +5144,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "36090352",
+                              "asInt": "13297232",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4754,11 +5157,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
-                              "asInt": "64133120",
+                              "asInt": "84181504",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4767,8 +5170,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4781,8 +5184,8 @@
                         "dataPoints": [
                            {
                               "asInt": "53",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4819,8 +5222,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4842,8 +5245,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4855,8 +5258,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4868,8 +5271,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4883,8 +5286,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },
@@ -4906,8 +5309,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4919,8 +5322,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4932,8 +5335,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            },
                            {
                               "asInt": "0",
@@ -4945,8 +5348,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563042715406000",
-                              "timeUnixNano": "1662563052715818000"
+                              "startTimeUnixNano": "1662563239984708000",
+                              "timeUnixNano": "1662563249986155000"
                            }
                         ]
                      },

--- a/unreleased/elasticsearchreceiver-collect-state_update-metrics.yaml
+++ b/unreleased/elasticsearchreceiver-collect-state_update-metrics.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: elasticsearchreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add "discovery" path in client request to collect elasticsearch.cluster_state.* metrics
+note: "Fix issue where `elasticsearch.cluster_state.*` metrics were not being collected
 
 # One or more tracking issues related to the change
 issues: [13930]

--- a/unreleased/elasticsearchreceiver-collect-state_update-metrics.yaml
+++ b/unreleased/elasticsearchreceiver-collect-state_update-metrics.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: elasticsearchreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Fix issue where `elasticsearch.cluster_state.*` metrics were not being collected
+note: "Fix issue where `elasticsearch.cluster_state.*` metrics were not being collected"
 
 # One or more tracking issues related to the change
 issues: [13930]

--- a/unreleased/elasticsearchreceiver-collect-state_update-metrics.yaml
+++ b/unreleased/elasticsearchreceiver-collect-state_update-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add "discovery" path in client request to collect elasticsearch.cluster_state.* metrics
+
+# One or more tracking issues related to the change
+issues: [13930]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
Fix a bug with elastic search not collecting the `cluster.state_update.*` metrics.

The elasticsearch client request does not include the `discovery` path and therefore not collecting the `elasticsearch.cluster.state_update.count` and `elasticsearch.cluster.state_update.time` metrics. This is confirmed with an integration test 7_16 before w/o the state_update metrics and then later with the state_update metrics once the `discovery` field was added in the client request.

**Link to tracking Issue:**
#13930 

**Testing:**
A new integration test 7.16 was created because [7.16](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.0.html)  added `cluster applier stats` which include the `cluster.state_update.*` metrics

**Documentation:**
Since elasticsearch requires version 7.16+ to collect the `cluster.state_update.*` metrics, this has been added in the readme
