### PR TITLE
[exporter/fileexporter] Add  some options for compression, self-rotate log and proto encoding

### DIFF
--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -6,11 +6,13 @@
 | Supported pipeline types | traces, metrics, logs |
 | Distributions            | [core], [contrib]     |
 
-This exporter will write pipeline data to a JSON file. The data is written in.
-[Protobuf JSON
-encoding](https://developers.google.com/protocol-buffers/docs/proto3#json)
-using [OpenTelemetry
-protocol](https://github.com/open-telemetry/opentelemetry-proto).
+Exporter supports the following features：
+
++ Support for writing pipeline data to a JSON file.
++ Support for encoding data using a protobuf stream in OTLP batch format described in [Add proto messages for signals data independent of OTLP protocol opentelemetry-proto#332](https://github.com/open-telemetry/opentelemetry-proto/pull/332)
++ Support for self-rotate log files.
++ Support for data compression using [Zstd](http://facebook.github.io/zstd/).
+
 
 Please note that there is no guarantee that exact field names will remain stable.
 This intended for primarily for debugging Collector without setting up backends.
@@ -27,6 +29,13 @@ Example:
 exporters:
   file:
     path: ./filename.json
+    proto_marshal_option: true
+    zstd_option: true
+    rolling_logger_options:
+      max_size: 10
+      max_age: 3
+      max_backups: 3
+      localtime: true
 ```
 
 

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -32,6 +32,33 @@ type Config struct {
 
 	// ZstdOption Zstd compression option
 	ZstdOption bool
+
+	// RollingLoggerOptions defines an option to self-rotate log files
+	RollingLoggerOptions RollingLoggerOptions
+}
+
+// RollingLoggerOptions an option to rolling log files
+type RollingLoggerOptions struct {
+	// MaxSize is the maximum size in megabytes of the log file before it gets
+	// rotated. It defaults to 100 megabytes.
+	MaxSize int `json:"maxsize" yaml:"maxsize"`
+
+	// MaxAge is the maximum number of days to retain old log files based on the
+	// timestamp encoded in their filename.  Note that a day is defined as 24
+	// hours and may not exactly correspond to calendar days due to daylight
+	// savings, leap seconds, etc. The default is not to remove old log files
+	// based on age.
+	MaxAge int `json:"maxage" yaml:"maxage"`
+
+	// MaxBackups is the maximum number of old log files to retain.  The default
+	// is to retain all old log files (though MaxAge may still cause them to get
+	// deleted.)
+	MaxBackups int `json:"maxbackups" yaml:"maxbackups"`
+
+	// LocalTime determines if the time used for formatting the timestamps in
+	// backup files is the computer's local time.  The default is to use UTC
+	// time.
+	LocalTime bool `json:"localtime" yaml:"localtime"`
 }
 
 var _ config.Exporter = (*Config)(nil)

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -26,6 +26,9 @@ type Config struct {
 
 	// Path of the file to write to. Path is relative to current directory.
 	Path string `mapstructure:"path"`
+
+	// PbMarshalOption defines whether encodes data using a protobuf stream in OTLP batch format
+	PbMarshalOption bool
 }
 
 var _ config.Exporter = (*Config)(nil)

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -28,37 +28,37 @@ type Config struct {
 	Path string `mapstructure:"path"`
 
 	// PbMarshalOption defines whether encodes data using a protobuf stream in OTLP batch format
-	PbMarshalOption bool
+	PbMarshalOption bool `mapstructure:"proto_marshal_option"`
 
 	// ZstdOption Zstd compression option
-	ZstdOption bool
+	ZstdOption bool `mapstructure:"zstd_option"`
 
 	// RollingLoggerOptions defines an option to self-rotate log files
-	RollingLoggerOptions RollingLoggerOptions
+	RollingLoggerOptions RollingLoggerOptions `mapstructure:"rolling_logger_options"`
 }
 
 // RollingLoggerOptions an option to rolling log files
 type RollingLoggerOptions struct {
 	// MaxSize is the maximum size in megabytes of the log file before it gets
 	// rotated. It defaults to 100 megabytes.
-	MaxSize int `json:"maxsize" yaml:"maxsize"`
+	MaxSize int `mapstructure:"max_size"`
 
 	// MaxAge is the maximum number of days to retain old log files based on the
 	// timestamp encoded in their filename.  Note that a day is defined as 24
 	// hours and may not exactly correspond to calendar days due to daylight
 	// savings, leap seconds, etc. The default is not to remove old log files
 	// based on age.
-	MaxAge int `json:"maxage" yaml:"maxage"`
+	MaxAge int `mapstructure:"max_age" `
 
 	// MaxBackups is the maximum number of old log files to retain.  The default
 	// is to retain all old log files (though MaxAge may still cause them to get
 	// deleted.)
-	MaxBackups int `json:"maxbackups" yaml:"maxbackups"`
+	MaxBackups int `mapstructure:"max_backups" `
 
 	// LocalTime determines if the time used for formatting the timestamps in
 	// backup files is the computer's local time.  The default is to use UTC
 	// time.
-	LocalTime bool `json:"localtime" yaml:"localtime"`
+	LocalTime bool `mapstructure:"localtime"`
 }
 
 var _ config.Exporter = (*Config)(nil)

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -29,6 +29,9 @@ type Config struct {
 
 	// PbMarshalOption defines whether encodes data using a protobuf stream in OTLP batch format
 	PbMarshalOption bool
+
+	// ZstdOption Zstd compression option
+	ZstdOption bool
 }
 
 var _ config.Exporter = (*Config)(nil)

--- a/exporter/fileexporter/config_test.go
+++ b/exporter/fileexporter/config_test.go
@@ -43,5 +43,13 @@ func TestLoadConfig(t *testing.T) {
 		&Config{
 			ExporterSettings: config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "2")),
 			Path:             "./filename.json",
+			PbMarshalOption:  true,
+			ZstdOption:       true,
+			RollingLoggerOptions: RollingLoggerOptions{
+				MaxSize:    10,
+				MaxAge:     3,
+				MaxBackups: 3,
+				LocalTime:  true,
+			},
 		})
 }

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -20,6 +20,9 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 )
@@ -53,7 +56,17 @@ func createTracesExporter(
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
-		return &fileExporter{path: cfg.(*Config).Path}
+		conf := cfg.(*Config)
+		marshaler := func() ptrace.Marshaler {
+			if conf.PbMarshalOption {
+				return ptrace.NewProtoMarshaler()
+			}
+			return ptrace.NewProtoMarshaler()
+		}()
+		return &fileExporter{
+			path:            conf.Path,
+			tracesMarshaler: marshaler,
+		}
 	})
 	return exporterhelper.NewTracesExporter(
 		ctx,
@@ -71,7 +84,17 @@ func createMetricsExporter(
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
-		return &fileExporter{path: cfg.(*Config).Path}
+		conf := cfg.(*Config)
+		marshaler := func() pmetric.Marshaler {
+			if conf.PbMarshalOption {
+				return pmetric.NewProtoMarshaler()
+			}
+			return pmetric.NewProtoMarshaler()
+		}()
+		return &fileExporter{
+			path:             conf.Path,
+			metricsMarshaler: marshaler,
+		}
 	})
 	return exporterhelper.NewMetricsExporter(
 		ctx,
@@ -89,7 +112,17 @@ func createLogsExporter(
 	cfg config.Exporter,
 ) (component.LogsExporter, error) {
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
-		return &fileExporter{path: cfg.(*Config).Path}
+		conf := cfg.(*Config)
+		marshaler := func() plog.Marshaler {
+			if conf.PbMarshalOption {
+				return plog.NewProtoMarshaler()
+			}
+			return plog.NewProtoMarshaler()
+		}()
+		return &fileExporter{
+			path:          cfg.(*Config).Path,
+			logsMarshaler: marshaler,
+		}
 	})
 	return exporterhelper.NewLogsExporter(
 		ctx,

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -16,16 +16,10 @@ package fileexporter // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
-	"gopkg.in/natefinch/lumberjack.v2"
-
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.opentelemetry.io/collector/pdata/plog"
-	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/pdata/ptrace"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 )
 
 const (
@@ -57,25 +51,7 @@ func createTracesExporter(
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
-		conf := cfg.(*Config)
-		marshaler := func() ptrace.Marshaler {
-			if conf.PbMarshalOption {
-				return ptrace.NewProtoMarshaler()
-			}
-			return ptrace.NewProtoMarshaler()
-		}()
-		return &fileExporter{
-			path:            conf.Path,
-			tracesMarshaler: marshaler,
-			isCompressed:    conf.ZstdOption,
-			logger: &lumberjack.Logger{
-				Filename:   conf.Path,
-				MaxSize:    conf.RollingLoggerOptions.MaxSize,
-				MaxAge:     conf.RollingLoggerOptions.MaxAge,
-				MaxBackups: conf.RollingLoggerOptions.MaxBackups,
-				LocalTime:  conf.RollingLoggerOptions.LocalTime,
-			},
-		}
+		return newFileExporter(cfg.(*Config))
 	})
 	return exporterhelper.NewTracesExporter(
 		ctx,
@@ -93,25 +69,7 @@ func createMetricsExporter(
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
-		conf := cfg.(*Config)
-		marshaler := func() pmetric.Marshaler {
-			if conf.PbMarshalOption {
-				return pmetric.NewProtoMarshaler()
-			}
-			return pmetric.NewProtoMarshaler()
-		}()
-		return &fileExporter{
-			path:             conf.Path,
-			metricsMarshaler: marshaler,
-			isCompressed:     conf.ZstdOption,
-			logger: &lumberjack.Logger{
-				Filename:   conf.Path,
-				MaxSize:    conf.RollingLoggerOptions.MaxSize,
-				MaxAge:     conf.RollingLoggerOptions.MaxAge,
-				MaxBackups: conf.RollingLoggerOptions.MaxBackups,
-				LocalTime:  conf.RollingLoggerOptions.LocalTime,
-			},
-		}
+		return newFileExporter(cfg.(*Config))
 	})
 	return exporterhelper.NewMetricsExporter(
 		ctx,
@@ -129,25 +87,7 @@ func createLogsExporter(
 	cfg config.Exporter,
 ) (component.LogsExporter, error) {
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
-		conf := cfg.(*Config)
-		marshaler := func() plog.Marshaler {
-			if conf.PbMarshalOption {
-				return plog.NewProtoMarshaler()
-			}
-			return plog.NewProtoMarshaler()
-		}()
-		return &fileExporter{
-			path:          cfg.(*Config).Path,
-			logsMarshaler: marshaler,
-			isCompressed:  conf.ZstdOption,
-			logger: &lumberjack.Logger{
-				Filename:   conf.Path,
-				MaxSize:    conf.RollingLoggerOptions.MaxSize,
-				MaxAge:     conf.RollingLoggerOptions.MaxAge,
-				MaxBackups: conf.RollingLoggerOptions.MaxBackups,
-				LocalTime:  conf.RollingLoggerOptions.LocalTime,
-			},
-		}
+		return newFileExporter(cfg.(*Config))
 	})
 	return exporterhelper.NewLogsExporter(
 		ctx,

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -16,7 +16,9 @@ package fileexporter // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -66,6 +66,7 @@ func createTracesExporter(
 		return &fileExporter{
 			path:            conf.Path,
 			tracesMarshaler: marshaler,
+			isCompressed:    conf.ZstdOption,
 		}
 	})
 	return exporterhelper.NewTracesExporter(
@@ -94,6 +95,7 @@ func createMetricsExporter(
 		return &fileExporter{
 			path:             conf.Path,
 			metricsMarshaler: marshaler,
+			isCompressed:     conf.ZstdOption,
 		}
 	})
 	return exporterhelper.NewMetricsExporter(
@@ -122,6 +124,7 @@ func createLogsExporter(
 		return &fileExporter{
 			path:          cfg.(*Config).Path,
 			logsMarshaler: marshaler,
+			isCompressed:  conf.ZstdOption,
 		}
 	})
 	return exporterhelper.NewLogsExporter(

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -16,6 +16,7 @@ package fileexporter // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -67,6 +68,13 @@ func createTracesExporter(
 			path:            conf.Path,
 			tracesMarshaler: marshaler,
 			isCompressed:    conf.ZstdOption,
+			logger: &lumberjack.Logger{
+				Filename:   conf.Path,
+				MaxSize:    conf.RollingLoggerOptions.MaxSize,
+				MaxAge:     conf.RollingLoggerOptions.MaxAge,
+				MaxBackups: conf.RollingLoggerOptions.MaxBackups,
+				LocalTime:  conf.RollingLoggerOptions.LocalTime,
+			},
 		}
 	})
 	return exporterhelper.NewTracesExporter(
@@ -96,6 +104,13 @@ func createMetricsExporter(
 			path:             conf.Path,
 			metricsMarshaler: marshaler,
 			isCompressed:     conf.ZstdOption,
+			logger: &lumberjack.Logger{
+				Filename:   conf.Path,
+				MaxSize:    conf.RollingLoggerOptions.MaxSize,
+				MaxAge:     conf.RollingLoggerOptions.MaxAge,
+				MaxBackups: conf.RollingLoggerOptions.MaxBackups,
+				LocalTime:  conf.RollingLoggerOptions.LocalTime,
+			},
 		}
 	})
 	return exporterhelper.NewMetricsExporter(
@@ -125,6 +140,13 @@ func createLogsExporter(
 			path:          cfg.(*Config).Path,
 			logsMarshaler: marshaler,
 			isCompressed:  conf.ZstdOption,
+			logger: &lumberjack.Logger{
+				Filename:   conf.Path,
+				MaxSize:    conf.RollingLoggerOptions.MaxSize,
+				MaxAge:     conf.RollingLoggerOptions.MaxAge,
+				MaxBackups: conf.RollingLoggerOptions.MaxBackups,
+				LocalTime:  conf.RollingLoggerOptions.LocalTime,
+			},
 		}
 	})
 	return exporterhelper.NewLogsExporter(

--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -16,7 +16,6 @@ package fileexporter // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
-	"github.com/spf13/cast"
 	"io"
 	"sync"
 
@@ -26,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	"github.com/spf13/cast"
 	"github.com/valyala/gozstd"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -82,8 +82,8 @@ func (e *fileExporter) ConsumeTraces(_ context.Context, td ptrace.Traces) error 
 	if e.isCompressed {
 		buf = gozstd.Compress(nil, buf)
 	}
-	isJson := !(e.isCompressed || e.isProtoMarshal)
-	return exportMessage(e, buf, isJson)
+	isJSON := !(e.isCompressed || e.isProtoMarshal)
+	return exportMessage(e, buf, isJSON)
 }
 
 func (e *fileExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
@@ -94,8 +94,8 @@ func (e *fileExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) err
 	if e.isCompressed {
 		buf = gozstd.Compress(nil, buf)
 	}
-	isJson := !(e.isCompressed || e.isProtoMarshal)
-	return exportMessage(e, buf, isJson)
+	isJSON := !(e.isCompressed || e.isProtoMarshal)
+	return exportMessage(e, buf, isJSON)
 }
 
 func (e *fileExporter) ConsumeLogs(_ context.Context, ld plog.Logs) error {
@@ -106,12 +106,12 @@ func (e *fileExporter) ConsumeLogs(_ context.Context, ld plog.Logs) error {
 	if e.isCompressed {
 		buf = gozstd.Compress(nil, buf)
 	}
-	isJson := !(e.isCompressed || e.isProtoMarshal)
-	return exportMessage(e, buf, isJson)
+	isJSON := !(e.isCompressed || e.isProtoMarshal)
+	return exportMessage(e, buf, isJSON)
 }
 
-func exportMessage(e *fileExporter, buf []byte, isJson bool) error {
-	if isJson {
+func exportMessage(e *fileExporter, buf []byte, isJSON bool) error {
+	if isJSON {
 		return exportMessageAsLine(e, buf)
 	}
 	return exportStreamMessages(e, buf)

--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -27,17 +27,15 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-// Marshaler configuration used for marhsaling Protobuf to JSON.
-var tracesMarshaler = ptrace.NewJSONMarshaler()
-var metricsMarshaler = pmetric.NewJSONMarshaler()
-var logsMarshaler = plog.NewJSONMarshaler()
-
 // fileExporter is the implementation of file exporter that writes telemetry data to a file
 // in Protobuf-JSON format.
 type fileExporter struct {
-	path  string
-	file  io.WriteCloser
-	mutex sync.Mutex
+	path             string
+	file             io.WriteCloser
+	mutex            sync.Mutex
+	tracesMarshaler  ptrace.Marshaler
+	metricsMarshaler pmetric.Marshaler
+	logsMarshaler    plog.Marshaler
 }
 
 func (e *fileExporter) Capabilities() consumer.Capabilities {
@@ -45,7 +43,7 @@ func (e *fileExporter) Capabilities() consumer.Capabilities {
 }
 
 func (e *fileExporter) ConsumeTraces(_ context.Context, td ptrace.Traces) error {
-	buf, err := tracesMarshaler.MarshalTraces(td)
+	buf, err := e.tracesMarshaler.MarshalTraces(td)
 	if err != nil {
 		return err
 	}
@@ -53,7 +51,7 @@ func (e *fileExporter) ConsumeTraces(_ context.Context, td ptrace.Traces) error 
 }
 
 func (e *fileExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
-	buf, err := metricsMarshaler.MarshalMetrics(md)
+	buf, err := e.metricsMarshaler.MarshalMetrics(md)
 	if err != nil {
 		return err
 	}
@@ -61,7 +59,7 @@ func (e *fileExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) err
 }
 
 func (e *fileExporter) ConsumeLogs(_ context.Context, ld plog.Logs) error {
-	buf, err := logsMarshaler.MarshalLogs(ld)
+	buf, err := e.logsMarshaler.MarshalLogs(ld)
 	if err != nil {
 		return err
 	}

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -21,17 +21,18 @@ import (
 	"os"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/gozstd"
 	"gopkg.in/natefinch/lumberjack.v2"
 
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/pdata/plog"
-	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/pdata/ptrace"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 )
 
 func TestFileTracesExporter_JSONMarshal(t *testing.T) {
@@ -112,17 +113,18 @@ func TestFileTracesExporter_JSONMarshal(t *testing.T) {
 			assert.NoError(t, fe.Shutdown(context.Background()))
 
 			fi, err := os.Open(fe.path)
-			defer fi.Close()
 			assert.NoError(t, err)
+			defer fi.Close()
 			br := bufio.NewReader(fi)
-			isJson := !(tt.args.conf.ZstdOption || tt.args.conf.PbMarshalOption)
+			isJSON := !(tt.args.conf.ZstdOption || tt.args.conf.PbMarshalOption)
 			for {
 				buf, isEnd, err := func() ([]byte, bool, error) {
-					if isJson {
+					if isJSON {
 						return readJSONMessage(br)
 					}
 					return readMessageFromStream(br)
 				}()
+				assert.NoError(t, err)
 				if isEnd {
 					break
 				}
@@ -257,17 +259,18 @@ func TestFileMetricsExporter(t *testing.T) {
 			assert.NoError(t, fe.Shutdown(context.Background()))
 
 			fi, err := os.Open(fe.path)
-			defer fi.Close()
 			assert.NoError(t, err)
+			defer fi.Close()
 			br := bufio.NewReader(fi)
-			isJson := !(tt.args.conf.ZstdOption || tt.args.conf.PbMarshalOption)
+			isJSON := !(tt.args.conf.ZstdOption || tt.args.conf.PbMarshalOption)
 			for {
 				buf, isEnd, err := func() ([]byte, bool, error) {
-					if isJson {
+					if isJSON {
 						return readJSONMessage(br)
 					}
 					return readMessageFromStream(br)
 				}()
+				assert.NoError(t, err)
 				if isEnd {
 					break
 				}
@@ -403,17 +406,18 @@ func TestFileLogsExporter(t *testing.T) {
 			assert.NoError(t, fe.Shutdown(context.Background()))
 
 			fi, err := os.Open(fe.path)
-			defer fi.Close()
 			assert.NoError(t, err)
+			defer fi.Close()
 			br := bufio.NewReader(fi)
-			isJson := !(tt.args.conf.ZstdOption || tt.args.conf.PbMarshalOption)
+			isJSON := !(tt.args.conf.ZstdOption || tt.args.conf.PbMarshalOption)
 			for {
 				buf, isEnd, err := func() ([]byte, bool, error) {
-					if isJson {
+					if isJSON {
 						return readJSONMessage(br)
 					}
 					return readMessageFromStream(br)
 				}()
+				assert.NoError(t, err)
 				if isEnd {
 					break
 				}

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -17,18 +17,19 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	"github.com/spf13/cast"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 	"io"
 	"os"
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
+	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.59.0
 	github.com/stretchr/testify v1.8.0
+	github.com/valyala/gozstd v1.17.0
 	go.opentelemetry.io/collector v0.59.1-0.20220909192754-8d66f408a79a
 	go.opentelemetry.io/collector/pdata v0.59.1-0.20220909192754-8d66f408a79a
 )

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.59.0
+	github.com/spf13/cast v1.5.0
 	github.com/stretchr/testify v1.8.0
 	github.com/valyala/gozstd v1.17.0
 	go.opentelemetry.io/collector v0.59.1-0.20220909192754-8d66f408a79a

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/valyala/gozstd v1.17.0
 	go.opentelemetry.io/collector v0.59.1-0.20220909192754-8d66f408a79a
 	go.opentelemetry.io/collector/pdata v0.59.1-0.20220909192754-8d66f408a79a
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 
 require (

--- a/exporter/fileexporter/go.sum
+++ b/exporter/fileexporter/go.sum
@@ -260,6 +260,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/valyala/gozstd v1.17.0 h1:M4Ds4MIrw+pD+s6vYtuFZ8D3iEw9htzfdytOV3C3iQU=
+github.com/valyala/gozstd v1.17.0/go.mod h1:y5Ew47GLlP37EkTB+B4s7r6A5rdaeB7ftbl9zoYiIPQ=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/exporter/fileexporter/go.sum
+++ b/exporter/fileexporter/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -439,6 +440,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -447,6 +450,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/exporter/fileexporter/go.sum
+++ b/exporter/fileexporter/go.sum
@@ -53,6 +53,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -166,8 +167,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -247,6 +248,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
+github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/exporter/fileexporter/testdata/config.yaml
+++ b/exporter/fileexporter/testdata/config.yaml
@@ -14,13 +14,20 @@ exporters:
     # just a dump of internal structures which can be changed over time.
     # This intended for primarily for debugging Collector without setting up backends.
     path: ./filename.json
+    proto_marshal_option: true
+    zstd_option: true
+    rolling_logger_options:
+      max_size: 10
+      max_age: 3
+      max_backups: 3
+      localtime: true
 
 service:
   pipelines:
     traces:
-      receivers: [nop]
-      processors: [nop]
-      exporters: [file]
+      receivers: [ nop ]
+      processors: [ nop ]
+      exporters: [ file ]
     metrics:
-      receivers: [nop]
-      exporters: [file,file/2]
+      receivers: [ nop ]
+      exporters: [ file,file/2 ]

--- a/unreleased/fileexporter-data-for-experimental.yaml
+++ b/unreleased/fileexporter-data-for-experimental.yaml
@@ -1,0 +1,22 @@
+package unreleased
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: fileexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+  Support for file-logging OTLP Metrics/Traces/LogsData data for experimental and research purposes
+
+# One or more tracking issues related to the change
+issues: [13626]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+  Add an option to encode data using a protobuf stream in OTLP batch format.|
+  Add an option to self-rotate log files.|
+  Add a Zstd compression option.|


### PR DESCRIPTION
**Description:** 
Add an option to encode data using a protobuf stream in OTLP batch formal.

Add an option to self-rotate log files.

Add an option  for the user to decide whether to enable compression.

**Link to tracking Issue:** <Issue number if applicable>
#13626 

**Testing:** <Describe what testing was performed and which tests were added.>
Updated unit tests

**Documentation:** <Describe the documentation added.>
Update  Readme.md