### PR TITLE
[receiver/elasticsearchreceiver] Add os in client request nodeStatsPath

### DIFF
--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -82,7 +82,7 @@ func newElasticsearchClient(settings component.TelemetrySettings, c Config, h co
 // nodeStatsMetrics is a comma separated list of metrics that will be gathered from NodeStats.
 // The available metrics are documented here for Elasticsearch 7.9:
 // https://www.elastic.co/guide/en/elasticsearch/reference/7.9/cluster-nodes-stats.html#cluster-nodes-stats-api-path-params
-const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http,fs,indexing_pressure,ingest,indices,adaptive_selection,discovery,script"
+const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http,fs,indexing_pressure,ingest,indices,adaptive_selection,discovery,script,os"
 
 // nodeStatsIndexMetrics is a comma separated list of index metrics that will be gathered from NodeStats.
 const nodeStatsIndexMetrics = "store,docs,indexing,get,search,merge,refresh,flush,warmer,query_cache,fielddata,translog"

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
@@ -12,7 +12,7 @@
                {
                   "key": "elasticsearch.node.name",
                   "value": {
-                     "stringValue": "0da8aeb51b5a"
+                     "stringValue": "b832058343ad"
                   }
                }
             ]
@@ -25,7 +25,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "330550336",
+                              "asInt": "228545544",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -34,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -47,8 +47,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -60,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -73,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -86,8 +86,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -99,8 +99,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "11472",
@@ -112,8 +112,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -136,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "322122547",
@@ -149,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "214748364",
@@ -162,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "536870912",
@@ -175,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "268435456",
@@ -188,8 +188,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "268435456",
@@ -201,8 +201,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "536870912",
@@ -214,8 +214,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -237,8 +237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -250,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -263,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -276,8 +276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -289,8 +289,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -302,8 +302,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -315,8 +315,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -339,8 +339,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -352,8 +352,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -367,8 +367,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -390,8 +390,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -403,8 +403,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -417,19 +417,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "46",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "unchanged"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
                               "asInt": "57",
                               "attributes": [
                                  {
@@ -439,8 +426,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -452,8 +439,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "45",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -467,121 +467,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "20",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "unchanged"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "computation"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "unchanged"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "notification"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "unchanged"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "context_construction"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "unchanged"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "commit"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "unchanged"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "completion"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "unchanged"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "master_apply"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "758",
+                              "asInt": "911",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -596,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "10",
@@ -615,11 +501,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "53",
+                              "asInt": "57",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -634,11 +520,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "1316",
+                              "asInt": "1338",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -653,11 +539,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "1399",
+                              "asInt": "1402",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -672,11 +558,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "990",
+                              "asInt": "1161",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -691,8 +577,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -710,8 +596,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -729,8 +615,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -748,8 +634,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -767,8 +653,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -786,8 +672,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -805,8 +691,122 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "19",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -819,8 +819,8 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -835,8 +835,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -851,8 +851,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -875,8 +875,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -888,8 +888,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -901,8 +901,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -924,8 +924,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -937,8 +937,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -961,8 +961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -974,8 +974,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -989,8 +989,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1012,8 +1012,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1025,8 +1025,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -1041,8 +1041,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1056,8 +1056,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1079,8 +1079,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1092,8 +1092,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1106,9 +1106,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "175017701376",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "175017705472",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1121,9 +1121,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "186630746112",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "186630750208",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1137,8 +1137,8 @@
                         "dataPoints": [
                            {
                               "asInt": "228220321792",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1152,8 +1152,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1167,8 +1167,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -1183,8 +1183,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1198,8 +1198,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -1214,8 +1214,8 @@
                         "dataPoints": [
                            {
                               "asInt": "305",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1237,8 +1237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1250,8 +1250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1263,8 +1263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "44",
@@ -1276,8 +1276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "44",
@@ -1289,8 +1289,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "3",
@@ -1302,8 +1302,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1315,8 +1315,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1328,8 +1328,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "15",
@@ -1341,8 +1341,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "3",
@@ -1354,8 +1354,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "10",
@@ -1367,8 +1367,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -1382,7 +1382,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "998",
+                              "asInt": "992",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1391,8 +1391,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1404,8 +1404,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1417,11 +1417,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "71",
+                              "asInt": "78",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1430,11 +1430,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "76",
+                              "asInt": "90",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1443,11 +1443,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "59",
+                              "asInt": "70",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1456,8 +1456,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1469,8 +1469,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1482,11 +1482,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "151",
+                              "asInt": "155",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1495,11 +1495,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "212",
+                              "asInt": "205",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1508,8 +1508,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "1",
@@ -1521,8 +1521,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -1545,8 +1545,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1558,8 +1558,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1581,8 +1581,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1594,8 +1594,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1617,8 +1617,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1630,8 +1630,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -1646,8 +1646,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -1662,8 +1662,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -1678,8 +1678,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1692,9 +1692,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "40731656",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "40731649",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1708,8 +1708,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1722,9 +1722,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "40731656",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "40731649",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -1737,12 +1737,12 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "12",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "get"
+                                       "stringValue": "refresh"
                                     }
                                  },
                                  {
@@ -1752,8 +1752,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1761,7 +1761,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "get"
+                                       "stringValue": "refresh"
                                     }
                                  },
                                  {
@@ -1771,8 +1771,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1780,7 +1780,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search"
+                                       "stringValue": "search_throttled"
                                     }
                                  },
                                  {
@@ -1790,8 +1790,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1799,7 +1799,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search"
+                                       "stringValue": "search_throttled"
                                     }
                                  },
                                  {
@@ -1809,8 +1809,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1818,7 +1818,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "warmer"
+                                       "stringValue": "snapshot_meta"
                                     }
                                  },
                                  {
@@ -1828,8 +1828,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1837,7 +1837,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "warmer"
+                                       "stringValue": "snapshot_meta"
                                     }
                                  },
                                  {
@@ -1847,8 +1847,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1866,8 +1866,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1885,8 +1885,198 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "48",
@@ -1904,8 +2094,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -1923,388 +2113,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "11",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "88",
@@ -2322,8 +2132,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2341,274 +2151,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "13",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "80",
@@ -2626,8 +2170,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2645,8 +2189,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2664,8 +2208,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2683,16 +2227,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "4",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "write"
+                                       "stringValue": "search"
                                     }
                                  },
                                  {
@@ -2702,8 +2246,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2711,7 +2255,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "write"
+                                       "stringValue": "search"
                                     }
                                  },
                                  {
@@ -2721,8 +2265,84 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2740,8 +2360,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2759,84 +2379,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2854,8 +2398,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2873,8 +2417,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2882,7 +2426,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "fetch_shard_started"
+                                       "stringValue": "ml_job_comms"
                                     }
                                  },
                                  {
@@ -2892,8 +2436,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2901,7 +2445,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "fetch_shard_started"
+                                       "stringValue": "ml_job_comms"
                                     }
                                  },
                                  {
@@ -2911,11 +2455,163 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "378",
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "379",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
@@ -2930,8 +2626,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2949,8 +2645,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2958,7 +2654,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "snapshot_meta"
+                                       "stringValue": "security-crypto"
                                     }
                                  },
                                  {
@@ -2968,8 +2664,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -2977,7 +2673,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "snapshot_meta"
+                                       "stringValue": "security-crypto"
                                     }
                                  },
                                  {
@@ -2987,8 +2683,236 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "12",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -3006,8 +2930,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -3025,8 +2949,84 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -3045,233 +3045,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "get"
+                                       "stringValue": "refresh"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -3283,177 +3062,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -3465,8 +3075,372 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -3478,8 +3452,34 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -3497,804 +3497,6 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "refresh"
                                     }
                                  },
