### PR TITLE
Log message to announce `direction` attribute feature gate deprecation

### DIFF
--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -58,22 +58,13 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-There is a proposal to change some elasticsearch metrics from being reported with a `direction` attribute to being
-reported with the direction included in the metric name.
+The proposal to change metrics from being reported with a `direction` attribute has been reverted in the specification. As a result, the
+following feature gates will be removed in v0.62.0:
 
-- `elasticsearch.node.cluster.io` will become:
-  - `elasticsearch.node.cluster.io.received`
-  - `elasticsearch.node.cluster.io.sent`
+- **receiver.elasticsearchreceiver.emitMetricsWithoutDirectionAttribute**
+- **receiver.elasticsearchreceiver.emitMetricsWithDirectionAttribute**
 
-The following feature gates control the transition process:
-
-- **receiver.elasticsearchreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without `direction` attribute are emitted by the receiver.
-- **receiver.elasticsearchreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with `direction` attribute are emitted by the receiver.
-
-##### Transition schedule:
-
-The final decision on the transition is not finalized yet. The transition is on hold until
-https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
+For additional information, see https://github.com/open-telemetry/opentelemetry-specification/issues/2726.
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/elasticsearchreceiver/factory.go
+++ b/receiver/elasticsearchreceiver/factory.go
@@ -64,7 +64,7 @@ func createDefaultConfig() config.Receiver {
 var errConfigNotES = errors.New("config was not an elasticsearch receiver config")
 
 func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
-	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+	log.Warn("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
 		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
 		"for additional details.")
 }

--- a/receiver/elasticsearchreceiver/factory.go
+++ b/receiver/elasticsearchreceiver/factory.go
@@ -24,6 +24,8 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
+	"go.opentelemetry.io/collector/service/featuregate"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver/internal/metadata"
 )
