### PR TITLE
[receiver/elasticsearchreceiver] Add metric version check for elasticsearch.node.shards.data_set.size

### DIFF
--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -48,6 +48,7 @@ The full list of settings exposed for this receiver are documented [here](./conf
 
 The following metric are available with versions:
 - `elasticsearch.indexing_pressure.memory.limit` >= [7.10](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.10.0.html)
+- `elasticsearch.node.shards.data_set.size` >= [7.13](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.13.0.html)
 - `elasticsearch.cluster.state_update.count` >= [7.16.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.0.html)
 - `elasticsearch.cluster.state_update.time` >= [7.16.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.0.html)
 

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.json
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.json
@@ -12,7 +12,7 @@
                {
                   "key": "elasticsearch.node.name",
                   "value": {
-                     "stringValue": "c1643244007a"
+                     "stringValue": "a3fd1f595e8a"
                   }
                }
             ]
@@ -30,12 +30,25 @@
                                  {
                                     "key": "name",
                                     "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
                                        "stringValue": "fielddata"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -47,8 +60,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -60,8 +73,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -73,11 +86,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
-                              "asInt": "162183760",
+                              "asInt": "275730616",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -86,21 +99,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -114,6 +114,19 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
+                              "asInt": "322122547",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
                               "asInt": "214748364",
                               "attributes": [
                                  {
@@ -123,8 +136,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "536870912",
@@ -136,8 +149,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "268435456",
@@ -149,8 +162,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "536870912",
@@ -162,8 +175,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "510027366",
@@ -175,21 +188,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "322122547",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -207,12 +207,25 @@
                                  {
                                     "key": "name",
                                     "value": {
+                                       "stringValue": "request"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "name",
+                                    "value": {
                                        "stringValue": "fielddata"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -224,8 +237,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -237,8 +250,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -250,8 +263,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -263,21 +276,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "name",
-                                    "value": {
-                                       "stringValue": "request"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -300,8 +300,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -313,8 +313,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -328,8 +328,8 @@
                         "dataPoints": [
                            {
                               "asInt": "2",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -351,8 +351,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -364,8 +364,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -379,8 +379,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -395,8 +395,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -419,8 +419,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -432,8 +432,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -445,12 +445,48 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "Total count of query cache misses across all shards assigned to selected nodes.",
+                     "name": "elasticsearch.node.cache.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "hit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "miss"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           }
+                        ]
+                     },
+                     "unit": "{count}"
                   },
                   {
                      "description": "The number of evictions from the cache.",
@@ -468,8 +504,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -481,8 +517,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -505,8 +541,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -518,8 +554,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -533,8 +569,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -556,8 +592,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -569,8 +605,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -585,8 +621,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -600,8 +636,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -623,8 +659,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -636,8 +672,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -650,9 +686,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "175194243072",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asInt": "176129617920",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -665,9 +701,9 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "186807287808",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asInt": "187742662656",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -681,8 +717,8 @@
                         "dataPoints": [
                            {
                               "asInt": "228220321792",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -696,8 +732,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -711,8 +747,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -727,8 +763,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -742,8 +778,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -758,8 +794,8 @@
                         "dataPoints": [
                            {
                               "asInt": "262",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -781,8 +817,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -794,8 +830,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -807,8 +843,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -820,8 +856,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -833,8 +869,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -846,8 +882,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -859,8 +895,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -872,8 +908,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -885,8 +921,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -898,8 +934,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -911,8 +947,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -935,8 +971,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -948,8 +984,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -961,8 +997,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -974,8 +1010,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -987,8 +1023,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1000,8 +1036,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1013,8 +1049,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1026,8 +1062,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1039,8 +1075,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1052,8 +1088,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1065,8 +1101,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -1089,8 +1125,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1102,8 +1138,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -1125,8 +1161,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1138,8 +1174,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -1161,8 +1197,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1174,8 +1210,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -1190,8 +1226,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -1206,8 +1242,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -1222,27 +1258,12 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
                      "unit": "{compilations}"
-                  },
-                  {
-                     "description": "Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.",
-                     "name": "elasticsearch.node.shards.data_set.size",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           }
-                        ]
-                     },
-                     "unit": "By"
                   },
                   {
                      "description": "A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available.",
@@ -1252,8 +1273,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -1267,8 +1288,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -1286,120 +1307,6 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "analyze"
                                     }
                                  },
@@ -1410,8 +1317,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1429,540 +1336,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "222",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "11",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "completed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "rejected"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "4",
@@ -1980,8 +1355,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -1999,8 +1374,426 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "11",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2018,8 +1811,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2037,8 +1830,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2056,8 +1849,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2075,8 +1868,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2084,7 +1877,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "transform_indexing"
+                                       "stringValue": "warmer"
                                     }
                                  },
                                  {
@@ -2094,8 +1887,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2103,7 +1896,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "transform_indexing"
+                                       "stringValue": "warmer"
                                     }
                                  },
                                  {
@@ -2113,8 +1906,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2132,8 +1925,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2151,8 +1944,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2170,8 +1963,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2189,8 +1982,236 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "222",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "completed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -2209,233 +2230,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "analyze"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2447,8 +2247,151 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2460,8 +2403,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2473,8 +2416,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2482,12 +2425,12 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "transform_indexing"
+                                       "stringValue": "warmer"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2499,8 +2442,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2512,8 +2455,86 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -2531,120 +2552,6 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "force_merge"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "refresh"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "warmer"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
                                        "stringValue": "analyze"
                                     }
                                  },
@@ -2655,8 +2562,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -2674,540 +2581,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_store"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "flush"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "6",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "generic"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "listener"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_job_comms"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "search"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "snapshot"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "fetch_shard_started"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_utility"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "rollup_indexing"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "security-token-key"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "write"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "ml_datafeed"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "active"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
-                           },
-                           {
-                              "asInt": "0",
-                              "attributes": [
-                                 {
-                                    "key": "thread_pool_name",
-                                    "value": {
-                                       "stringValue": "get"
-                                    }
-                                 },
-                                 {
-                                    "key": "state",
-                                    "value": {
-                                       "stringValue": "idle"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "1",
@@ -3225,8 +2600,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "1",
@@ -3244,8 +2619,426 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_datafeed"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "refresh"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_store"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "force_merge"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_utility"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "security-token-key"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "fetch_shard_started"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "listener"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "rollup_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3263,8 +3056,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3282,8 +3075,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3301,8 +3094,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3320,8 +3113,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3329,7 +3122,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "transform_indexing"
+                                       "stringValue": "warmer"
                                     }
                                  },
                                  {
@@ -3339,8 +3132,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3348,7 +3141,7 @@
                                  {
                                     "key": "thread_pool_name",
                                     "value": {
-                                       "stringValue": "transform_indexing"
+                                       "stringValue": "warmer"
                                     }
                                  },
                                  {
@@ -3358,8 +3151,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3377,8 +3170,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3396,8 +3189,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3415,8 +3208,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3434,8 +3227,236 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "9",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "generic"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "ml_job_comms"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "search"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "snapshot"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "thread_pool_name",
+                                    "value": {
+                                       "stringValue": "transform_indexing"
+                                    }
+                                 },
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "idle"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3449,8 +3470,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -3465,8 +3486,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3480,8 +3501,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3492,9 +3513,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asDouble": 0.68,
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asDouble": 0.96,
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3506,9 +3527,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asDouble": 3.07,
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asDouble": 6.13,
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3520,9 +3541,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asDouble": 1.24,
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asDouble": 1.98,
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3534,9 +3555,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "54",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asInt": "55",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3548,7 +3569,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "3363241984",
+                              "asInt": "10171203584",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -3557,11 +3578,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
-                              "asInt": "7084138496",
+                              "asInt": "276176896",
                               "attributes": [
                                  {
                                     "key": "state",
@@ -3570,8 +3591,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3583,9 +3604,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "19050",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asInt": "19069",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3599,7 +3620,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "9",
+                              "asInt": "11",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -3608,8 +3629,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3621,8 +3642,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -3636,7 +3657,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "253",
+                              "asInt": "586",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -3645,8 +3666,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3658,8 +3679,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ],
                         "isMonotonic": true
@@ -3672,8 +3693,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3686,8 +3707,8 @@
                         "dataPoints": [
                            {
                               "asInt": "536870912",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3699,9 +3720,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "161135184",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asInt": "275730616",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3713,9 +3734,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "125878272",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asInt": "125550592",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3727,9 +3748,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "119878096",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asInt": "119346480",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3750,8 +3771,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3763,8 +3784,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "536870912",
@@ -3776,8 +3797,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3789,7 +3810,7 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "80740352",
+                              "asInt": "196083712",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -3798,11 +3819,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
-                              "asInt": "22833232",
+                              "asInt": "22865592",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -3811,11 +3832,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
-                              "asInt": "57561600",
+                              "asInt": "56781312",
                               "attributes": [
                                  {
                                     "key": "name",
@@ -3824,8 +3845,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3837,9 +3858,9 @@
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "34",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "asInt": "38",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3876,8 +3897,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
@@ -3899,8 +3920,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3912,8 +3933,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3925,12 +3946,27 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
                      "unit": "{status}"
+                  },
+                  {
+                     "description": "The number of unfinished fetches.",
+                     "name": "elasticsearch.cluster.in_flight_fetch",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           }
+                        ]
+                     },
+                     "unit": "{fetches}"
                   },
                   {
                      "description": "The total number of nodes in the cluster.",
@@ -3940,12 +3976,27 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },
                      "unit": "{nodes}"
+                  },
+                  {
+                     "description": "The number of cluster-level changes that have not yet been executed.",
+                     "name": "elasticsearch.cluster.pending_tasks",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
+                           }
+                        ]
+                     },
+                     "unit": "{tasks}"
                   },
                   {
                      "description": "The number of shards in the cluster.",
@@ -3963,8 +4014,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3976,8 +4027,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -3989,8 +4040,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            },
                            {
                               "asInt": "0",
@@ -4002,8 +4053,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1662755391254834000",
-                              "timeUnixNano": "1662755401255264000"
+                              "startTimeUnixNano": "1663084088275038000",
+                              "timeUnixNano": "1663084098275677000"
                            }
                         ]
                      },

--- a/unreleased/elasticsearchreceiver-data_set-size-version-check.yaml
+++ b/unreleased/elasticsearchreceiver-data_set-size-version-check.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix issue where `elasticsearch.node.shards.data_set.size` emits 0 value for unsupported version"
+
+# One or more tracking issues related to the change
+issues: [14012]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This pr adds a version check before recording metric `elasticsearch.node.shards.data_set.size` which was introduced in [7.13](https://github.com/elastic/elasticsearch/pull/70625/files#diff-354b5b1f25978b5c638cb707622ae79b42b40aace6f27f3f9d5dd1e31e67b1caR7). Integration test 7.9 used to show a 0 metric value but after this pr will become a non-existent metric for integration test 7.9 since it is not supported. 

**Link to tracking Issue:** <Issue number if applicable>
#14012 

**Testing:** <Describe what testing was performed and which tests were added.>
unit test pass and Integration test has been updated

**Documentation:** <Describe the documentation added.>
Added ES metric availability with version documentation in readme