### PR TITLE
[receiver/mongodbatlas] Fix log parsing for v4.2 clusters

### DIFF
--- a/receiver/mongodbatlasreceiver/internal/model/logs.go
+++ b/receiver/mongodbatlasreceiver/internal/model/logs.go
@@ -14,7 +14,9 @@
 
 package model // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
 
-// LogEntry represents a MongoDB Atlas JSON log entry
+import (
+	"encoding/json"
+) // LogEntry represents a MongoDB Atlas JSON log entry
 type LogEntry struct {
 	Timestamp  LogTimestamp           `json:"t"`
 	Severity   string                 `json:"s"`
@@ -23,6 +25,19 @@ type LogEntry struct {
 	Context    string                 `json:"ctx"`
 	Message    string                 `json:"msg"`
 	Attributes map[string]interface{} `json:"attr"`
+	Raw        *string                `json:"-"`
+}
+
+// RawLog returns a raw representation of the log entry.
+// In the case of console logs, this is the actual log line.
+// In the case of JSON logs, it is reconstructed (re-marshaled) after being unmarshalled
+func (l LogEntry) RawLog() (string, error) {
+	if l.Raw != nil {
+		return *l.Raw, nil
+	}
+
+	data, err := json.Marshal(l)
+	return string(data), err
 }
 
 // AuditLog represents a MongoDB Atlas JSON audit log entry

--- a/receiver/mongodbatlasreceiver/internal/model/logs.go
+++ b/receiver/mongodbatlasreceiver/internal/model/logs.go
@@ -16,7 +16,9 @@ package model // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"encoding/json"
-) // LogEntry represents a MongoDB Atlas JSON log entry
+)
+
+// LogEntry represents a MongoDB Atlas JSON log entry
 type LogEntry struct {
 	Timestamp  LogTimestamp           `json:"t"`
 	Severity   string                 `json:"s"`
@@ -25,7 +27,8 @@ type LogEntry struct {
 	Context    string                 `json:"ctx"`
 	Message    string                 `json:"msg"`
 	Attributes map[string]interface{} `json:"attr"`
-	Raw        *string                `json:"-"`
+	// Raw, if it is present, is the original log line. It is not a part of the payload, but transient data added during decoding.
+	Raw *string `json:"-"`
 }
 
 // RawLog returns a raw representation of the log entry.

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -21,11 +21,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
 )
 
 func TestDecode4_2(t *testing.T) {

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -24,9 +24,7 @@ func TestDecode4_2(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, gzipWriter.Close())
 
-	decoder := decoderForVersion(zaptest.NewLogger(t), "4.2")
-
-	entries, err := decoder.Decode(zippedBuffer)
+	entries, err := decodeLogs(zaptest.NewLogger(t), "4.2", zippedBuffer)
 	require.NoError(t, err)
 
 	require.Equal(t, []model.LogEntry{
@@ -74,9 +72,7 @@ func TestDecode4_2InvalidLog(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, gzipWriter.Close())
 
-	decoder := decoderForVersion(zaptest.NewLogger(t), "4.2")
-
-	entries, err := decoder.Decode(zippedBuffer)
+	entries, err := decodeLogs(zaptest.NewLogger(t), "4.2", zippedBuffer)
 	require.NoError(t, err)
 
 	require.Equal(t, []model.LogEntry{
@@ -104,8 +100,7 @@ func TestDecode4_2InvalidLog(t *testing.T) {
 }
 
 func TestDecode4_2NotGzip(t *testing.T) {
-	decoder := decoderForVersion(zaptest.NewLogger(t), "4.2")
-	entries, err := decoder.Decode(bytes.NewBuffer([]byte("Not compressed log")))
+	entries, err := decodeLogs(zaptest.NewLogger(t), "4.2", bytes.NewBuffer([]byte("Not compressed log")))
 	require.ErrorContains(t, err, "gzip: invalid header")
 	require.Nil(t, entries)
 }
@@ -121,9 +116,7 @@ func TestDecode5_0(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, gzipWriter.Close())
 
-	decoder := decoderForVersion(zaptest.NewLogger(t), "5.0")
-
-	entries, err := decoder.Decode(zippedBuffer)
+	entries, err := decodeLogs(zaptest.NewLogger(t), "5.0", zippedBuffer)
 	require.NoError(t, err)
 
 	require.Equal(t, []model.LogEntry{
@@ -186,9 +179,7 @@ func TestDecode5_0InvalidLog(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, gzipWriter.Close())
 
-	decoder := decoderForVersion(zaptest.NewLogger(t), "5.0")
-
-	entries, err := decoder.Decode(zippedBuffer)
+	entries, err := decodeLogs(zaptest.NewLogger(t), "5.0", zippedBuffer)
 	assert.ErrorContains(t, err, "entry could not be decoded into LogEntry")
 
 	assert.Equal(t, []model.LogEntry{
@@ -212,8 +203,7 @@ func TestDecode5_0InvalidLog(t *testing.T) {
 }
 
 func TestDecode5_0NotGzip(t *testing.T) {
-	decoder := decoderForVersion(zaptest.NewLogger(t), "5.0")
-	entries, err := decoder.Decode(bytes.NewBuffer([]byte("Not compressed log")))
+	entries, err := decodeLogs(zaptest.NewLogger(t), "5.0", bytes.NewBuffer([]byte("Not compressed log")))
 	require.ErrorContains(t, err, "gzip: invalid header")
 	require.Nil(t, entries)
 }

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -1,3 +1,17 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlasreceiver
 
 import (
@@ -8,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"

--- a/receiver/mongodbatlasreceiver/log_decoder.go
+++ b/receiver/mongodbatlasreceiver/log_decoder.go
@@ -23,9 +23,9 @@ import (
 	"io"
 	"regexp"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
-
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
 )
 
 func decodeLogs(logger *zap.Logger, clusterMajorVersion string, r io.Reader) ([]model.LogEntry, error) {

--- a/receiver/mongodbatlasreceiver/log_decoder.go
+++ b/receiver/mongodbatlasreceiver/log_decoder.go
@@ -1,3 +1,17 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlasreceiver
 
 import (
@@ -10,6 +24,7 @@ import (
 	"regexp"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
+
 	"go.uber.org/zap"
 )
 

--- a/receiver/mongodbatlasreceiver/log_decoder.go
+++ b/receiver/mongodbatlasreceiver/log_decoder.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mongodbatlasreceiver
+package mongodbatlasreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver"
 
 import (
 	"bufio"

--- a/receiver/mongodbatlasreceiver/log_decoder.go
+++ b/receiver/mongodbatlasreceiver/log_decoder.go
@@ -1,0 +1,124 @@
+package mongodbatlasreceiver
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
+	"go.uber.org/zap"
+)
+
+// logDecoder is an interface that decodes logs from an io.Reader into LogEntry structs.
+type logDecoder interface {
+	Decode(r io.Reader) ([]model.LogEntry, error)
+}
+
+func decoderForVersion(logger *zap.Logger, clusterMajorVersion string) logDecoder {
+	var decoder logDecoder
+	switch clusterMajorVersion {
+	case mongoDBMajorVersion4_2:
+		// 4.2 clusters use a console log format
+		decoder = newConsoleLogDecoder(logger.Named("consoledecoder"))
+	default:
+		// All other versions use JSON logging
+		decoder = newJSONLogDecoder(logger.Named("jsondecoder"))
+	}
+
+	return decoder
+}
+
+// jsonLogDecoder is a logDecoder that decodes JSON formatted mongodb logs.
+// This is the format used for mongodb 4.4+
+type jsonLogDecoder struct {
+	logger *zap.Logger
+}
+
+func newJSONLogDecoder(logger *zap.Logger) *jsonLogDecoder {
+	return &jsonLogDecoder{
+		logger: logger,
+	}
+}
+
+func (j *jsonLogDecoder) Decode(r io.Reader) ([]model.LogEntry, error) {
+	// Pass this into a gzip reader for decoding
+	reader, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Logs are in JSON format so create a JSON decoder to process them
+	dec := json.NewDecoder(reader)
+
+	var entries []model.LogEntry
+	for {
+		var entry model.LogEntry
+		err := dec.Decode(&entry)
+		if errors.Is(err, io.EOF) {
+			return entries, nil
+		}
+		if err != nil {
+			return entries, fmt.Errorf("entry could not be decoded into LogEntry: %w", err)
+		}
+
+		entries = append(entries, entry)
+	}
+}
+
+var consoleLogRegex = regexp.MustCompile(`^(?P<timestamp>\S+)\s+(?P<severity>\w+)\s+(?P<component>[\w-]+)\s+\[(?P<context>\S+)\]\s+(?P<message>.*)$`)
+
+// consoleLogDecoder is a logDecoder that decodes "console" formatted mongodb logs.
+// This is the format used for mongodb 4.2
+type consoleLogDecoder struct {
+	logger *zap.Logger
+}
+
+func newConsoleLogDecoder(logger *zap.Logger) *consoleLogDecoder {
+	return &consoleLogDecoder{
+		logger: logger,
+	}
+}
+
+func (c *consoleLogDecoder) Decode(r io.Reader) ([]model.LogEntry, error) {
+
+	// Pass this into a gzip reader for decoding
+	gzipReader, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(gzipReader)
+	var entries []model.LogEntry
+	for {
+		if !scanner.Scan() {
+			// Scan failed; This might just be EOF, in which case Err will be nil, or it could be some other IO error.
+			return entries, scanner.Err()
+		}
+
+		submatches := consoleLogRegex.FindSubmatch(scanner.Bytes())
+		if submatches == nil || len(submatches) != 6 {
+			// Match failed for line
+			c.logger.Error("Entry did not match regex", zap.String("entry", scanner.Text()))
+			continue
+		}
+
+		rawLog := string(submatches[0])
+
+		entry := model.LogEntry{
+			Timestamp: model.LogTimestamp{
+				Date: string(submatches[1]),
+			},
+			Severity:  string(submatches[2]),
+			Component: string(submatches[3]),
+			Context:   string(submatches[4]),
+			Message:   string(submatches[5]),
+			Raw:       &rawLog,
+		}
+
+		entries = append(entries, entry)
+	}
+}

--- a/receiver/mongodbatlasreceiver/log_decoder_test.go
+++ b/receiver/mongodbatlasreceiver/log_decoder_test.go
@@ -1,0 +1,223 @@
+package mongodbatlasreceiver
+
+import (
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestDecode4_2(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("testdata", "logs", "sample-payloads", "4.2.log"))
+	require.NoError(t, err)
+
+	zippedBuffer := &bytes.Buffer{}
+	gzipWriter := gzip.NewWriter(zippedBuffer)
+
+	_, err = gzipWriter.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+
+	decoder := decoderForVersion(zaptest.NewLogger(t), "4.2")
+
+	entries, err := decoder.Decode(zippedBuffer)
+	require.NoError(t, err)
+
+	require.Equal(t, []model.LogEntry{
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:02.541+0000",
+			},
+			Severity:  "I",
+			Component: "NETWORK",
+			Context:   "listener",
+			Message:   "connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)",
+			Raw:       strp("2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)"),
+		},
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:02.541+0000",
+			},
+			Severity:  "I",
+			Component: "NETWORK",
+			Context:   "listener",
+			Message:   "connection accepted from 192.168.248.5:51974 #25289 (32 connections now open)",
+			Raw:       strp("2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51974 #25289 (32 connections now open)"),
+		},
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:02.563+0000",
+			},
+			Severity:  "I",
+			Component: "NETWORK",
+			Context:   "conn25289",
+			Message:   `received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`,
+			Raw:       strp(`2022-09-11T18:53:02.563+0000 I  NETWORK  [conn25289] received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`),
+		},
+	}, entries)
+}
+
+func TestDecode4_2InvalidLog(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("testdata", "logs", "sample-payloads", "4.2_invalid_log.log"))
+	require.NoError(t, err)
+
+	zippedBuffer := &bytes.Buffer{}
+	gzipWriter := gzip.NewWriter(zippedBuffer)
+
+	_, err = gzipWriter.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+
+	decoder := decoderForVersion(zaptest.NewLogger(t), "4.2")
+
+	entries, err := decoder.Decode(zippedBuffer)
+	require.NoError(t, err)
+
+	require.Equal(t, []model.LogEntry{
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:02.541+0000",
+			},
+			Severity:  "I",
+			Component: "NETWORK",
+			Context:   "listener",
+			Message:   "connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)",
+			Raw:       strp("2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)"),
+		},
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:02.563+0000",
+			},
+			Severity:  "I",
+			Component: "NETWORK",
+			Context:   "conn25289",
+			Message:   `received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`,
+			Raw:       strp(`2022-09-11T18:53:02.563+0000 I  NETWORK  [conn25289] received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`),
+		},
+	}, entries)
+}
+
+func TestDecode4_2NotGzip(t *testing.T) {
+	decoder := decoderForVersion(zaptest.NewLogger(t), "4.2")
+	entries, err := decoder.Decode(bytes.NewBuffer([]byte("Not compressed log")))
+	require.ErrorContains(t, err, "gzip: invalid header")
+	require.Nil(t, entries)
+}
+
+func TestDecode5_0(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("testdata", "logs", "sample-payloads", "5.0.log"))
+	require.NoError(t, err)
+
+	zippedBuffer := &bytes.Buffer{}
+	gzipWriter := gzip.NewWriter(zippedBuffer)
+
+	_, err = gzipWriter.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+
+	decoder := decoderForVersion(zaptest.NewLogger(t), "5.0")
+
+	entries, err := decoder.Decode(zippedBuffer)
+	require.NoError(t, err)
+
+	require.Equal(t, []model.LogEntry{
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:14.675+00:00",
+			},
+			Severity:  "I",
+			Component: "NETWORK",
+			ID:        22944,
+			Context:   "conn35107",
+			Message:   "Connection ended",
+			Attributes: map[string]interface{}{
+				"remote":          "192.168.248.2:52066",
+				"uuid":            "d3f4641a-14ca-4a24-b5bb-7d7b391a02e7",
+				"connectionId":    float64(35107),
+				"connectionCount": float64(33),
+			},
+		},
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:14.676+00:00",
+			},
+			Severity:  "I",
+			Component: "NETWORK",
+			ID:        22944,
+			Context:   "conn35109",
+			Message:   "Connection ended",
+			Attributes: map[string]interface{}{
+				"remote":          "192.168.248.2:52070",
+				"uuid":            "dcdb08ac-981d-41ea-9d6b-f85fe0475bd1",
+				"connectionId":    float64(35109),
+				"connectionCount": float64(32),
+			},
+		},
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:37.727+00:00",
+			},
+			Severity:  "I",
+			Component: "SHARDING",
+			ID:        20997,
+			Context:   "conn9957",
+			Message:   "Refreshed RWC defaults",
+			Attributes: map[string]interface{}{
+				"newDefaults": map[string]interface{}{},
+			},
+		},
+	}, entries)
+}
+
+func TestDecode5_0InvalidLog(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("testdata", "logs", "sample-payloads", "5.0_invalid_log.log"))
+	require.NoError(t, err)
+
+	zippedBuffer := &bytes.Buffer{}
+	gzipWriter := gzip.NewWriter(zippedBuffer)
+
+	_, err = gzipWriter.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+
+	decoder := decoderForVersion(zaptest.NewLogger(t), "5.0")
+
+	entries, err := decoder.Decode(zippedBuffer)
+	assert.ErrorContains(t, err, "entry could not be decoded into LogEntry")
+
+	assert.Equal(t, []model.LogEntry{
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:14.675+00:00",
+			},
+			Severity:  "I",
+			Component: "NETWORK",
+			ID:        22944,
+			Context:   "conn35107",
+			Message:   "Connection ended",
+			Attributes: map[string]interface{}{
+				"remote":          "192.168.248.2:52066",
+				"uuid":            "d3f4641a-14ca-4a24-b5bb-7d7b391a02e7",
+				"connectionId":    float64(35107),
+				"connectionCount": float64(33),
+			},
+		},
+	}, entries)
+}
+
+func TestDecode5_0NotGzip(t *testing.T) {
+	decoder := decoderForVersion(zaptest.NewLogger(t), "5.0")
+	entries, err := decoder.Decode(bytes.NewBuffer([]byte("Not compressed log")))
+	require.ErrorContains(t, err, "gzip: invalid header")
+	require.Nil(t, entries)
+}
+
+func strp(s string) *string {
+	return &s
+}

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -34,6 +34,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
 )
 
