### PR TITLE
[processor/filter] prevent the matcher from panicking

### DIFF
--- a/internal/coreinternal/processor/filterexpr/matcher.go
+++ b/internal/coreinternal/processor/filterexpr/matcher.go
@@ -15,6 +15,8 @@
 package filterexpr // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterexpr"
 
 import (
+	"fmt"
+
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/vm"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -151,5 +153,12 @@ func (m *Matcher) match(env env) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return result.(bool), nil
+
+	v, ok := result.(bool)
+	if !ok {
+		return false, fmt.Errorf("filter returned non-boolean value type=%T result=%v metric=%s, attributes=%v",
+			result, result, env.MetricName, env.attributes.AsRaw())
+	}
+
+	return v, nil
 }

--- a/unreleased/processor-filter_prevent_panic.yaml
+++ b/unreleased/processor-filter_prevent_panic.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filterexpr
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: prevent the matcher from panicking
+
+# One or more tracking issues related to the change
+issues: [13573]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Prevent the filterexpr matcher from panicking. Followed the approach from @GCHQDeveloper638 - https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13573#issuecomment-1229263242

**Link to tracking Issue:** <Issue number if applicable> #13573

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>