### PR TITLE
[pkg/stanza] Remove custom json and yaml marshal funcs

### DIFF
--- a/pkg/stanza/entry/attribute_field.go
+++ b/pkg/stanza/entry/attribute_field.go
@@ -193,12 +193,6 @@ func (f *AttributeField) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-// MarshalJSON will marshal the field for JSON.
-func (f AttributeField) MarshalJSON() ([]byte, error) {
-	json := fmt.Sprintf(`"%s"`, toJSONDot(AttributesPrefix, f.Keys))
-	return []byte(json), nil
-}
-
 // UnmarshalYAML will attempt to unmarshal a field from YAML.
 func (f *AttributeField) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var value string
@@ -217,11 +211,6 @@ func (f *AttributeField) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 	*f = AttributeField{keys[1:]}
 	return nil
-}
-
-// MarshalYAML will marshal the field for YAML.
-func (f AttributeField) MarshalYAML() (interface{}, error) {
-	return toJSONDot(AttributesPrefix, f.Keys), nil
 }
 
 // UnmarshalText will unmarshal a field from text

--- a/pkg/stanza/entry/attribute_field_test.go
+++ b/pkg/stanza/entry/attribute_field_test.go
@@ -396,48 +396,6 @@ func TestAttributeFieldMerge(t *testing.T) {
 	require.Equal(t, expected, entry.Attributes)
 }
 
-func TestAttributeFieldMarshal(t *testing.T) {
-	cases := []struct {
-		name    string
-		keys    []string
-		jsonDot string
-	}{
-		{
-			"root",
-			[]string{},
-			"attributes",
-		},
-		{
-			"standard",
-			[]string{"test"},
-			"attributes.test",
-		},
-		{
-			"bracketed",
-			[]string{"test.foo"},
-			"attributes['test.foo']",
-		},
-		{
-			"double_bracketed",
-			[]string{"test.foo", "bar"},
-			"attributes['test.foo']['bar']",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			field := AttributeField{Keys: tc.keys}
-			yaml, err := field.MarshalYAML()
-			require.NoError(t, err)
-			require.Equal(t, tc.jsonDot, yaml)
-
-			json, err := field.MarshalJSON()
-			require.NoError(t, err)
-			require.Equal(t, []byte(fmt.Sprintf(`"%s"`, tc.jsonDot)), json)
-		})
-	}
-}
-
 func TestAttributeFieldUnmarshal(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/pkg/stanza/entry/body_field.go
+++ b/pkg/stanza/entry/body_field.go
@@ -185,12 +185,6 @@ func (f *BodyField) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-// MarshalJSON will marshal the field for JSON.
-func (f BodyField) MarshalJSON() ([]byte, error) {
-	json := fmt.Sprintf(`"%s"`, toJSONDot(BodyPrefix, f.Keys))
-	return []byte(json), nil
-}
-
 // UnmarshalYAML will attempt to unmarshal a field from YAML.
 func (f *BodyField) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var value string
@@ -209,11 +203,6 @@ func (f *BodyField) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	*f = BodyField{keys[1:]}
 	return nil
-}
-
-// MarshalYAML will marshal the field for YAML.
-func (f BodyField) MarshalYAML() (interface{}, error) {
-	return toJSONDot(BodyPrefix, f.Keys), nil
 }
 
 // UnmarshalText will unmarshal a field from text

--- a/pkg/stanza/entry/body_field_test.go
+++ b/pkg/stanza/entry/body_field_test.go
@@ -322,48 +322,6 @@ func TestBodyFieldMerge(t *testing.T) {
 	require.Equal(t, expected, entry.Body)
 }
 
-func TestBodyFieldMarshal(t *testing.T) {
-	cases := []struct {
-		name    string
-		keys    []string
-		jsonDot string
-	}{
-		{
-			"root",
-			[]string{},
-			"body",
-		},
-		{
-			"standard",
-			[]string{"test"},
-			"body.test",
-		},
-		{
-			"bracketed",
-			[]string{"test.foo"},
-			"body['test.foo']",
-		},
-		{
-			"double_bracketed",
-			[]string{"test.foo", "bar"},
-			"body['test.foo']['bar']",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			field := BodyField{Keys: tc.keys}
-			yaml, err := field.MarshalYAML()
-			require.NoError(t, err)
-			require.Equal(t, tc.jsonDot, yaml)
-
-			json, err := field.MarshalJSON()
-			require.NoError(t, err)
-			require.Equal(t, []byte(fmt.Sprintf(`"%s"`, tc.jsonDot)), json)
-		})
-	}
-}
-
 func TestBodyFieldUnmarshal(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/pkg/stanza/entry/field.go
+++ b/pkg/stanza/entry/field.go
@@ -94,16 +94,6 @@ func NewField(s string) (Field, error) {
 	}
 }
 
