### PR TITLE
exporter/datadogexporter: simplify hostmetrics example

### DIFF
--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -21,8 +21,6 @@ receivers:
         metrics:
           system.paging.utilization:
             enabled: true
-          system.paging.usage:
-            enabled: true
       cpu:
         metrics:
           system.cpu.utilization:
@@ -38,11 +36,6 @@ receivers:
           system.memory.utilization:
             enabled: true
       network:
-        metrics:
-          system.network.io.receive:
-            enabled: true
-          system.network.io.transmit:
-            enabled: true
       processes:
   # # Comment out this block below to get access to system metrics regarding
   # # the OpenTelemetry Collector and its environment, such as spans or metrics

--- a/exporter/datadogexporter/examples/k8s-chart/configmap.yaml
+++ b/exporter/datadogexporter/examples/k8s-chart/configmap.yaml
@@ -20,8 +20,6 @@ data:
             metrics:
               system.paging.utilization:
                 enabled: true
-              system.paging.usage:
-                enabled: true
           cpu:
             metrics:
               system.cpu.utilization:
@@ -37,11 +35,6 @@ data:
               system.memory.utilization:
                 enabled: true
           network:
-            metrics:
-              system.network.io.receive:
-                enabled: true
-              system.network.io.transmit:
-                enabled: true
           processes:
       # # Comment out this block below to get access to system metrics regarding
       # # the OpenTelemetry Collector and its environment, such as spans or metrics


### PR DESCRIPTION
This change removes the `system.paging.usage` metric which is already [enabled by default](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/7cebf27348f05e591ab78f274f049a26e205161e/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go#L43-L45), along with the `system.network.io.*` metrics which are also [enabled by default](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/7cebf27348f05e591ab78f274f049a26e205161e/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go#L70-L75).