### PR TITLE
[chore] prometheusreceiver: simplify Append logic

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -152,14 +152,13 @@ func TestTransactionAppendDuplicateLabels(t *testing.T) {
 		model.JobLabel, "test",
 		model.MetricNameLabel, "counter_test",
 		"a", "1",
-		"a", "1",
+		"a", "6",
 		"z", "9",
-		"z", "1",
 	)
 
 	_, err := tr.Append(0, dupLabels, 1917, 1.0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `invalid sample: non-unique label names: ["a" "z"]`)
+	assert.Contains(t, err.Error(), `invalid sample: non-unique label names: "a"`)
 }
 
 func TestTransactionAppendHistogramNoLe(t *testing.T) {


### PR DESCRIPTION
* Remove duplicate logic to determine duplicates in labels, downside is that only the first one is determined.
* Combine AddDataPoint with Append, remove duplicate calls to Get metric name.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
