### PR TITLE
[pkg/stanza] Move mapstructure.go into operatortest package

### DIFF
--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -578,7 +578,7 @@ func TestMapStructureDecodeConfigWithHook(t *testing.T) {
 	}
 
 	var actual Config
-	dc := &mapstructure.DecoderConfig{Result: &actual, DecodeHook: helper.JSONUnmarshalerHook()}
+	dc := &mapstructure.DecoderConfig{Result: &actual, DecodeHook: operatortest.JSONUnmarshalerHook()}
 	ms, err := mapstructure.NewDecoder(dc)
 	require.NoError(t, err)
 	err = ms.Decode(cfgMap)

--- a/pkg/stanza/operator/helper/bytesize_test.go
+++ b/pkg/stanza/operator/helper/bytesize_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 )
 
 type testCase struct {
@@ -108,7 +110,7 @@ func TestByteSizeUnmarshalYAML(t *testing.T) {
 			var raw string
 			_ = yaml.Unmarshal([]byte(tc.input), &raw)
 
-			dc := &mapstructure.DecoderConfig{Result: &bs, DecodeHook: JSONUnmarshalerHook()}
+			dc := &mapstructure.DecoderConfig{Result: &bs, DecodeHook: operatortest.JSONUnmarshalerHook()}
 			ms, err := mapstructure.NewDecoder(dc)
 			require.NoError(t, err)
 

--- a/pkg/stanza/operator/helper/operatortest/mapstructure.go
+++ b/pkg/stanza/operator/helper/operatortest/mapstructure.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package helper // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+package operatortest // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 
 import (
 	"encoding/json"

--- a/pkg/stanza/operator/helper/operatortest/operatortest.go
+++ b/pkg/stanza/operator/helper/operatortest/operatortest.go
@@ -23,8 +23,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
 func configFromFileViaYaml(file string, config interface{}) error {
@@ -55,7 +53,7 @@ func configFromFileViaMapstructure(file string, config interface{}) error {
 		Result: config,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			mapstructure.StringToTimeDurationHookFunc(),
-			helper.JSONUnmarshalerHook(),
+			JSONUnmarshalerHook(),
 		),
 	}
 	ms, err := mapstructure.NewDecoder(dc)

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -694,7 +695,7 @@ func TestMapStructureDecodeParserConfigWithHook(t *testing.T) {
 	}
 
 	var actual ParserConfig
-	dc := &mapstructure.DecoderConfig{Result: &actual, DecodeHook: JSONUnmarshalerHook()}
+	dc := &mapstructure.DecoderConfig{Result: &actual, DecodeHook: operatortest.JSONUnmarshalerHook()}
 	ms, err := mapstructure.NewDecoder(dc)
 	require.NoError(t, err)
 	err = ms.Decode(input)

--- a/pkg/stanza/operator/helper/scope_name_test.go
+++ b/pkg/stanza/operator/helper/scope_name_test.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 )
 
 const testScopeName = "my.logger"
@@ -181,6 +182,6 @@ func ScopeConfigFromFileViaMapstructure(file string, result *ScopeNameParser) er
 		return fmt.Errorf("failed to read data from yaml: %w", err)
 	}
 
-	err = UnmarshalMapstructure(raw, result)
+	err = operatortest.UnmarshalMapstructure(raw, result)
 	return err
 }

--- a/pkg/stanza/operator/helper/severity_test.go
+++ b/pkg/stanza/operator/helper/severity_test.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -581,7 +582,7 @@ func severityConfigFromFileViaMapstructure(file string, result *SeverityConfig) 
 		return fmt.Errorf("failed to read data from yaml: %w", err)
 	}
 
-	err = UnmarshalMapstructure(raw, result)
+	err = operatortest.UnmarshalMapstructure(raw, result)
 	return err
 }
 

--- a/pkg/stanza/operator/helper/time_test.go
+++ b/pkg/stanza/operator/helper/time_test.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 )
 
 func Test_setTimestampYear(t *testing.T) {
@@ -722,7 +723,7 @@ func timeConfigFromFileViaMapstructure(file string, result *TimeParser) error {
 		return fmt.Errorf("failed to read data from yaml: %w", err)
 	}
 
-	err = UnmarshalMapstructure(raw, result)
+	err = operatortest.UnmarshalMapstructure(raw, result)
 	return err
 }
 

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -714,7 +714,7 @@ func TestMapStructureDecodeConfigWithHook(t *testing.T) {
 	}
 
 	var actual Config