-// MarshalJSON will marshal a field into JSON
-func (f Field) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, f.String())), nil
-}
-
-// MarshalYAML will marshal a field into YAML
-func (f Field) MarshalYAML() (interface{}, error) {
-	return f.String(), nil
-}
-
 type splitState uint
 
 const (

--- a/pkg/stanza/entry/field_test.go
+++ b/pkg/stanza/entry/field_test.go
@@ -169,38 +169,6 @@ func TestFieldUnmarshalJSONFailure(t *testing.T) {
 	}
 }
 
-func TestFieldMarshalJSON(t *testing.T) {
-	cases := []struct {
-		name     string
-		input    Field
-		expected []byte
-	}{
-		{
-			"BodyRoot",
-			NewBodyField(),
-			[]byte(`"body"`),
-		},
-		{
-			"SimpleField",
-			NewBodyField("test1"),
-			[]byte(`"body.test1"`),
-		},
-		{
-			"ComplexField",
-			NewBodyField("test1", "test2"),
-			[]byte(`"body.test1.test2"`),
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			res, err := json.Marshal(tc.input)
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, res)
-		})
-	}
-}
-
 func TestFieldUnmarshalYAML(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -274,74 +242,6 @@ func TestFieldUnmarshalYAMLFailure(t *testing.T) {
 			err := yaml.UnmarshalStrict(tc.input, &f)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.expected)
-		})
-	}
-}
-
-func TestFieldMarshalYAML(t *testing.T) {
-	cases := []struct {
-		name     string
-		input    interface{}
-		expected string
-	}{
-		{
-			"BodyRoot",
-			NewBodyField(),
-			"body\n",
-		},
-		{
-			"SimpleField",
-			NewBodyField("test1"),
-			"body.test1\n",
-		},
-		{
-			"ComplexField",
-			NewBodyField("test1", "test2"),
-			"body.test1.test2\n",
-		},
-		{
-			"FieldWithDots",
-			NewBodyField("test.1"),
-			"body['test.1']\n",
-		},
-		{
-			"FieldWithDotsThenNone",
-			NewBodyField("test.1", "test2"),
-			"body['test.1']['test2']\n",
-		},
-		{
-			"FieldWithNoDotsThenDots",
-			NewBodyField("test1", "test.2"),
-			"body['test1']['test.2']\n",
-		},
-		{
-			"AttributeField",
-			NewAttributeField("test1"),
-			"attributes.test1\n",
-		},
-		{
-			"AttributeFieldWithDots",
-			NewAttributeField("test.1"),
-			"attributes['test.1']\n",
-		},
-		{
-			"ResourceField",
-			NewResourceField("test1"),
-			"resource.test1\n",
-		},
-		{
-			"ResourceFieldWithDots",
-			NewResourceField("test.1"),
-			"resource['test.1']\n",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			res, err := yaml.Marshal(tc.input)
-			require.NoError(t, err)
-
-			require.Equal(t, tc.expected, string(res))
 		})
 	}
 }

--- a/pkg/stanza/entry/resource_field.go
+++ b/pkg/stanza/entry/resource_field.go
@@ -193,12 +193,6 @@ func (f *ResourceField) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-// MarshalJSON will marshal the field for JSON.
-func (f ResourceField) MarshalJSON() ([]byte, error) {
-	json := fmt.Sprintf(`"%s"`, toJSONDot(ResourcePrefix, f.Keys))
-	return []byte(json), nil
-}
-
 // UnmarshalYAML will attempt to unmarshal a field from YAML.
 func (f *ResourceField) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var value string
@@ -217,11 +211,6 @@ func (f *ResourceField) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	*f = ResourceField{keys[1:]}
 	return nil