+const mongoDBMajorVersion4_2 = "4.2"
+
 type logsReceiver struct {
 	log         *zap.Logger
 	cfg         *Config
@@ -174,8 +176,8 @@ func (s *logsReceiver) collectClusterLogs(clusters []mongodbatlas.Cluster, proje
 	for _, cluster := range clusters {
 		hostnames := parseHostNames(cluster.ConnectionStrings.Standard, s.log)
 		for _, hostname := range hostnames {
-			s.collectLogs(pc, hostname, "mongodb.gz", cluster.Name)
-			s.collectLogs(pc, hostname, "mongos.gz", cluster.Name)
+			s.collectLogs(pc, hostname, "mongodb.gz", cluster.Name, cluster.MongoDBMajorVersion)
+			s.collectLogs(pc, hostname, "mongos.gz", cluster.Name, cluster.MongoDBMajorVersion)
 
 			if projectCfg.EnableAuditLogs {
 				s.collectAuditLogs(pc, hostname, "mongodb-audit-log.gz", cluster.Name)
@@ -201,34 +203,14 @@ func filterClusters(clusters []mongodbatlas.Cluster, clusterNames []string, incl
 	return filtered
 }
 
-func (s *logsReceiver) getHostLogs(groupID, hostname, logName string) ([]model.LogEntry, error) {
+func (s *logsReceiver) getHostLogs(groupID, hostname, logName string, decoder logDecoder) ([]model.LogEntry, error) {
 	// Get gzip bytes buffer from API
 	buf, err := s.client.GetLogs(context.Background(), groupID, hostname, logName, s.start, s.end)
 	if err != nil {
 		return nil, err
 	}
-	// Pass this into a gzip reader for decoding
-	reader, err := gzip.NewReader(buf)
-	if err != nil {
-		return nil, err
-	}
 
-	// Logs are in JSON format so create a JSON decoder to process them
-	dec := json.NewDecoder(reader)
-
-	var entries []model.LogEntry
-	for {
-		var entry model.LogEntry
-		err := dec.Decode(&entry)
-		if errors.Is(err, io.EOF) {
-			return entries, nil
-		}
-		if err != nil {
-			s.log.Error("Entry could not be decoded into LogEntry", zap.Error(err))
-		}
-
-		entries = append(entries, entry)
-	}
+	return decoder.Decode(buf)
 }
 
 func (s *logsReceiver) getHostAuditLogs(groupID, hostname, logName string) ([]model.AuditLog, error) {
@@ -259,8 +241,9 @@ func (s *logsReceiver) getHostAuditLogs(groupID, hostname, logName string) ([]mo
 	}
 }
 
-func (s *logsReceiver) collectLogs(pc ProjectContext, hostname, logName, clusterName string) {
-	logs, err := s.getHostLogs(pc.Project.ID, hostname, logName)
+func (s *logsReceiver) collectLogs(pc ProjectContext, hostname, logName, clusterName, clusterMajorVersion string) {
+	decoder := decoderForVersion(s.log, clusterMajorVersion)
+	logs, err := s.getHostLogs(pc.Project.ID, hostname, logName, decoder)
 	if err != nil && !errors.Is(err, io.EOF) {
 		s.log.Warn("Failed to retrieve logs from: "+logName, zap.Error(err))
 	}
@@ -270,7 +253,8 @@ func (s *logsReceiver) collectLogs(pc ProjectContext, hostname, logName, cluster
 		pc,
 		hostname,
 		logName,
-		clusterName)
+		clusterName,
+		clusterMajorVersion)
 	err = s.consumer.ConsumeLogs(context.Background(), plog)
 	if err != nil {
 		s.log.Error("Failed to consume logs", zap.Error(err))

--- a/receiver/mongodbatlasreceiver/mongodb_event_to_logdata_test.go
+++ b/receiver/mongodbatlasreceiver/mongodb_event_to_logdata_test.go
@@ -19,42 +19,69 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
 )
 
-func TestMongoeventToLogData(t *testing.T) {
-	mongoevent := GetTestEvent()
+func TestMongoeventToLogData4_4(t *testing.T) {
+	mongoevent := GetTestEvent4_4()
 	pc := ProjectContext{
 		orgName: "Org",
 		Project: mongodbatlas.Project{Name: "Project"},
 	}
 
-	ld := mongodbEventToLogData(zap.NewNop(), []model.LogEntry{mongoevent}, pc, "hostname", "clusterName", "logName")
+	ld := mongodbEventToLogData(zap.NewNop(), []model.LogEntry{mongoevent}, pc, "hostname", "clusterName", "logName", "4.4")
 	rl := ld.ResourceLogs().At(0)
 	resourceAttrs := rl.Resource().Attributes()
-	lr := rl.ScopeLogs().At(0)
-	attrs := lr.LogRecords().At(0).Attributes()
+	sl := rl.ScopeLogs().At(0)
+	lr := sl.LogRecords().At(0)
+	attrs := lr.Attributes()
 	assert.Equal(t, ld.ResourceLogs().Len(), 1)
 	assert.Equal(t, resourceAttrs.Len(), 4)
 	assert.Equal(t, attrs.Len(), 9)
+	assert.Equal(t, pcommon.Timestamp(1663006227215000000), lr.Timestamp())
+	_, exists := attrs.Get("id")
+	assert.True(t, exists, "expected attribute id to exist, but it didn't")
 
 	// Count attribute will not be present in the LogData
-	ld = mongodbEventToLogData(zap.NewNop(), []model.LogEntry{mongoevent}, pc, "hostname", "clusterName", "logName")
+	ld = mongodbEventToLogData(zap.NewNop(), []model.LogEntry{mongoevent}, pc, "hostname", "clusterName", "logName", "4.4")
 	assert.Equal(t, ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Len(), 9)
 }
 
+func TestMongoeventToLogData4_2(t *testing.T) {
+	mongoevent := GetTestEvent4_2()
+	pc := ProjectContext{
+		orgName: "Org",
+		Project: mongodbatlas.Project{Name: "Project"},
+	}
+
+	ld := mongodbEventToLogData(zaptest.NewLogger(t), []model.LogEntry{mongoevent}, pc, "hostname", "clusterName", "logName", "4.2")
+	rl := ld.ResourceLogs().At(0)
+	resourceAttrs := rl.Resource().Attributes()
+	sl := rl.ScopeLogs().At(0)
+	lr := sl.LogRecords().At(0)
+	attrs := lr.Attributes()
+	assert.Equal(t, ld.ResourceLogs().Len(), 1)
+	assert.Equal(t, resourceAttrs.Len(), 4)
+	assert.Equal(t, attrs.Len(), 5)
+	assert.Equal(t, pcommon.Timestamp(1663004293902000000), lr.Timestamp())
+	_, exists := attrs.Get("id")
+	assert.False(t, exists, "expected attribute id to not exist, but it did")
+}
+
 func TestUnknownSeverity(t *testing.T) {
-	mongoevent := GetTestEvent()
+	mongoevent := GetTestEvent4_4()
 	mongoevent.Severity = "Unknown"
 	pc := ProjectContext{
 		orgName: "Org",
 		Project: mongodbatlas.Project{Name: "Project"},
 	}
 
-	ld := mongodbEventToLogData(zap.NewNop(), []model.LogEntry{mongoevent}, pc, "hostname", "clusterName", "logName")
+	ld := mongodbEventToLogData(zap.NewNop(), []model.LogEntry{mongoevent}, pc, "hostname", "clusterName", "logName", "4.4")
 	rl := ld.ResourceLogs().At(0)
 	logEntry := rl.ScopeLogs().At(0).LogRecords().At(0)
 
@@ -82,14 +109,29 @@ func TestMongoEventToAuditLogData(t *testing.T) {
 	assert.Equal(t, 12, ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Len())
 }
 
-func GetTestEvent() model.LogEntry {
+func GetTestEvent4_4() model.LogEntry {
 	return model.LogEntry{
+		Timestamp: model.LogTimestamp{
+			Date: "2022-09-12T18:10:27.215+00:00",
+		},
 		Severity:   "I",
 		Component:  "NETWORK",
 		ID:         12312,
 		Context:    "context",
 		Message:    "Connection ended",
 		Attributes: map[string]interface{}{"connectionCount": 47, "connectionId": 9052, "remote": "192.168.253.105:59742", "id": "93a8f190-afd0-422d-9de6-f6c5e833e35f"},
+	}
+}
+
+func GetTestEvent4_2() model.LogEntry {
+	return model.LogEntry{
+		Severity:  "I",
+		Component: "NETWORK",
+		Context:   "context",
+		Message:   "Connection ended",
+		Timestamp: model.LogTimestamp{
+			Date: "2022-09-12T17:38:13.902+0000",
+		},
 	}
 }
 

--- a/receiver/mongodbatlasreceiver/testdata/logs/sample-payloads/4.2.log
+++ b/receiver/mongodbatlasreceiver/testdata/logs/sample-payloads/4.2.log
@@ -1,0 +1,3 @@
+2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)
+2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51974 #25289 (32 connections now open)
+2022-09-11T18:53:02.563+0000 I  NETWORK  [conn25289] received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }

--- a/receiver/mongodbatlasreceiver/testdata/logs/sample-payloads/4.2_invalid_log.log
+++ b/receiver/mongodbatlasreceiver/testdata/logs/sample-payloads/4.2_invalid_log.log
@@ -1,0 +1,3 @@
+2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)
+2022-09-11T18:53:02.541+0000 I  NETWORK connection accepted from 192.168.248.5:51974 #25289 (32 connections now open)
+2022-09-11T18:53:02.563+0000 I  NETWORK  [conn25289] received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }

--- a/receiver/mongodbatlasreceiver/testdata/logs/sample-payloads/5.0.log
+++ b/receiver/mongodbatlasreceiver/testdata/logs/sample-payloads/5.0.log
@@ -1,0 +1,3 @@
+{"t":{"$date":"2022-09-11T18:53:14.675+00:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn35107","msg":"Connection ended","attr":{"remote":"192.168.248.2:52066","uuid":"d3f4641a-14ca-4a24-b5bb-7d7b391a02e7","connectionId":35107,"connectionCount":33}}
+{"t":{"$date":"2022-09-11T18:53:14.676+00:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn35109","msg":"Connection ended","attr":{"remote":"192.168.248.2:52070","uuid":"dcdb08ac-981d-41ea-9d6b-f85fe0475bd1","connectionId":35109,"connectionCount":32}}
+{"t":{"$date":"2022-09-11T18:53:37.727+00:00"},"s":"I",  "c":"SHARDING", "id":20997,   "ctx":"conn9957","msg":"Refreshed RWC defaults","attr":{"newDefaults":{}}}

--- a/receiver/mongodbatlasreceiver/testdata/logs/sample-payloads/5.0_invalid_log.log
+++ b/receiver/mongodbatlasreceiver/testdata/logs/sample-payloads/5.0_invalid_log.log
@@ -1,0 +1,3 @@
+{"t":{"$date":"2022-09-11T18:53:14.675+00:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn35107","msg":"Connection ended","attr":{"remote":"192.168.248.2:52066","uuid":"d3f4641a-14ca-4a24-b5bb-7d7b391a02e7","connectionId":35107,"connectionCount":33}}
+"t":{"$date":"2022-09-11T18:53:14.676+00:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn35109","msg":"Connection ended","attr":{"remote":"192.168.248.2:52070","uuid":"dcdb08ac-981d-41ea-9d6b-f85fe0475bd1","connectionId":35109,"connectionCount":32}}
+{"t":{"$date":"2022-09-11T18:53:37.727+00:00"},"s":"I",  "c":"SHARDING", "id":20997,   "ctx":"conn9957","msg":"Refreshed RWC defaults","attr":{"newDefaults":{}}}

--- a/unreleased/mongodb-atlas-4_2-logging.yaml
+++ b/unreleased/mongodb-atlas-4_2-logging.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix log parsing for clusters using major version 4.2
+
+# One or more tracking issues related to the change
+issues: [14008]


### PR DESCRIPTION
**Description:**
* Add in support for parsing logs from v4.2 clusters

MongoDB Atlas supports multiple MongoDB versions. v4.2 was the last version to use a non-structured log (https://www.mongodb.com/docs/v4.2/reference/log-messages/) - the next supported version begins using structured logging (https://www.mongodb.com/docs/v4.4/reference/log-messages/).

This means that v4.2 host logs must be parsed differently. Audit logs have remained JSON between versions (for 4.2: https://www.mongodb.com/docs/v4.2/reference/audit-message/#audit-message), so they didn't require any change to parse.

**Link to tracking Issue:** Resolves #14008

**Testing:**
* Added unit tests with sample data for decoding
* Manually tested against both a v4.2 cluster and v5.0 cluster