### PR TITLE
[receiver/vcenter] Fix incorrect KBy and MBy units

### DIFF
--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -23,10 +23,10 @@ These are the metrics available for this scraper.
 | **vcenter.host.disk.latency.avg.read** | The latency of reads to the host system's disk. This latency is the sum of the device and kernel read latencies. Requires Performance Counter level 2 for metric to populate. | ms | Gauge(Int) | <ul> </ul> |
 | **vcenter.host.disk.latency.avg.write** | The latency of writes to the host system's disk. This latency is the sum of the device and kernel write latencies. Requires Performance Counter level 2 for metric to populate. | ms | Gauge(Int) | <ul> </ul> |
 | **vcenter.host.disk.latency.max** | Highest latency value across all disks used by the host. As measured over the most recent 20s interval. Requires Performance Level 3. | ms | Gauge(Int) | <ul> </ul> |
-| **vcenter.host.disk.throughput** | Average number of kilobytes read from or written to the disk each second. As measured over the most recent 20s interval. Aggregated disk I/O rate. Requires Performance Level 4. | {KBy/s} | Sum(Int) | <ul> <li>disk_direction</li> </ul> |
-| **vcenter.host.disk.throughput.read** | Average number of kilobytes read from the disk each second. As measured over the most recent 20s interval. Aggregated disk read rate. Requires Performance Level 4. | {KBy/s} | Sum(Int) | <ul> </ul> |
-| **vcenter.host.disk.throughput.write** | Average number of kilobytes written to the disk each second. As measured over the most recent 20s interval. Aggregated disk write rate. Requires Performance Level 4. | {KBy/s} | Sum(Int) | <ul> </ul> |
-| **vcenter.host.memory.usage** | The amount of memory the host system is using. | MBy | Sum(Int) | <ul> </ul> |
+| **vcenter.host.disk.throughput** | Average number of kilobytes read from or written to the disk each second. As measured over the most recent 20s interval. Aggregated disk I/O rate. Requires Performance Level 4. | {KiBy/s} | Sum(Int) | <ul> <li>disk_direction</li> </ul> |
+| **vcenter.host.disk.throughput.read** | Average number of kilobytes read from the disk each second. As measured over the most recent 20s interval. Aggregated disk read rate. Requires Performance Level 4. | {KiBy/s} | Sum(Int) | <ul> </ul> |
+| **vcenter.host.disk.throughput.write** | Average number of kilobytes written to the disk each second. As measured over the most recent 20s interval. Aggregated disk write rate. Requires Performance Level 4. | {KiBy/s} | Sum(Int) | <ul> </ul> |
+| **vcenter.host.memory.usage** | The amount of memory the host system is using. | MiBy | Sum(Int) | <ul> </ul> |
 | **vcenter.host.memory.utilization** | The percentage of the host system's memory capacity that is being utilized. | % | Gauge(Double) | <ul> </ul> |
 | **vcenter.host.network.packet.count** | The number of packets transmitted and received, as measured over the most recent 20s interval. | {packets/sec} | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
 | **vcenter.host.network.packet.count.receive** | The number of packets received, as measured over the most recent 20s interval. | {packets/sec} | Sum(Int) | <ul> </ul> |
@@ -34,14 +34,14 @@ These are the metrics available for this scraper.
 | **vcenter.host.network.packet.errors** | The summation of packet errors on the host network. As measured over the most recent 20s interval. | {errors} | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
 | **vcenter.host.network.packet.errors.receive** | The summation of receive packet errors on the host network. As measured over the most recent 20s interval. | {errors} | Sum(Int) | <ul> </ul> |
 | **vcenter.host.network.packet.errors.transmit** | The summation of transmit packet errors on the host network. As measured over the most recent 20s interval. | {errors} | Sum(Int) | <ul> </ul> |
