### PR TITLE
[chore] remove blank template, add "other"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: OpenTelemetry Collector Slack Channel
+    url: https://cloud-native.slack.com/archives/C01N6P7KR6W
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -1,0 +1,10 @@
+name: Other issue
+description: Create a report to help us improve the collector
+labels: ["needs triage"]
+body:
+  - type: textarea
+    attributes:
+      label: Describe the issue you're reporting
+      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+    validations:
+      required: true


### PR DESCRIPTION
To ensure all new issues have the "needs-triage" label, I've configured to remove the blank template and added a custom blank template called "other". I've also added a link to the slack channel that will show up in the new issues page.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14014