### PR TITLE
[pkg/stanza] Allow 'parse_to' fields to accept 'attributes' and 'resource'

### DIFF
--- a/pkg/stanza/entry/field_test.go
+++ b/pkg/stanza/entry/field_test.go
@@ -155,19 +155,19 @@ func TestFieldUnmarshalJSON(t *testing.T) {
 			switch {
 			case tc.expectedErrRootable != "":
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expected)
+				require.Contains(t, err.Error(), tc.expectedErr)
 				require.Error(t, errRootable)
-				require.Contains(t, errRootable.Error(), tc.expected)
+				require.Contains(t, errRootable.Error(), tc.expectedErrRootable)
 			case tc.expectedErr != "":
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expected)
+				require.Contains(t, err.Error(), tc.expectedErr)
 				require.NoError(t, errRootable)
-				require.Equal(t, tc.expected, rootableField)
+				require.Equal(t, tc.expected, rootableField.Field)
 			default:
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, field)
 				require.NoError(t, errRootable)
-				require.Equal(t, tc.expected, rootableField)
+				require.Equal(t, tc.expected, rootableField.Field)
 			}
 		})
 	}

--- a/pkg/stanza/entry/field_test.go
+++ b/pkg/stanza/entry/field_test.go
@@ -24,147 +24,151 @@ import (
 
 func TestFieldUnmarshalJSON(t *testing.T) {
 	cases := []struct {
-		name     string
-		input    []byte
-		expected Field
+		name                string
+		input               []byte
+		expected            Field
+		expectedErr         string
+		expectedErrRootable string
 	}{
 		{
-			"BodyLong",
-			[]byte(`"body"`),
-			NewBodyField(),
+			name:     "BodyLong",
+			input:    []byte(`"body"`),
+			expected: NewBodyField(),
 		},
 		{
-			"SimpleField",
-			[]byte(`"body.test1"`),
-			NewBodyField("test1"),
+			name:     "SimpleField",
+			input:    []byte(`"body.test1"`),
+			expected: NewBodyField("test1"),
 		},
 		{
-			"ComplexField",
-			[]byte(`"body.test1.test2"`),
-			NewBodyField("test1", "test2"),
+			name:     "ComplexField",
+			input:    []byte(`"body.test1.test2"`),
+			expected: NewBodyField("test1", "test2"),
 		},
 		{
-			"BracketedField",
-			[]byte(`"body.test1['file.name']"`),
-			NewBodyField("test1", "file.name"),
+			name:     "BracketedField",
+			input:    []byte(`"body.test1['file.name']"`),
+			expected: NewBodyField("test1", "file.name"),
 		},
 		{
-			"DoubleBracketedField",
-			[]byte(`"body.test1['file.details']['file.name']"`),
-			NewBodyField("test1", "file.details", "file.name"),
+			name:     "DoubleBracketedField",
+			input:    []byte(`"body.test1['file.details']['file.name']"`),
+			expected: NewBodyField("test1", "file.details", "file.name"),
 		},
 		{
-			"PostBracketField",
-			[]byte(`"body.test1['file.details'].name"`),
-			NewBodyField("test1", "file.details", "name"),
+			name:     "PostBracketField",
+			input:    []byte(`"body.test1['file.details'].name"`),
+			expected: NewBodyField("test1", "file.details", "name"),
 		},
 		{
-			"AttributesSimpleField",
-			[]byte(`"attributes.test1"`),
-			NewAttributeField("test1"),
+			name:     "AttributesSimpleField",
+			input:    []byte(`"attributes.test1"`),
+			expected: NewAttributeField("test1"),
 		},
 		{
-			"AttributesComplexField",
-			[]byte(`"attributes.test1.test2"`),
-			NewAttributeField("test1", "test2"),
+			name:     "AttributesComplexField",
+			input:    []byte(`"attributes.test1.test2"`),
+			expected: NewAttributeField("test1", "test2"),
 		},
 		{
-			"AttributesBracketedField",
-			[]byte(`"attributes.test1['file.name']"`),
-			NewAttributeField("test1", "file.name"),
+			name:     "AttributesBracketedField",
+			input:    []byte(`"attributes.test1['file.name']"`),
+			expected: NewAttributeField("test1", "file.name"),
 		},
 		{
-			"AttributesDoubleBracketedField",
-			[]byte(`"attributes.test1['file.details']['file.name']"`),
-			NewAttributeField("test1", "file.details", "file.name"),
+			name:     "AttributesDoubleBracketedField",
+			input:    []byte(`"attributes.test1['file.details']['file.name']"`),
+			expected: NewAttributeField("test1", "file.details", "file.name"),
 		},
 		{
-			"AttributesPostBracketField",
-			[]byte(`"attributes.test1['file.details'].name"`),
-			NewAttributeField("test1", "file.details", "name"),
+			name:     "AttributesPostBracketField",
+			input:    []byte(`"attributes.test1['file.details'].name"`),
+			expected: NewAttributeField("test1", "file.details", "name"),
 		},
 		{
-			"AttributesSimpleField",
-			[]byte(`"attributes.test1"`),
-			NewAttributeField("test1"),
-		},
-
-		{
-			"ResourceSimpleField",
-			[]byte(`"resource.test1"`),
-			NewResourceField("test1"),
+			name:     "AttributesSimpleField",
+			input:    []byte(`"attributes.test1"`),
+			expected: NewAttributeField("test1"),
 		},
 		{
-			"ResourceComplexField",
-			[]byte(`"resource.test1.test2"`),
-			NewResourceField("test1", "test2"),
+			name:     "ResourceSimpleField",
+			input:    []byte(`"resource.test1"`),
+			expected: NewResourceField("test1"),
 		},
 		{
-			"ResourceBracketedField",
-			[]byte(`"resource.test1['file.name']"`),
-			NewResourceField("test1", "file.name"),
+			name:     "ResourceComplexField",
+			input:    []byte(`"resource.test1.test2"`),
+			expected: NewResourceField("test1", "test2"),
 		},
 		{
-			"ResourceDoubleBracketedField",
-			[]byte(`"resource.test1['file.details']['file.name']"`),
-			NewResourceField("test1", "file.details", "file.name"),
+			name:     "ResourceBracketedField",
+			input:    []byte(`"resource.test1['file.name']"`),
+			expected: NewResourceField("test1", "file.name"),
 		},
 		{
-			"ResourcePostBracketField",
-			[]byte(`"resource.test1['file.details'].name"`),
-			NewResourceField("test1", "file.details", "name"),
+			name:     "ResourceDoubleBracketedField",
+			input:    []byte(`"resource.test1['file.details']['file.name']"`),
+			expected: NewResourceField("test1", "file.details", "file.name"),
 		},
 		{
-			"ResourceSimpleField",
-			[]byte(`"resource.test1"`),
-			NewResourceField("test1"),
+			name:     "ResourcePostBracketField",
+			input:    []byte(`"resource.test1['file.details'].name"`),
+			expected: NewResourceField("test1", "file.details", "name"),
+		},
+		{
+			name:     "ResourceSimpleField",
+			input:    []byte(`"resource.test1"`),
+			expected: NewResourceField("test1"),
+		},
+		{
+			name:        "AttributesRoot",
+			input:       []byte(`"attributes"`),
+			expectedErr: "attributes cannot be referenced without subfield",
+			expected:    NewAttributeField(),
+		},
+		{
+			name:        "ResourceRoot",
+			input:       []byte(`"resource"`),
+			expectedErr: "resource cannot be referenced without subfield",
+			expected:    NewResourceField(),
+		},
+		{
+			name:                "Bool",
+			input:               []byte(`"bool"`),
+			expectedErrRootable: "unrecognized prefix",
+		},
+		{
+			name:                "Object",
+			input:               []byte(`{"key":"value"}`),
+			expectedErrRootable: "cannot unmarshal object into Go value of type string",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var f Field
-			err := json.Unmarshal(tc.input, &f)
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, f)
-		})
-	}
-}
+			var field Field
+			err := json.Unmarshal(tc.input, &field)
 