-}
-
-// MarshalYAML will marshal the field for YAML.
-func (f ResourceField) MarshalYAML() (interface{}, error) {
-	return toJSONDot(ResourcePrefix, f.Keys), nil
 }
 
 // UnmarshalText will unmarshal a field from text

--- a/pkg/stanza/entry/resource_field_test.go
+++ b/pkg/stanza/entry/resource_field_test.go
@@ -396,48 +396,6 @@ func TestResourceFieldMerge(t *testing.T) {
 	require.Equal(t, expected, entry.Resource)
 }
 
-func TestResourceFieldMarshal(t *testing.T) {
-	cases := []struct {
-		name    string
-		keys    []string
-		jsonDot string
-	}{
-		{
-			"root",
-			[]string{},
-			"resource",
-		},
-		{
-			"standard",
-			[]string{"test"},
-			"resource.test",
-		},
-		{
-			"bracketed",
-			[]string{"test.foo"},
-			"resource['test.foo']",
-		},
-		{
-			"double_bracketed",
-			[]string{"test.foo", "bar"},
-			"resource['test.foo']['bar']",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			field := ResourceField{Keys: tc.keys}
-			yaml, err := field.MarshalYAML()
-			require.NoError(t, err)
-			require.Equal(t, tc.jsonDot, yaml)
-
-			json, err := field.MarshalJSON()
-			require.NoError(t, err)
-			require.Equal(t, []byte(fmt.Sprintf(`"%s"`, tc.jsonDot)), json)
-		})
-	}
-}
-
 func TestResourceFieldUnmarshal(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/pkg/stanza/operator/config.go
+++ b/pkg/stanza/operator/config.go
@@ -68,11 +68,6 @@ func (c *Config) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
-// MarshalJSON will marshal a config to JSON.
-func (c Config) MarshalJSON() ([]byte, error) {
-	return json.Marshal(c.Builder)
-}
-
 // UnmarshalYAML will unmarshal a config from YAML.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	rawConfig := map[string]interface{}{}
@@ -103,11 +98,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	c.Builder = builder
 	return nil
-}
-
-// MarshalYAML will marshal a config to YAML.
-func (c Config) MarshalYAML() (interface{}, error) {
-	return c.Builder, nil
 }
 
 func (c *Config) Unmarshal(component *confmap.Conf) error {

--- a/pkg/stanza/operator/config_test.go
+++ b/pkg/stanza/operator/config_test.go
@@ -84,20 +84,6 @@ func TestUnmarshalJSONErrors(t *testing.T) {
 	})
 }
 
-func TestMarshalJSON(t *testing.T) {
-	cfg := Config{
-		Builder: &FakeBuilder{
-			OperatorID:   "operator",
-			OperatorType: "operator",
-			Array:        []string{"test"},
-		},
-	}
-	out, err := json.Marshal(cfg)
-	require.NoError(t, err)
-	expected := `{"id":"operator","type":"operator","array":["test"]}`
-	require.Equal(t, expected, string(out))
-}
-
 func TestUnmarshalYAMLErrors(t *testing.T) {
 	t.Run("ValidYAML", func(t *testing.T) {
 		Register("fake_operator", func() Builder { return &FakeBuilder{} })
@@ -148,18 +134,4 @@ func TestUnmarshalYAMLErrors(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot unmarshal !!str")
 	})
-}
-
-func TestMarshalYAML(t *testing.T) {
-	cfg := Config{
-		Builder: &FakeBuilder{
-			OperatorID:   "operator",
-			OperatorType: "operator",
-			Array:        []string{"test"},
-		},
-	}
-	out, err := yaml.Marshal(cfg)
-	require.NoError(t, err)
-	expected := "id: operator\ntype: operator\narray:\n- test\n"
-	require.Equal(t, expected, string(out))
 }

--- a/pkg/stanza/operator/helper/bytesize_test.go
+++ b/pkg/stanza/operator/helper/bytesize_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 

--- a/pkg/stanza/operator/helper/bytesize_test.go
+++ b/pkg/stanza/operator/helper/bytesize_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 


### PR DESCRIPTION
This is part of an ongoing cleanup of un/marshaling throughout the module. These funcs are legacy code that is not used anywhere. Some of these may break when json and yaml struct tags are removed later.

Blocked by #14174 