### PR TITLE
[receiver/elasticsearchreceiver] Add translog in client request nodeStatsPath

### DIFF
--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -85,7 +85,7 @@ func newElasticsearchClient(settings component.TelemetrySettings, c Config, h co
 const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http,fs,indexing_pressure,ingest,indices,adaptive_selection,discovery,script"
 
 // nodeStatsIndexMetrics is a comma separated list of index metrics that will be gathered from NodeStats.
-const nodeStatsIndexMetrics = "store,docs,indexing,get,search,merge,refresh,flush,warmer,query_cache,fielddata"
+const nodeStatsIndexMetrics = "store,docs,indexing,get,search,merge,refresh,flush,warmer,query_cache,fielddata,translog"
 
 func (c defaultElasticsearchClient) NodeStats(ctx context.Context, nodes []string) (*model.NodeStats, error) {
 	var nodeSpec string

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
@@ -12,7 +12,7 @@
                {
                   "key": "elasticsearch.node.name",
                   "value": {
-                     "stringValue": "4e5b89464842"
+                     "stringValue": "0da8aeb51b5a"
                   }
                }
             ]
@@ -25,20 +25,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "10364",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "101278496",
+                              "asInt": "330550336",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -47,8 +34,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -60,8 +47,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -73,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -86,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -99,8 +86,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -112,8 +99,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "11472",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -127,19 +127,6 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "536870912",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
                               "asInt": "510027366",
                               "attributes": [
                                  {
@@ -149,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "322122547",
@@ -162,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "214748364",
@@ -175,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "536870912",
@@ -188,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "268435456",
@@ -201,8 +188,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "268435456",
@@ -214,8 +201,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "536870912",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -233,25 +233,12 @@
                                  {
                                     "key": "name",
                                     "value": {
-                                       "stringValue": "accounting"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
                                        "stringValue": "parent"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -263,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -276,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -289,8 +276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -302,8 +289,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -315,8 +302,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "accounting"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -339,8 +339,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -352,8 +352,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -367,8 +367,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -390,8 +390,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -403,8 +403,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -426,8 +426,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "57",
@@ -439,8 +439,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -452,8 +452,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -482,11 +482,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "2",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -501,8 +501,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -520,8 +520,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -539,8 +539,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -558,8 +558,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -577,11 +577,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "844",
+                              "asInt": "758",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -596,8 +596,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "10",
@@ -615,11 +615,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "58",
+                              "asInt": "53",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -634,11 +634,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "1260",
+                              "asInt": "1316",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -653,11 +653,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "1316",
+                              "asInt": "1399",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -672,11 +672,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "1048",
+                              "asInt": "990",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -691,8 +691,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -710,8 +710,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -729,8 +729,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -748,8 +748,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -767,8 +767,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -786,8 +786,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -805,8 +805,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -819,8 +819,8 @@
                         "dataPoints": [
                            {
                               "asInt": "53687091",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -835,8 +835,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -851,8 +851,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -875,8 +875,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -888,8 +888,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -901,8 +901,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -924,8 +924,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -937,8 +937,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -961,8 +961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -974,8 +974,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -989,8 +989,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1012,8 +1012,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1025,8 +1025,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -1041,8 +1041,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1056,8 +1056,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1079,8 +1079,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1092,8 +1092,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1106,9 +1106,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "175017713664",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "175017701376",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1121,9 +1121,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "186630758400",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "186630746112",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1137,8 +1137,8 @@
                         "dataPoints": [
                            {
                               "asInt": "228220321792",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1152,8 +1152,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1167,8 +1167,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -1183,8 +1183,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1198,8 +1198,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -1213,9 +1213,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "304",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "305",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1237,8 +1237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1250,8 +1250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1263,8 +1263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "44",
@@ -1276,8 +1276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "44",
@@ -1289,8 +1289,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "3",
@@ -1302,8 +1302,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1315,8 +1315,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1328,11 +1328,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "14",
+                              "asInt": "15",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1341,8 +1341,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "3",
@@ -1354,11 +1354,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "9",
+                              "asInt": "10",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1367,8 +1367,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -1382,7 +1382,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "1324",
+                              "asInt": "998",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1391,8 +1391,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1404,8 +1404,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1417,11 +1417,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "73",
+                              "asInt": "71",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1430,11 +1430,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "84",
+                              "asInt": "76",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1443,11 +1443,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "68",
+                              "asInt": "59",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1456,8 +1456,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1469,8 +1469,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1482,11 +1482,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "132",
+                              "asInt": "151",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1495,11 +1495,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "219",
+                              "asInt": "212",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -1508,8 +1508,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "1",
@@ -1521,8 +1521,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -1545,8 +1545,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1558,8 +1558,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1581,8 +1581,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1594,8 +1594,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1617,8 +1617,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1630,8 +1630,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -1646,8 +1646,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -1662,8 +1662,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -1678,8 +1678,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1692,9 +1692,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "40728131",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "40731656",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1708,8 +1708,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1722,9 +1722,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "40728131",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "40731656",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -1742,82 +1742,6 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "get"
                                     }
                                  },
@@ -1828,8 +1752,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1847,8 +1771,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1856,7 +1780,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                       "stringValue": "search"
                                     }
                                  },
                                  {
@@ -1866,8 +1790,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1875,7 +1799,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                       "stringValue": "search"
                                     }
                                  },
                                  {
@@ -1885,8 +1809,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1894,7 +1818,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "snapshot"
+                                       "stringValue": "warmer"
                                     }
                                  },
                                  {
@@ -1904,8 +1828,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1913,7 +1837,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "snapshot"
+                                       "stringValue": "warmer"
                                     }
                                  },
                                  {
@@ -1923,8 +1847,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1932,7 +1856,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "system_critical_write"
+                                       "stringValue": "analyze"
                                     }
                                  },
                                  {
@@ -1942,8 +1866,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -1951,7 +1875,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "system_critical_write"
+                                       "stringValue": "analyze"
                                     }
                                  },
                                  {
@@ -1961,198 +1885,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "48",
@@ -2170,8 +1904,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2189,388 +1923,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "88",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "378",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "80",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "3",
@@ -2588,8 +1942,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2607,8 +1961,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2616,7 +1970,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "security-token-key"
+                                       "stringValue": "ml_job_comms"
                                     }
                                  },
                                  {
@@ -2626,8 +1980,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2635,7 +1989,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "security-token-key"
+                                       "stringValue": "ml_job_comms"
                                     }
                                  },
                                  {
@@ -2645,84 +1999,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "11",
@@ -2740,8 +2018,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2759,8 +2037,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2768,7 +2046,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search"
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
                                     }
                                  },
                                  {
@@ -2778,8 +2056,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2787,7 +2065,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search"
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
                                     }
                                  },
                                  {
@@ -2797,8 +2075,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2806,7 +2084,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search_throttled"
+                                       "stringValue": "snapshot"
                                     }
                                  },
                                  {
@@ -2816,8 +2094,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2825,7 +2103,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "search_throttled"
+                                       "stringValue": "snapshot"
                                     }
                                  },
                                  {
@@ -2835,8 +2113,160 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2854,8 +2284,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2873,16 +2303,16 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "0",
+                              "asInt": "88",
                               "attributes": [
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "warmer"
+                                       "stringValue": "system_read"
                                     }
                                  },
                                  {
@@ -2892,8 +2322,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2901,7 +2331,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "warmer"
+                                       "stringValue": "system_read"
                                     }
                                  },
                                  {
@@ -2911,8 +2341,198 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "13",
@@ -2930,8 +2550,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2949,8 +2569,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2958,7 +2578,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "vector_tile_generation"
+                                       "stringValue": "rollup_indexing"
                                     }
                                  },
                                  {
@@ -2968,8 +2588,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -2977,7 +2597,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "vector_tile_generation"
+                                       "stringValue": "rollup_indexing"
                                     }
                                  },
                                  {
@@ -2987,8 +2607,84 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "80",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "4",
@@ -3006,8 +2702,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -3025,8 +2721,312 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "378",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -3045,350 +3045,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "get"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -3400,34 +3062,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -3439,8 +3075,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -3448,12 +3084,168 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "refresh"
+                                       "stringValue": "analyze"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -3465,8 +3257,112 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -3478,8 +3374,112 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -3497,82 +3497,6 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "analyze"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "get"
                                     }
                                  },