@@ -61,6 +63,12 @@ func createDefaultConfig() config.Receiver {
 
 var errConfigNotES = errors.New("config was not an elasticsearch receiver config")
 
+func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
+	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
+		"for additional details.")
+}
+
 // createMetricsReceiver creates a metrics receiver for scraping elasticsearch metrics.
 func createMetricsReceiver(
 	_ context.Context,
@@ -73,6 +81,14 @@ func createMetricsReceiver(
 		return nil, errConfigNotES
 	}
 	es := newElasticSearchScraper(params, c)
+
+	if !es.emitMetricsWithDirectionAttribute {
+		logDeprecatedFeatureGateForDirection(es.settings.Logger, emitMetricsWithDirectionAttributeFeatureGate)
+	}
+
+	if es.emitMetricsWithoutDirectionAttribute {
+		logDeprecatedFeatureGateForDirection(es.settings.Logger, emitMetricsWithoutDirectionAttributeFeatureGate)
+	}
 	scraper, err := scraperhelper.NewScraper(typeStr, es.scrape, scraperhelper.WithStart(es.start))
 	if err != nil {
 		return nil, err

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -135,83 +135,13 @@ service:
 
 #### Transition from metrics with "direction" attribute
 
-There is a proposal to change some host metrics from being reported with a `direction` attribute to being
-reported with the direction included in the metric name.
+The proposal to change metrics from being reported with a `direction` attribute has been reverted in the specification. As a result, the
+following feature gates will be removed in v0.62.0:
 
-- `disk` scraper metrics:
-  - `system.disk.io` will become:
-    - `system.disk.io.read`
-    - `system.disk.io.write`
-  - `system.disk.operations` will become:
-    - `system.disk.operations.read`
-    - `system.disk.operations.write`
-  - `system.disk.operation_time` will become:
-    - `system.disk.operation_time.read`
-    - `system.disk.operation_time.write`
-  - `system.disk.merged` will become:
-    - `system.disk.merged.read`
-    - `system.disk.merged.write`
-- `network` scraper metrics:
-  - `system.network.dropped` will become:
-    - `system.network.dropped.receive`
-    - `system.network.dropped.transmit`
-  - `system.network.errors` will become:
-    - `system.network.errors.receive`
-    - `system.network.errors.transmit`
-  - `system.network.io` will become:
-    - `system.network.io.receive`
-    - `system.network.io.transmit`
-  - `system.network.packets` will become:
-    - `system.network.packets.receive`
-    - `system.network.packets.transmit`
-- `paging` scraper metrics:
-  - `system.paging.operations` will become:
-    - `system.paging.operations.page_in`
-    - `system.paging.operations.page_out`
-- `process` scraper metrics:
-  - `process.disk.io` will become:
-    - `process.disk.io.read`
-    - `process.disk.io.write`
+- **receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute**
+- **receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute**
 
-The following feature gates control the transition process:
-
-- **receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without
-  `direction` attribute are emitted by the receiver.
-- **receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with 
-  `direction`
-  attribute are emitted by the receiver.
-
-##### Transition schedule:
-
-The final decision on the transition is not finalized yet. The transition is on hold until
-https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
-
-##### Usage:
-
-To enable the new metrics without `direction` attribute and disable the deprecated metrics, run OTel Collector with the 
-following arguments:
-
-```sh
-otelcol --feature-gates=-receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute,+receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute
-```
-
-It's also possible to emit both the deprecated and the new metrics:
-
-```sh
-otelcol --feature-gates=+receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute,+receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute
-```
-
-If both feature gates are enabled, each particular metric can be disabled with the user settings, for example:
-
-```yaml
-receivers:
-  hostmetrics:
-    scrapers:
-      paging:
-        metrics:
-          system.paging.operations:
-            enabled: false
-```
+For additional information, see https://github.com/open-telemetry/opentelemetry-specification/issues/2726.
 
 ##### More information:
 

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -104,7 +104,7 @@ func createMetricsReceiver(
 }
 
 func logDeprecatedFeatureGateForDirection(log *zap.Logger, gateID string) {
-	log.Info("WARNING: The " + gateID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+	log.Warn("WARNING: The " + gateID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
 		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
 		"for additional details.")
 }

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -22,6 +22,8 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
+	"go.opentelemetry.io/collector/service/featuregate"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"
@@ -101,6 +103,12 @@ func createMetricsReceiver(
 	)
 }
 
+func logDeprecatedFeatureGateForDirection(log *zap.Logger, gateID string) {
+	log.Info("WARNING: The " + gateID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
+		"for additional details.")
+}
+
 func createAddScraperOptions(
 	ctx context.Context,
 	set component.ReceiverCreateSettings,
@@ -121,6 +129,13 @@ func createAddScraperOptions(
 		}
 
 		return nil, fmt.Errorf("host metrics scraper factory not found for key: %q", key)
+	}
+
+	if !featuregate.GetRegistry().IsEnabled(internal.EmitMetricsWithDirectionAttributeFeatureGateID) {
+		logDeprecatedFeatureGateForDirection(set.Logger, internal.EmitMetricsWithDirectionAttributeFeatureGateID)
+	}
+	if featuregate.GetRegistry().IsEnabled(internal.EmitMetricsWithoutDirectionAttributeFeatureGateID) {
+		logDeprecatedFeatureGateForDirection(set.Logger, internal.EmitMetricsWithoutDirectionAttributeFeatureGateID)
 	}
 
 	return scraperControllerOptions, nil

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -195,25 +195,13 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-There is a proposal to change some host metrics from being reported with a `direction` attribute to being
-reported with the direction included in the metric name.
+The proposal to change metrics from being reported with a `direction` attribute has been reverted in the specification. As a result, the
+following feature gates will be removed in v0.62.0:
 
-- `k8s.node.network.io` will become:
-  - `k8s.node.network.io.transmit`
-  - `k8s.node.network.io.receive`
-- `k8s.node.network.errors` will become:
-  - `k8s.node.network.errors.transmit`
-  - `k8s.node.network.errors.receive`
+- **receiver.kubeletstatsreceiver.emitMetricsWithoutDirectionAttribute**
+- **receiver.kubeletstatsreceiver.emitMetricsWithDirectionAttribute**
 
-The following feature gates control the transition process:
-
-- **receiver.kubeletstatsreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without `direction` attribute are emitted by the receiver.
-- **receiver.kubeletstatsreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with `direction` attribute are emitted by the receiver.
-
-##### Transition schedule:
-
-The final decision on the transition is not finalized yet. The transition is on hold until
-https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
+For additional information, see https://github.com/open-telemetry/opentelemetry-specification/issues/2726.
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/kubeletstatsreceiver/scraper.go
+++ b/receiver/kubeletstatsreceiver/scraper.go
@@ -86,6 +86,12 @@ type kubletScraper struct {
 	emitMetricsWithoutDirectionAttribute bool
 }
 
+func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
+	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
+		"for additional details.")
+}
+
 func newKubletScraper(
 	restClient kubelet.RestClient,
 	set component.ReceiverCreateSettings,
@@ -108,6 +114,13 @@ func newKubletScraper(
 		},
 		emitMetricsWithDirectionAttribute:    featuregate.GetRegistry().IsEnabled(emitMetricsWithDirectionAttributeFeatureGateID),
 		emitMetricsWithoutDirectionAttribute: featuregate.GetRegistry().IsEnabled(emitMetricsWithoutDirectionAttributeFeatureGateID),
+	}
+	if !ks.emitMetricsWithDirectionAttribute {
+		logDeprecatedFeatureGateForDirection(ks.logger, emitMetricsWithDirectionAttributeFeatureGate)
+	}
+
+	if ks.emitMetricsWithoutDirectionAttribute {
+		logDeprecatedFeatureGateForDirection(ks.logger, emitMetricsWithoutDirectionAttributeFeatureGate)
 	}
 	return scraperhelper.NewScraper(typeStr, ks.scrape)
 }