-| **vcenter.host.network.throughput** | The amount of data that was transmitted or received over the network by the host. As measured over the most recent 20s interval. | {KBy/s} | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
-| **vcenter.host.network.throughput.receive** | The amount of data that was received over the network by the host. As measured over the most recent 20s interval. | {KBy/s} | Sum(Int) | <ul> </ul> |
-| **vcenter.host.network.throughput.transmit** | The amount of data that was transmitted over the network by the host. As measured over the most recent 20s interval. | {KBy/s} | Sum(Int) | <ul> </ul> |
-| **vcenter.host.network.usage** | The sum of the data transmitted and received for all the NIC instances of the host. | {KBy/s} | Sum(Int) | <ul> </ul> |
+| **vcenter.host.network.throughput** | The amount of data that was transmitted or received over the network by the host. As measured over the most recent 20s interval. | {KiBy/s} | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
+| **vcenter.host.network.throughput.receive** | The amount of data that was received over the network by the host. As measured over the most recent 20s interval. | {KiBy/s} | Sum(Int) | <ul> </ul> |
+| **vcenter.host.network.throughput.transmit** | The amount of data that was transmitted over the network by the host. As measured over the most recent 20s interval. | {KiBy/s} | Sum(Int) | <ul> </ul> |
+| **vcenter.host.network.usage** | The sum of the data transmitted and received for all the NIC instances of the host. | {KiBy/s} | Sum(Int) | <ul> </ul> |
 | **vcenter.resource_pool.cpu.shares** | The amount of shares of CPU in the resource pool. | {shares} | Sum(Int) | <ul> </ul> |
 | **vcenter.resource_pool.cpu.usage** | The usage of the CPU used by the resource pool. | {MHz} | Sum(Int) | <ul> </ul> |
 | **vcenter.resource_pool.memory.shares** | The amount of shares of memory in the resource pool. | {shares} | Sum(Int) | <ul> </ul> |
-| **vcenter.resource_pool.memory.usage** | The usage of the memory by the resource pool. | MBy | Sum(Int) | <ul> </ul> |
+| **vcenter.resource_pool.memory.usage** | The usage of the memory by the resource pool. | MiBy | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.disk.latency.avg** | The latency of operations to the virtual machine's disk. Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval. | ms | Gauge(Int) | <ul> <li>disk_direction</li> <li>disk_type</li> </ul> |
 | **vcenter.vm.disk.latency.avg.read** | The latency of reads to the virtual machine's disk. Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval. | ms | Gauge(Int) | <ul> <li>disk_type</li> </ul> |
 | **vcenter.vm.disk.latency.avg.write** | The latency of writes to the virtual machine's disk. Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval. | ms | Gauge(Int) | <ul> <li>disk_type</li> </ul> |
@@ -50,14 +50,14 @@ These are the metrics available for this scraper.
 | **vcenter.vm.disk.usage** | The amount of storage space used by the virtual machine. | By | Sum(Int) | <ul> <li>disk_state</li> </ul> |
 | **vcenter.vm.disk.utilization** | The utilization of storage on the virtual machine. | % | Gauge(Double) | <ul> </ul> |
 | **vcenter.vm.memory.ballooned** | The amount of memory that is ballooned due to virtualization. | By | Sum(Int) | <ul> </ul> |
-| **vcenter.vm.memory.usage** | The amount of memory that is used by the virtual machine. | MBy | Sum(Int) | <ul> </ul> |
+| **vcenter.vm.memory.usage** | The amount of memory that is used by the virtual machine. | MiBy | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.network.packet.count** | The amount of packets that was received or transmitted over the instance's network. | {packets/sec} | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
 | **vcenter.vm.network.packet.count.receive** | The amount of packets that was received over the instance's network. | {packets/sec} | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.network.packet.count.transmit** | The amount of packets that was transmitted over the instance's network. | {packets/sec} | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.network.throughput** | The amount of data that was transmitted or received over the network of the virtual machine. As measured over the most recent 20s interval. | By/sec | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
 | **vcenter.vm.network.throughput.receive** | The amount of data that was received over the network of the virtual machine. As measured over the most recent 20s interval. | By/sec | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.network.throughput.transmit** | The amount of data that was transmitted over the network of the virtual machine. As measured over the most recent 20s interval. | By/sec | Sum(Int) | <ul> </ul> |