@@ -4305,8 +3507,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "1",
@@ -4324,8 +3526,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -4333,7 +3535,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "rollup_indexing"
+                                       "stringValue": "search_throttled"
                                     }
                                  },
                                  {
@@ -4343,8 +3545,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -4352,7 +3554,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "rollup_indexing"
+                                       "stringValue": "search_throttled"
                                     }
                                  },
                                  {
@@ -4362,350 +3564,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
-                           },
-                           {
-                              "asInt": "7",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -4723,8 +3583,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -4742,8 +3602,1072 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -4761,8 +4685,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -4780,8 +4704,84 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -4795,8 +4795,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -4811,8 +4811,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1318",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -4826,8 +4826,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1318",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -4838,9 +4838,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asDouble": 0,
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asDouble": 0.19,
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -4852,9 +4852,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asDouble": 0,
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asDouble": 2.16,
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -4866,9 +4866,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asDouble": 0,
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asDouble": 0.55,
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -4880,9 +4880,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "45",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -4894,7 +4894,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "0",
+                              "asInt": "2555547648",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -4903,11 +4903,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "7891832832",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -4916,8 +4916,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -4929,9 +4929,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "23907",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "23894",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -4954,8 +4954,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -4967,8 +4967,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -4982,7 +4982,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "256",
+                              "asInt": "231",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4991,8 +4991,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -5004,8 +5004,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ],
                         "isMonotonic": true
@@ -5018,8 +5018,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5032,8 +5032,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5045,9 +5045,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "330550336",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "228545544",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5059,9 +5059,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "150994944",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "150470656",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5073,9 +5073,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "148027440",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "147256984",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5096,8 +5096,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -5109,8 +5109,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "536870912",
@@ -5122,8 +5122,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5135,7 +5135,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "230686720",
+                              "asInt": "130023424",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -5144,11 +5144,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "26279488",
+                              "asInt": "14794248",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -5157,11 +5157,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
-                              "asInt": "73584128",
+                              "asInt": "83727872",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -5170,8 +5170,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5183,9 +5183,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "52",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "asInt": "48",
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5222,8 +5222,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5245,8 +5245,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -5258,8 +5258,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -5271,8 +5271,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5286,8 +5286,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },
@@ -5309,8 +5309,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -5322,8 +5322,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -5335,8 +5335,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            },
                            {
                               "asInt": "0",
@@ -5348,8 +5348,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662656573864843000",
-                              "timeUnixNano": "1662656583866336000"
+                              "startTimeUnixNano": "1662660479658118000",
+                              "timeUnixNano": "1662660489658233000"
                            }
                         ]
                      },

--- a/unreleased/elasticsearchreceiver-add-os-in-client-request.yaml
+++ b/unreleased/elasticsearchreceiver-add-os-in-client-request.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix issue where `elasticsearch.os.*` metrics were not being collected"
+
+# One or more tracking issues related to the change
+issues: [13983]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** 
Add `os` in nodeStatsPath to collect `elasticsearch.os.*` related metrics.

You can see that `elasticsearch.os.cpu.load_avg.15m` shown in the issue had a value of [`0`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/db6987e83c05080891e12ef96c1b3f394d62a9ad/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json#L4841-L4847) and now in this pr has a value of [`0.25`](https://github.com/observIQ/opentelemetry-collector-contrib/blob/67241a2a67baa445ca128a84554eb53d70ca54a5/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json#L4841-L4847)


**Link to tracking Issue:** 
#13983 

**Testing:**
Integration test was ran for 7.16
