### PR TITLE
Fixed build of otelcontribcol due to unused import

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
-	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"


### PR DESCRIPTION
**Description:** 
Fixed build of otelcontribcol due to unused import

**Testing:** 
Before the fix, running the docker-compose from examples/tracing didn't work due to fail in build, now it works.