-| **vcenter.vm.network.usage** | The network utilization combined transmit and receive rates during an interval. As measured over the most recent 20s interval. | {KBy/s} | Sum(Int) | <ul> </ul> |
+| **vcenter.vm.network.usage** | The network utilization combined transmit and receive rates during an interval. As measured over the most recent 20s interval. | {KiBy/s} | Sum(Int) | <ul> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
 Any metric can be enabled or disabled with the following scraper configuration:

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -1151,7 +1151,7 @@ type metricVcenterHostDiskThroughput struct {
 func (m *metricVcenterHostDiskThroughput) init() {
 	m.data.SetName("vcenter.host.disk.throughput")
 	m.data.SetDescription("Average number of kilobytes read from or written to the disk each second.")
-	m.data.SetUnit("{KBy/s}")
+	m.data.SetUnit("{KiBy/s}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -1204,7 +1204,7 @@ type metricVcenterHostDiskThroughputRead struct {
 func (m *metricVcenterHostDiskThroughputRead) init() {
 	m.data.SetName("vcenter.host.disk.throughput.read")
 	m.data.SetDescription("Average number of kilobytes read from the disk each second.")
-	m.data.SetUnit("{KBy/s}")
+	m.data.SetUnit("{KiBy/s}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -1255,7 +1255,7 @@ type metricVcenterHostDiskThroughputWrite struct {
 func (m *metricVcenterHostDiskThroughputWrite) init() {
 	m.data.SetName("vcenter.host.disk.throughput.write")
 	m.data.SetDescription("Average number of kilobytes written to the disk each second.")
-	m.data.SetUnit("{KBy/s}")
+	m.data.SetUnit("{KiBy/s}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -1306,7 +1306,7 @@ type metricVcenterHostMemoryUsage struct {
 func (m *metricVcenterHostMemoryUsage) init() {
 	m.data.SetName("vcenter.host.memory.usage")
 	m.data.SetDescription("The amount of memory the host system is using.")
-	m.data.SetUnit("MBy")
+	m.data.SetUnit("MiBy")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -1716,7 +1716,7 @@ type metricVcenterHostNetworkThroughput struct {
 func (m *metricVcenterHostNetworkThroughput) init() {
 	m.data.SetName("vcenter.host.network.throughput")
 	m.data.SetDescription("The amount of data that was transmitted or received over the network by the host.")
-	m.data.SetUnit("{KBy/s}")
+	m.data.SetUnit("{KiBy/s}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -1769,7 +1769,7 @@ type metricVcenterHostNetworkThroughputReceive struct {
 func (m *metricVcenterHostNetworkThroughputReceive) init() {
 	m.data.SetName("vcenter.host.network.throughput.receive")
 	m.data.SetDescription("The amount of data that was received over the network by the host.")
-	m.data.SetUnit("{KBy/s}")
+	m.data.SetUnit("{KiBy/s}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -1820,7 +1820,7 @@ type metricVcenterHostNetworkThroughputTransmit struct {
 func (m *metricVcenterHostNetworkThroughputTransmit) init() {
 	m.data.SetName("vcenter.host.network.throughput.transmit")
 	m.data.SetDescription("The amount of data that was transmitted over the network by the host.")
-	m.data.SetUnit("{KBy/s}")
+	m.data.SetUnit("{KiBy/s}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -1871,7 +1871,7 @@ type metricVcenterHostNetworkUsage struct {
 func (m *metricVcenterHostNetworkUsage) init() {
 	m.data.SetName("vcenter.host.network.usage")
 	m.data.SetDescription("The sum of the data transmitted and received for all the NIC instances of the host.")
-	m.data.SetUnit("{KBy/s}")
+	m.data.SetUnit("{KiBy/s}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -2075,7 +2075,7 @@ type metricVcenterResourcePoolMemoryUsage struct {
 func (m *metricVcenterResourcePoolMemoryUsage) init() {
 	m.data.SetName("vcenter.resource_pool.memory.usage")
 	m.data.SetDescription("The usage of the memory by the resource pool.")
-	m.data.SetUnit("MBy")
+	m.data.SetUnit("MiBy")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -2533,7 +2533,7 @@ type metricVcenterVMMemoryUsage struct {
 func (m *metricVcenterVMMemoryUsage) init() {
 	m.data.SetName("vcenter.vm.memory.usage")
 	m.data.SetDescription("The amount of memory that is used by the virtual machine.")
-	m.data.SetUnit("MBy")
+	m.data.SetUnit("MiBy")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -2894,7 +2894,7 @@ type metricVcenterVMNetworkUsage struct {
 func (m *metricVcenterVMNetworkUsage) init() {
 	m.data.SetName("vcenter.vm.network.usage")
 	m.data.SetDescription("The network utilization combined transmit and receive rates during an interval.")
-	m.data.SetUnit("{KBy/s}")
+	m.data.SetUnit("{KiBy/s}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -164,7 +164,7 @@ metrics:
   vcenter.host.disk.throughput:
     enabled: true
     description: Average number of kilobytes read from or written to the disk each second.
-    unit: "{KBy/s}"
+    unit: "{KiBy/s}"
     sum:
       monotonic: false
       value_type: int
@@ -175,7 +175,7 @@ metrics:
   vcenter.host.disk.throughput.read:
     enabled: true
     description: Average number of kilobytes read from the disk each second.
-    unit: "{KBy/s}"
+    unit: "{KiBy/s}"
     sum:
       monotonic: false
       value_type: int
@@ -185,7 +185,7 @@ metrics:
   vcenter.host.disk.throughput.write:
     enabled: true
     description: Average number of kilobytes written to the disk each second.
-    unit: "{KBy/s}"
+    unit: "{KiBy/s}"
     sum:
       monotonic: false
       value_type: int
@@ -234,7 +234,7 @@ metrics:
   vcenter.host.memory.usage:
     enabled: true
     description: The amount of memory the host system is using.
-    unit: MBy
+    unit: MiBy
     sum:
       monotonic: false
       value_type: int
@@ -244,7 +244,7 @@ metrics:
   vcenter.host.network.throughput:
     enabled: true
     description: The amount of data that was transmitted or received over the network by the host.
-    unit: "{KBy/s}"
+    unit: "{KiBy/s}"
     sum:
       monotonic: false
       value_type: int
@@ -255,7 +255,7 @@ metrics:
   vcenter.host.network.throughput.receive:
     enabled: true
     description: The amount of data that was received over the network by the host.
-    unit: "{KBy/s}"
+    unit: "{KiBy/s}"
     sum:
       monotonic: false
       value_type: int
@@ -265,7 +265,7 @@ metrics:
   vcenter.host.network.throughput.transmit:
     enabled: true
     description: The amount of data that was transmitted over the network by the host.
-    unit: "{KBy/s}"
+    unit: "{KiBy/s}"
     sum:
       monotonic: false
       value_type: int
@@ -274,7 +274,7 @@ metrics:
   vcenter.host.network.usage:
     enabled: true
     description: The sum of the data transmitted and received for all the NIC instances of the host.
-    unit: "{KBy/s}"
+    unit: "{KiBy/s}"
     sum:
       monotonic: false
       value_type: int
@@ -342,7 +342,7 @@ metrics:
   vcenter.resource_pool.memory.usage:
     enabled: true
     description: The usage of the memory by the resource pool.
-    unit: MBy
+    unit: MiBy
     sum:
       monotonic: false
       value_type: int
@@ -387,7 +387,7 @@ metrics:
   vcenter.vm.memory.usage:
     enabled: true
     description: The amount of memory that is used by the virtual machine.
-    unit: MBy
+    unit: MiBy
     sum:
       monotonic: false
       value_type: int
@@ -514,7 +514,7 @@ metrics:
   vcenter.vm.network.usage:
     enabled: true
     description: The network utilization combined transmit and receive rates during an interval.
-    unit: "{KBy/s}"
+    unit: "{KiBy/s}"
     sum:
       monotonic: false
       value_type: int

--- a/receiver/vcenterreceiver/testdata/metrics/expected.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.json
@@ -229,7 +229,7 @@
                         {
                             "name": "vcenter.host.disk.throughput",
                             "description": "Average number of kilobytes read from or written to the disk each second.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -954,7 +954,7 @@
                         {
                             "name": "vcenter.host.memory.usage",
                             "description": "The amount of memory the host system is using.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -2303,7 +2303,7 @@
                         {
                             "name": "vcenter.host.network.throughput",
                             "description": "The amount of data that was transmitted or received over the network by the host.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -2963,7 +2963,7 @@
                         {
                             "name": "vcenter.host.network.usage",
                             "description": "The sum of the data transmitted and received for all the NIC instances of the host.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -3342,7 +3342,7 @@
                         {
                             "name": "vcenter.vm.memory.usage",
                             "description": "The amount of memory that is used by the virtual machine.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -3689,7 +3689,7 @@
                         {
                             "name": "vcenter.vm.network.usage",
                             "description": "The network utilization combined transmit and receive rates during an interval.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -3950,7 +3950,7 @@
                         {
                             "name": "vcenter.resource_pool.memory.usage",
                             "description": "The usage of the memory by the resource pool.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {

--- a/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
@@ -158,7 +158,7 @@
                         {
                             "name": "vcenter.host.disk.throughput.read",
                             "description": "Average number of kilobytes read from the disk each second.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -418,7 +418,7 @@
                         {
                             "name": "vcenter.host.disk.throughput.write",
                             "description": "Average number of kilobytes written to the disk each second.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -453,7 +453,7 @@
                         {
                             "name": "vcenter.host.memory.usage",
                             "description": "The amount of memory the host system is using.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -1022,7 +1022,7 @@
                         {
                             "name": "vcenter.host.network.throughput.transmit",
                             "description": "The amount of data that was transmitted over the network by the host.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -1157,7 +1157,7 @@
                         {
                             "name": "vcenter.host.network.throughput.receive",
                             "description": "The amount of data that was received over the network by the host.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -1292,7 +1292,7 @@
                         {
                             "name": "vcenter.host.network.usage",
                             "description": "The sum of the data transmitted and received for all the NIC instances of the host.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -1668,7 +1668,7 @@
                         {
                             "name": "vcenter.vm.memory.usage",
                             "description": "The amount of memory that is used by the virtual machine.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -1843,7 +1843,7 @@
                         {
                             "name": "vcenter.vm.network.usage",
                             "description": "The network utilization combined transmit and receive rates during an interval.",
-                            "unit": "{KBy/s}",
+                            "unit": "{KiBy/s}",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -2104,7 +2104,7 @@
                         {
                             "name": "vcenter.resource_pool.memory.usage",
                             "description": "The usage of the memory by the resource pool.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {

--- a/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
+++ b/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
@@ -56,7 +56,7 @@
                         {
                             "name": "vcenter.host.memory.usage",
                             "description": "The amount of memory the host system is using.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -142,7 +142,7 @@
                         {
                             "name": "vcenter.host.memory.usage",
                             "description": "The amount of memory the host system is using.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -228,7 +228,7 @@
                         {
                             "name": "vcenter.host.memory.usage",
                             "description": "The amount of memory the host system is using.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -426,7 +426,7 @@
                         {
                             "name": "vcenter.vm.memory.usage",
                             "description": "The amount of memory that is used by the virtual machine.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -532,7 +532,7 @@
                         {
                             "name": "vcenter.vm.memory.usage",
                             "description": "The amount of memory that is used by the virtual machine.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -638,7 +638,7 @@
                         {
                             "name": "vcenter.vm.memory.usage",
                             "description": "The amount of memory that is used by the virtual machine.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {
@@ -744,7 +744,7 @@
                         {
                             "name": "vcenter.vm.memory.usage",
                             "description": "The amount of memory that is used by the virtual machine.",
-                            "unit": "MBy",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {

--- a/unreleased/vcenter-fix-kibi-mibi.yaml
+++ b/unreleased/vcenter-fix-kibi-mibi.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix incorrect KBy and MBy units, updating them to KiBy and MiBy"
+
+# One or more tracking issues related to the change
+issues: [13935]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
The vcenter receiver indicates that it uses kilobytes (kBy), but instead the units are actually kibibytes (KiBy). The vSphere API docs claims they are in kilobytes, but [documentation on the data counters units](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.monitoring.doc/GUID-12B1493A-5657-4BB3-8935-44B6B8E8B67C.html) indicates that they use kilobytes to mean 1024 bytes, which in UCUM is actually kibibytes (KiBy).

Similar logic applies to the MBy units. VMware, in general, seems to prefer returning in power of 2 units instead of power of 10 units.

**Link to tracking Issue:** Part of #13935