-func TestFieldUnmarshalJSONFailure(t *testing.T) {
-	cases := []struct {
-		name     string
-		input    []byte
-		expected string
-	}{
-		{
-			"Bool",
-			[]byte(`"bool"`),
-			"unrecognized prefix",
-		},
-		{
-			"Object",
-			[]byte(`{"key":"value"}`),
-			"cannot unmarshal object into Go value of type string",
-		},
-		{
-			"AttributesRoot",
-			[]byte(`"attributes"`),
-			"attributes cannot be referenced without subfield",
-		},
-		{
-			"ResourceRoot",
-			[]byte(`"resource"`),
-			"resource cannot be referenced without subfield",
-		},
-	}
+			var rootableField RootableField
+			errRootable := json.Unmarshal(tc.input, &rootableField)
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			var f Field
-			err := json.Unmarshal(tc.input, &f)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expected)
+			switch {
+			case tc.expectedErrRootable != "":
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expected)
+				require.Error(t, errRootable)
+				require.Contains(t, errRootable.Error(), tc.expected)
+			case tc.expectedErr != "":
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expected)
+				require.NoError(t, errRootable)
+				require.Equal(t, tc.expected, rootableField)
+			default:
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, field)
+				require.NoError(t, errRootable)
+				require.Equal(t, tc.expected, rootableField)
+			}
 		})
 	}
 }

