### PR TITLE
[receiver/elasticsearchreceiver] Add script in client request nodeStatsPath

### DIFF
--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -82,7 +82,7 @@ func newElasticsearchClient(settings component.TelemetrySettings, c Config, h co
 // nodeStatsMetrics is a comma separated list of metrics that will be gathered from NodeStats.
 // The available metrics are documented here for Elasticsearch 7.9:
 // https://www.elastic.co/guide/en/elasticsearch/reference/7.9/cluster-nodes-stats.html#cluster-nodes-stats-api-path-params
-const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http,fs,indexing_pressure,ingest,indices,adaptive_selection,discovery"
+const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http,fs,indexing_pressure,ingest,indices,adaptive_selection,discovery,script"
 
 // nodeStatsIndexMetrics is a comma separated list of index metrics that will be gathered from NodeStats.
 const nodeStatsIndexMetrics = "store,docs,indexing,get,search,merge,refresh,flush,warmer,query_cache,fielddata"

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
@@ -12,7 +12,7 @@
                {
                   "key": "elasticsearch.node.name",
                   "value": {
-                     "stringValue": "3a5967785724"
+                     "stringValue": "4e5b89464842"
                   }
                }
             ]
@@ -25,20 +25,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "eql_sequence"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "9288",
+                              "asInt": "10364",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -47,11 +34,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "231696464",
+                              "asInt": "101278496",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -60,8 +47,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -73,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -86,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -99,8 +86,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -112,8 +99,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "eql_sequence"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -127,19 +127,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "268435456",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "eql_sequence"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
                               "asInt": "536870912",
                               "attributes": [
                                  {
@@ -149,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "510027366",
@@ -162,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "322122547",
@@ -175,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "214748364",
@@ -188,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "536870912",
@@ -201,8 +188,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "268435456",
@@ -214,8 +201,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "268435456",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "eql_sequence"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -233,25 +233,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "eql_sequence"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
                                        "stringValue": "accounting"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -263,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -276,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -289,8 +276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -302,8 +289,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -315,8 +302,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "eql_sequence"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -330,7 +330,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "53",
+                              "asInt": "55",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -339,8 +339,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -352,8 +352,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -367,8 +367,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -390,8 +390,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -403,8 +403,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -417,7 +417,20 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "55",
+                              "asInt": "46",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "unchanged"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "57",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -426,8 +439,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -439,21 +452,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "46",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "unchanged"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -467,235 +467,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "743",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "success"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "computation"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "7",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "success"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "notification"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "40",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "success"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "context_construction"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "1016",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "success"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "commit"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "1080",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "success"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "completion"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "832",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "success"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "master_apply"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "failure"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "computation"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "failure"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "notification"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "failure"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "context_construction"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "failure"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "commit"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "failure"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "completion"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "failure"
-                                    }
-                                 },
-                                 {
-                                    "key": "type",
-                                    "value": {
-                                       "stringValue": "master_apply"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "14",
+                              "asInt": "20",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -710,8 +482,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "2",
@@ -729,8 +501,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -748,8 +520,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -767,8 +539,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -786,8 +558,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -805,8 +577,236 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "844",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "10",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "58",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "1260",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "1316",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "1048",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "success"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "computation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "notification"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "context_construction"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "completion"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "failure"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "master_apply"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -819,8 +819,8 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -835,8 +835,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -851,8 +851,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -875,8 +875,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -888,8 +888,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -901,8 +901,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -924,8 +924,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -937,8 +937,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -961,8 +961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -974,8 +974,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -989,8 +989,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1012,8 +1012,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1025,8 +1025,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -1041,12 +1041,12 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "KiBy"
                   },
                   {
                      "description": "The total number of kilobytes written across all file stores for this node.",
@@ -1056,12 +1056,12 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
-                     "unit": "By"
+                     "unit": "KiBy"
                   },
                   {
                      "description": "The number of documents on the node.",
@@ -1070,7 +1070,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "41",
+                              "asInt": "42",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -1079,8 +1079,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1092,8 +1092,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1106,9 +1106,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "175102779392",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "175017713664",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1121,9 +1121,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "186715824128",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "186630758400",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1137,8 +1137,8 @@
                         "dataPoints": [
                            {
                               "asInt": "228220321792",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1152,8 +1152,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1167,8 +1167,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -1183,8 +1183,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1198,8 +1198,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -1213,9 +1213,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "305",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "304",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1228,7 +1228,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "41",
+                              "asInt": "42",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1237,8 +1237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1250,8 +1250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1263,11 +1263,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "43",
+                              "asInt": "44",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1276,11 +1276,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "43",
+                              "asInt": "44",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1289,8 +1289,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "3",
@@ -1302,8 +1302,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1315,8 +1315,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1328,8 +1328,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "14",
@@ -1341,8 +1341,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "3",
@@ -1354,11 +1354,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "8",
+                              "asInt": "9",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1367,8 +1367,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -1382,7 +1382,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "890",
+                              "asInt": "1324",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1391,8 +1391,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1404,8 +1404,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1417,11 +1417,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "63",
+                              "asInt": "73",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1430,11 +1430,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "78",
+                              "asInt": "84",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1443,11 +1443,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "51",
+                              "asInt": "68",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1456,8 +1456,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1469,8 +1469,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1482,11 +1482,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "97",
+                              "asInt": "132",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1495,11 +1495,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "173",
+                              "asInt": "219",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1508,8 +1508,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "1",
@@ -1521,8 +1521,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -1545,8 +1545,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1558,8 +1558,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1581,8 +1581,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1594,8 +1594,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1617,8 +1617,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1630,8 +1630,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -1646,8 +1646,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -1662,8 +1662,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -1677,9 +1677,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "1",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1692,9 +1692,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "40107780",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "40728131",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1708,8 +1708,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1722,9 +1722,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "40107780",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "40728131",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -1736,6 +1736,842 @@
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "48",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "88",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "378",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "80",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
                            {
                               "asInt": "3",
                               "attributes": [
@@ -1752,8 +2588,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1771,46 +2607,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1828,8 +2626,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1847,8 +2645,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1856,7 +2654,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "snapshot"
+                                       "stringValue": "snapshot_meta"
                                     }
                                  },
                                  {
@@ -1866,8 +2664,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -1875,7 +2673,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "snapshot"
+                                       "stringValue": "snapshot_meta"
                                     }
                                  },
                                  {
@@ -1885,160 +2683,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "47",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2056,8 +2702,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2075,16 +2721,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "11",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "listener"
+                                       "stringValue": "ml_utility"
                                     }
                                  },
                                  {
@@ -2094,8 +2740,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2103,7 +2749,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "listener"
+                                       "stringValue": "ml_utility"
                                     }
                                  },
                                  {
@@ -2113,8 +2759,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2122,7 +2768,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search_coordination"
+                                       "stringValue": "search"
                                     }
                                  },
                                  {
@@ -2132,8 +2778,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2141,7 +2787,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search_coordination"
+                                       "stringValue": "search"
                                     }
                                  },
                                  {
@@ -2151,8 +2797,46 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2170,8 +2854,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2189,8 +2873,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2198,7 +2882,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "fetch_shard_started"
+                                       "stringValue": "warmer"
                                     }
                                  },
                                  {
@@ -2208,8 +2892,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2217,7 +2901,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "fetch_shard_started"
+                                       "stringValue": "warmer"
                                     }
                                  },
                                  {
@@ -2227,46 +2911,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "13",
@@ -2284,8 +2930,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2303,616 +2949,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "12",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "361",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "78",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "86",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2930,8 +2968,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2949,16 +2987,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "4",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search"
+                                       "stringValue": "write"
                                     }
                                  },
                                  {
@@ -2968,8 +3006,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -2977,7 +3015,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search"
+                                       "stringValue": "write"
                                     }
                                  },
                                  {
@@ -2987,46 +3025,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -3045,155 +3045,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "flush"
+                                       "stringValue": "analyze"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -3205,73 +3062,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -3283,190 +3075,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -3478,8 +3088,398 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -3497,652 +3497,6 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "analyze"
                                     }
                                  },
