### PR TITLE
[receiver/dockerstats] For V2 implementation, create sensible enabled defaults 

### DIFF
--- a/receiver/dockerstatsreceiver/documentation.md
+++ b/receiver/dockerstatsreceiver/documentation.md
@@ -8,69 +8,69 @@ These are the metrics available for this scraper.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
-| **container.blockio.io_merged_recursive** | Number of bios/requests merged into requests belonging to this cgroup and its descendant cgroups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | {operations} | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
-| **container.blockio.io_queued_recursive** | Number of requests queued up for this cgroup and its descendant cgroups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | {operations} | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
+| container.blockio.io_merged_recursive | Number of bios/requests merged into requests belonging to this cgroup and its descendant cgroups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | {operations} | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
+| container.blockio.io_queued_recursive | Number of requests queued up for this cgroup and its descendant cgroups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | {operations} | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
 | **container.blockio.io_service_bytes_recursive** | Number of bytes transferred to/from the disk by the group and descendant groups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | By | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
-| **container.blockio.io_service_time_recursive** | Total amount of time in nanoseconds between request dispatch and request completion for the IOs done by this cgroup and descendant cgroups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | ns | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
-| **container.blockio.io_serviced_recursive** | Number of IOs (bio) issued to the disk by the group and descendant groups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | {operations} | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
-| **container.blockio.io_time_recursive** | Disk time allocated to cgroup (and descendant cgroups) per device in milliseconds. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | ms | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
-| **container.blockio.io_wait_time_recursive** | Total amount of time the IOs for this cgroup (and descendant cgroups) spent waiting in the scheduler queues for service. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | ns | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
-| **container.blockio.sectors_recursive** | Number of sectors transferred to/from disk by the group and descendant groups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | {sectors} | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
+| container.blockio.io_service_time_recursive | Total amount of time in nanoseconds between request dispatch and request completion for the IOs done by this cgroup and descendant cgroups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | ns | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
+| container.blockio.io_serviced_recursive | Number of IOs (bio) issued to the disk by the group and descendant groups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | {operations} | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
+| container.blockio.io_time_recursive | Disk time allocated to cgroup (and descendant cgroups) per device in milliseconds. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | ms | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
+| container.blockio.io_wait_time_recursive | Total amount of time the IOs for this cgroup (and descendant cgroups) spent waiting in the scheduler queues for service. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | ns | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
+| container.blockio.sectors_recursive | Number of sectors transferred to/from disk by the group and descendant groups. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt). | {sectors} | Sum(Int) | <ul> <li>device_major</li> <li>device_minor</li> <li>operation</li> </ul> |
 | **container.cpu.percent** | Percent of CPU used by the container. | 1 | Gauge(Double) | <ul> </ul> |
-| **container.cpu.throttling_data.periods** | Number of periods with throttling active. | {periods} | Sum(Int) | <ul> </ul> |
-| **container.cpu.throttling_data.throttled_periods** | Number of periods when the container hits its throttling limit. | {periods} | Sum(Int) | <ul> </ul> |
-| **container.cpu.throttling_data.throttled_time** | Aggregate time the container was throttled. | ns | Sum(Int) | <ul> </ul> |
+| container.cpu.throttling_data.periods | Number of periods with throttling active. | {periods} | Sum(Int) | <ul> </ul> |
+| container.cpu.throttling_data.throttled_periods | Number of periods when the container hits its throttling limit. | {periods} | Sum(Int) | <ul> </ul> |
+| container.cpu.throttling_data.throttled_time | Aggregate time the container was throttled. | ns | Sum(Int) | <ul> </ul> |
 | **container.cpu.usage.kernelmode** | Time spent by tasks of the cgroup in kernel mode (Linux).  Time spent by all container processes in kernel mode (Windows). | ns | Sum(Int) | <ul> </ul> |
 | container.cpu.usage.percpu | Per-core CPU usage by the container. | ns | Sum(Int) | <ul> <li>core</li> </ul> |
 | **container.cpu.usage.system** | System CPU usage. | ns | Sum(Int) | <ul> </ul> |
 | **container.cpu.usage.total** | Total CPU time consumed. | ns | Sum(Int) | <ul> </ul> |
 | **container.cpu.usage.usermode** | Time spent by tasks of the cgroup in user mode (Linux).  Time spent by all container processes in user mode (Windows). | ns | Sum(Int) | <ul> </ul> |
