### PR TITLE
[CI] Do not cancel "Build Status" badge workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   setup-environment:


### PR DESCRIPTION
This repo's README contains a prominent "Build Status" badge that is backed by the 'build-and-test' workflow on main. This badge is regularly in a failing state due to cancelation of this workflow (whenever multiple PRs are merged to main within ~30 minutes of each other).

This change makes an exception for the main branch, so that this workflow will run completely for each merge to main.

This should not only improve the appearance of the badge, but it also gives us a more complete record of merges to main, which is helpful to quickly pinpoint the occasional bad commit.