### PR TITLE
[chore] Apply new Map.PutEmptyBytes method

### DIFF
--- a/cmd/mdatagen/metrics.tmpl
+++ b/cmd/mdatagen/metrics.tmpl
@@ -113,7 +113,7 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	{{- else if eq (attributeInfo .).Type.Primitive "float64" }}
 	dp.Attributes().PutDouble("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
 	{{- else if eq (attributeInfo .).Type.Primitive "[]byte" }}
-	dp.Attributes().PutEmpty("{{ attributeKey .}}").SetEmptyBytesVal().FromRaw({{ .RenderUnexported }}AttributeValue)
+	dp.Attributes().PutEmptyBytes("{{ attributeKey .}}").FromRaw({{ .RenderUnexported }}AttributeValue)
 	{{- else }}
 	dp.Attributes().PutString("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
 	{{- end }}

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -222,7 +222,7 @@ func TestConvert(t *testing.T) {
 		m.PutInt("int", 123)
 		m.PutDouble("double", 12.34)
 		m.PutString("string", "hello")
-		m.PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte("asdf"))
+		m.PutEmptyBytes("bytes").FromRaw([]byte("asdf"))
 		assert.EqualValues(t, m.Sort(), lr.Body().MapVal().Sort())
 	}
 }

--- a/pkg/stanza/adapter/frompdataconverter_test.go
+++ b/pkg/stanza/adapter/frompdataconverter_test.go
@@ -55,7 +55,7 @@ func fillBaseMap(m pcommon.Map) {
 	m.PutInt("int", 123)
 	m.PutDouble("double", 12.34)
 	m.PutString("string", "hello")
-	m.PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{0xa1, 0xf0, 0x02, 0xff})
+	m.PutEmptyBytes("bytes").FromRaw([]byte{0xa1, 0xf0, 0x02, 0xff})
 }
 
 func complexPdataForNDifferentHosts(count int, n int) plog.Logs {

--- a/pkg/telemetryquerylanguage/contexts/internal/tqlcommon/resource_test.go
+++ b/pkg/telemetryquerylanguage/contexts/internal/tqlcommon/resource_test.go
@@ -126,7 +126,7 @@ func TestResourcePathGetSetter(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(resource pcommon.Resource) {
-				resource.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
+				resource.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -254,7 +254,7 @@ func createResource() pcommon.Resource {
 	resource.Attributes().PutBool("bool", true)
 	resource.Attributes().PutInt("int", 10)
 	resource.Attributes().PutDouble("double", 1.2)
-	resource.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
+	resource.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
 
 	arrStr := resource.Attributes().PutEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")

--- a/pkg/telemetryquerylanguage/contexts/internal/tqlcommon/scope_test.go
+++ b/pkg/telemetryquerylanguage/contexts/internal/tqlcommon/scope_test.go
@@ -151,7 +151,7 @@ func TestScopePathGetSetter(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(is pcommon.InstrumentationScope) {
-				is.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
+				is.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -274,7 +274,7 @@ func createInstrumentationScope() pcommon.InstrumentationScope {
 	is.Attributes().PutBool("bool", true)
 	is.Attributes().PutInt("int", 10)
 	is.Attributes().PutDouble("double", 1.2)
-	is.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
+	is.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
 
 	arrStr := is.Attributes().PutEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")

--- a/pkg/telemetryquerylanguage/contexts/tqllogs/logs_test.go
+++ b/pkg/telemetryquerylanguage/contexts/tqllogs/logs_test.go
@@ -264,7 +264,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource) {
-				log.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
+				log.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -425,7 +425,7 @@ func createTelemetry() (plog.LogRecord, pcommon.InstrumentationScope, pcommon.Re
 	log.Attributes().PutBool("bool", true)
 	log.Attributes().PutInt("int", 10)
 	log.Attributes().PutDouble("double", 1.2)
-	log.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
+	log.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
 
 	arrStr := log.Attributes().PutEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")

--- a/pkg/telemetryquerylanguage/contexts/tqlmetrics/metrics_test.go
+++ b/pkg/telemetryquerylanguage/contexts/tqlmetrics/metrics_test.go
@@ -199,7 +199,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(datapoint pmetric.NumberDataPoint) {
-				datapoint.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
+				datapoint.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -525,7 +525,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(datapoint pmetric.HistogramDataPoint) {
-				datapoint.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
+				datapoint.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -947,7 +947,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
-				datapoint.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
+				datapoint.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -1254,7 +1254,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(datapoint pmetric.SummaryDataPoint) {
-				datapoint.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
+				datapoint.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -1383,7 +1383,7 @@ func createAttributeTelemetry(attributes pcommon.Map) {
 	attributes.PutBool("bool", true)
 	attributes.PutInt("int", 10)
 	attributes.PutDouble("double", 1.2)
-	attributes.PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
+	attributes.PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
 
 	arrStr := attributes.PutEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")

--- a/pkg/telemetryquerylanguage/contexts/tqltraces/traces_test.go
+++ b/pkg/telemetryquerylanguage/contexts/tqltraces/traces_test.go
@@ -287,7 +287,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
 			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
-				span.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{2, 3, 4})
+				span.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
 		{
@@ -554,7 +554,7 @@ func createTelemetry() (ptrace.Span, pcommon.InstrumentationScope, pcommon.Resou
 	span.Attributes().PutBool("bool", true)
 	span.Attributes().PutInt("int", 10)
 	span.Attributes().PutDouble("double", 1.2)
-	span.Attributes().PutEmpty("bytes").SetEmptyBytesVal().FromRaw([]byte{1, 3, 2})
+	span.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
 
 	arrStr := span.Attributes().PutEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStringVal("one")

--- a/receiver/solacereceiver/unmarshaller.go
+++ b/receiver/solacereceiver/unmarshaller.go
@@ -431,7 +431,7 @@ func (u *solaceMessageUnmarshallerV1) insertUserProperty(toMap pcommon.Map, key 
 	case *model_v1.SpanData_UserPropertyValue_DoubleValue:
 		toMap.PutDouble(k, v.DoubleValue)
 	case *model_v1.SpanData_UserPropertyValue_ByteArrayValue:
-		toMap.PutEmpty(k).SetEmptyBytesVal().FromRaw(v.ByteArrayValue)
+		toMap.PutEmptyBytes(k).FromRaw(v.ByteArrayValue)
 	case *model_v1.SpanData_UserPropertyValue_FloatValue:
 		toMap.PutDouble(k, float64(v.FloatValue))
 	case *model_v1.SpanData_UserPropertyValue_Int8Value:


### PR DESCRIPTION
Now, when `PutEmptyBytes` method is available, https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14118 and https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14123 can be reverted