--- a/pkg/stanza/operator/helper/parser.go
+++ b/pkg/stanza/operator/helper/parser.go
@@ -29,21 +29,20 @@ func NewParserConfig(operatorID, operatorType string) ParserConfig {
 	return ParserConfig{
 		TransformerConfig: NewTransformerConfig(operatorID, operatorType),
 		ParseFrom:         entry.NewBodyField(),
-		ParseTo:           entry.NewAttributeField(),
+		ParseTo:           entry.RootableField{Field: entry.NewAttributeField()},
 	}
 }
 
 // ParserConfig provides the basic implementation of a parser config.
 type ParserConfig struct {
 	TransformerConfig `mapstructure:",squash" yaml:",inline"`
-
-	ParseFrom       entry.Field      `mapstructure:"parse_from"          json:"parse_from"          yaml:"parse_from"`
-	ParseTo         entry.Field      `mapstructure:"parse_to"            json:"parse_to"            yaml:"parse_to"`
-	BodyField       *entry.Field     `mapstructure:"body"                json:"body"                yaml:"body"`
-	TimeParser      *TimeParser      `mapstructure:"timestamp,omitempty" json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
-	SeverityConfig  *SeverityConfig  `mapstructure:"severity,omitempty"  json:"severity,omitempty"  yaml:"severity,omitempty"`
-	TraceParser     *TraceParser     `mapstructure:"trace,omitempty"     json:"trace,omitempty"     yaml:"trace,omitempty"`
-	ScopeNameParser *ScopeNameParser `mapstructure:"scope_name,omitempty"     json:"scope_name,omitempty"     yaml:"scope_name,omitempty"`
+	ParseFrom         entry.Field         `mapstructure:"parse_from"          json:"parse_from"          yaml:"parse_from"`
+	ParseTo           entry.RootableField `mapstructure:"parse_to"            json:"parse_to"            yaml:"parse_to"`
+	BodyField         *entry.Field        `mapstructure:"body"                json:"body"                yaml:"body"`
+	TimeParser        *TimeParser         `mapstructure:"timestamp,omitempty" json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+	SeverityConfig    *SeverityConfig     `mapstructure:"severity,omitempty"  json:"severity,omitempty"  yaml:"severity,omitempty"`
+	TraceParser       *TraceParser        `mapstructure:"trace,omitempty"     json:"trace,omitempty"     yaml:"trace,omitempty"`
+	ScopeNameParser   *ScopeNameParser    `mapstructure:"scope_name,omitempty"     json:"scope_name,omitempty"     yaml:"scope_name,omitempty"`
 }
 
 // Build will build a parser operator.
