### PR TITLE
[receiver/apache]: add support for more metrics

### DIFF
--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -9,11 +9,8 @@ These are the metrics available for this scraper.
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
 | **apache.bytes_per_second** | The average number of bytes per second. | By/s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.cpu_children_system** | Jiffies used in system mode by children processes. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.cpu_children_user** | Jiffies used in user mode by children processes. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.cpu.time** | Jiffs used by processes of given category. | {jiff} | Sum(Double) | <ul> <li>server_name</li> <li>cpu_level</li> <li>cpu_mode</li> </ul> |
 | **apache.cpu_load** | Current load of the CPU. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.cpu_system** | Jiffies used in system mode. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.cpu_user** | Jiffies used in user mode. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.current_connections** | The number of active connections currently attached to the HTTP server. | {connections} | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.load.1** | The average server load during the last minute. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.load.15** | The average server load during the last 15 minutes. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
@@ -41,6 +38,8 @@ metrics:
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
+| cpu_level (level) | Level of processes. | self, children |
+| cpu_mode (mode) | Mode of processes. | system, user |
 | scoreboard_state (state) | The state of a connection. | open, waiting, starting, reading, sending, keepalive, dnslookup, closing, logging, finishing, idle_cleanup, unknown |
 | server_name | The name of the Apache HTTP server. |  |
 | workers_state (state) | The state of workers. | busy, idle |

