### PR TITLE
GoogleCloudSpannerReceiver: Fix errors when Spanner transaction-stats table-columns are NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@
 - `telemetryquerylanguage`: Add the Int factory function. (#11810)
 - `telemetryquerylanguage`: Add split factory function to separate a string by the delimiter, and returns an array of substrings. (#11790)
 - `processor/transform`: Add `Concat`, which allows concatenating an arbitrary number of strings with a delimiter (#12476)
-- `googlecloudspannerreceiver`: Fixed errors when transaction-stats columns are NULL (#14189)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - `telemetryquerylanguage`: Add the Int factory function. (#11810)
 - `telemetryquerylanguage`: Add split factory function to separate a string by the delimiter, and returns an array of substrings. (#11790)
 - `processor/transform`: Add `Concat`, which allows concatenating an arbitrary number of strings with a delimiter (#12476)
+- `googlecloudspannerreceiver`: Fixed errors when transaction-stats columns are NULL (#14189)
 
 ### 🧰 Bug fixes 🧰
 

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metadata_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metadata_test.go
@@ -22,10 +22,11 @@ const (
 	labelName       = "LabelName"
 	labelColumnName = "LabelColumnName"
 
-	stringValue  = "stringValue"
-	int64Value   = int64(64)
-	float64Value = float64(64.64)
-	boolValue    = true
+	stringValue             = "stringValue"
+	int64Value              = int64(64)
+	float64Value            = float64(64.64)
+	defaultNullFloat64Value = float64(0)
+	boolValue               = true
 
 	metricName       = "metricName"
 	metricColumnName = "metricColumnName"

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/spanner"
-
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 

--- a/receiver/googlecloudspannerreceiver/internal/metadata/valuemetadata.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/valuemetadata.go
@@ -21,6 +21,7 @@ const (
 	StringValueType           ValueType = "string"
 	IntValueType              ValueType = "int"
 	FloatValueType            ValueType = "float"
+	NullFloatValueType        ValueType = "null_float"
 	BoolValueType             ValueType = "bool"
 	StringSliceValueType      ValueType = "string_slice"
 	ByteSliceValueType        ValueType = "byte_slice"

--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
@@ -371,13 +371,13 @@ metadata:
         unit: "one"
       - name: "avg_participants"
         column_name: "AVG_PARTICIPANTS"
-        value_type: "float"
+        value_type: "null_float"
         data:
           type: "gauge"
         unit: "one"
       - name: "avg_total_latency_seconds"
         column_name: "AVG_TOTAL_LATENCY_SECONDS"
-        value_type: "float"
+        value_type: "null_float"
         data:
           type: "gauge"
         unit: "second"
@@ -425,13 +425,13 @@ metadata:
         unit: "one"
       - name: "avg_participants"
         column_name: "AVG_PARTICIPANTS"
-        value_type: "float"
+        value_type: "null_float"
         data:
           type: "gauge"
         unit: "one"
       - name: "avg_total_latency_seconds"
         column_name: "AVG_TOTAL_LATENCY_SECONDS"
-        value_type: "float"
+        value_type: "null_float"
         data:
           type: "gauge"
         unit: "second"

--- a/unreleased/googlecloudspannerreceiver-fix-errors-when-transaction-stats-null.yaml
+++ b/unreleased/googlecloudspannerreceiver-fix-errors-when-transaction-stats-null.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: googlecloudspannerreceiver
+note: Fixed errors when transaction-stats columns are NULL
+issues: [14189]
+subtext:


### PR DESCRIPTION
**Description:** GoogleCloudSpannerReceiver is not working when transaction-stats columns "avg_participants" or "avg_total_latency_seconds" are NULL. This issue arose because of a change in Cloud Spanner Go library of default float64 not being able to handle NULLs. Hence, this fix changes float64 type to spanner.NullFloat64 type  in metadata.yaml, for these columns -- so that the receiver can work correctly and without-errors even when the above columns are NULL

Note that avg_participants and avg_total_latency_seconds are NULL when transaction aborts during the read phase or before the commit phase. 

**Link to tracking Issue:** Internal tracking issue in Google

**Testing:** Unit tests were added in metricvalue_test.go for code coverage.
I performed manual testing by replicating the bug and verifying that the receiver no longer crashes and works as expected.