--- a/receiver/kubeletstatsreceiver/scraper.go
+++ b/receiver/kubeletstatsreceiver/scraper.go
@@ -87,7 +87,7 @@ type kubletScraper struct {
 }
 
 func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
-	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+	log.Warn("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
 		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
 		"for additional details.")
 }

--- a/receiver/memcachedreceiver/README.md
+++ b/receiver/memcachedreceiver/README.md
@@ -50,25 +50,13 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-There is a proposal to change some memcached metrics from being reported with a `direction` attribute to being
-reported with the direction included in the metric name.
+The proposal to change metrics from being reported with a `direction` attribute has been reverted in the specification. As a result, the
+following feature gates will be removed in v0.62.0:
 
-- `memcached.network` will become:
-  - `memcached.network.sent`
-  - `memcached.network.received`
+- **receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute**
+- **receiver.memcachedreceiver.emitMetricsWithDirectionAttribute**
 
-The following feature gates control the transition process:
-
-- **receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without
-  `direction` attribute are emitted by the receiver.
-- **receiver.memcachedreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with
-  `direction`
-  attribute are emitted by the receiver.
-
-##### Transition schedule:
-
-The final decision on the transition is not finalized yet. The transition is on hold until
-https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
+For additional information, see https://github.com/open-telemetry/opentelemetry-specification/issues/2726.
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/memcachedreceiver/factory.go
+++ b/receiver/memcachedreceiver/factory.go
@@ -60,7 +60,7 @@ func createDefaultConfig() config.Receiver {
 }
 
 func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
-	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+	log.Warn("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
 		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
 		"for additional details.")
 }

--- a/receiver/memcachedreceiver/factory.go
+++ b/receiver/memcachedreceiver/factory.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
+	"go.opentelemetry.io/collector/service/featuregate"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver/internal/metadata"
 )
@@ -57,6 +59,12 @@ func createDefaultConfig() config.Receiver {
 	}
 }
 