@@ -3583,8 +3507,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -3602,920 +3526,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_prewarming"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ccr"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "searchable_snapshots_cache_fetch_async"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "transform_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "management"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_coordination"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_critical_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_read"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "6",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "system_write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "auto_complete"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot_meta"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "watcher"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4533,8 +3545,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4552,84 +3564,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search_throttled"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-crypto"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4647,8 +3583,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4666,8 +3602,692 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "analyze"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "management"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_fetch_async"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_coordination"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "searchable_snapshots_cache_prewarming"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-crypto"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "vector_tile_generation"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search_throttled"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4685,8 +4305,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "1",
@@ -4704,8 +4324,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4713,7 +4333,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "vector_tile_generation"
+                                       "stringValue": "rollup_indexing"
                                     }
                                  },
                                  {
@@ -4723,8 +4343,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4732,7 +4352,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "vector_tile_generation"
+                                       "stringValue": "rollup_indexing"
                                     }
                                  },
                                  {
@@ -4742,8 +4362,84 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "watcher"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4761,8 +4457,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "4",
@@ -4780,8 +4476,312 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "auto_complete"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ccr"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "7",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot_meta"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "system_critical_read"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -4794,9 +4794,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "1",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -4810,9 +4810,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "1318",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -4825,9 +4825,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "1318",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -4839,8 +4839,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -4853,8 +4853,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -4867,8 +4867,8 @@
                         "dataPoints": [
                            {
                               "asDouble": 0,
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -4881,8 +4881,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -4903,8 +4903,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4916,8 +4916,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -4929,9 +4929,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "23911",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "23907",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -4945,7 +4945,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "16",
+                              "asInt": "15",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4954,8 +4954,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -4967,8 +4967,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -4982,7 +4982,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "319",
+                              "asInt": "256",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -4991,8 +4991,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -5004,8 +5004,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ],
                         "isMonotonic": true
@@ -5018,8 +5018,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5032,8 +5032,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5045,9 +5045,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "101278496",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "330550336",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5059,9 +5059,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "150798336",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "150994944",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5073,9 +5073,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "147603616",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "148027440",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5096,8 +5096,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -5109,8 +5109,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "536870912",
@@ -5122,8 +5122,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5135,7 +5135,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "4194304",
+                              "asInt": "230686720",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -5144,11 +5144,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "17477920",
+                              "asInt": "26279488",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -5157,11 +5157,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
-                              "asInt": "79606272",
+                              "asInt": "73584128",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -5170,8 +5170,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5183,9 +5183,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "51",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "asInt": "52",
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5222,8 +5222,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5245,8 +5245,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -5258,8 +5258,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -5271,8 +5271,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5286,8 +5286,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },
@@ -5309,8 +5309,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -5322,8 +5322,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -5335,8 +5335,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            },
                            {
                               "asInt": "0",
@@ -5348,8 +5348,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662651665465817000",
-                              "timeUnixNano": "1662651675466522000"
+                              "startTimeUnixNano": "1662656573864843000",
+                              "timeUnixNano": "1662656583866336000"
                            }
                         ]
                      },

--- a/unreleased/elasticsearchreceiver-add-translog-in-client-request.yaml
+++ b/unreleased/elasticsearchreceiver-add-translog-in-client-request.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix issue where `elasticsearch.node.translog.*` metrics were not being collected"
+
+# One or more tracking issues related to the change
+issues: [13983]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Add `translog` in nodeStatsPath to collect `elasticsearch.node.translog.*` related metrics.

You can see that `elasticsearch.node.translog.size` shown in the issue had a value of [`0`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/db6987e83c05080891e12ef96c1b3f394d62a9ad/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json#L4808-L4813)  and now in this pr has a value of [`3330`](https://github.com/observIQ/opentelemetry-collector-contrib/blob/elasticsearchreceiver-add-translog-in-client-request/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json#L4808-L4813)

**Link to tracking Issue:** <Issue number if applicable>
#13983 

**Testing:** <Describe what testing was performed and which tests were added.>
integration test was ran for 7.16