### PR TITLE
[receiver/mongodbatlas] Fix timestamp parsing for mongodb 4.2 audit logs

### DIFF
--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -180,8 +180,8 @@ func (s *logsReceiver) collectClusterLogs(clusters []mongodbatlas.Cluster, proje
 			s.collectLogs(pc, hostname, "mongos.gz", cluster.Name, cluster.MongoDBMajorVersion)
 
 			if projectCfg.EnableAuditLogs {
-				s.collectAuditLogs(pc, hostname, "mongodb-audit-log.gz", cluster.Name)
-				s.collectAuditLogs(pc, hostname, "mongos-audit-log.gz", cluster.Name)
+				s.collectAuditLogs(pc, hostname, "mongodb-audit-log.gz", cluster.Name, cluster.MongoDBMajorVersion)
+				s.collectAuditLogs(pc, hostname, "mongos-audit-log.gz", cluster.Name, cluster.MongoDBMajorVersion)
 			}
 		}
 	}
@@ -260,7 +260,7 @@ func (s *logsReceiver) collectLogs(pc ProjectContext, hostname, logName, cluster
 	}
 }
 
-func (s *logsReceiver) collectAuditLogs(pc ProjectContext, hostname, logName, clusterName string) {
+func (s *logsReceiver) collectAuditLogs(pc ProjectContext, hostname, logName, clusterName, clusterMajorVersion string) {
 	logs, err := s.getHostAuditLogs(
 		pc.Project.ID,
 		hostname,
@@ -276,7 +276,8 @@ func (s *logsReceiver) collectAuditLogs(pc ProjectContext, hostname, logName, cl
 		pc,
 		hostname,
 		logName,
-		clusterName)
+		clusterName,
+		clusterMajorVersion)
 	err = s.consumer.ConsumeLogs(context.Background(), plog)
 	if err != nil {
 		s.log.Error("Failed to consume logs", zap.Error(err))

--- a/receiver/mongodbatlasreceiver/mongodb_event_to_logdata.go
+++ b/receiver/mongodbatlasreceiver/mongodb_event_to_logdata.go
@@ -52,7 +52,7 @@ var severityMap = map[string]plog.SeverityNumber{
 }
 
 // mongoAuditEventToLogRecord converts model.AuditLog event to plog.LogRecordSlice and adds the resource attributes.
-func mongodbAuditEventToLogData(logger *zap.Logger, logs []model.AuditLog, pc ProjectContext, hostname, logName, clusterName string) plog.Logs {
+func mongodbAuditEventToLogData(logger *zap.Logger, logs []model.AuditLog, pc ProjectContext, hostname, logName, clusterName, clusterMajorVersion string) plog.Logs {
 	ld := plog.NewLogs()
 	rl := ld.ResourceLogs().AppendEmpty()
 	sl := rl.ScopeLogs().AppendEmpty()
@@ -72,10 +72,13 @@ func mongodbAuditEventToLogData(logger *zap.Logger, logs []model.AuditLog, pc Pr
 		if err != nil {
 			logger.Warn("failed to marshal", zap.Error(err))
 		}
-		t, err := time.Parse(jsonTimestampLayout, log.Timestamp.Date)
+
+		logTsFormat := tsLayout(clusterMajorVersion)
+		t, err := time.Parse(logTsFormat, log.Timestamp.Date)
 		if err != nil {
 			logger.Warn("Time failed to parse correctly", zap.Error(err))
 		}
+
 		lr.SetTimestamp(pcommon.NewTimestampFromTime(t))
 		lr.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 		// Insert Raw Log message into Body of LogRecord

--- a/receiver/mongodbatlasreceiver/mongodb_event_to_logdata_test.go
+++ b/receiver/mongodbatlasreceiver/mongodb_event_to_logdata_test.go
@@ -89,23 +89,49 @@ func TestUnknownSeverity(t *testing.T) {
 	assert.Equal(t, logEntry.SeverityText(), "")
 }
 
-func TestMongoEventToAuditLogData(t *testing.T) {
-	mongoevent := GetTestAuditEvent()
+func TestMongoEventToAuditLogData4_4(t *testing.T) {
+	mongoevent := GetTestAuditEvent4_4()
 	pc := ProjectContext{
 		orgName: "Org",
 		Project: mongodbatlas.Project{Name: "Project"},
 	}
 
-	ld := mongodbAuditEventToLogData(zap.NewNop(), []model.AuditLog{mongoevent}, pc, "hostname", "clusterName", "logName")
+	ld := mongodbAuditEventToLogData(zap.NewNop(), []model.AuditLog{mongoevent}, pc, "hostname", "clusterName", "logName", "4.4")
 	rl := ld.ResourceLogs().At(0)
 	resourceAttrs := rl.Resource().Attributes()
-	lr := rl.ScopeLogs().At(0)
-	attrs := lr.LogRecords().At(0).Attributes()
+	sl := rl.ScopeLogs().At(0)
+	lr := sl.LogRecords().At(0)
+	attrs := lr.Attributes()
+
 	assert.Equal(t, ld.ResourceLogs().Len(), 1)
 	assert.Equal(t, resourceAttrs.Len(), 4)
 	assert.Equal(t, 12, attrs.Len())
+	assert.Equal(t, pcommon.Timestamp(1663342012563000000), lr.Timestamp())
 
-	ld = mongodbAuditEventToLogData(zap.NewNop(), []model.AuditLog{mongoevent}, pc, "hostname", "clusterName", "logName")
+	ld = mongodbAuditEventToLogData(zap.NewNop(), []model.AuditLog{mongoevent}, pc, "hostname", "clusterName", "logName", "4.4")
+	assert.Equal(t, 12, ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Len())
+}
+
+func TestMongoEventToAuditLogData4_2(t *testing.T) {
+	mongoevent := GetTestEventAuditEvent4_2()
+	pc := ProjectContext{
+		orgName: "Org",
+		Project: mongodbatlas.Project{Name: "Project"},
+	}
+
+	ld := mongodbAuditEventToLogData(zap.NewNop(), []model.AuditLog{mongoevent}, pc, "hostname", "clusterName", "logName", "4.2")
+	rl := ld.ResourceLogs().At(0)
+	resourceAttrs := rl.Resource().Attributes()
+	sl := rl.ScopeLogs().At(0)
+	lr := sl.LogRecords().At(0)
+	attrs := lr.Attributes()
+
+	assert.Equal(t, ld.ResourceLogs().Len(), 1)
+	assert.Equal(t, resourceAttrs.Len(), 4)
+	assert.Equal(t, 12, attrs.Len())
+	assert.Equal(t, pcommon.Timestamp(1663342012563000000), lr.Timestamp())
+
+	ld = mongodbAuditEventToLogData(zap.NewNop(), []model.AuditLog{mongoevent}, pc, "hostname", "clusterName", "logName", "4.2")
 	assert.Equal(t, 12, ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Len())
 }
 
@@ -135,8 +161,38 @@ func GetTestEvent4_2() model.LogEntry {
 	}
 }
 
-func GetTestAuditEvent() model.AuditLog {
+func GetTestAuditEvent4_4() model.AuditLog {
 	return model.AuditLog{
+		Timestamp: model.LogTimestamp{
+			Date: "2022-09-16T15:26:52.563+00:00",
+		},
+		AuthType: "authtype",
+		ID: model.ID{
+			Type:   "type",
+			Binary: "binary",
+		},
+		Local: model.Address{
+			IP:   "Ip",
+			Port: 12345,
+		},
+		Remote: model.Address{
+			IP:   "Ip",
+			Port: 12345,
+		},
+		Result: 40,
+		Param: model.Param{
+			User:      "name",
+			Database:  "db",
+			Mechanism: "mechanism",
+		},
+	}
+}
+
+func GetTestEventAuditEvent4_2() model.AuditLog {
+	return model.AuditLog{
+		Timestamp: model.LogTimestamp{
+			Date: "2022-09-16T15:26:52.563+0000",
+		},
 		AuthType: "authtype",
 		ID: model.ID{
 			Type:   "type",

--- a/unreleased/mongodb-atlas-4-2-audit-timestamp.yaml
+++ b/unreleased/mongodb-atlas-4-2-audit-timestamp.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix timestamp parsing for mongodb 4.2 audit logs
+
+# One or more tracking issues related to the change
+issues: [14168]


### PR DESCRIPTION
**Description:**
* The timestamp format differed slightly between 4.2 and 4.4 clusters; This PR changes the timestamp format based on the cluster version, similar to the normal mongodb logs.

**Link to tracking Issue:** Resolves #14168

**Testing:** 
* Added unit test testing timestamp parsing for 4.2 formatted timestamps
* Manually tested against a 4.2 cluster to ensure audit log timestamps parsed correctly