### PR TITLE
[chore] Temporarily replace UpsertEmptyBytes

### DIFF
--- a/cmd/mdatagen/metrics.tmpl
+++ b/cmd/mdatagen/metrics.tmpl
@@ -113,7 +113,7 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	{{- else if eq (attributeInfo .).Type.Primitive "float64" }}
 	dp.Attributes().UpsertDouble("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
 	{{- else if eq (attributeInfo .).Type.Primitive "[]byte" }}
-	dp.Attributes().UpsertEmptyBytes("{{ attributeKey .}}").FromRaw({{ .RenderUnexported }}AttributeValue)
+	dp.Attributes().UpsertEmpty("{{ attributeKey .}}").SetEmptyBytesVal().FromRaw({{ .RenderUnexported }}AttributeValue)
 	{{- else }}
 	dp.Attributes().UpsertString("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
 	{{- end }}

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -222,7 +222,7 @@ func TestConvert(t *testing.T) {
 		m.UpsertInt("int", 123)
 		m.UpsertDouble("double", 12.34)
 		m.UpsertString("string", "hello")
-		m.UpsertEmptyBytes("bytes").FromRaw([]byte("asdf"))
+		m.UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte("asdf"))
 		assert.EqualValues(t, m.Sort(), lr.Body().MapVal().Sort())
 	}
 }

--- a/pkg/stanza/adapter/frompdataconverter_test.go
+++ b/pkg/stanza/adapter/frompdataconverter_test.go
@@ -55,7 +55,7 @@ func fillBaseMap(m pcommon.Map) {
 	m.UpsertInt("int", 123)
 	m.UpsertDouble("double", 12.34)
 	m.UpsertString("string", "hello")
-	m.UpsertEmptyBytes("bytes").FromRaw([]byte{0xa1, 0xf0, 0x02, 0xff})
+	m.UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{0xa1, 0xf0, 0x02, 0xff})
 }
 
 func complexPdataForNDifferentHosts(count int, n int) plog.Logs {

--- a/pkg/telemetryquerylanguage/contexts/internal/tqlcommon/resource_test.go
+++ b/pkg/telemetryquerylanguage/contexts/internal/tqlcommon/resource_test.go
@@ -126,7 +126,7 @@ func TestResourcePathGetSetter(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(resource pcommon.Resource) {
-				resource.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+				resource.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -254,7 +254,7 @@ func createResource() pcommon.Resource {
 	resource.Attributes().UpsertBool("bool", true)
 	resource.Attributes().UpsertInt("int", 10)
 	resource.Attributes().UpsertDouble("double", 1.2)
-	resource.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+	resource.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
 
 	arrStr := resource.Attributes().UpsertEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")

--- a/pkg/telemetryquerylanguage/contexts/internal/tqlcommon/scope_test.go
+++ b/pkg/telemetryquerylanguage/contexts/internal/tqlcommon/scope_test.go
@@ -151,7 +151,7 @@ func TestScopePathGetSetter(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(is pcommon.InstrumentationScope) {
-				is.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+				is.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -274,7 +274,7 @@ func createInstrumentationScope() pcommon.InstrumentationScope {
 	is.Attributes().UpsertBool("bool", true)
 	is.Attributes().UpsertInt("int", 10)
 	is.Attributes().UpsertDouble("double", 1.2)
-	is.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+	is.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
 
 	arrStr := is.Attributes().UpsertEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")

--- a/pkg/telemetryquerylanguage/contexts/tqllogs/logs_test.go
+++ b/pkg/telemetryquerylanguage/contexts/tqllogs/logs_test.go
@@ -264,7 +264,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource) {
-				log.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+				log.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -425,7 +425,7 @@ func createTelemetry() (plog.LogRecord, pcommon.InstrumentationScope, pcommon.Re
 	log.Attributes().UpsertBool("bool", true)
 	log.Attributes().UpsertInt("int", 10)
 	log.Attributes().UpsertDouble("double", 1.2)
-	log.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+	log.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
 
 	arrStr := log.Attributes().UpsertEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")

--- a/pkg/telemetryquerylanguage/contexts/tqlmetrics/metrics_test.go
+++ b/pkg/telemetryquerylanguage/contexts/tqlmetrics/metrics_test.go
@@ -199,7 +199,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(datapoint pmetric.NumberDataPoint) {
-				datapoint.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+				datapoint.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -525,7 +525,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(datapoint pmetric.HistogramDataPoint) {
-				datapoint.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+				datapoint.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -947,7 +947,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
-				datapoint.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+				datapoint.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -1254,7 +1254,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(datapoint pmetric.SummaryDataPoint) {
-				datapoint.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+				datapoint.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -1383,7 +1383,7 @@ func createAttributeTelemetry(attributes pcommon.Map) {
 	attributes.UpsertBool("bool", true)
 	attributes.UpsertInt("int", 10)
 	attributes.UpsertDouble("double", 1.2)
-	attributes.UpsertEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+	attributes.UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
 
 	arrStr := attributes.UpsertEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")

--- a/pkg/telemetryquerylanguage/contexts/tqltraces/traces_test.go
+++ b/pkg/telemetryquerylanguage/contexts/tqltraces/traces_test.go
@@ -287,7 +287,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
-				span.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+				span.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -554,7 +554,7 @@ func createTelemetry() (ptrace.Span, pcommon.InstrumentationScope, pcommon.Resou
 	span.Attributes().UpsertBool("bool", true)
 	span.Attributes().UpsertInt("int", 10)
 	span.Attributes().UpsertDouble("double", 1.2)
-	span.Attributes().UpsertEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+	span.Attributes().UpsertEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
 
 	arrStr := span.Attributes().UpsertEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")


### PR DESCRIPTION
In order to let contrib-check job pass in core https://github.com/open-telemetry/opentelemetry-collector/actions/runs/3049157563/jobs/4914943203.

Once https://github.com/open-telemetry/opentelemetry-collector/pull/6064 is merged, this can be renamed to PutEmptyBytes

We want to avoid releasing `UpserEmptyBytes` if https://github.com/open-telemetry/opentelemetry-collector/pull/6064 is merged before the release.
