### PR TITLE
prometheuesreceiver: revert exemplars support added in #12987

### DIFF
--- a/receiver/prometheusreceiver/internal/metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/metricfamily_test.go
@@ -15,7 +15,6 @@
 package internal
 
 import (
-	"encoding/hex"
 	"math"
 	"testing"
 	"time"
@@ -96,35 +95,12 @@ var mc = testMetadataStore{
 	},
 }
 
-func createNewExemplar(value float64, timestamp int64, traceid string) map[float64]pmetric.Exemplar {
-	var (
-		tid   [16]byte
-		sid   [8]byte
-		exMap = make(map[float64]pmetric.Exemplar)
-	)
-	ex := pmetric.NewExemplar()
-	ex.SetDoubleVal(value)
-	ex.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(timestamp)))
-
-	t, _ := hex.DecodeString(traceid)
-	copyToLowerBytes(tid[:], t)
-	ex.SetTraceID(tid)
-
-	s, _ := hex.DecodeString(traceid)
-	copyToLowerBytes(sid[:], s)
-	ex.SetSpanID(sid)
-
-	exMap[value] = ex
-
-	return exMap
-}
 func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 	type scrape struct {
 		at         int64
 		value      float64
 		metric     string
 		extraLabel labels.Label
-		exemplars  map[float64]pmetric.Exemplar
 	}
 	tests := []struct {
 		name                string
@@ -143,15 +119,11 @@ func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 			scrapes: []*scrape{
 				{at: 11, value: 66, metric: "histogram_count"},
 				{at: 11, value: 1004.78, metric: "histogram_sum"},
-				{at: 11, value: 33, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "0.75"}, exemplars: createNewExemplar(33, 11, "0000c5bd3caea93d")},
-				{at: 11, value: 55, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "2.75"}, exemplars: createNewExemplar(55, 11, "0006f0ea595fa831")},
+				{at: 11, value: 33, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "0.75"}},
+				{at: 11, value: 55, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "2.75"}},
 				{at: 11, value: 66, metric: "histogram_bucket", extraLabel: labels.Label{Name: "le", Value: "+Inf"}},
 			},
 			want: func() pmetric.HistogramDataPoint {
-				var (
-					tid1, tid2 [16]byte
-					sid1, sid2 [8]byte
-				)
 				point := pmetric.NewHistogramDataPoint()
 				point.SetCount(66)
 				point.SetSum(1004.78)
@@ -162,29 +134,6 @@ func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 				attributes := point.Attributes()
 				attributes.UpsertString("a", "A")
 				attributes.UpsertString("b", "B")
-
-				// add exemplars
-				exemplars := pmetric.NewExemplarSlice()
-
-				e1 := exemplars.AppendEmpty()
-				e1.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(11)))
-				e1.SetDoubleVal(33)
-				tr, _ := hex.DecodeString("0000c5bd3caea93d")
-				copyToLowerBytes(tid1[:], tr)
-				sp, _ := hex.DecodeString("0000c5bd3caea93d")
-				copyToLowerBytes(sid1[:], sp)
-				e1.SetTraceID(tid1)
-				e1.SetSpanID(sid1)
-
-				e2 := exemplars.AppendEmpty()
-				e2.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(11)))
-				e2.SetDoubleVal(55)
-				tr1, _ := hex.DecodeString("0006f0ea595fa831")
-				copyToLowerBytes(tid2[:], tr1)
-				sp1, _ := hex.DecodeString("0006f0ea595fa831")
-				copyToLowerBytes(sid2[:], sp1)
-				e2.SetTraceID(tid2)
-				e2.SetSpanID(sid2)
 				return point
 			},
 		},

--- a/unreleased/append-exemplars-to-prometheus-receiver.yaml
+++ b/unreleased/append-exemplars-to-prometheus-receiver.yaml
@@ -1,9 +1,0 @@
-change_type: enhancement
-
-component: receiver/prometheusreceiver
-
-note: Append exemplars to the metrics received by prometheus receiver
-
-issues: [8353]
-
-subtext: Acknowledge exemplars coming from prometheus receiver and append it to otel format


### PR DESCRIPTION
Few reasons:
* Current implementation crashes if the metric group is not present in the family, see the access to `mg`
* Current implementation does not respect the separation of concerns, the family should be the owner of the groups.
* Current implementation crashes if the trace-id is larger than 32hex, since copyToLowerBytes copies into the destination without len check.

There are too many bugs to worth fixing this implementation. Reviewers please make sure you put more attention into this.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
