### PR TITLE
[scrapertest] Stabilize golden files (1/N)

### DIFF
--- a/internal/scrapertest/sort/attributes.go
+++ b/internal/scrapertest/sort/attributes.go
@@ -1,0 +1,111 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sort // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest/sort"
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// Assumes a.Sort() and b.Sort() have been called previously
+// 0: same
+// -: a less than b
+// +: a greater than b
+func compareMaps(a, b pcommon.Map) int {
+	if a.Len() != b.Len() {
+		return a.Len() - b.Len()
+	}
+
+	var aKeys, bKeys []string
+	a.Range(func(k string, _ pcommon.Value) bool {
+		aKeys = append(aKeys, k)
+		return true
+	})
+	b.Range(func(k string, _ pcommon.Value) bool {
+		bKeys = append(bKeys, k)
+		return true
+	})
+
+	for i := 0; i < len(aKeys); i++ {
+		if aKeys[i] != bKeys[i] {
+			return strings.Compare(aKeys[i], bKeys[i])
+		}
+	}
+
+	for _, k := range aKeys {
+		av, _ := a.Get(k)
+		bv, _ := b.Get(k)
+		if e := compareValues(av, bv); e != 0 {
+			return e
+		}
+	}
+
+	return 0
+}
+
+// Assumes a.Sort() and b.Sort() have been called previously
+// 0: same
+// -: a less than b
+// +: a greater than b
+func compareSlices(a, b pcommon.Slice) int {
+	if a.Len() != b.Len() {
+		return a.Len() - b.Len()
+	}
+	for i := 0; i < a.Len(); i++ {
+		if e := compareValues(a.At(i), b.At(i)); e != 0 {
+			return e
+		}
+	}
+	return 0
+}
+
+func compareValues(a, b pcommon.Value) int {
+	if a.Type() != b.Type() {
+		return int(a.Type()) - int(b.Type())
+	}
+
+	switch a.Type() {
+	case pcommon.ValueTypeBool:
+		switch {
+		case a.BoolVal() == b.BoolVal():
+			return 0
+		case !a.BoolVal():
+			return -1
+		case !b.BoolVal():
+			return 1
+		}
+	case pcommon.ValueTypeBytes:
+		return strings.Compare(string(a.BytesVal().AsRaw()), string(b.BytesVal().AsRaw()))
+	case pcommon.ValueTypeDouble:
+		switch {
+		case a.DoubleVal() == b.DoubleVal():
+			return 0
+		case a.DoubleVal() < b.DoubleVal():
+			return -1
+		case a.DoubleVal() > b.DoubleVal():
+			return 1
+		}
+	case pcommon.ValueTypeInt:
+		return int(a.IntVal() - b.IntVal())
+	case pcommon.ValueTypeMap:
+		return compareMaps(a.MapVal(), b.MapVal())
+	case pcommon.ValueTypeSlice:
+		return compareSlices(a.SliceVal(), b.SliceVal())
+	case pcommon.ValueTypeString:
+		return strings.Compare(a.StringVal(), b.StringVal())
+	}
+	return 0
+}

