### PR TITLE
[receiver/dockerstats] Fix mistake where config has wrong key (V2 featuregate only)

### DIFF
--- a/receiver/dockerstatsreceiver/config.go
+++ b/receiver/dockerstatsreceiver/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	DockerAPIVersion float64 `mapstructure:"api_version"`
 
 	// Metrics config. Enable or disable stats by name.
-	MetricsConfig metadata.MetricsSettings `mapstructure:"stats"`
+	MetricsConfig metadata.MetricsSettings `mapstructure:"metrics"`
 }
 
 func (config Config) Validate() error {

--- a/receiver/dockerstatsreceiver/config_test.go
+++ b/receiver/dockerstatsreceiver/config_test.go
@@ -78,6 +78,9 @@ func TestLoadConfig(t *testing.T) {
 	}, ascfg.EnvVarsToMetricLabels)
 
 	assert.True(t, ascfg.ProvidePerCoreCPUMetrics)
+
+	assert.False(t, ascfg.MetricsConfig.ContainerCPUUsageSystem.Enabled)
+	assert.True(t, ascfg.MetricsConfig.ContainerMemoryTotalRss.Enabled)
 }
 
 func TestValidateErrors(t *testing.T) {

--- a/receiver/dockerstatsreceiver/testdata/config.yaml
+++ b/receiver/dockerstatsreceiver/testdata/config.yaml
@@ -15,6 +15,11 @@ receivers:
       - undesired-container
       - another-*-container
     provide_per_core_cpu_metrics: true
+    metrics:
+      container.cpu.usage.system:
+        enabled: false
+      container.memory.total_rss:
+        enabled: true
 
 processors:
   nop:

--- a/unreleased/dockerstats-typo.yaml
+++ b/unreleased/dockerstats-typo.yaml
@@ -1,0 +1,5 @@
+change_type: breaking
+component: dockerstatsreceiver
+note: "Change 'stats' config key to 'metrics'."
+issues: [9794, 14184]
+subtext: "Note: this is only breaking for those who have explicitly enabled the featuregate `receiver.dockerstatsd.useScraperV2`."


### PR DESCRIPTION
**Description:** 

The key in the config was "stats" but it should be "metrics" so it's consistent with `documentation.md` and other similar scrapers.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9794

**Testing:** 

I've updated the test so it validates the `metrics` key (this probably should've already been there). 