-	dc := &mapstructure.DecoderConfig{Result: &actual, DecodeHook: helper.JSONUnmarshalerHook()}
+	dc := &mapstructure.DecoderConfig{Result: &actual, DecodeHook: operatortest.JSONUnmarshalerHook()}
 	ms, err := mapstructure.NewDecoder(dc)
 	require.NoError(t, err)
 	err = ms.Decode(input)

--- a/pkg/stanza/operator/input/journald/journald_test.go
+++ b/pkg/stanza/operator/input/journald/journald_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -130,7 +130,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	var actual Config
-	err := helper.UnmarshalMapstructure(input, &actual)
+	err := operatortest.UnmarshalMapstructure(input, &actual)
 	require.NoError(t, err)
 	require.Equal(t, expect, &actual)
 }

--- a/pkg/stanza/operator/input/windows/operator_test.go
+++ b/pkg/stanza/operator/input/windows/operator_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 )
 
 func TestConfig(t *testing.T) {
@@ -40,7 +40,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	var actual Config
-	err := helper.UnmarshalMapstructure(input, &actual)
+	err := operatortest.UnmarshalMapstructure(input, &actual)
 	require.NoError(t, err)
 	require.Equal(t, expect, &actual)
 }

--- a/pkg/stanza/operator/parser/json/json_test.go
+++ b/pkg/stanza/operator/parser/json/json_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -186,7 +187,7 @@ func TestJsonParserConfig(t *testing.T) {
 			"on_error":   "send",
 		}
 		var actual Config
-		err := helper.UnmarshalMapstructure(input, &actual)
+		err := operatortest.UnmarshalMapstructure(input, &actual)
 		require.NoError(t, err)
 		require.Equal(t, expect, &actual)
 	})

--- a/pkg/stanza/operator/parser/regex/regex_test.go
+++ b/pkg/stanza/operator/parser/regex/regex_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -224,7 +224,7 @@ func TestConfig(t *testing.T) {
 			"on_error":   "send",
 		}
 		var actual Config
-		err := helper.UnmarshalMapstructure(input, &actual)
+		err := operatortest.UnmarshalMapstructure(input, &actual)
 		require.NoError(t, err)
 		require.Equal(t, expect, &actual)
 	})

--- a/pkg/stanza/operator/parser/severity/severity_test.go
+++ b/pkg/stanza/operator/parser/severity/severity_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -293,7 +294,7 @@ func TestConfig(t *testing.T) {
 			"preset":     "test",
 		}
 		var actual Config
-		err := helper.UnmarshalMapstructure(input, &actual)
+		err := operatortest.UnmarshalMapstructure(input, &actual)
 		require.NoError(t, err)
 		require.Equal(t, expect, &actual)
 	})

--- a/pkg/stanza/operator/parser/time/time_test.go
+++ b/pkg/stanza/operator/parser/time/time_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -567,7 +568,7 @@ func TestConfig(t *testing.T) {
 			"parse_from":  "body.from",
 		}
 		var actual Config
-		err := helper.UnmarshalMapstructure(input, &actual)
+		err := operatortest.UnmarshalMapstructure(input, &actual)
 		require.NoError(t, err)
 		require.Equal(t, expect, &actual)
 	})

--- a/pkg/stanza/operator/parser/uri/uri_test.go
+++ b/pkg/stanza/operator/parser/uri/uri_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -722,7 +722,7 @@ func TestConfig(t *testing.T) {
 			"on_error":   "send",
 		}
 		var actual Config
-		err := helper.UnmarshalMapstructure(input, &actual)
+		err := operatortest.UnmarshalMapstructure(input, &actual)
 		require.NoError(t, err)
 		require.Equal(t, expect, &actual)
 	})


### PR DESCRIPTION
This file contains test-only code, so it is more appropriately located in the operatortest package.