--- a/internal/scrapertest/sort/attributes_test.go
+++ b/internal/scrapertest/sort/attributes_test.go
@@ -1,0 +1,306 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sort
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestCompareValues(t *testing.T) {
+	pTypes.test(t)
+	pStrings.test(t)
+	pInts.test(t)
+	pDoubles.test(t)
+	pBools.test(t)
+	pMaps.test(t)
+	pSlices.test(t)
+	pBytes.test(t)
+}
+
+var pTypes ascendingValues = []pcommon.Value{
+	pcommon.NewValueEmpty(),
+	pcommon.NewValueString(""),
+	pcommon.NewValueInt(0),
+	pcommon.NewValueDouble(0),
+	pcommon.NewValueBool(false),
+	pcommon.NewValueMap(),
+	pcommon.NewValueSlice(),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte(""))),
+}
+
+var pBools ascendingValues = []pcommon.Value{
+	pcommon.NewValueBool(false),
+	pcommon.NewValueBool(true),
+}
+
+var pStrings ascendingValues = []pcommon.Value{
+	pcommon.NewValueString(""),
+	pcommon.NewValueString(" "),
+	pcommon.NewValueString("A"),
+	pcommon.NewValueString("AA"),
+	pcommon.NewValueString("_"),
+	pcommon.NewValueString("a"),
+	pcommon.NewValueString("aa"),
+	pcommon.NewValueString("b"),
+	pcommon.NewValueString("long"),
+	pcommon.NewValueString("z"),
+}
+
+var pBytes ascendingValues = []pcommon.Value{
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte(""))),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte(" "))),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte("A"))),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte("AA"))),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte("_"))),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte("a"))),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte("aa"))),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte("b"))),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte("long"))),
+	pcommon.NewValueBytes(pcommon.NewImmutableByteSlice([]byte("z"))),
+}
+
+var pInts ascendingValues = []pcommon.Value{
+	pcommon.NewValueInt(-10),
+	pcommon.NewValueInt(-1),
+	pcommon.NewValueInt(0),
+	pcommon.NewValueInt(1),
+	pcommon.NewValueInt(99),
+	pcommon.NewValueInt(1000),
+}
+
+var pDoubles ascendingValues = []pcommon.Value{
+	pcommon.NewValueDouble(-1.123),
+	pcommon.NewValueDouble(-0.01),
+	pcommon.NewValueDouble(0),
+	pcommon.NewValueDouble(0.001),
+	pcommon.NewValueDouble(0.01),
+	pcommon.NewValueDouble(1.23),
+}
+
+// ascending lengths -> keys -> types -> values
+var pMaps ascendingValues = []pcommon.Value{
+	pcommon.NewValueMap(),
+	func() pcommon.Value {
+		v := pcommon.NewValueMap()
+		m := v.SetEmptyMapVal()
+		m.InsertString("a", "")
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueMap()
+		m := v.SetEmptyMapVal()
+		m.InsertInt("a", 123)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueMap()
+		m := v.SetEmptyMapVal()
+		m.InsertInt("b", 100)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueMap()
+		m := v.SetEmptyMapVal()
+		m.InsertString("c", "")
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueMap()
+		m := v.SetEmptyMapVal()
+		m.InsertString("a", "")
+		m.InsertString("b", "")
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueMap()
+		m := v.SetEmptyMapVal()
+		m.InsertString("a", "")
+		mv := pcommon.NewValueMap()
+		m.Insert("m", mv)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueMap()
+		m := v.SetEmptyMapVal()
+		m.InsertString("a", "")
+		mv := pcommon.NewValueMap()
+		mv.MapVal().InsertInt("i", 0)
+		m.Insert("m", mv)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueMap()
+		m := v.SetEmptyMapVal()
+		m.InsertString("a", "")
+		vs := pcommon.NewValueSlice()
+		s := vs.SetEmptySliceVal()
+		s.AppendEmpty().SetDoubleVal(100)
+		m.Insert("s", vs)
+		return v
+	}(),
+}
+
+// ascending lengths -> types -> values
+var pSlices ascendingValues = []pcommon.Value{
+	pcommon.NewValueSlice(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetStringVal("")
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetIntVal(100)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetDoubleVal(100)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetBoolVal(true)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetEmptyMapVal()
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		m := s.AppendEmpty().SetEmptyMapVal()
+		m.InsertString("a", "")
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		m := s.AppendEmpty().SetEmptyMapVal()
+		m.InsertString("b", "")
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetEmptySliceVal()
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		ns := s.AppendEmpty().SetEmptySliceVal()
+		ns.AppendEmpty().SetStringVal("")
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetBytesVal(pcommon.NewImmutableByteSlice([]byte("A")))
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetStringVal("")
+		s.AppendEmpty().SetStringVal("a")
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetStringVal("")
+		s.AppendEmpty().SetBoolVal(false)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetIntVal(0)
+		s.AppendEmpty().SetBoolVal(true)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetIntVal(100)
+		s.AppendEmpty().SetIntVal(0)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetIntVal(100)
+		s.AppendEmpty().SetDoubleVal(0)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetBoolVal(false)
+		s.AppendEmpty().SetBoolVal(true)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetBoolVal(true)
+		s.AppendEmpty().SetBoolVal(false)
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetBoolVal(true)
+		s.AppendEmpty().SetBytesVal(pcommon.NewImmutableByteSlice([]byte("A")))
+		return v
+	}(),
+	func() pcommon.Value {
+		v := pcommon.NewValueSlice()
+		s := v.SetEmptySliceVal()
+		s.AppendEmpty().SetStringVal("")
+		s.AppendEmpty().SetStringVal("")
+		s.AppendEmpty().SetStringVal("")
+		return v
+	}(),
+}
+
+type ascendingValues []pcommon.Value
+
+func (a ascendingValues) test(t *testing.T) {
+
+	// Test each value matches itself
+	for i := 0; i < len(a); i++ {
+		require.Zero(t, compareValues(a[i], a[i]), "expected '%s' == '%s'", a[i].AsString(), a[i].AsString())
+	}
+
+	// Test each combo
+	for i := 0; i+1 < len(a); i++ {
+		for j := i + 1; j < len(a); j++ {
+			require.Negative(t, compareValues(a[i], a[j]), "expected '%s' < '%s'", a[i].AsString(), a[j].AsString())
+			require.Positive(t, compareValues(a[j], a[i]), "expected '%s' > '%s'", a[i].AsString(), a[j].AsString())
+		}
+	}
+}


### PR DESCRIPTION
Golden files written and validated by this package have proven very helpful, but they would be more so if they were written deterministically. There are several levels within the pmetric.Metric data structure where slices will need to be sorted in order to generate files deterministically.

This PR starts with a low level implemenation of comparing pcommon.Values, primarily for the purpose of sorting attributes. The comparison function is implemented as a LT/EQ/GT function, as opposed to just a LT function, because a detailed comparison will be helpful when validating expected results. The comparison function can and will easily be wrapped to present a LT sort func.