@@ -60,7 +59,7 @@ func (c ParserConfig) Build(logger *zap.SugaredLogger) (ParserOperator, error) {
 	parserOperator := ParserOperator{
 		TransformerOperator: transformerOperator,
 		ParseFrom:           c.ParseFrom,
-		ParseTo:             c.ParseTo,
+		ParseTo:             c.ParseTo.Field,
 		BodyField:           c.BodyField,
 	}
 

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -21,14 +21,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -670,64 +668,6 @@ func NewTestParserConfig() ParserConfig {
 	lnp.ParseFrom = entry.NewBodyField("logger")
 	expect.ScopeNameParser = &lnp
 	return expect
-}
-
-func TestMapStructureDecodeParserConfigWithHook(t *testing.T) {
-	expect := NewTestParserConfig()
-	input := map[string]interface{}{
-		"id":         "parser_config",
-		"type":       "test_type",
-		"on_error":   "send",
-		"parse_from": "body.from",
-		"parse_to":   "body.to",
-		"timestamp": map[string]interface{}{
-			"layout_type": "strptime",
-		},
-		"severity": map[string]interface{}{
-			"mapping": map[interface{}]interface{}{
-				"info": "3xx",
-				"warn": "4xx",
-			},
-		},
-		"scope_name": map[string]interface{}{
-			"parse_from": "body.logger",
-		},
-	}
-
-	var actual ParserConfig
-	dc := &mapstructure.DecoderConfig{Result: &actual, DecodeHook: operatortest.JSONUnmarshalerHook()}
-	ms, err := mapstructure.NewDecoder(dc)
-	require.NoError(t, err)
-	err = ms.Decode(input)
-	require.NoError(t, err)
-	require.Equal(t, expect, actual)
-}
-
-func TestMapStructureDecodeParserConfig(t *testing.T) {
-	expect := NewTestParserConfig()
-	input := map[string]interface{}{
-		"id":         "parser_config",
-		"type":       "test_type",
-		"on_error":   "send",
-		"parse_from": "body.from",
-		"parse_to":   "body.to",
-		"timestamp": map[string]interface{}{
-			"layout_type": "strptime",
-		},
-		"severity": map[string]interface{}{
-			"mapping": map[interface{}]interface{}{
-				"info": "3xx",
-				"warn": "4xx",
-			},
-		},
-		"scope_name": map[string]interface{}{
-			"parse_from": "body.logger",
-		},
-	}
-
-	var actual ParserConfig
-	require.NoError(t, UnmarshalMapstructure(input, &actual))
-	require.Equal(t, expect, actual)
 }
 
 func writerWithFakeOut(t *testing.T) (*WriterOperator, *testutil.FakeOutput) {

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -55,7 +55,7 @@ func TestParserConfigInvalidTimeParser(t *testing.T) {
 
 func TestParserConfigBodyCollision(t *testing.T) {
 	cfg := NewParserConfig("test-id", "test-type")
-	cfg.ParseTo = entry.NewBodyField()
+	cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
 
 	b := entry.NewAttributeField("message")
 	cfg.BodyField = &b
@@ -388,7 +388,7 @@ func TestParserFields(t *testing.T) {
 		{
 			"ParseToBodyRoot",
 			func(cfg *ParserConfig) {
-				cfg.ParseTo = entry.NewBodyField()
+				cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
 			},
 			func() *entry.Entry {
 				e := entry.New()
@@ -408,7 +408,7 @@ func TestParserFields(t *testing.T) {
 		{
 			"ParseToAttributesRoot",
 			func(cfg *ParserConfig) {
-				cfg.ParseTo = entry.NewAttributeField()
+				cfg.ParseTo = entry.RootableField{Field: entry.NewAttributeField()}
 			},
 			func() *entry.Entry {
 				e := entry.New()
@@ -429,7 +429,7 @@ func TestParserFields(t *testing.T) {
 		{
 			"ParseToResourceRoot",
 			func(cfg *ParserConfig) {
-				cfg.ParseTo = entry.NewResourceField()
+				cfg.ParseTo = entry.RootableField{Field: entry.NewResourceField()}
 			},
 			func() *entry.Entry {
 				e := entry.New()
@@ -450,7 +450,7 @@ func TestParserFields(t *testing.T) {
 		{
 			"ParseToBodyField",
 			func(cfg *ParserConfig) {
-				cfg.ParseTo = entry.NewBodyField("one", "two")
+				cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("one", "two")}
 			},
 			func() *entry.Entry {
 				e := entry.New()
@@ -474,7 +474,7 @@ func TestParserFields(t *testing.T) {
 		{
 			"ParseToAttributeField",
 			func(cfg *ParserConfig) {
-				cfg.ParseTo = entry.NewAttributeField("one", "two")
+				cfg.ParseTo = entry.RootableField{Field: entry.NewAttributeField("one", "two")}
 			},
 			func() *entry.Entry {
 				e := entry.New()
@@ -499,7 +499,7 @@ func TestParserFields(t *testing.T) {
 		{
 			"ParseToResourceField",
 			func(cfg *ParserConfig) {
-				cfg.ParseTo = entry.NewResourceField("one", "two")
+				cfg.ParseTo = entry.RootableField{Field: entry.NewResourceField("one", "two")}
 			},
 			func() *entry.Entry {
 				e := entry.New()
@@ -655,7 +655,7 @@ func TestParserFields(t *testing.T) {
 func NewTestParserConfig() ParserConfig {
 	expect := NewParserConfig("parser_config", "test_type")
 	expect.ParseFrom = entry.NewBodyField("from")
-	expect.ParseTo = entry.NewBodyField("to")
+	expect.ParseTo = entry.RootableField{Field: entry.NewBodyField("to")}
 	tp := NewTimeParser()
 	expect.TimeParser = &tp
 
@@ -709,8 +709,8 @@ func TestMapStructureDecodeParserConfig(t *testing.T) {
 		"id":         "parser_config",
 		"type":       "test_type",
 		"on_error":   "send",
-		"parse_from": entry.NewBodyField("from"),
-		"parse_to":   entry.NewBodyField("to"),
+		"parse_from": "body.from",
+		"parse_to":   "body.to",
 		"timestamp": map[string]interface{}{
 			"layout_type": "strptime",
 		},
@@ -721,13 +721,12 @@ func TestMapStructureDecodeParserConfig(t *testing.T) {
 			},
 		},
 		"scope_name": map[string]interface{}{
-			"parse_from": entry.NewBodyField("logger"),
+			"parse_from": "body.logger",
 		},
 	}
 
 	var actual ParserConfig
-	err := mapstructure.Decode(input, &actual)
-	require.NoError(t, err)
+	require.NoError(t, UnmarshalMapstructure(input, &actual))
 	require.Equal(t, expect, actual)
 }
 

--- a/pkg/stanza/operator/parser/csv/config_test.go
+++ b/pkg/stanza/operator/parser/csv/config_test.go
@@ -90,6 +90,30 @@ func TestConfig(t *testing.T) {
 					return p
 				}(),
 			},
+			{
+				Name: "parse_to_attributes",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewAttributeField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_body",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_resource",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewResourceField()}
+					return p
+				}(),
+			},
 		},
 	}.Run(t)
 }

--- a/pkg/stanza/operator/parser/csv/csv_test.go
+++ b/pkg/stanza/operator/parser/csv/csv_test.go
@@ -963,7 +963,7 @@ cc""",dddd,eeee`,
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := NewConfigWithID("test")
-			cfg.ParseTo = entry.NewBodyField()
+			cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
 			cfg.OutputIDs = []string{"fake"}
 			cfg.Header = "A,B,C,D,E"
 

--- a/pkg/stanza/operator/parser/csv/testdata/config.yaml
+++ b/pkg/stanza/operator/parser/csv/testdata/config.yaml
@@ -22,6 +22,15 @@ ignore_quotes:
   parse_from: body.message
   header: id,severity,message
   ignore_quotes: true
+parse_to_attributes:
+  type: csv_parser
+  parse_to: attributes
+parse_to_body:
+  type: csv_parser
+  parse_to: body
+parse_to_resource:
+  type: csv_parser
+  parse_to: resource
 timestamp:
   type: csv_parser
   header: timestamp_field,severity,message

--- a/pkg/stanza/operator/parser/json/config_test.go
+++ b/pkg/stanza/operator/parser/json/config_test.go
@@ -51,7 +51,7 @@ func TestConfig(t *testing.T) {
 				Name: "parse_to_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseTo = entry.NewBodyField("log")
+					cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("log")}
 					return cfg
 				}(),
 			},
@@ -95,6 +95,30 @@ func TestConfig(t *testing.T) {
 					loggerNameParser.ParseFrom = entry.NewBodyField("logger_name_field")
 					cfg.ScopeNameParser = &loggerNameParser
 					return cfg
+				}(),
+			},
+			{
+				Name: "parse_to_attributes",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewAttributeField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_body",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_resource",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewResourceField()}
+					return p
 				}(),
 			},
 		},

--- a/pkg/stanza/operator/parser/json/testdata/config.yaml
+++ b/pkg/stanza/operator/parser/json/testdata/config.yaml
@@ -6,6 +6,15 @@ on_error_drop:
 parse_from_simple:
   type: json_parser
   parse_from: body.from
+parse_to_attributes:
+  type: json_parser
+  parse_to: attributes
+parse_to_body:
+  type: json_parser
+  parse_to: body
+parse_to_resource:
+  type: json_parser
+  parse_to: resource
 parse_to_simple:
   type: json_parser
   parse_to: body.log

--- a/pkg/stanza/operator/parser/keyvalue/config_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/config_test.go
@@ -43,7 +43,7 @@ func TestConfig(t *testing.T) {
 				Name: "parse_to_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseTo = entry.NewBodyField("log")
+					cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("log")}
 					return cfg
 				}(),
 			},
@@ -101,6 +101,30 @@ func TestConfig(t *testing.T) {
 					cfg := NewConfig()
 					cfg.PairDelimiter = ";"
 					return cfg
+				}(),
+			},
+			{
+				Name: "parse_to_attributes",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewAttributeField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_body",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_resource",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewResourceField()}
+					return p
 				}(),
 			},
 		},

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
@@ -204,7 +204,7 @@ func TestParser(t *testing.T) {
 		{
 			"parse-to",
 			func(kv *Config) {
-				kv.ParseTo = entry.NewBodyField("test")
+				kv.ParseTo = entry.RootableField{Field: entry.NewBodyField("test")}
 			},
 			&entry.Entry{
 				Body: "name=stanza age=10",
@@ -224,7 +224,7 @@ func TestParser(t *testing.T) {
 			"from-to",
 			func(kv *Config) {
 				kv.ParseFrom = entry.NewAttributeField("from")
-				kv.ParseTo = entry.NewBodyField("to")
+				kv.ParseTo = entry.RootableField{Field: entry.NewBodyField("to")}
 			},
 			&entry.Entry{
 				Attributes: map[string]interface{}{
@@ -329,7 +329,7 @@ func TestParser(t *testing.T) {
 			func(kv *Config) {
 				kv.Delimiter = "|"
 				kv.ParseFrom = entry.NewBodyField("testfield")
-				kv.ParseTo = entry.NewBodyField("testparsed")
+				kv.ParseTo = entry.RootableField{Field: entry.NewBodyField("testparsed")}
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{

--- a/pkg/stanza/operator/parser/keyvalue/testdata/config.yaml
+++ b/pkg/stanza/operator/parser/keyvalue/testdata/config.yaml
@@ -12,6 +12,15 @@ pair_delimiter:
 parse_from_simple:
   type: key_value_parser
   parse_from: body.from
+parse_to_attributes:
+  type: key_value_parser
+  parse_to: attributes
+parse_to_body:
+  type: key_value_parser
+  parse_to: body
+parse_to_resource:
+  type: key_value_parser
+  parse_to: resource
 parse_to_simple:
   type: key_value_parser
   parse_to: body.log

--- a/pkg/stanza/operator/parser/regex/config_test.go
+++ b/pkg/stanza/operator/parser/regex/config_test.go
@@ -51,7 +51,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseTo = entry.NewBodyField("log")
+					cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("log")}
 					return cfg
 				}(),
 			},
@@ -113,6 +113,30 @@ func TestParserGoldenConfig(t *testing.T) {
 					loggerNameParser.ParseFrom = parseField
 					cfg.ScopeNameParser = &loggerNameParser
 					return cfg
+				}(),
+			},
+			{
+				Name: "parse_to_attributes",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewAttributeField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_body",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_resource",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewResourceField()}
+					return p
 				}(),
 			},
 		},

--- a/pkg/stanza/operator/parser/regex/testdata/config.yaml
+++ b/pkg/stanza/operator/parser/regex/testdata/config.yaml
@@ -10,6 +10,15 @@ on_error_drop:
 parse_from_simple:
   type: regex_parser
   parse_from: "body.from"
+parse_to_attributes:
+  type: regex_parser
+  parse_to: attributes
+parse_to_body:
+  type: regex_parser
+  parse_to: body
+parse_to_resource:
+  type: regex_parser
+  parse_to: resource
 parse_to_simple:
   type: regex_parser
   parse_to: "body.log"

--- a/pkg/stanza/operator/parser/syslog/config_test.go
+++ b/pkg/stanza/operator/parser/syslog/config_test.go
@@ -83,7 +83,7 @@ func TestUnmarshal(t *testing.T) {
 				Expect: func() *Config {
 					cfg := NewConfig()
 					cfg.Protocol = RFC5424
-					cfg.ParseTo = entry.NewBodyField("log")
+					cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("log")}
 					return cfg
 				}(),
 			},

--- a/pkg/stanza/operator/parser/uri/config_test.go
+++ b/pkg/stanza/operator/parser/uri/config_test.go
@@ -43,7 +43,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseTo = entry.NewBodyField("log")
+					cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("log")}
 					return cfg
 				}(),
 			},
@@ -85,6 +85,30 @@ func TestParserGoldenConfig(t *testing.T) {
 					severityField.Mapping = mapping
 					cfg.SeverityConfig = &severityField
 					return cfg
+				}(),
+			},
+			{
+				Name: "parse_to_attributes",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewAttributeField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_body",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
+					return p
+				}(),
+			},
+			{
+				Name: "parse_to_resource",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.ParseTo = entry.RootableField{Field: entry.NewResourceField()}
+					return p
 				}(),
 			},
 		},

--- a/pkg/stanza/operator/parser/uri/testdata/config.yaml
+++ b/pkg/stanza/operator/parser/uri/testdata/config.yaml
@@ -6,6 +6,15 @@ on_error_drop:
 parse_from_simple:
   type: uri_parser
   parse_from: "body.from"
+parse_to_attributes:
+  type: uri_parser
+  parse_to: attributes
+parse_to_body:
+  type: uri_parser
+  parse_to: body
+parse_to_resource:
+  type: uri_parser
+  parse_to: resource
 parse_to_simple:
   type: uri_parser
   parse_to: "body.log"

--- a/pkg/stanza/operator/parser/uri/uri_test.go
+++ b/pkg/stanza/operator/parser/uri/uri_test.go
@@ -104,7 +104,7 @@ func TestProcess(t *testing.T) {
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
-				cfg.ParseTo = entry.NewBodyField("url2")
+				cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("url2")}
 				return cfg.Build(testutil.Logger(t))
 			},
 			&entry.Entry{

--- a/unreleased/rootable-parse-to.yaml
+++ b/unreleased/rootable-parse-to.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelog, journald, syslog, tcplog, udplog, windowseventlog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow 'parse_to' fields to accept 'attributes' and 'resource'
+
+# One or more tracking issues related to the change
+issues: [14089]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
This change enables parsers to parse directly to 'attributes' or 'resource'.

In order to allow alternate validation behavior while unmarshaling, a new RootableField struct was introduced, which wraps the Field struct.

See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10280

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14002