### PR TITLE
[receiver/elasticsearchreceiver] Add new client method Version

### DIFF
--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -40,6 +40,7 @@ var (
 type elasticsearchClient interface {
 	NodeStats(ctx context.Context, nodes []string) (*model.NodeStats, error)
 	ClusterHealth(ctx context.Context) (*model.ClusterHealth, error)
+	Version(ctx context.Context) (*model.VersionResponse, error)
 }
 
 // defaultElasticsearchClient is the main implementation of elasticsearchClient.
@@ -116,6 +117,17 @@ func (c defaultElasticsearchClient) ClusterHealth(ctx context.Context) (*model.C
 	clusterHealth := model.ClusterHealth{}
 	err = json.Unmarshal(body, &clusterHealth)
 	return &clusterHealth, err
+}
+
+func (c defaultElasticsearchClient) Version(ctx context.Context) (*model.VersionResponse, error) {
+	body, err := c.doRequest(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	versionResponse := model.VersionResponse{}
+	err = json.Unmarshal(body, &versionResponse)
+	return &versionResponse, err
 }
 
 func (c defaultElasticsearchClient) doRequest(ctx context.Context, path string) ([]byte, error) {

--- a/receiver/elasticsearchreceiver/go.mod
+++ b/receiver/elasticsearchreceiver/go.mod
@@ -9,7 +9,10 @@ require (
 	go.uber.org/zap v1.23.0
 )
 
-require github.com/testcontainers/testcontainers-go v0.14.0
+require (
+	github.com/hashicorp/go-version v1.6.0
+	github.com/testcontainers/testcontainers-go v0.14.0
+)
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect

--- a/receiver/elasticsearchreceiver/go.sum
+++ b/receiver/elasticsearchreceiver/go.sum
@@ -572,6 +572,8 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/receiver/elasticsearchreceiver/internal/mocks/elasticsearchClient.go
+++ b/receiver/elasticsearchreceiver/internal/mocks/elasticsearchClient.go
@@ -60,3 +60,26 @@ func (_m *MockElasticsearchClient) NodeStats(ctx context.Context, nodes []string
 
 	return r0, r1
 }
+
+// Version provides a mock function with given fields: ctx
+func (_m *MockElasticsearchClient) Version(ctx context.Context) (*model.VersionResponse, error) {
+	ret := _m.Called(ctx)
+
+	var r0 *model.VersionResponse
+	if rf, ok := ret.Get(0).(func(context.Context) *model.VersionResponse); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.VersionResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/receiver/elasticsearchreceiver/internal/model/version.go
+++ b/receiver/elasticsearchreceiver/internal/model/version.go
@@ -1,0 +1,21 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver/internal/model"
+
+type VersionResponse struct {
+	Version struct {
+		Number string `json:"number"`
+	} `json:"version"`
+}

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -97,7 +97,7 @@ func (r *elasticsearchScraper) scrape(ctx context.Context) (pmetric.Metrics, err
 
 	now := pcommon.NewTimestampFromTime(time.Now())
 
-	r.getVersion(ctx, errs)
+	r.getVersion(ctx)
 	r.scrapeNodeMetrics(ctx, now, errs)
 	r.scrapeClusterMetrics(ctx, now, errs)
 
@@ -105,7 +105,7 @@ func (r *elasticsearchScraper) scrape(ctx context.Context) (pmetric.Metrics, err
 }
 
 // scrapeVersion gets and assigns the elasticsearch version number
-func (r *elasticsearchScraper) getVersion(ctx context.Context, errs *scrapererror.ScrapeErrors) {
+func (r *elasticsearchScraper) getVersion(ctx context.Context) {
 	versionResponse, err := r.client.Version(ctx)
 	if err != nil {
 		return

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -48,6 +48,7 @@ func TestScraper(t *testing.T) {
 	require.NoError(t, err)
 
 	mockClient := mocks.MockElasticsearchClient{}
+	mockClient.On("Version", mock.Anything).Return(versionNumber(t), nil)
 	mockClient.On("ClusterHealth", mock.Anything).Return(clusterHealth(t), nil)
 	mockClient.On("NodeStats", mock.Anything, []string{"_all"}).Return(nodeStats(t), nil)
 
@@ -73,6 +74,7 @@ func TestScraperMetricsWithoutDirection(t *testing.T) {
 	require.NoError(t, err)
 
 	mockClient := mocks.MockElasticsearchClient{}
+	mockClient.On("Version", mock.Anything).Return(versionNumber(t), nil)
 	mockClient.On("ClusterHealth", mock.Anything).Return(clusterHealth(t), nil)
 	mockClient.On("NodeStats", mock.Anything, []string{"_all"}).Return(nodeStats(t), nil)
 
@@ -99,6 +101,7 @@ func TestScraperSkipClusterMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	mockClient := mocks.MockElasticsearchClient{}
+	mockClient.On("Version", mock.Anything).Return(versionNumber(t), nil)
 	mockClient.On("ClusterHealth", mock.Anything).Return(clusterHealth(t), nil)
 	mockClient.On("NodeStats", mock.Anything, []string{"_all"}).Return(nodeStats(t), nil)
 
@@ -125,6 +128,7 @@ func TestScraperNoNodesMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	mockClient := mocks.MockElasticsearchClient{}
+	mockClient.On("Version", mock.Anything).Return(versionNumber(t), nil)
 	mockClient.On("ClusterHealth", mock.Anything).Return(clusterHealth(t), nil)
 	mockClient.On("NodeStats", mock.Anything, []string{}).Return(nodeStats(t), nil)
 
@@ -175,6 +179,7 @@ func TestScrapingError(t *testing.T) {
 				err404 := errors.New("expected status 200 but got 404")
 
 				mockClient := mocks.MockElasticsearchClient{}
+				mockClient.On("Version", mock.Anything).Return(versionNumber(t), nil)
 				mockClient.On("NodeStats", mock.Anything, []string{"_all"}).Return(nil, err404)
 				mockClient.On("ClusterHealth", mock.Anything).Return(clusterHealth(t), nil)
 
@@ -198,6 +203,7 @@ func TestScrapingError(t *testing.T) {
 				err404 := errors.New("expected status 200 but got 404")
 
 				mockClient := mocks.MockElasticsearchClient{}
+				mockClient.On("Version", mock.Anything).Return(versionNumber(t), nil)
 				mockClient.On("NodeStats", mock.Anything, []string{"_all"}).Return(nodeStats(t), nil)
 				mockClient.On("ClusterHealth", mock.Anything).Return(nil, err404)
 
@@ -222,6 +228,7 @@ func TestScrapingError(t *testing.T) {
 				err500 := errors.New("expected status 200 but got 500")
 
 				mockClient := mocks.MockElasticsearchClient{}
+				mockClient.On("Version", mock.Anything).Return(versionNumber(t), nil)
 				mockClient.On("NodeStats", mock.Anything, []string{"_all"}).Return(nil, err500)
 				mockClient.On("ClusterHealth", mock.Anything).Return(nil, err404)
 
@@ -247,6 +254,7 @@ func TestScrapingError(t *testing.T) {
 				ch.Status = "pink"
 
 				mockClient := mocks.MockElasticsearchClient{}
+				mockClient.On("Version", mock.Anything).Return(versionNumber(t), nil)
 				mockClient.On("NodeStats", mock.Anything, []string{"_all"}).Return(nodeStats(t), nil)
 				mockClient.On("ClusterHealth", mock.Anything).Return(ch, nil)
 
@@ -285,4 +293,13 @@ func nodeStats(t *testing.T) *model.NodeStats {
 	nodeStats := model.NodeStats{}
 	require.NoError(t, json.Unmarshal(nodeJSON, &nodeStats))
 	return &nodeStats
+}
+
+func versionNumber(t *testing.T) *model.VersionResponse {
+	versionJSON, err := os.ReadFile("./testdata/sample_payloads/version.json")
+	require.NoError(t, err)
+
+	versionResponse := model.VersionResponse{}
+	require.NoError(t, json.Unmarshal(versionJSON, &versionResponse))
+	return &versionResponse
 }

--- a/receiver/elasticsearchreceiver/testdata/sample_payloads/version.json
+++ b/receiver/elasticsearchreceiver/testdata/sample_payloads/version.json
@@ -1,0 +1,17 @@
+{
+    "name" : "2e86337accef",
+    "cluster_name" : "docker-cluster",
+    "cluster_uuid" : "sRnzQpHOQm61US0Hdbz0qg",
+    "version" : {
+      "number" : "7.17.0",
+      "build_flavor" : "default",
+      "build_type" : "docker",
+      "build_hash" : "bee86328705acaa9a6daede7140defd4d9ec56bd",
+      "build_date" : "2022-01-28T08:36:04.875279988Z",
+      "build_snapshot" : false,
+      "lucene_version" : "8.11.1",
+      "minimum_wire_compatibility_version" : "6.8.0",
+      "minimum_index_compatibility_version" : "6.0.0-beta1"
+    },
+    "tagline" : "You Know, for Search"
+  }

--- a/unreleased/elasticsearchreceiver-metric-versioning-client.yaml
+++ b/unreleased/elasticsearchreceiver-metric-versioning-client.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Adds new method Version in the client request to get the elasticsearch version number"
+
+# One or more tracking issues related to the change
+issues: [14012]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This pr adds a client method Version to get elasticsearch version number. This is task 1 of 3 for the issue. This pr will be required in order to compare the current elasticsearch version number to the when a specific metric version became supported which will happen in task 2 and 3. 

**Link to tracking Issue:** <Issue number if applicable>
#14012 

**Testing:** <Describe what testing was performed and which tests were added.>
Added client and scraper test

**Documentation:** <Describe the documentation added.>