@@ -4153,8 +3507,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4172,8 +3526,46 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4191,8 +3583,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4210,8 +3602,426 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4229,8 +4039,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4248,8 +4058,426 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "6",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4267,8 +4495,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "1",
@@ -4286,426 +4514,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "8",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "vector_tile_generation"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4723,8 +4533,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4742,8 +4552,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4751,7 +4561,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                       "stringValue": "search_throttled"
                                     }
                                  },
                                  {
@@ -4761,8 +4571,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4770,7 +4580,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                       "stringValue": "search_throttled"
                                     }
                                  },
                                  {
@@ -4780,8 +4590,198 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "warmer"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -4795,8 +4795,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -4811,8 +4811,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -4826,8 +4826,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -4839,8 +4839,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -4853,8 +4853,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -4867,8 +4867,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -4881,8 +4881,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -4903,8 +4903,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4916,8 +4916,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -4929,9 +4929,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "23891",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "23911",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -4945,7 +4945,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "15",
+                              "asInt": "16",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4954,8 +4954,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -4967,8 +4967,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -4982,7 +4982,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "218",
+                              "asInt": "319",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4991,8 +4991,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -5004,8 +5004,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ],
                         "isMonotonic": true
@@ -5018,8 +5018,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5032,8 +5032,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5045,9 +5045,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "231696464",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "101278496",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5059,9 +5059,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "150405120",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "150798336",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5073,9 +5073,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "147272120",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "147603616",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5096,8 +5096,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -5109,8 +5109,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "536870912",
@@ -5122,8 +5122,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5135,7 +5135,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "134217728",
+                              "asInt": "4194304",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -5144,11 +5144,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "13297232",
+                              "asInt": "17477920",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -5157,11 +5157,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
-                              "asInt": "84181504",
+                              "asInt": "79606272",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -5170,8 +5170,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5183,9 +5183,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "53",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "asInt": "51",
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5222,8 +5222,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5245,8 +5245,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -5258,8 +5258,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -5271,8 +5271,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5286,8 +5286,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },
@@ -5309,8 +5309,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -5322,8 +5322,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -5335,8 +5335,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            },
                            {
                               "asInt": "0",
@@ -5348,8 +5348,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662563239984708000",
-                              "timeUnixNano": "1662563249986155000"
+                              "startTimeUnixNano": "1662651665465817000",
+                              "timeUnixNano": "1662651675466522000"
                            }
                         ]
                      },

--- a/unreleased/elasticsearchreceiver-add-script-in-client-request.yaml
+++ b/unreleased/elasticsearchreceiver-add-script-in-client-request.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix issue where `elasticsearch.node.script.*` metrics were not being collected"
+
+# One or more tracking issues related to the change
+issues: [13983]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add `script` in nodeStatsPath to collect `elasticsearch.node.script.*` related metrics.

You can see that `elasticsearch.node.script.compilations` shown in the issue had a value [`0`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/db6987e83c05080891e12ef96c1b3f394d62a9ad/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json#L1675-L1680) of  and now in this pr has a value of [`1`](https://github.com/observIQ/opentelemetry-collector-contrib/blob/2ea05a6e0cf44ee490bf355ed622d711735293ca/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json#L1675-L1680)

**Link to tracking Issue:** <Issue number if applicable>
#13983 

**Testing:** <Describe what testing was performed and which tests were added.>
integration test was ran for 7.16