--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -8,22 +8,22 @@ These are the metrics available for this scraper.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
-| **apache.bytes_per_request** | The average number of bytes per request. | By | Sum(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.bytes_per_second** | The average number of bytes per second. | By | Sum(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.bytes_per_second** | The average number of bytes per second. | By/s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.cpu_children_system** | Jiffies used in system mode by children processes. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.cpu_children_user** | Jiffies used in user mode by children processes. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.cpu_load** | Current load of the CPU. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.cpu_system** | Jiffies used in system mode. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.cpu_user** | Jiffies used in user mode. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.current_connections** | The number of active connections currently attached to the HTTP server. | {connections} | Sum(Int) | <ul> <li>server_name</li> </ul> |
-| **apache.duration_per_request** | The average time of handling requests. | s | Sum(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.load_1** | The average server load during the last minute. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.load_15** | The average server load during the last 15 minutes. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.load_5** | The average server load during the last 5 minutes. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.load.1** | The average server load during the last minute. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.load.15** | The average server load during the last 15 minutes. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.load.5** | The average server load during the last 5 minutes. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.request.average_time** | The average time of handling requests. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.request.rate** | The average number of requests per second. | {requests}/s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.request.size** | The average number of bytes per request. | By/{request} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.request.time** | Total time spent on handling requests. | ms | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.requests** | The number of requests serviced by the HTTP server per second. | {requests} | Sum(Int) | <ul> <li>server_name</li> </ul> |
-| **apache.requests_per_second** | The average number of requests per second. | {requests} | Sum(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.scoreboard** | The number of workers in each state. The apache scoreboard is an encoded representation of the state of all the server's workers. This metric decodes the scoreboard and presents a count of workers in each state. Additional details can be found [here](https://metacpan.org/pod/Apache::Scoreboard#DESCRIPTION). | {workers} | Sum(Int) | <ul> <li>server_name</li> <li>scoreboard_state</li> </ul> |
-| **apache.total_duration** | Total time spent on handling requests. | s | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.traffic** | Total HTTP server traffic. | By | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.uptime** | The amount of time that the server has been running in seconds. | s | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.workers** | The number of workers currently attached to the HTTP server. | {workers} | Sum(Int) | <ul> <li>server_name</li> <li>workers_state</li> </ul> |

--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -8,9 +8,22 @@ These are the metrics available for this scraper.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
+| **apache.bytes_per_request** | The average number of bytes per request. | By | Sum(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.bytes_per_second** | The average number of bytes per second. | By | Sum(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.cpu_children_system** | Jiffies used in system mode by children processes. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.cpu_children_user** | Jiffies used in user mode by children processes. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.cpu_load** | Current load of the CPU. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.cpu_system** | Jiffies used in system mode. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.cpu_user** | Jiffies used in user mode. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.current_connections** | The number of active connections currently attached to the HTTP server. | {connections} | Sum(Int) | <ul> <li>server_name</li> </ul> |
+| **apache.duration_per_request** | The average time of handling requests. | s | Sum(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.load_1** | The average server load during the last minute. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.load_15** | The average server load during the last 15 minutes. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.load_5** | The average server load during the last 5 minutes. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.requests** | The number of requests serviced by the HTTP server per second. | {requests} | Sum(Int) | <ul> <li>server_name</li> </ul> |
+| **apache.requests_per_second** | The average number of requests per second. | {requests} | Sum(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.scoreboard** | The number of workers in each state. The apache scoreboard is an encoded representation of the state of all the server's workers. This metric decodes the scoreboard and presents a count of workers in each state. Additional details can be found [here](https://metacpan.org/pod/Apache::Scoreboard#DESCRIPTION). | {workers} | Sum(Int) | <ul> <li>server_name</li> <li>scoreboard_state</li> </ul> |
+| **apache.total_duration** | Total time spent on handling requests. | s | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.traffic** | Total HTTP server traffic. | By | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.uptime** | The amount of time that the server has been running in seconds. | s | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.workers** | The number of workers currently attached to the HTTP server. | {workers} | Sum(Int) | <ul> <li>server_name</li> <li>workers_state</li> </ul> |

--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -8,16 +8,12 @@ These are the metrics available for this scraper.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
-| **apache.bytes_per_second** | The average number of bytes per second. | By/s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.cpu.time** | Jiffs used by processes of given category. | {jiff} | Sum(Double) | <ul> <li>server_name</li> <li>cpu_level</li> <li>cpu_mode</li> </ul> |
 | **apache.cpu_load** | Current load of the CPU. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.current_connections** | The number of active connections currently attached to the HTTP server. | {connections} | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.load.1** | The average server load during the last minute. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.load.15** | The average server load during the last 15 minutes. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.load.5** | The average server load during the last 5 minutes. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.request.average_time** | The average time of handling requests. | s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.request.rate** | The average number of requests per second. | {requests}/s | Gauge(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.request.size** | The average number of bytes per request. | By/{request} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.request.time** | Total time spent on handling requests. | ms | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.requests** | The number of requests serviced by the HTTP server per second. | {requests} | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.scoreboard** | The number of workers in each state. The apache scoreboard is an encoded representation of the state of all the server's workers. This metric decodes the scoreboard and presents a count of workers in each state. Additional details can be found [here](https://metacpan.org/pod/Apache::Scoreboard#DESCRIPTION). | {workers} | Sum(Int) | <ul> <li>server_name</li> <li>scoreboard_state</li> </ul> |

--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -8,12 +8,12 @@ These are the metrics available for this scraper.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
+| **apache.cpu.load** | Current load of the CPU. | % | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.cpu.time** | Jiffs used by processes of given category. | {jiff} | Sum(Double) | <ul> <li>server_name</li> <li>cpu_level</li> <li>cpu_mode</li> </ul> |
-| **apache.cpu_load** | Current load of the CPU. | {load} | Sum(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.current_connections** | The number of active connections currently attached to the HTTP server. | {connections} | Sum(Int) | <ul> <li>server_name</li> </ul> |
-| **apache.load.1** | The average server load during the last minute. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.load.15** | The average server load during the last 15 minutes. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
-| **apache.load.5** | The average server load during the last 5 minutes. | {load} | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.load.1** | The average server load during the last minute. | % | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.load.15** | The average server load during the last 15 minutes. | % | Gauge(Double) | <ul> <li>server_name</li> </ul> |
+| **apache.load.5** | The average server load during the last 5 minutes. | % | Gauge(Double) | <ul> <li>server_name</li> </ul> |
 | **apache.request.time** | Total time spent on handling requests. | ms | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.requests** | The number of requests serviced by the HTTP server per second. | {requests} | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.scoreboard** | The number of workers in each state. The apache scoreboard is an encoded representation of the state of all the server's workers. This metric decodes the scoreboard and presents a count of workers in each state. Additional details can be found [here](https://metacpan.org/pod/Apache::Scoreboard#DESCRIPTION). | {workers} | Sum(Int) | <ul> <li>server_name</li> <li>scoreboard_state</li> </ul> |

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -76,6 +76,129 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [ server_name ]
+  apache.bytes_per_request:
+    enabled: true
+    description: The average number of bytes per request.
+    unit: By
+    sum:
+      value_type: double
+      input_type: string
+      monotonic: false
+      aggregation: delta
+    attributes: [ server_name ]
+  apache.bytes_per_second:
+    enabled: true
+    description: The average number of bytes per second.
+    unit: By
+    sum:
+      value_type: double
+      input_type: string
+      monotonic: false
+      aggregation: delta
+    attributes: [ server_name ]
+  apache.cpu_children_system:
+    enabled: true
+    description: Jiffies used in system mode by children processes.
+    unit: s
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: [ server_name ]
+  apache.cpu_children_user:
+    enabled: true
+    description: Jiffies used in user mode by children processes.
+    unit: s
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: [ server_name ]
+  apache.cpu_system:
+    enabled: true
+    description: Jiffies used in system mode.
+    unit: s
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: [ server_name ]
+  apache.cpu_user:
+    enabled: true
+    description: Jiffies used in user mode.
+    unit: s
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: [ server_name ]
+  apache.cpu_load:
+    enabled: true
+    description: Current load of the CPU.
+    unit: "{load}"
+    sum:
+      value_type: double
+      input_type: string
+      monotonic: false
+      aggregation: delta
+    attributes: [ server_name ]
+  apache.duration_per_request:
+    enabled: true
+    description: The average time of handling requests.
+    unit: s
+    sum:
+      value_type: double
+      input_type: string
+      monotonic: false
+      aggregation: delta
+    attributes: [ server_name ]
+  apache.load_1:
+    enabled: true
+    description: The average server load during the last minute.
+    unit: "{load}"
+    sum:
+      value_type: double
+      input_type: string
+      monotonic: false
+      aggregation: delta
+    attributes: [ server_name ]
+  apache.load_5:
+    enabled: true
+    description: The average server load during the last 5 minutes.
+    unit: "{load}"
+    sum:
+      value_type: double
+      input_type: string
+      monotonic: false
+      aggregation: delta
+    attributes: [ server_name ]
+  apache.load_15:
+    enabled: true
+    description: The average server load during the last 15 minutes.
+    unit: "{load}"
+    sum:
+      value_type: double
+      input_type: string
+      monotonic: false
+      aggregation: delta
+    attributes: [ server_name ]
+  apache.requests_per_second:
+    enabled: true
+    description: The average number of requests per second.
+    unit: "{requests}"
+    sum:
+      value_type: double
+      input_type: string
+      monotonic: false
+      aggregation: delta
+    attributes: [ server_name ]
+  apache.total_duration:
+    enabled: true
+    description: Total time spent on handling requests.
+    unit: s
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation: delta
+    attributes: [ server_name ]
+
   apache.scoreboard:
     enabled: true
     description: The number of workers in each state.

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -9,6 +9,18 @@ attributes:
     enum:
       - busy
       - idle
+  cpu_level:
+    value: level
+    description: Level of processes.
+    enum:
+      - self
+      - children
+  cpu_mode:
+    value: mode
+    description: Mode of processes.
+    enum:
+    - system
+    - user
   scoreboard_state:
     value: state
     description: The state of a connection.
@@ -92,38 +104,16 @@ metrics:
       value_type: double
       input_type: string
     attributes: [ server_name ]
-  apache.cpu_children_system:
+  apache.cpu.time:
     enabled: true
-    description: Jiffies used in system mode by children processes.
-    unit: s
-    gauge:
+    description: Jiffs used by processes of given category.
+    unit: "{jiff}"
+    sum:
       value_type: double
       input_type: string
-    attributes: [ server_name ]
-  apache.cpu_children_user:
-    enabled: true
-    description: Jiffies used in user mode by children processes.
-    unit: s
-    gauge:
-      value_type: double
-      input_type: string
-    attributes: [ server_name ]
-  apache.cpu_system:
-    enabled: true
-    description: Jiffies used in system mode.
-    unit: s
-    gauge:
-      value_type: double
-      input_type: string
-    attributes: [ server_name ]
-  apache.cpu_user:
-    enabled: true
-    description: Jiffies used in user mode.
-    unit: s
-    gauge:
-      value_type: double
-      input_type: string
-    attributes: [ server_name ]
+      monotonic: true
+      aggregation: cumulative
+    attributes: [ server_name, cpu_level, cpu_mode ]
   apache.cpu_load:
     enabled: true
     description: Current load of the CPU.

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -76,25 +76,21 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [ server_name ]
-  apache.bytes_per_request:
+  apache.request.size:
     enabled: true
     description: The average number of bytes per request.
-    unit: By
-    sum:
+    unit: "By/{request}"
+    gauge:
       value_type: double
       input_type: string
-      monotonic: false
-      aggregation: delta
     attributes: [ server_name ]
   apache.bytes_per_second:
     enabled: true
     description: The average number of bytes per second.
-    unit: By
-    sum:
+    unit: By/s
+    gauge:
       value_type: double
       input_type: string
-      monotonic: false
-      aggregation: delta
     attributes: [ server_name ]
   apache.cpu_children_system:
     enabled: true
@@ -138,65 +134,55 @@ metrics:
       monotonic: false
       aggregation: delta
     attributes: [ server_name ]
-  apache.duration_per_request:
+  apache.request.average_time:
     enabled: true
     description: The average time of handling requests.
     unit: s
-    sum:
+    gauge:
       value_type: double
       input_type: string
-      monotonic: false
-      aggregation: delta
     attributes: [ server_name ]
-  apache.load_1:
+  apache.load.1:
     enabled: true
     description: The average server load during the last minute.
     unit: "{load}"
-    sum:
+    gauge:
       value_type: double
       input_type: string
-      monotonic: false
-      aggregation: delta
     attributes: [ server_name ]
-  apache.load_5:
+  apache.load.5:
     enabled: true
     description: The average server load during the last 5 minutes.
     unit: "{load}"
-    sum:
+    gauge:
       value_type: double
       input_type: string
-      monotonic: false
-      aggregation: delta
     attributes: [ server_name ]
-  apache.load_15:
+  apache.load.15:
     enabled: true
     description: The average server load during the last 15 minutes.
     unit: "{load}"
-    sum:
+    gauge:
       value_type: double
       input_type: string
-      monotonic: false
-      aggregation: delta
     attributes: [ server_name ]
-  apache.requests_per_second:
+  apache.request.rate:
     enabled: true
     description: The average number of requests per second.
-    unit: "{requests}"
-    sum:
+    unit: "{requests}/s"
+    gauge:
       value_type: double
       input_type: string
-      monotonic: false
-      aggregation: delta
     attributes: [ server_name ]
-  apache.total_duration:
+  apache.request.time:
     enabled: true
     description: Total time spent on handling requests.
-    unit: s
+    unit: ms
     sum:
       value_type: int
       input_type: string
-      monotonic: false
-      aggregation: delta
+      monotonic: true
+      aggregation: cumulative
     attributes: [ server_name ]
 
   apache.scoreboard:

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -98,20 +98,18 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [ server_name, cpu_level, cpu_mode ]
-  apache.cpu_load:
+  apache.cpu.load:
     enabled: true
     description: Current load of the CPU.
-    unit: "{load}"
-    sum:
+    unit: "%"
+    gauge:
       value_type: double
       input_type: string
-      monotonic: false
-      aggregation: delta
     attributes: [ server_name ]
   apache.load.1:
     enabled: true
     description: The average server load during the last minute.
-    unit: "{load}"
+    unit: "%"
     gauge:
       value_type: double
       input_type: string
@@ -119,7 +117,7 @@ metrics:
   apache.load.5:
     enabled: true
     description: The average server load during the last 5 minutes.
-    unit: "{load}"
+    unit: "%"
     gauge:
       value_type: double
       input_type: string
@@ -127,7 +125,7 @@ metrics:
   apache.load.15:
     enabled: true
     description: The average server load during the last 15 minutes.
-    unit: "{load}"
+    unit: "%"
     gauge:
       value_type: double
       input_type: string

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -88,22 +88,6 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [ server_name ]
-  apache.request.size:
-    enabled: true
-    description: The average number of bytes per request.
-    unit: "By/{request}"
-    gauge:
-      value_type: double
-      input_type: string
-    attributes: [ server_name ]
-  apache.bytes_per_second:
-    enabled: true
-    description: The average number of bytes per second.
-    unit: By/s
-    gauge:
-      value_type: double
-      input_type: string
-    attributes: [ server_name ]
   apache.cpu.time:
     enabled: true
     description: Jiffs used by processes of given category.
@@ -123,14 +107,6 @@ metrics:
       input_type: string
       monotonic: false
       aggregation: delta
-    attributes: [ server_name ]
-  apache.request.average_time:
-    enabled: true
-    description: The average time of handling requests.
-    unit: s
-    gauge:
-      value_type: double
-      input_type: string
     attributes: [ server_name ]
   apache.load.1:
     enabled: true
@@ -156,14 +132,6 @@ metrics:
       value_type: double
       input_type: string
     attributes: [ server_name ]
-  apache.request.rate:
-    enabled: true
-    description: The average number of requests per second.
-    unit: "{requests}/s"
-    gauge:
-      value_type: double
-      input_type: string
-    attributes: [ server_name ]
   apache.request.time:
     enabled: true
     description: Total time spent on handling requests.
@@ -174,7 +142,6 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [ server_name ]
-
   apache.scoreboard:
     enabled: true
     description: The number of workers in each state.

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -93,6 +93,32 @@ func (r *apacheScraper) scrape(context.Context) (pmetric.Metrics, error) {
 			} else {
 				r.mb.RecordApacheTrafficDataPoint(now, kbytesToBytes(i), r.cfg.serverName)
 			}
+		case "BytesPerReq":
+			addPartialIfError(errs, r.mb.RecordApacheBytesPerRequestDataPoint(now, metricValue, r.cfg.serverName))
+		case "BytesPerSec":
+			addPartialIfError(errs, r.mb.RecordApacheBytesPerSecondDataPoint(now, metricValue, r.cfg.serverName))
+		case "CPUChildrenSystem":
+			addPartialIfError(errs, r.mb.RecordApacheCPUChildrenSystemDataPoint(now, metricValue, r.cfg.serverName))
+		case "CPUChildrenUser":
+			addPartialIfError(errs, r.mb.RecordApacheCPUChildrenUserDataPoint(now, metricValue, r.cfg.serverName))
+		case "CPUSystem":
+			addPartialIfError(errs, r.mb.RecordApacheCPUSystemDataPoint(now, metricValue, r.cfg.serverName))
+		case "CPUUser":
+			addPartialIfError(errs, r.mb.RecordApacheCPUUserDataPoint(now, metricValue, r.cfg.serverName))
+		case "CPULoad":
+			addPartialIfError(errs, r.mb.RecordApacheCPULoadDataPoint(now, metricValue, r.cfg.serverName))
+		case "DurationPerReq":
+			addPartialIfError(errs, r.mb.RecordApacheDurationPerRequestDataPoint(now, metricValue, r.cfg.serverName))
+		case "Load1":
+			addPartialIfError(errs, r.mb.RecordApacheLoad1DataPoint(now, metricValue, r.cfg.serverName))
+		case "Load5":
+			addPartialIfError(errs, r.mb.RecordApacheLoad5DataPoint(now, metricValue, r.cfg.serverName))
+		case "Load15":
+			addPartialIfError(errs, r.mb.RecordApacheLoad15DataPoint(now, metricValue, r.cfg.serverName))
+		case "ReqPerSec":
+			addPartialIfError(errs, r.mb.RecordApacheRequestsPerSecondDataPoint(now, metricValue, r.cfg.serverName))
+		case "Total Duration":
+			addPartialIfError(errs, r.mb.RecordApacheTotalDurationDataPoint(now, metricValue, r.cfg.serverName))
 		case "Scoreboard":
 			scoreboardMap := parseScoreboard(metricValue)
 			for state, score := range scoreboardMap {

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -94,7 +94,7 @@ func (r *apacheScraper) scrape(context.Context) (pmetric.Metrics, error) {
 				r.mb.RecordApacheTrafficDataPoint(now, kbytesToBytes(i), r.cfg.serverName)
 			}
 		case "BytesPerReq":
-			addPartialIfError(errs, r.mb.RecordApacheBytesPerRequestDataPoint(now, metricValue, r.cfg.serverName))
+			addPartialIfError(errs, r.mb.RecordApacheRequestSizeDataPoint(now, metricValue, r.cfg.serverName))
 		case "BytesPerSec":
 			addPartialIfError(errs, r.mb.RecordApacheBytesPerSecondDataPoint(now, metricValue, r.cfg.serverName))
 		case "CPUChildrenSystem":
@@ -108,7 +108,7 @@ func (r *apacheScraper) scrape(context.Context) (pmetric.Metrics, error) {
 		case "CPULoad":
 			addPartialIfError(errs, r.mb.RecordApacheCPULoadDataPoint(now, metricValue, r.cfg.serverName))
 		case "DurationPerReq":
-			addPartialIfError(errs, r.mb.RecordApacheDurationPerRequestDataPoint(now, metricValue, r.cfg.serverName))
+			addPartialIfError(errs, r.mb.RecordApacheRequestAverageTimeDataPoint(now, metricValue, r.cfg.serverName))
 		case "Load1":
 			addPartialIfError(errs, r.mb.RecordApacheLoad1DataPoint(now, metricValue, r.cfg.serverName))
 		case "Load5":
@@ -116,9 +116,9 @@ func (r *apacheScraper) scrape(context.Context) (pmetric.Metrics, error) {
 		case "Load15":
 			addPartialIfError(errs, r.mb.RecordApacheLoad15DataPoint(now, metricValue, r.cfg.serverName))
 		case "ReqPerSec":
-			addPartialIfError(errs, r.mb.RecordApacheRequestsPerSecondDataPoint(now, metricValue, r.cfg.serverName))
+			addPartialIfError(errs, r.mb.RecordApacheRequestRateDataPoint(now, metricValue, r.cfg.serverName))
 		case "Total Duration":
-			addPartialIfError(errs, r.mb.RecordApacheTotalDurationDataPoint(now, metricValue, r.cfg.serverName))
+			addPartialIfError(errs, r.mb.RecordApacheRequestTimeDataPoint(now, metricValue, r.cfg.serverName))
 		case "Scoreboard":
 			scoreboardMap := parseScoreboard(metricValue)
 			for state, score := range scoreboardMap {

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -98,13 +98,25 @@ func (r *apacheScraper) scrape(context.Context) (pmetric.Metrics, error) {
 		case "BytesPerSec":
 			addPartialIfError(errs, r.mb.RecordApacheBytesPerSecondDataPoint(now, metricValue, r.cfg.serverName))
 		case "CPUChildrenSystem":
-			addPartialIfError(errs, r.mb.RecordApacheCPUChildrenSystemDataPoint(now, metricValue, r.cfg.serverName))
+			addPartialIfError(
+				errs,
+				r.mb.RecordApacheCPUTimeDataPoint(now, metricValue, r.cfg.serverName, metadata.AttributeCPULevelChildren, metadata.AttributeCPUModeSystem),
+			)
 		case "CPUChildrenUser":
-			addPartialIfError(errs, r.mb.RecordApacheCPUChildrenUserDataPoint(now, metricValue, r.cfg.serverName))
+			addPartialIfError(
+				errs,
+				r.mb.RecordApacheCPUTimeDataPoint(now, metricValue, r.cfg.serverName, metadata.AttributeCPULevelChildren, metadata.AttributeCPUModeUser),
+			)
 		case "CPUSystem":
-			addPartialIfError(errs, r.mb.RecordApacheCPUSystemDataPoint(now, metricValue, r.cfg.serverName))
+			addPartialIfError(
+				errs,
+				r.mb.RecordApacheCPUTimeDataPoint(now, metricValue, r.cfg.serverName, metadata.AttributeCPULevelSelf, metadata.AttributeCPUModeSystem),
+			)
 		case "CPUUser":
-			addPartialIfError(errs, r.mb.RecordApacheCPUUserDataPoint(now, metricValue, r.cfg.serverName))
+			addPartialIfError(
+				errs,
+				r.mb.RecordApacheCPUTimeDataPoint(now, metricValue, r.cfg.serverName, metadata.AttributeCPULevelSelf, metadata.AttributeCPUModeUser),
+			)
 		case "CPULoad":
 			addPartialIfError(errs, r.mb.RecordApacheCPULoadDataPoint(now, metricValue, r.cfg.serverName))
 		case "DurationPerReq":

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -93,10 +93,6 @@ func (r *apacheScraper) scrape(context.Context) (pmetric.Metrics, error) {
 			} else {
 				r.mb.RecordApacheTrafficDataPoint(now, kbytesToBytes(i), r.cfg.serverName)
 			}
-		case "BytesPerReq":
-			addPartialIfError(errs, r.mb.RecordApacheRequestSizeDataPoint(now, metricValue, r.cfg.serverName))
-		case "BytesPerSec":
-			addPartialIfError(errs, r.mb.RecordApacheBytesPerSecondDataPoint(now, metricValue, r.cfg.serverName))
 		case "CPUChildrenSystem":
 			addPartialIfError(
 				errs,
@@ -119,16 +115,12 @@ func (r *apacheScraper) scrape(context.Context) (pmetric.Metrics, error) {
 			)
 		case "CPULoad":
 			addPartialIfError(errs, r.mb.RecordApacheCPULoadDataPoint(now, metricValue, r.cfg.serverName))
-		case "DurationPerReq":
-			addPartialIfError(errs, r.mb.RecordApacheRequestAverageTimeDataPoint(now, metricValue, r.cfg.serverName))
 		case "Load1":
 			addPartialIfError(errs, r.mb.RecordApacheLoad1DataPoint(now, metricValue, r.cfg.serverName))
 		case "Load5":
 			addPartialIfError(errs, r.mb.RecordApacheLoad5DataPoint(now, metricValue, r.cfg.serverName))
 		case "Load15":
 			addPartialIfError(errs, r.mb.RecordApacheLoad15DataPoint(now, metricValue, r.cfg.serverName))
-		case "ReqPerSec":
-			addPartialIfError(errs, r.mb.RecordApacheRequestRateDataPoint(now, metricValue, r.cfg.serverName))
 		case "Total Duration":
 			addPartialIfError(errs, r.mb.RecordApacheRequestTimeDataPoint(now, metricValue, r.cfg.serverName))
 		case "Scoreboard":

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -141,11 +141,13 @@ func TestParseStats(t *testing.T) {
 ReqPerSec: 719.771
 IdleWorkers: 227
 ConnsTotal: 110
+BytesPerSec: 73.12
 		`
 		want := map[string]string{
 			"ReqPerSec":   "719.771",
 			"IdleWorkers": "227",
 			"ConnsTotal":  "110",
+			"BytesPerSec": "73.12",
 		}
 		require.EqualValues(t, want, parseStats(got))
 	})
@@ -172,6 +174,19 @@ Total kBytes: 20910
 BusyWorkers: 13
 IdleWorkers: 227
 ConnsTotal: 110
+BytesPerReq: 4.2
+BytesPerSec: 8.4
+CPUChildrenSystem: 0.01
+CPUChildrenUser: 0.02
+CPUSystem: 0.03
+CPUUser: 0.04
+CPULoad: 0.66
+DurationPerReq: 21.7
+Load1: 0.9
+Load5: 0.4
+Load15: 0.3
+ReqPerSec: 12.5
+Total Duration: 1501
 Scoreboard: S_DD_L_GGG_____W__IIII_C________________W__________________________________.........................____WR______W____W________________________C______________________________________W_W____W______________R_________R________C_________WK_W________K_____W__C__________W___R______.............................................................................................................................
 `))
 			require.NoError(t, err)

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -174,18 +174,14 @@ Total kBytes: 20910
 BusyWorkers: 13
 IdleWorkers: 227
 ConnsTotal: 110
-BytesPerReq: 4.2
-BytesPerSec: 8.4
 CPUChildrenSystem: 0.01
 CPUChildrenUser: 0.02
 CPUSystem: 0.03
 CPUUser: 0.04
 CPULoad: 0.66
-DurationPerReq: 21.7
 Load1: 0.9
 Load5: 0.4
 Load15: 0.3
-ReqPerSec: 12.5
 Total Duration: 1501
 Scoreboard: S_DD_L_GGG_____W__IIII_C________________W__________________________________.........................____WR______W____W________________________C______________________________________W_W____W______________R_________R________C_________WK_W________K_____W__C__________W___R______.............................................................................................................................
 `))

--- a/receiver/apachereceiver/testdata/integration/expected.json
+++ b/receiver/apachereceiver/testdata/integration/expected.json
@@ -146,48 +146,6 @@
                      "unit": "By"
                   },
                   {
-                     "name": "apache.request.size",
-                     "description": "The average number of bytes per request.",
-                     "unit": "By/{request}",
-                     "gauge": {
-                     "dataPoints": [
-                        {
-                           "attributes": [
-                           {
-                              "key": "server_name",
-                              "value": {
-                                 "stringValue": ""
-                              }
-                           }
-                           ],
-                           "timeUnixNano": "1632495518500962000",
-                           "asDouble": "4.2"
-                        }
-                     ]
-                     }
-                  },
-                  {
-                     "name": "apache.bytes_per_second",
-                     "description": "The average number of bytes per second.",
-                     "unit": "By/s",
-                     "gauge": {
-                     "dataPoints": [
-                        {
-                           "attributes": [
-                           {
-                              "key": "server_name",
-                              "value": {
-                                 "stringValue": ""
-                              }
-                           }
-                           ],
-                           "timeUnixNano": "1632495518500962000",
-                           "asDouble": "8.4"
-                        }
-                     ]
-                     }
-                  },
-                  {
                      "name": "apache.cpu.time",
                      "description": "Jiffs used by processes of given category.",
                      "unit": "{jiff}",
@@ -318,27 +276,6 @@
                      }
                   },
                   {
-                     "name": "apache.request.average_time",
-                     "description": "The average time of handling requests.",
-                     "unit": "s",
-                     "gauge": {
-                     "dataPoints": [
-                        {
-                           "attributes": [
-                           {
-                              "key": "server_name",
-                              "value": {
-                                 "stringValue": ""
-                              }
-                           }
-                           ],
-                           "timeUnixNano": "1632495518500962000",
-                           "asDouble": "21.7"
-                        }
-                     ]
-                     }
-                  },
-                  {
                      "name": "apache.load.1",
                      "description": "The average server load during the last minute.",
                      "unit": "{load}",
@@ -397,27 +334,6 @@
                            ],
                            "timeUnixNano": "1632495518500962000",
                            "asDouble": "0.3"
-                        }
-                     ]
-                     }
-                  },
-                  {
-                     "name": "apache.request.rate",
-                     "description": "The average number of requests per second.",
-                     "unit": "{requests}/s",
-                     "gauge": {
-                     "dataPoints": [
-                        {
-                           "attributes": [
-                           {
-                              "key": "server_name",
-                              "value": {
-                                 "stringValue": ""
-                              }
-                           }
-                           ],
-                           "timeUnixNano": "1632495518500962000",
-                           "asDouble": "12.5"
                         }
                      ]
                      }

--- a/receiver/apachereceiver/testdata/integration/expected.json
+++ b/receiver/apachereceiver/testdata/integration/expected.json
@@ -253,10 +253,10 @@
                      }
                   },
                   {
-                     "name": "apache.cpu_load",
+                     "name": "apache.cpu.load",
                      "description": "Current load of the CPU.",
-                     "unit": "{load}",
-                     "sum": {
+                     "unit": "%",
+                     "gauge": {
                      "dataPoints": [
                         {
                            "attributes": [
@@ -270,15 +270,13 @@
                            "timeUnixNano": "1632495518500962000",
                            "asDouble": "0.66"
                         }
-                     ],
-                     "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                     "isMonotonic": false
+                     ]
                      }
                   },
                   {
                      "name": "apache.load.1",
                      "description": "The average server load during the last minute.",
-                     "unit": "{load}",
+                     "unit": "%",
                      "gauge": {
                      "dataPoints": [
                         {
@@ -299,7 +297,7 @@
                   {
                      "name": "apache.load.5",
                      "description": "The average server load during the last 5 minutes.",
-                     "unit": "{load}",
+                     "unit": "%",
                      "gauge": {
                      "dataPoints": [
                         {
@@ -320,7 +318,7 @@
                   {
                      "name": "apache.load.15",
                      "description": "The average server load during the last 15 minutes.",
-                     "unit": "{load}",
+                     "unit": "%",
                      "gauge": {
                      "dataPoints": [
                         {

--- a/receiver/apachereceiver/testdata/integration/expected.json
+++ b/receiver/apachereceiver/testdata/integration/expected.json
@@ -146,6 +146,306 @@
                      "unit": "By"
                   },
                   {
+                     "name": "apache.request.size",
+                     "description": "The average number of bytes per request.",
+                     "unit": "By/{request}",
+                     "gauge": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "4.2"
+                        }
+                     ]
+                     }
+                  },
+                  {
+                     "name": "apache.bytes_per_second",
+                     "description": "The average number of bytes per second.",
+                     "unit": "By/s",
+                     "gauge": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "8.4"
+                        }
+                     ]
+                     }
+                  },
+                  {
+                     "name": "apache.cpu.time",
+                     "description": "Jiffs used by processes of given category.",
+                     "unit": "{jiff}",
+                     "sum": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           },
+                           {
+                              "key": "level",
+                              "value": {
+                                 "stringValue": "children"
+                              }
+                           },
+                           {
+                              "key": "mode",
+                              "value": {
+                                 "stringValue": "system"
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "0.01"
+                        },
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           },
+                           {
+                              "key": "level",
+                              "value": {
+                                 "stringValue": "children"
+                              }
+                           },
+                           {
+                              "key": "mode",
+                              "value": {
+                                 "stringValue": "user"
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "0.02"
+                        },
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           },
+                           {
+                              "key": "level",
+                              "value": {
+                                 "stringValue": "self"
+                              }
+                           },
+                           {
+                              "key": "mode",
+                              "value": {
+                                 "stringValue": "system"
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "0.03"
+                        },
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           },
+                           {
+                              "key": "level",
+                              "value": {
+                                 "stringValue": "self"
+                              }
+                           },
+                           {
+                              "key": "mode",
+                              "value": {
+                                 "stringValue": "user"
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "0.04"
+                        }
+                     ],
+                     "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                     "isMonotonic": true
+                     }
+                  },
+                  {
+                     "name": "apache.cpu_load",
+                     "description": "Current load of the CPU.",
+                     "unit": "{load}",
+                     "sum": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "0.66"
+                        }
+                     ],
+                     "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                     "isMonotonic": false
+                     }
+                  },
+                  {
+                     "name": "apache.request.average_time",
+                     "description": "The average time of handling requests.",
+                     "unit": "s",
+                     "gauge": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "21.7"
+                        }
+                     ]
+                     }
+                  },
+                  {
+                     "name": "apache.load.1",
+                     "description": "The average server load during the last minute.",
+                     "unit": "{load}",
+                     "gauge": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "0.9"
+                        }
+                     ]
+                     }
+                  },
+                  {
+                     "name": "apache.load.5",
+                     "description": "The average server load during the last 5 minutes.",
+                     "unit": "{load}",
+                     "gauge": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "0.4"
+                        }
+                     ]
+                     }
+                  },
+                  {
+                     "name": "apache.load.15",
+                     "description": "The average server load during the last 15 minutes.",
+                     "unit": "{load}",
+                     "gauge": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "0.3"
+                        }
+                     ]
+                     }
+                  },
+                  {
+                     "name": "apache.request.rate",
+                     "description": "The average number of requests per second.",
+                     "unit": "{requests}/s",
+                     "gauge": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asDouble": "12.5"
+                        }
+                     ]
+                     }
+                  },
+                  {
+                     "name": "apache.request.time",
+                     "description": "Total time spent on handling requests.",
+                     "unit": "ms",
+                     "sum": {
+                     "dataPoints": [
+                        {
+                           "attributes": [
+                           {
+                              "key": "server_name",
+                              "value": {
+                                 "stringValue": ""
+                              }
+                           }
+                           ],
+                           "timeUnixNano": "1632495518500962000",
+                           "asInt": "1501"
+                        }
+                     ],
+                     "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                     "isMonotonic": true
+                     }
+                  },
+                  {
                      "description": "The number of workers in each state.",
                      "name": "apache.scoreboard",
                      "sum": {

--- a/receiver/apachereceiver/testdata/scraper/expected.json
+++ b/receiver/apachereceiver/testdata/scraper/expected.json
@@ -149,6 +149,297 @@
               }
             },
             {
+              "name": "apache.bytes_per_request",
+              "description": "The average number of bytes per request.",
+              "unit": "By",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "4.2"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                "isMonotonic": false
+              }
+            },
+            {
+              "name": "apache.bytes_per_second",
+              "description": "The average number of bytes per second.",
+              "unit": "By",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "8.4"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                "isMonotonic": false
+              }
+            },
+            {
+              "name": "apache.cpu_children_system",
+              "description": "Jiffies used in system mode by children processes.",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "0.01"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "apache.cpu_children_user",
+              "description": "Jiffies used in user mode by children processes.",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "0.02"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "apache.cpu_system",
+              "description": "Jiffies used in system mode.",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "0.03"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "apache.cpu_user",
+              "description": "Jiffies used in user mode.",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "0.04"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "apache.cpu_load",
+              "description": "Current load of the CPU.",
+              "unit": "{load}",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "0.66"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                "isMonotonic": false
+              }
+            },
+            {
+              "name": "apache.duration_per_request",
+              "description": "The average time of handling requests.",
+              "unit": "s",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "21.7"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                "isMonotonic": false
+              }
+            },
+            {
+              "name": "apache.load_1",
+              "description": "The average server load during the last minute.",
+              "unit": "{load}",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "0.9"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                "isMonotonic": false
+              }
+            },
+            {
+              "name": "apache.load_5",
+              "description": "The average server load during the last 5 minutes.",
+              "unit": "{load}",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "0.4"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                "isMonotonic": false
+              }
+            },
+            {
+              "name": "apache.load_15",
+              "description": "The average server load during the last 15 minutes.",
+              "unit": "{load}",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "0.3"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                "isMonotonic": false
+              }
+            },
+            {
+              "name": "apache.requests_per_second",
+              "description": "The average number of requests per second.",
+              "unit": "{requests}",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asDouble": "12.5"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                "isMonotonic": false
+              }
+            },
+            {
+              "name": "apache.total_duration",
+              "description": "Total time spent on handling requests.",
+              "unit": "s",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "server_name",
+                        "value": {
+                          "stringValue": "127.0.0.1"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1632495518500962000",
+                    "asInt": "1501"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+                "isMonotonic": false
+              }
+            },
+            {
               "name": "apache.scoreboard",
               "description": "The number of workers in each state.",
               "unit": "{workers}",

--- a/receiver/apachereceiver/testdata/scraper/expected.json
+++ b/receiver/apachereceiver/testdata/scraper/expected.json
@@ -149,10 +149,10 @@
               }
             },
             {
-              "name": "apache.bytes_per_request",
+              "name": "apache.request.size",
               "description": "The average number of bytes per request.",
-              "unit": "By",
-              "sum": {
+              "unit": "By/{request}",
+              "gauge": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -166,16 +166,14 @@
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "4.2"
                   }
-                ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                "isMonotonic": false
+                ]
               }
             },
             {
               "name": "apache.bytes_per_second",
               "description": "The average number of bytes per second.",
-              "unit": "By",
-              "sum": {
+              "unit": "By/s",
+              "gauge": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -189,9 +187,7 @@
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "8.4"
                   }
-                ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                "isMonotonic": false
+                ]
               }
             },
             {
@@ -302,10 +298,10 @@
               }
             },
             {
-              "name": "apache.duration_per_request",
+              "name": "apache.request.average_time",
               "description": "The average time of handling requests.",
               "unit": "s",
-              "sum": {
+              "gauge": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -319,16 +315,14 @@
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "21.7"
                   }
-                ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                "isMonotonic": false
+                ]
               }
             },
             {
-              "name": "apache.load_1",
+              "name": "apache.load.1",
               "description": "The average server load during the last minute.",
               "unit": "{load}",
-              "sum": {
+              "gauge": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -342,16 +336,14 @@
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "0.9"
                   }
-                ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                "isMonotonic": false
+                ]
               }
             },
             {
-              "name": "apache.load_5",
+              "name": "apache.load.5",
               "description": "The average server load during the last 5 minutes.",
               "unit": "{load}",
-              "sum": {
+              "gauge": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -365,16 +357,14 @@
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "0.4"
                   }
-                ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                "isMonotonic": false
+                ]
               }
             },
             {
-              "name": "apache.load_15",
+              "name": "apache.load.15",
               "description": "The average server load during the last 15 minutes.",
               "unit": "{load}",
-              "sum": {
+              "gauge": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -388,16 +378,14 @@
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "0.3"
                   }
-                ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                "isMonotonic": false
+                ]
               }
             },
             {
-              "name": "apache.requests_per_second",
+              "name": "apache.request.rate",
               "description": "The average number of requests per second.",
-              "unit": "{requests}",
-              "sum": {
+              "unit": "{requests}/s",
+              "gauge": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -411,15 +399,13 @@
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "12.5"
                   }
-                ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                "isMonotonic": false
+                ]
               }
             },
             {
-              "name": "apache.total_duration",
+              "name": "apache.request.time",
               "description": "Total time spent on handling requests.",
-              "unit": "s",
+              "unit": "ms",
               "sum": {
                 "dataPoints": [
                   {
@@ -435,8 +421,8 @@
                     "asInt": "1501"
                   }
                 ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                "isMonotonic": false
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                "isMonotonic": true
               }
             },
             {

--- a/receiver/apachereceiver/testdata/scraper/expected.json
+++ b/receiver/apachereceiver/testdata/scraper/expected.json
@@ -191,10 +191,10 @@
               }
             },
             {
-              "name": "apache.cpu_children_system",
-              "description": "Jiffies used in system mode by children processes.",
-              "unit": "s",
-              "gauge": {
+              "name": "apache.cpu.time",
+              "description": "Jiffs used by processes of given category.",
+              "unit": "{jiff}",
+              "sum": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -202,42 +202,48 @@
                         "key": "server_name",
                         "value": {
                           "stringValue": "127.0.0.1"
+                        }
+                      },
+                      {
+                        "key": "level",
+                        "value": {
+                          "stringValue": "children"
+                        }
+                      },
+                      {
+                        "key": "mode",
+                        "value": {
+                          "stringValue": "system"
                         }
                       }
                     ],
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "0.01"
-                  }
-                ]
-              }
-            },
-            {
-              "name": "apache.cpu_children_user",
-              "description": "Jiffies used in user mode by children processes.",
-              "unit": "s",
-              "gauge": {
-                "dataPoints": [
+                  },
                   {
                     "attributes": [
                       {
                         "key": "server_name",
                         "value": {
                           "stringValue": "127.0.0.1"
+                        }
+                      },
+                      {
+                        "key": "level",
+                        "value": {
+                          "stringValue": "children"
+                        }
+                      },
+                      {
+                        "key": "mode",
+                        "value": {
+                          "stringValue": "user"
                         }
                       }
                     ],
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "0.02"
-                  }
-                ]
-              }
-            },
-            {
-              "name": "apache.cpu_system",
-              "description": "Jiffies used in system mode.",
-              "unit": "s",
-              "gauge": {
-                "dataPoints": [
+                  },
                   {
                     "attributes": [
                       {
@@ -245,33 +251,50 @@
                         "value": {
                           "stringValue": "127.0.0.1"
                         }
+                      },
+                      {
+                        "key": "level",
+                        "value": {
+                          "stringValue": "self"
+                        }
+                      },
+                      {
+                        "key": "mode",
+                        "value": {
+                          "stringValue": "system"
+                        }
                       }
                     ],
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "0.03"
-                  }
-                ]
-              }
-            },
-            {
-              "name": "apache.cpu_user",
-              "description": "Jiffies used in user mode.",
-              "unit": "s",
-              "gauge": {
-                "dataPoints": [
+                  },
                   {
                     "attributes": [
                       {
                         "key": "server_name",
                         "value": {
                           "stringValue": "127.0.0.1"
+                        }
+                      },
+                      {
+                        "key": "level",
+                        "value": {
+                          "stringValue": "self"
+                        }
+                      },
+                      {
+                        "key": "mode",
+                        "value": {
+                          "stringValue": "user"
                         }
                       }
                     ],
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "0.04"
                   }
-                ]
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                "isMonotonic": true
               }
             },
             {

--- a/receiver/apachereceiver/testdata/scraper/expected.json
+++ b/receiver/apachereceiver/testdata/scraper/expected.json
@@ -256,10 +256,10 @@
               }
             },
             {
-              "name": "apache.cpu_load",
+              "name": "apache.cpu.load",
               "description": "Current load of the CPU.",
-              "unit": "{load}",
-              "sum": {
+              "unit": "%",
+              "gauge": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -273,15 +273,13 @@
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "0.66"
                   }
-                ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
-                "isMonotonic": false
+                ]
               }
             },
             {
               "name": "apache.load.1",
               "description": "The average server load during the last minute.",
-              "unit": "{load}",
+              "unit": "%",
               "gauge": {
                 "dataPoints": [
                   {
@@ -302,7 +300,7 @@
             {
               "name": "apache.load.5",
               "description": "The average server load during the last 5 minutes.",
-              "unit": "{load}",
+              "unit": "%",
               "gauge": {
                 "dataPoints": [
                   {
@@ -323,7 +321,7 @@
             {
               "name": "apache.load.15",
               "description": "The average server load during the last 15 minutes.",
-              "unit": "{load}",
+              "unit": "%",
               "gauge": {
                 "dataPoints": [
                   {

--- a/receiver/apachereceiver/testdata/scraper/expected.json
+++ b/receiver/apachereceiver/testdata/scraper/expected.json
@@ -149,48 +149,6 @@
               }
             },
             {
-              "name": "apache.request.size",
-              "description": "The average number of bytes per request.",
-              "unit": "By/{request}",
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "attributes": [
-                      {
-                        "key": "server_name",
-                        "value": {
-                          "stringValue": "127.0.0.1"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "1632495518500962000",
-                    "asDouble": "4.2"
-                  }
-                ]
-              }
-            },
-            {
-              "name": "apache.bytes_per_second",
-              "description": "The average number of bytes per second.",
-              "unit": "By/s",
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "attributes": [
-                      {
-                        "key": "server_name",
-                        "value": {
-                          "stringValue": "127.0.0.1"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "1632495518500962000",
-                    "asDouble": "8.4"
-                  }
-                ]
-              }
-            },
-            {
               "name": "apache.cpu.time",
               "description": "Jiffs used by processes of given category.",
               "unit": "{jiff}",
@@ -321,27 +279,6 @@
               }
             },
             {
-              "name": "apache.request.average_time",
-              "description": "The average time of handling requests.",
-              "unit": "s",
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "attributes": [
-                      {
-                        "key": "server_name",
-                        "value": {
-                          "stringValue": "127.0.0.1"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "1632495518500962000",
-                    "asDouble": "21.7"
-                  }
-                ]
-              }
-            },
-            {
               "name": "apache.load.1",
               "description": "The average server load during the last minute.",
               "unit": "{load}",
@@ -400,27 +337,6 @@
                     ],
                     "timeUnixNano": "1632495518500962000",
                     "asDouble": "0.3"
-                  }
-                ]
-              }
-            },
-            {
-              "name": "apache.request.rate",
-              "description": "The average number of requests per second.",
-              "unit": "{requests}/s",
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "attributes": [
-                      {
-                        "key": "server_name",
-                        "value": {
-                          "stringValue": "127.0.0.1"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "1632495518500962000",
-                    "asDouble": "12.5"
                   }
                 ]
               }

--- a/unreleased/apachereceiver-add-support-for-more-metrics.yaml
+++ b/unreleased/apachereceiver-add-support-for-more-metrics.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: apachereceiver
+note: The receiver now supports 13 more metrics, more information in the linked issue.
+issues: [14095]
+subtext:

--- a/unreleased/apachereceiver-add-support-for-more-metrics.yaml
+++ b/unreleased/apachereceiver-add-support-for-more-metrics.yaml
@@ -1,5 +1,5 @@
 change_type: enhancement
 component: apachereceiver
-note: The receiver now supports 13 more metrics, more information in the linked issue.
+note: The receiver now supports 6 more metrics, more information in the linked issue.
 issues: [14095]
 subtext:


### PR DESCRIPTION
**Description:** 
The receiver now scrapes 6 more metrics, described in more detail in the issue.

**Link to tracking Issue:** #14095 

**Testing:** 
Unit and integration tests for the scraper have been extended with data for new metrics.

**Documentation:**
Documentation generated by `mdatagen` has been added.