### PR TITLE
[pkg/stanza] Fix name of SeverityConfig

### DIFF
--- a/pkg/stanza/operator/helper/parser.go
+++ b/pkg/stanza/operator/helper/parser.go
@@ -41,7 +41,7 @@ type ParserConfig struct {
 	ParseTo         entry.Field      `mapstructure:"parse_to"            json:"parse_to"            yaml:"parse_to"`
 	BodyField       *entry.Field     `mapstructure:"body"                json:"body"                yaml:"body"`
 	TimeParser      *TimeParser      `mapstructure:"timestamp,omitempty" json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
-	Config          *SeverityConfig  `mapstructure:"severity,omitempty"  json:"severity,omitempty"  yaml:"severity,omitempty"`
+	SeverityConfig  *SeverityConfig  `mapstructure:"severity,omitempty"  json:"severity,omitempty"  yaml:"severity,omitempty"`
 	TraceParser     *TraceParser     `mapstructure:"trace,omitempty"     json:"trace,omitempty"     yaml:"trace,omitempty"`
 	ScopeNameParser *ScopeNameParser `mapstructure:"scope_name,omitempty"     json:"scope_name,omitempty"     yaml:"scope_name,omitempty"`
 }
@@ -71,8 +71,8 @@ func (c ParserConfig) Build(logger *zap.SugaredLogger) (ParserOperator, error) {
 		parserOperator.TimeParser = c.TimeParser
 	}
 
-	if c.Config != nil {
-		severityParser, err := c.Config.Build(logger)
+	if c.SeverityConfig != nil {
+		severityParser, err := c.SeverityConfig.Build(logger)
 		if err != nil {
 			return ParserOperator{}, err
 		}

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -75,7 +75,7 @@ func TestParserConfigBuildValid(t *testing.T) {
 	}
 
 	sevField := entry.NewBodyField("timestamp")
-	cfg.Config = &SeverityConfig{
+	cfg.SeverityConfig = &SeverityConfig{
 		ParseFrom: &sevField,
 	}
 
@@ -663,7 +663,7 @@ func NewTestParserConfig() ParserConfig {
 		"info": "3xx",
 		"warn": "4xx",
 	}
-	expect.Config = &sp
+	expect.SeverityConfig = &sp
 
 	lnp := NewScopeNameParser()
 	lnp.ParseFrom = entry.NewBodyField("logger")

--- a/pkg/stanza/operator/parser/json/config_test.go
+++ b/pkg/stanza/operator/parser/json/config_test.go
@@ -83,7 +83,7 @@ func TestConfig(t *testing.T) {
 						"debug":    "2xx",
 					}
 					severityParser.Mapping = mapping
-					cfg.Config = &severityParser
+					cfg.SeverityConfig = &severityParser
 					return cfg
 				}(),
 			},

--- a/pkg/stanza/operator/parser/keyvalue/config_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/config_test.go
@@ -83,7 +83,7 @@ func TestConfig(t *testing.T) {
 						"debug":    "2xx",
 					}
 					severityField.Mapping = mapping
-					cfg.Config = &severityField
+					cfg.SeverityConfig = &severityField
 					return cfg
 				}(),
 			},

--- a/pkg/stanza/operator/parser/regex/config_test.go
+++ b/pkg/stanza/operator/parser/regex/config_test.go
@@ -91,7 +91,7 @@ func TestParserGoldenConfig(t *testing.T) {
 						"debug":    "2xx",
 					}
 					severityParser.Mapping = mapping
-					cfg.Config = &severityParser
+					cfg.SeverityConfig = &severityParser
 					return cfg
 				}(),
 			},

--- a/pkg/stanza/operator/parser/syslog/config_test.go
+++ b/pkg/stanza/operator/parser/syslog/config_test.go
@@ -117,7 +117,7 @@ func TestUnmarshal(t *testing.T) {
 						"debug":    "2xx",
 					}
 					severityParser.Mapping = mapping
-					cfg.Config = &severityParser
+					cfg.SeverityConfig = &severityParser
 					return cfg
 				}(),
 			},

--- a/pkg/stanza/operator/parser/uri/config_test.go
+++ b/pkg/stanza/operator/parser/uri/config_test.go
@@ -83,7 +83,7 @@ func TestParserGoldenConfig(t *testing.T) {
 						"debug":    "2xx",
 					}
 					severityField.Mapping = mapping
-					cfg.Config = &severityField
+					cfg.SeverityConfig = &severityField
 					return cfg
 				}(),
 			},

--- a/unreleased/pkg-stanza-fix-sevconfname.yaml
+++ b/unreleased/pkg-stanza-fix-sevconfname.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change name of ParserConfig.Config to more specific ParserConfig.SeverityConfig
+
+# One or more tracking issues related to the change
+issues: [14126]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
The `Parser` struct which is embedded in many parser operators contains a 
`SeverityConfig` struct, but gives it the oddly generic name, `Config`. This
reads strangely when working with the struct. 