+func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
+	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
+		"for additional details.")
+}
+
 func createMetricsReceiver(
 	_ context.Context,
 	params component.ReceiverCreateSettings,
@@ -66,6 +74,15 @@ func createMetricsReceiver(
 	cfg := rConf.(*Config)
 
 	ms := newMemcachedScraper(params, cfg)
+
+	if !ms.emitMetricsWithDirectionAttribute {
+		logDeprecatedFeatureGateForDirection(ms.logger, emitMetricsWithDirectionAttributeFeatureGate)
+	}
+
+	if ms.emitMetricsWithoutDirectionAttribute {
+		logDeprecatedFeatureGateForDirection(ms.logger, emitMetricsWithoutDirectionAttributeFeatureGate)
+	}
+
 	scraper, err := scraperhelper.NewScraper(typeStr, ms.scrape)
 	if err != nil {
 		return nil, err

--- a/receiver/vcenterreceiver/README.md
+++ b/receiver/vcenterreceiver/README.md
@@ -51,46 +51,13 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-There is a proposal to change some memcached metrics from being reported with a `direction` attribute to being
-reported with the direction included in the metric name.
+The proposal to change metrics from being reported with a `direction` attribute has been reverted in the specification. As a result, the
+following feature gates will be removed in v0.62.0:
 
-- `vcenter.host.disk.throughput` will become:
-  - `vcenter.host.disk.throughput.read`
-  - `vcenter.host.disk.throughput.write`
-- `vcenter.host.disk.latency.avg` will become:
-  - `vcenter.host.disk.latency.avg.read`
-  - `vcenter.host.disk.latency.avg.write`
-- `vcenter.host.network.throughput` will become:
-  - `vcenter.host.network.throughputt.receive`
-  - `vcenter.host.network.throughput.transmit`
-- `vcenter.host.network.packet.errors` will become:
-  - `vcenter.host.network.packet.errors.receive`
-  - `vcenter.host.network.packet.errors.transmit`
-- `vcenter.host.network.packet.count` will become:
-  - `vcenter.host.network.packet.count.receive`
-  - `vcenter.host.network.packet.count.transmit`
-- `vcenter.vm.disk.latency.avg.read` will become:
-  - `vcenter.vm.disk.latency.avg.read`
-  - `vcenter.vm.disk.latency.avg.write`
-- `vcenter.vm.network.throughput` will become:
-  - `vcenter.vm.network.throughput.receive`
-  - `vcenter.vm.network.throughput.transmit`
-- `vcenter.vm.network.packet.count` will become:
-  - `vcenter.vm.network.packet.count.receive`
-  - `vcenter.vm.network.packet.count.transmit`
+- **receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute**
+- **receiver.vcenterreceiver.emitMetricsWithDirectionAttribute**
 
-The following feature gates control the transition process:
-
-- **receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without
-  `direction` attribute are emitted by the receiver.
-- **receiver.vcenterreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with 
-  `direction`
-  attribute are emitted by the receiver.
-
-##### Transition schedule:
-
-The final decision on the transition is not finalized yet. The transition is on hold until
-https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
+For additional information, see https://github.com/open-telemetry/opentelemetry-specification/issues/2726.
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/vcenterreceiver/factory.go
+++ b/receiver/vcenterreceiver/factory.go
@@ -58,7 +58,7 @@ func createDefaultConfig() config.Receiver {
 var errConfigNotVcenter = errors.New("config was not an vcenter receiver config")
 
 func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
-	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+	log.Warn("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
 		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
 		"for additional details.")
 }

--- a/receiver/vcenterreceiver/factory.go
+++ b/receiver/vcenterreceiver/factory.go
@@ -24,6 +24,8 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
+	"go.opentelemetry.io/collector/service/featuregate"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver/internal/metadata"
 )
@@ -55,6 +57,12 @@ func createDefaultConfig() config.Receiver {
 
 var errConfigNotVcenter = errors.New("config was not an vcenter receiver config")
 
+func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
+	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
+		"for additional details.")
+}
+
 func createMetricsReceiver(
 	_ context.Context,
 	params component.ReceiverCreateSettings,
@@ -66,6 +74,14 @@ func createMetricsReceiver(
 		return nil, errConfigNotVcenter
 	}
 	vr := newVmwareVcenterScraper(params.Logger, cfg, params)
+
+	if !vr.emitMetricsWithDirectionAttribute {
+		logDeprecatedFeatureGateForDirection(vr.logger, emitMetricsWithDirectionAttributeFeatureGate)
+	}
+
+	if vr.emitMetricsWithoutDirectionAttribute {
+		logDeprecatedFeatureGateForDirection(vr.logger, emitMetricsWithoutDirectionAttributeFeatureGate)
+	}
 	scraper, err := scraperhelper.NewScraper(
 		typeStr,
 		vr.scrape,

--- a/receiver/zookeeperreceiver/README.md
+++ b/receiver/zookeeperreceiver/README.md
@@ -31,22 +31,13 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 #### Transition from metrics with "direction" attribute
 
-There is a proposal to change some zookeeper metrics from being reported with a `direction` attribute to being 
-reported with the direction included in the metric name.
+The proposal to change metrics from being reported with a `direction` attribute has been reverted in the specification. As a result, the
+following feature gates will be removed in v0.62.0:
 
-- `zookeeper.packet.count` will become:
-  - `zookeeper.packet.received.count`
-  - `zookeeper.packet.sent.count`
+- **receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute**
+- **receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute**
 
-The following feature gates control the transition process:
-
-- **receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without `direction` attribute are emitted by the receiver.
-- **receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with `direction` attribute are emitted by the receiver.
-
-##### Transition schedule:
-
-The final decision on the transition is not finalized yet. The transition is on hold until
-https://github.com/open-telemetry/opentelemetry-specification/issues/2726 is resolved.
+For additional information, see https://github.com/open-telemetry/opentelemetry-specification/issues/2726.
 
 [in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/zookeeperreceiver/scraper.go
+++ b/receiver/zookeeperreceiver/scraper.go
@@ -89,7 +89,7 @@ func (z *zookeeperMetricsScraper) Name() string {
 }
 
 func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
-	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+	log.Warn("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
 		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
 		"for additional details.")
 }

--- a/receiver/zookeeperreceiver/scraper.go
+++ b/receiver/zookeeperreceiver/scraper.go
@@ -88,6 +88,12 @@ func (z *zookeeperMetricsScraper) Name() string {
 	return typeStr
 }
 
+func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
+	log.Info("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
+		"for additional details.")
+}
+
 func newZookeeperMetricsScraper(settings component.ReceiverCreateSettings, config *Config) (*zookeeperMetricsScraper, error) {
 	_, _, err := net.SplitHostPort(config.TCPAddr.Endpoint)
 	if err != nil {
@@ -109,15 +115,12 @@ func newZookeeperMetricsScraper(settings component.ReceiverCreateSettings, confi
 		emitMetricsWithoutDirectionAttribute: featuregate.GetRegistry().IsEnabled(emitMetricsWithoutDirectionAttributeFeatureGateID),
 	}
 
-	if z.emitMetricsWithDirectionAttribute {
-		z.logger.Info("WARNING - Breaking Change: " + emitMetricsWithDirectionAttributeFeatureGate.Description)
-		z.logger.Info("The feature gate " + emitMetricsWithDirectionAttributeFeatureGate.ID + " is enabled. This " +
-			"otel collector will report metrics with a direction attribute, be aware this will not be supported in the future")
+	if !z.emitMetricsWithDirectionAttribute {
+		logDeprecatedFeatureGateForDirection(z.logger, emitMetricsWithDirectionAttributeFeatureGate)
 	}
 
 	if z.emitMetricsWithoutDirectionAttribute {
-		z.logger.Info("The " + emitMetricsWithoutDirectionAttributeFeatureGate.ID + " feature gate is enabled. This " +
-			"otel collector will report metrics without a direction attribute, which is good for future support")
+		logDeprecatedFeatureGateForDirection(z.logger, emitMetricsWithoutDirectionAttributeFeatureGate)
 	}
 
 	return z, nil

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -56,7 +56,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			msg: "WARNING: The " + emitMetricsWithDirectionAttributeFeatureGate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
 				"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
 				"for additional details.",
-			level: zapcore.InfoLevel,
+			level: zapcore.WarnLevel,
 		},
 	}
 
@@ -65,7 +65,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			msg: "WARNING: The " + emitMetricsWithoutDirectionAttributeFeatureGate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
 				"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
 				"for additional details.",
-			level: zapcore.InfoLevel,
+			level: zapcore.WarnLevel,
 		},
 	}
 

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -53,20 +53,18 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 	// additional temporary log messages expected while transitioning to metrics without a direction attribute
 	expectedLogsWithDirectionAttribute := []logMsg{
 		{
-			msg:   "WARNING - Breaking Change: " + emitMetricsWithDirectionAttributeFeatureGate.Description,
-			level: zapcore.InfoLevel,
-		},
-		{
-			msg: "The feature gate " + emitMetricsWithDirectionAttributeFeatureGate.ID + " is enabled. This " +
-				"otel collector will report metrics with a direction attribute, be aware this will not be supported in the future",
+			msg: "WARNING: The " + emitMetricsWithDirectionAttributeFeatureGate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+				"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
+				"for additional details.",
 			level: zapcore.InfoLevel,
 		},
 	}
 
 	expectedLogsWithoutDirectionAttribute := []logMsg{
 		{
-			msg: "The " + emitMetricsWithoutDirectionAttributeFeatureGate.ID + " feature gate is enabled. This " +
-				"otel collector will report metrics without a direction attribute, which is good for future support",
+			msg: "WARNING: The " + emitMetricsWithoutDirectionAttributeFeatureGate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
+				"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
+				"for additional details.",
 			level: zapcore.InfoLevel,
 		},
 	}
@@ -318,12 +316,12 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 
 			var expectedLogs []logMsg
 
-			if tt.emitMetricsWithoutDirectionAttribute {
-				expectedLogs = append(expectedLogs, expectedLogsWithoutDirectionAttribute...)
+			if !tt.emitMetricsWithDirectionAttribute {
+				expectedLogs = append(expectedLogs, expectedLogsWithDirectionAttribute...)
 			}
 
-			if tt.emitMetricsWithDirectionAttribute {
-				expectedLogs = append(expectedLogs, expectedLogsWithDirectionAttribute...)
+			if tt.emitMetricsWithoutDirectionAttribute {
+				expectedLogs = append(expectedLogs, expectedLogsWithoutDirectionAttribute...)
 			}
 
 			expectedLogs = append(expectedLogs, tt.expectedLogs...)

--- a/unreleased/deprecate-direction-flag.yaml
+++ b/unreleased/deprecate-direction-flag.yaml
@@ -1,0 +1,29 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver, hostmetricsreceiver, kubelestatsreceiver, memcachedreceiver, vcenterreceiver, zookeeperreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Log message to announce `direction` attribute feature gate deprecation"
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |-
+  The change to remove the `direction` attribute has been reverted in the specification. As a result, the following feature gates will be removed in v0.62.0:
+  - `receiver.elasticsearchreceiver.emitMetricsWithDirectionAttribute`
+  - `receiver.elasticsearchreceiver.emitMetricsWithoutDirectionAttribute`
+  - `receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute`
+  - `receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute`
+  - `receiver.kubelestatsreceiver.emitMetricsWithDirectionAttribute`
+  - `receiver.kubelestatsreceiver.emitMetricsWithoutDirectionAttribute`
+  - `receiver.memcachedreceiver.emitMetricsWithDirectionAttribute`
+  - `receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute`
+  - `receiver.vcenterreceiver.emitMetricsWithDirectionAttribute`
+  - `receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute`
+  - `receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute`
+  - `receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute`

--- a/unreleased/deprecate-direction-flag.yaml
+++ b/unreleased/deprecate-direction-flag.yaml
@@ -8,7 +8,7 @@ component: elasticsearchreceiver, hostmetricsreceiver, kubelestatsreceiver, memc
 note: "Log message to announce `direction` attribute feature gate deprecation"
 
 # One or more tracking issues related to the change
-issues: []
+issues: [14129]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.


### PR DESCRIPTION
The change to remove the `direction` attribute has been reverted in the specification. As a result, the following feature gates will be removed in v0.62.0:
  - `receiver.elasticsearchreceiver.emitMetricsWithDirectionAttribute`
  - `receiver.elasticsearchreceiver.emitMetricsWithoutDirectionAttribute`
  - `receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute`
  - `receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute`
  - `receiver.kubelestatsreceiver.emitMetricsWithDirectionAttribute`
  - `receiver.kubelestatsreceiver.emitMetricsWithoutDirectionAttribute`
  - `receiver.memcachedreceiver.emitMetricsWithDirectionAttribute`
  - `receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute`
  - `receiver.vcenterreceiver.emitMetricsWithDirectionAttribute`
  - `receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute`
  - `receiver.zookeeperreceiver.emitMetricsWithDirectionAttribute`
  - `receiver.zookeeperreceiver.emitMetricsWithoutDirectionAttribute`
