### PR TITLE
[CI] Apply stopgap for actions/cache bug across entire workflow

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
 env:
   TEST_RESULTS: testbed/tests/results/junit/results.xml
+  # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+  # Cache downloads for this workflow consistently run in under 10 minutes
+  SEGMENT_DOWNLOAD_TIMEOUT_MIN: 15
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -30,10 +33,6 @@ jobs:
           path: |
             ~\go\pkg\mod
           key: go-mod-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-        env:
-          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
-          # Cache downloads for this workflow consistently run in under 10 minutes
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 15
       - name: Install dependencies
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -71,20 +70,12 @@ jobs:
           path: |
             ~\go\pkg\mod
           key: go-mod-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-        env:
-          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
-          # Cache downloads for this workflow consistently run in under 10 minutes
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 15
       - name: Cache Go Build
         uses: actions/cache@v3
         with:
           path: |
             ~\AppData\Local\go-build
           key: go-build-cache-${{ runner.os }}-${{ matrix.group }}-go-${{ hashFiles('**/go.sum') }}
-        env:
-          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
-          # Cache downloads for this workflow consistently run in under 10 minutes
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 15
       - name: Run Unit tests
         run: make gotest GROUP=${{ matrix.group }}
   windows-unittest:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
 env:
   TEST_RESULTS: testbed/tests/results/junit/results.xml
+  # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+  # Cache downloads for this workflow consistently run in under 1 minute
+  SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -32,10 +35,6 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-        env:
-          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
-          # Cache downloads for this workflow consistently run in under 1 minute
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - main
 
+env:
+  # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+  # Cache downloads for this workflow consistently run in under 1 minute
+  SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
@@ -37,10 +42,6 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: changelog-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        env:
-          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
-          # Cache downloads for this workflow consistently run in under 1 minute
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
 
       - name: Ensure no changes to the CHANGELOG
         run: |

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+  # Cache downloads for this workflow consistently run in under 2 minutes
+  SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
+
 jobs:
   setup-environment:
     timeout-minutes: 30
@@ -33,10 +38,6 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
           key: loadtest-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        env:
-          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
-          # Cache downloads for this workflow consistently run in under 2 minutes
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
       - name: Install Dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
+  # Cache downloads for this workflow consistently run in under 1 minute
+  SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
+
 jobs:
   prometheus-compliance-tests:
     runs-on: ubuntu-latest
@@ -32,10 +37,6 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
           key: prometheus-${{ runner.os }}-go-${{ hashFiles('**/go.mod', '**/go.sum') }}
-        env:
-          # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
-          # Cache downloads for this workflow consistently run in under 1 minute
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5
       - run: make otelcontribcol
         working-directory: opentelemetry-collector-contrib
       - name: Checkout compliance repo


### PR DESCRIPTION
This is a followup to #13453, which applied the timeout only to the one cache step per workflow. Rather than apply this to each actions/cache step, this PR just applies the env var across the entire workflow.