-| **container.memory.active_anon** | The amount of anonymous memory that has been identified as active by the kernel. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.active_file** | Cache memory that has been identified as active by the kernel. [More docs](https://docs.docker.com/config/containers/runmetrics/) | By | Sum(Int) | <ul> </ul> |
-| **container.memory.cache** | The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.dirty** | Bytes that are waiting to get written back to the disk, from this cgroup. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.hierarchical_memory_limit** | The maximum amount of physical memory that can be used by the processes of this control group. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.hierarchical_memsw_limit** | The maximum amount of RAM + swap that can be used by the processes of this control group. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.inactive_anon** | The amount of anonymous memory that has been identified as inactive by the kernel. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.inactive_file** | Cache memory that has been identified as inactive by the kernel. [More docs](https://docs.docker.com/config/containers/runmetrics/) | By | Sum(Int) | <ul> </ul> |
-| **container.memory.mapped_file** | Indicates the amount of memory mapped by the processes in the control group. | By | Sum(Int) | <ul> </ul> |
+| container.memory.active_anon | The amount of anonymous memory that has been identified as active by the kernel. | By | Sum(Int) | <ul> </ul> |
+| container.memory.active_file | Cache memory that has been identified as active by the kernel. [More docs](https://docs.docker.com/config/containers/runmetrics/) | By | Sum(Int) | <ul> </ul> |
+| container.memory.cache | The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device. | By | Sum(Int) | <ul> </ul> |
+| container.memory.dirty | Bytes that are waiting to get written back to the disk, from this cgroup. | By | Sum(Int) | <ul> </ul> |
+| container.memory.hierarchical_memory_limit | The maximum amount of physical memory that can be used by the processes of this control group. | By | Sum(Int) | <ul> </ul> |
+| container.memory.hierarchical_memsw_limit | The maximum amount of RAM + swap that can be used by the processes of this control group. | By | Sum(Int) | <ul> </ul> |
+| container.memory.inactive_anon | The amount of anonymous memory that has been identified as inactive by the kernel. | By | Sum(Int) | <ul> </ul> |
+| container.memory.inactive_file | Cache memory that has been identified as inactive by the kernel. [More docs](https://docs.docker.com/config/containers/runmetrics/) | By | Sum(Int) | <ul> </ul> |
+| container.memory.mapped_file | Indicates the amount of memory mapped by the processes in the control group. | By | Sum(Int) | <ul> </ul> |
 | **container.memory.percent** | Percentage of memory used. | 1 | Gauge(Double) | <ul> </ul> |
-| **container.memory.pgfault** | Indicate the number of times that a process of the cgroup triggered a page fault. | {faults} | Sum(Int) | <ul> </ul> |
-| **container.memory.pgmajfault** | Indicate the number of times that a process of the cgroup triggered a major fault. | {faults} | Sum(Int) | <ul> </ul> |
-| **container.memory.pgpgin** | Number of pages read from disk by the cgroup. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt). | {operations} | Sum(Int) | <ul> </ul> |
-| **container.memory.pgpgout** | Number of pages written to disk by the cgroup. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt). | {operations} | Sum(Int) | <ul> </ul> |
-| **container.memory.rss** | The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.rss_huge** | Number of bytes of anonymous transparent hugepages in this cgroup. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.swap** | The amount of swap currently used by the processes in this cgroup. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_active_anon** | The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_active_file** | Cache memory that has been identified as active by the kernel. Includes descendant cgroups. [More docs](https://docs.docker.com/config/containers/runmetrics/). | By | Sum(Int) | <ul> </ul> |
+| container.memory.pgfault | Indicate the number of times that a process of the cgroup triggered a page fault. | {faults} | Sum(Int) | <ul> </ul> |
+| container.memory.pgmajfault | Indicate the number of times that a process of the cgroup triggered a major fault. | {faults} | Sum(Int) | <ul> </ul> |
+| container.memory.pgpgin | Number of pages read from disk by the cgroup. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt). | {operations} | Sum(Int) | <ul> </ul> |
+| container.memory.pgpgout | Number of pages written to disk by the cgroup. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt). | {operations} | Sum(Int) | <ul> </ul> |
+| container.memory.rss | The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. | By | Sum(Int) | <ul> </ul> |
+| container.memory.rss_huge | Number of bytes of anonymous transparent hugepages in this cgroup. | By | Sum(Int) | <ul> </ul> |
+| container.memory.swap | The amount of swap currently used by the processes in this cgroup. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_active_anon | The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_active_file | Cache memory that has been identified as active by the kernel. Includes descendant cgroups. [More docs](https://docs.docker.com/config/containers/runmetrics/). | By | Sum(Int) | <ul> </ul> |
 | **container.memory.total_cache** | Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_dirty** | Bytes that are waiting to get written back to the disk, from this cgroup and descendants. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_inactive_anon** | The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_inactive_file** | Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups. [More docs](https://docs.docker.com/config/containers/runmetrics/). | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_mapped_file** | Indicates the amount of memory mapped by the processes in the control group and descendant groups. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_pgfault** | Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a page fault. | {faults} | Sum(Int) | <ul> </ul> |
-| **container.memory.total_pgmajfault** | Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a major fault. | {faults} | Sum(Int) | <ul> </ul> |
-| **container.memory.total_pgpgin** | Number of pages read from disk by the cgroup and descendant groups. | {operations} | Sum(Int) | <ul> </ul> |
-| **container.memory.total_pgpgout** | Number of pages written to disk by the cgroup and descendant groups. | {operations} | Sum(Int) | <ul> </ul> |
-| **container.memory.total_rss** | The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_rss_huge** | Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_swap** | The amount of swap currently used by the processes in this cgroup and descendant groups. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_unevictable** | The amount of memory that cannot be reclaimed. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.total_writeback** | Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.unevictable** | The amount of memory that cannot be reclaimed. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_dirty | Bytes that are waiting to get written back to the disk, from this cgroup and descendants. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_inactive_anon | The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_inactive_file | Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups. [More docs](https://docs.docker.com/config/containers/runmetrics/). | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_mapped_file | Indicates the amount of memory mapped by the processes in the control group and descendant groups. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_pgfault | Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a page fault. | {faults} | Sum(Int) | <ul> </ul> |
+| container.memory.total_pgmajfault | Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a major fault. | {faults} | Sum(Int) | <ul> </ul> |
+| container.memory.total_pgpgin | Number of pages read from disk by the cgroup and descendant groups. | {operations} | Sum(Int) | <ul> </ul> |
+| container.memory.total_pgpgout | Number of pages written to disk by the cgroup and descendant groups. | {operations} | Sum(Int) | <ul> </ul> |
+| container.memory.total_rss | The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_rss_huge | Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_swap | The amount of swap currently used by the processes in this cgroup and descendant groups. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_unevictable | The amount of memory that cannot be reclaimed. Includes descendant cgroups. | By | Sum(Int) | <ul> </ul> |
+| container.memory.total_writeback | Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants. | By | Sum(Int) | <ul> </ul> |
+| container.memory.unevictable | The amount of memory that cannot be reclaimed. | By | Sum(Int) | <ul> </ul> |
 | **container.memory.usage.limit** | Memory limit of the container. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.usage.max** | Maximum memory usage. | By | Sum(Int) | <ul> </ul> |
+| container.memory.usage.max | Maximum memory usage. | By | Sum(Int) | <ul> </ul> |
 | **container.memory.usage.total** | Memory usage of the container. This excludes the total cache. | By | Sum(Int) | <ul> </ul> |
-| **container.memory.writeback** | Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup. | By | Sum(Int) | <ul> </ul> |
+| container.memory.writeback | Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup. | By | Sum(Int) | <ul> </ul> |
 | **container.network.io.usage.rx_bytes** | Bytes received by the container. | By | Sum(Int) | <ul> <li>interface</li> </ul> |
 | **container.network.io.usage.rx_dropped** | Incoming packets dropped. | {packets} | Sum(Int) | <ul> <li>interface</li> </ul> |
-| **container.network.io.usage.rx_errors** | Received errors. | {errors} | Sum(Int) | <ul> <li>interface</li> </ul> |
-| **container.network.io.usage.rx_packets** | Packets received. | {packets} | Sum(Int) | <ul> <li>interface</li> </ul> |
+| container.network.io.usage.rx_errors | Received errors. | {errors} | Sum(Int) | <ul> <li>interface</li> </ul> |
+| container.network.io.usage.rx_packets | Packets received. | {packets} | Sum(Int) | <ul> <li>interface</li> </ul> |
 | **container.network.io.usage.tx_bytes** | Bytes sent. | By | Sum(Int) | <ul> <li>interface</li> </ul> |
 | **container.network.io.usage.tx_dropped** | Outgoing packets dropped. | {packets} | Sum(Int) | <ul> <li>interface</li> </ul> |
-| **container.network.io.usage.tx_errors** | Sent errors. | {errors} | Sum(Int) | <ul> <li>interface</li> </ul> |
-| **container.network.io.usage.tx_packets** | Packets sent. | {packets} | Sum(Int) | <ul> <li>interface</li> </ul> |
+| container.network.io.usage.tx_errors | Sent errors. | {errors} | Sum(Int) | <ul> <li>interface</li> </ul> |
+| container.network.io.usage.tx_packets | Packets sent. | {packets} | Sum(Int) | <ul> <li>interface</li> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
 Any metric can be enabled or disabled with the following scraper configuration:

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -86,40 +86,40 @@ type MetricsSettings struct {
 func DefaultMetricsSettings() MetricsSettings {
 	return MetricsSettings{
 		ContainerBlockioIoMergedRecursive: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerBlockioIoQueuedRecursive: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerBlockioIoServiceBytesRecursive: MetricSettings{
 			Enabled: true,
 		},
 		ContainerBlockioIoServiceTimeRecursive: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerBlockioIoServicedRecursive: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerBlockioIoTimeRecursive: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerBlockioIoWaitTimeRecursive: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerBlockioSectorsRecursive: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerCPUPercent: MetricSettings{
 			Enabled: true,
 		},
 		ContainerCPUThrottlingDataPeriods: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerCPUThrottlingDataThrottledPeriods: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerCPUThrottlingDataThrottledTime: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerCPUUsageKernelmode: MetricSettings{
 			Enabled: true,
@@ -137,118 +137,118 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		ContainerMemoryActiveAnon: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryActiveFile: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryCache: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryDirty: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryHierarchicalMemoryLimit: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryHierarchicalMemswLimit: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryInactiveAnon: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryInactiveFile: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryMappedFile: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryPercent: MetricSettings{
 			Enabled: true,
 		},
 		ContainerMemoryPgfault: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryPgmajfault: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryPgpgin: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryPgpgout: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryRss: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryRssHuge: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemorySwap: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalActiveAnon: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalActiveFile: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalCache: MetricSettings{
 			Enabled: true,
 		},
 		ContainerMemoryTotalDirty: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalInactiveAnon: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalInactiveFile: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalMappedFile: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalPgfault: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalPgmajfault: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalPgpgin: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalPgpgout: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalRss: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalRssHuge: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalSwap: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalUnevictable: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryTotalWriteback: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryUnevictable: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryUsageLimit: MetricSettings{
 			Enabled: true,
 		},
 		ContainerMemoryUsageMax: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerMemoryUsageTotal: MetricSettings{
 			Enabled: true,
 		},
 		ContainerMemoryWriteback: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerNetworkIoUsageRxBytes: MetricSettings{
 			Enabled: true,
@@ -257,10 +257,10 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		ContainerNetworkIoUsageRxErrors: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerNetworkIoUsageRxPackets: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerNetworkIoUsageTxBytes: MetricSettings{
 			Enabled: true,
@@ -269,10 +269,10 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		ContainerNetworkIoUsageTxErrors: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerNetworkIoUsageTxPackets: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 	}
 }

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -86,7 +86,7 @@ metrics:
     attributes:
       - core
   container.cpu.throttling_data.periods:
-    enabled: true
+    enabled: false
     description: "Number of periods with throttling active."
     unit: "{periods}"
     sum:
@@ -94,7 +94,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
   container.cpu.throttling_data.throttled_periods:
-    enabled: true
+    enabled: false
     description: "Number of periods when the container hits its throttling limit."
     unit: "{periods}"
     sum:
@@ -102,7 +102,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
   container.cpu.throttling_data.throttled_time:
-    enabled: true
+    enabled: false
     description: "Aggregate time the container was throttled."
     unit: ns
     sum:
@@ -135,7 +135,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.usage.max:
-    enabled: true
+    enabled: false
     description: "Maximum memory usage."
     unit: By
     sum:
@@ -149,7 +149,7 @@ metrics:
     gauge:
       value_type: double
   container.memory.cache:
-    enabled: true
+    enabled: false
     description: "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device."
     unit: By
     sum:
@@ -157,7 +157,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.rss:
-    enabled: true
+    enabled: false
     description: "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps."
     unit: By
     sum:
@@ -165,7 +165,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.rss_huge:
-    enabled: true
+    enabled: false
     description: "Number of bytes of anonymous transparent hugepages in this cgroup."
     unit: By
     sum:
@@ -173,7 +173,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.dirty:
-    enabled: true
+    enabled: false
     description: "Bytes that are waiting to get written back to the disk, from this cgroup."
     unit: By
     sum:
@@ -181,7 +181,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.writeback:
-    enabled: true
+    enabled: false
     description: "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup."
     unit: By
     sum:
@@ -189,7 +189,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.mapped_file:
-    enabled: true
+    enabled: false
     description: "Indicates the amount of memory mapped by the processes in the control group."
     unit: By
     sum:
@@ -197,7 +197,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.pgpgin:
-    enabled: true
+    enabled: false
     description: "Number of pages read from disk by the cgroup."
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt)."
     unit: "{operations}"
@@ -206,7 +206,7 @@ metrics:
       aggregation: cumulative
       monotonic: true
   container.memory.pgpgout:
-    enabled: true
+    enabled: false
     description: "Number of pages written to disk by the cgroup."
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt)."
     unit: "{operations}"
@@ -215,7 +215,7 @@ metrics:
       aggregation: cumulative
       monotonic: true
   container.memory.swap:
-    enabled: true
+    enabled: false
     description: "The amount of swap currently used by the processes in this cgroup."
     unit: By
     sum:
@@ -223,7 +223,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.pgfault:
-    enabled: true
+    enabled: false
     description: "Indicate the number of times that a process of the cgroup triggered a page fault."
     unit: "{faults}"
     sum:
@@ -231,7 +231,7 @@ metrics:
       aggregation: cumulative
       monotonic: true
   container.memory.pgmajfault:
-    enabled: true
+    enabled: false
     description: "Indicate the number of times that a process of the cgroup triggered a major fault."
     unit: "{faults}"
     sum:
@@ -239,7 +239,7 @@ metrics:
       aggregation: cumulative
       monotonic: true
   container.memory.inactive_anon:
-    enabled: true
+    enabled: false
     description: "The amount of anonymous memory that has been identified as inactive by the kernel."
     unit: By
     sum:
@@ -247,7 +247,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.active_anon:
-    enabled: true
+    enabled: false
     description: "The amount of anonymous memory that has been identified as active by the kernel."
     unit: By
     sum:
@@ -255,7 +255,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.inactive_file:
-    enabled: true
+    enabled: false
     description: "Cache memory that has been identified as inactive by the kernel."
     extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)"
     unit: By
@@ -264,7 +264,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.active_file:
-    enabled: true
+    enabled: false
     description: "Cache memory that has been identified as active by the kernel."
     extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)"
     unit: By
@@ -273,7 +273,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.unevictable:
-    enabled: true
+    enabled: false
     description: "The amount of memory that cannot be reclaimed."
     unit: By
     sum:
@@ -281,7 +281,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.hierarchical_memory_limit:
-    enabled: true
+    enabled: false
     description: "The maximum amount of physical memory that can be used by the processes of this control group."
     unit: By
     sum:
@@ -289,7 +289,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.hierarchical_memsw_limit:
-    enabled: true
+    enabled: false
     description: "The maximum amount of RAM + swap that can be used by the processes of this control group."
     unit: By
     sum:
@@ -305,7 +305,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_rss:
-    enabled: true
+    enabled: false
     description: "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups."
     unit: By
     sum:
@@ -313,7 +313,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_rss_huge:
-    enabled: true
+    enabled: false
     description: "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups."
     unit: By
     sum:
@@ -321,7 +321,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_dirty:
-    enabled: true
+    enabled: false
     description: "Bytes that are waiting to get written back to the disk, from this cgroup and descendants."
     unit: By
     sum:
@@ -329,7 +329,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_writeback:
-    enabled: true
+    enabled: false
     description: "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants."
     unit: By
     sum:
@@ -337,7 +337,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_mapped_file:
-    enabled: true
+    enabled: false
     description: "Indicates the amount of memory mapped by the processes in the control group and descendant groups."
     unit: By
     sum:
@@ -345,7 +345,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_pgpgin:
-    enabled: true
+    enabled: false
     description: "Number of pages read from disk by the cgroup and descendant groups."
     unit: "{operations}"
     sum:
@@ -353,7 +353,7 @@ metrics:
       aggregation: cumulative
       monotonic: true
   container.memory.total_pgpgout:
-    enabled: true
+    enabled: false
     description: "Number of pages written to disk by the cgroup and descendant groups."
     unit: "{operations}"
     sum:
@@ -361,7 +361,7 @@ metrics:
       aggregation: cumulative
       monotonic: true
   container.memory.total_swap:
-    enabled: true
+    enabled: false
     description: "The amount of swap currently used by the processes in this cgroup and descendant groups."
     unit: By
     sum:
@@ -369,7 +369,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_pgfault:
-    enabled: true
+    enabled: false
     description: "Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a page fault."
     unit: "{faults}"
     sum:
@@ -377,7 +377,7 @@ metrics:
       aggregation: cumulative
       monotonic: true
   container.memory.total_pgmajfault:
-    enabled: true
+    enabled: false
     description: "Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a major fault."
     unit: "{faults}"
     sum:
@@ -385,7 +385,7 @@ metrics:
       aggregation: cumulative
       monotonic: true
   container.memory.total_inactive_anon:
-    enabled: true
+    enabled: false
     description: "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups."
     unit: By
     sum:
@@ -393,7 +393,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_active_anon:
-    enabled: true
+    enabled: false
     description: "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups."
     unit: By
     sum:
@@ -401,7 +401,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_inactive_file:
-    enabled: true
+    enabled: false
     description: "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups."
     extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)."
     unit: By
@@ -410,7 +410,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_active_file:
-    enabled: true
+    enabled: false
     description: "Cache memory that has been identified as active by the kernel. Includes descendant cgroups."
     extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)."
     unit: By
@@ -419,7 +419,7 @@ metrics:
       aggregation: cumulative
       monotonic: false
   container.memory.total_unevictable:
-    enabled: true
+    enabled: false
     description: "The amount of memory that cannot be reclaimed. Includes descendant cgroups."
     unit: By
     sum:
@@ -430,7 +430,7 @@ metrics:
 
   # BlockIO
   container.blockio.io_merged_recursive:
-    enabled: true
+    enabled: false
     description: "Number of bios/requests merged into requests belonging to this cgroup and its descendant cgroups."
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
     unit: "{operations}"
@@ -444,7 +444,7 @@ metrics:
       - operation
 
   container.blockio.io_queued_recursive:
-    enabled: true
+    enabled: false
     description: "Number of requests queued up for this cgroup and its descendant cgroups."
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
     unit: "{operations}"
@@ -472,7 +472,7 @@ metrics:
       - operation
 
   container.blockio.io_service_time_recursive:
-    enabled: true
+    enabled: false
     description: "Total amount of time in nanoseconds between request dispatch and request completion for the IOs done by this cgroup and descendant cgroups."
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
     unit: ns
@@ -486,7 +486,7 @@ metrics:
       - operation
 
   container.blockio.io_serviced_recursive:
-    enabled: true
+    enabled: false
     description: "Number of IOs (bio) issued to the disk by the group and descendant groups."
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
     unit: "{operations}"
@@ -500,7 +500,7 @@ metrics:
       - operation
 
   container.blockio.io_time_recursive:
-    enabled: true
+    enabled: false
     description: "Disk time allocated to cgroup (and descendant cgroups) per device in milliseconds."
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
     unit: ms
@@ -514,7 +514,7 @@ metrics:
       - operation
 
   container.blockio.io_wait_time_recursive:
-    enabled: true
+    enabled: false
     description: "Total amount of time the IOs for this cgroup (and descendant cgroups) spent waiting in the scheduler queues for service."
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
     unit: ns
@@ -528,7 +528,7 @@ metrics:
       - operation
 
   container.blockio.sectors_recursive:
-    enabled: true
+    enabled: false
     description: "Number of sectors transferred to/from disk by the group and descendant groups."
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
     unit: "{sectors}"
@@ -583,7 +583,7 @@ metrics:
     attributes:
       - interface
   container.network.io.usage.rx_errors:
-    enabled: true
+    enabled: false
     description: "Received errors."
     unit: "{errors}"
     sum:
@@ -593,7 +593,7 @@ metrics:
     attributes:
       - interface
   container.network.io.usage.tx_errors:
-    enabled: true
+    enabled: false
     description: "Sent errors."
     unit: "{errors}"
     sum:
@@ -603,7 +603,7 @@ metrics:
     attributes:
       - interface
   container.network.io.usage.rx_packets:
-    enabled: true
+    enabled: false
     description: "Packets received."
     unit: "{packets}"
     sum:
@@ -613,7 +613,7 @@ metrics:
     attributes:
       - interface
   container.network.io.usage.tx_packets:
-    enabled: true
+    enabled: false
     description: "Packets sent."
     unit: "{packets}"
     sum:

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -36,9 +36,79 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest/golden"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver/internal/metadata"
 )
 
 var mockFolder = filepath.Join("testdata", "mock")
+
+var (
+	metricEnabled     = metadata.MetricSettings{Enabled: true}
+	allMetricsEnabled = metadata.MetricsSettings{
+		ContainerBlockioIoMergedRecursive:          metricEnabled,
+		ContainerBlockioIoQueuedRecursive:          metricEnabled,
+		ContainerBlockioIoServiceBytesRecursive:    metricEnabled,
+		ContainerBlockioIoServiceTimeRecursive:     metricEnabled,
+		ContainerBlockioIoServicedRecursive:        metricEnabled,
+		ContainerBlockioIoTimeRecursive:            metricEnabled,
+		ContainerBlockioIoWaitTimeRecursive:        metricEnabled,
+		ContainerBlockioSectorsRecursive:           metricEnabled,
+		ContainerCPUPercent:                        metricEnabled,
+		ContainerCPUThrottlingDataPeriods:          metricEnabled,
+		ContainerCPUThrottlingDataThrottledPeriods: metricEnabled,
+		ContainerCPUThrottlingDataThrottledTime:    metricEnabled,
+		ContainerCPUUsageKernelmode:                metricEnabled,
+		ContainerCPUUsagePercpu:                    metricEnabled,
+		ContainerCPUUsageSystem:                    metricEnabled,
+		ContainerCPUUsageTotal:                     metricEnabled,
+		ContainerCPUUsageUsermode:                  metricEnabled,
+		ContainerMemoryActiveAnon:                  metricEnabled,
+		ContainerMemoryActiveFile:                  metricEnabled,
+		ContainerMemoryCache:                       metricEnabled,
+		ContainerMemoryDirty:                       metricEnabled,
+		ContainerMemoryHierarchicalMemoryLimit:     metricEnabled,
+		ContainerMemoryHierarchicalMemswLimit:      metricEnabled,
+		ContainerMemoryInactiveAnon:                metricEnabled,
+		ContainerMemoryInactiveFile:                metricEnabled,
+		ContainerMemoryMappedFile:                  metricEnabled,
+		ContainerMemoryPercent:                     metricEnabled,
+		ContainerMemoryPgfault:                     metricEnabled,
+		ContainerMemoryPgmajfault:                  metricEnabled,
+		ContainerMemoryPgpgin:                      metricEnabled,
+		ContainerMemoryPgpgout:                     metricEnabled,
+		ContainerMemoryRss:                         metricEnabled,
+		ContainerMemoryRssHuge:                     metricEnabled,
+		ContainerMemorySwap:                        metricEnabled,
+		ContainerMemoryTotalActiveAnon:             metricEnabled,
+		ContainerMemoryTotalActiveFile:             metricEnabled,
+		ContainerMemoryTotalCache:                  metricEnabled,
+		ContainerMemoryTotalDirty:                  metricEnabled,
+		ContainerMemoryTotalInactiveAnon:           metricEnabled,
+		ContainerMemoryTotalInactiveFile:           metricEnabled,
+		ContainerMemoryTotalMappedFile:             metricEnabled,
+		ContainerMemoryTotalPgfault:                metricEnabled,
+		ContainerMemoryTotalPgmajfault:             metricEnabled,
+		ContainerMemoryTotalPgpgin:                 metricEnabled,
+		ContainerMemoryTotalPgpgout:                metricEnabled,
+		ContainerMemoryTotalRss:                    metricEnabled,
+		ContainerMemoryTotalRssHuge:                metricEnabled,
+		ContainerMemoryTotalSwap:                   metricEnabled,
+		ContainerMemoryTotalUnevictable:            metricEnabled,
+		ContainerMemoryTotalWriteback:              metricEnabled,
+		ContainerMemoryUnevictable:                 metricEnabled,
+		ContainerMemoryUsageLimit:                  metricEnabled,
+		ContainerMemoryUsageMax:                    metricEnabled,
+		ContainerMemoryUsageTotal:                  metricEnabled,
+		ContainerMemoryWriteback:                   metricEnabled,
+		ContainerNetworkIoUsageRxBytes:             metricEnabled,
+		ContainerNetworkIoUsageRxDropped:           metricEnabled,
+		ContainerNetworkIoUsageRxErrors:            metricEnabled,
+		ContainerNetworkIoUsageRxPackets:           metricEnabled,
+		ContainerNetworkIoUsageTxBytes:             metricEnabled,
+		ContainerNetworkIoUsageTxDropped:           metricEnabled,
+		ContainerNetworkIoUsageTxErrors:            metricEnabled,
+		ContainerNetworkIoUsageTxPackets:           metricEnabled,
+	}
+)
 
 func TestNewReceiver(t *testing.T) {
 	cfg := &Config{
@@ -123,6 +193,7 @@ func TestScrapeV2(t *testing.T) {
 			cfg.EnvVarsToMetricLabels = map[string]string{"ENV_VAR": "env-var-metric-label"}
 			cfg.ContainerLabelsToMetricLabels = map[string]string{"container.label": "container-metric-label"}
 			cfg.ProvidePerCoreCPUMetrics = true
+			cfg.MetricsConfig = allMetricsEnabled
 
 			receiver := newReceiver(componenttest.NewNopReceiverCreateSettings(), cfg)
 			err := receiver.start(context.Background(), componenttest.NewNopHost())

--- a/unreleased/dockerstats-defaults.yaml
+++ b/unreleased/dockerstats-defaults.yaml
@@ -1,4 +1,5 @@
-change_type: enhancement
+change_type: breaking
 component: dockerstatsreceiver
 note: "For V2 scraper implementation, change the defaults from emitting everything to a sensible set of defaults."
 issues: [9794, 14093]
+subtext: "This is only breaking if you have explicitly enabled the featuregate `receiver.dockerstats.useScraperV2`."

--- a/unreleased/dockerstats-defaults.yaml
+++ b/unreleased/dockerstats-defaults.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: dockerstatsreceiver
+note: "For V2 scraper implementation, change the defaults from emitting everything to a sensible set of defaults."
+issues: [9794, 14093]


### PR DESCRIPTION
**Description:** 

This is not a breaking change unless you are using the non-default V2 scraper which is behind a feature gate. 

Currently almost every metric is enabled by default, which was done to demonstrate feature parity with the original V1 scraper which enables almost everything by default. 

This changes so most metrics are not enabled by default, and instead a sensible set of defaults are enabled. There are many very detailed memory and block IO metric that 99% of users will never need, and all it does it consume needless MTS.

The change brings the default set of metrics from 63 to 14. 

The new list of enabled metrics by default is below. I made it similar to the defaults of the signalfx agent. I am open to suggestions on changes here. 

- `container.cpu.usage.system`
- `container.cpu.usage.total`
- `container.cpu.usage.kernelmode`
- `container.cpu.usage.usermode`
- `container.cpu.percent`
- `container.memory.usage.limit`
- `container.memory.usage.total`
- `container.memory.percent`
- `container.memory.total_cache`
- `container.blockio.io_service_bytes_recursive`
- `container.network.io.usage.rx_bytes`
- `container.network.io.usage.tx_bytes`
- `container.network.io.usage.rx_dropped`
- `container.network.io.usage.tx_dropped`

**Link to tracking Issue:** 

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9794

**Testing:** 

All unit tests still test 100% of the metrics. 

**Documentation:**

Documentation automatically updated by `go generate` and `mdatagen`. 