### PR TITLE
[receiver/kubeletstats] fix use network io as network errors bug

### DIFF
--- a/receiver/kubeletstatsreceiver/internal/kubelet/network.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/network.go
@@ -21,22 +21,25 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/internal/metadata"
 )
 
+type getNetworkDataFunc func(s *stats.NetworkStats) (rx *uint64, tx *uint64)
+
 func addNetworkMetrics(mb *metadata.MetricsBuilder, networkMetrics metadata.NetworkMetrics, s *stats.NetworkStats, currentTime pcommon.Timestamp) {
 	if s == nil {
 		return
 	}
 
-	recordNetworkDataPoint(mb, networkMetrics.IO, s, currentTime)
-	recordNetworkDataPoint(mb, networkMetrics.Errors, s, currentTime)
+	recordNetworkDataPoint(mb, networkMetrics.IO, s, getNetworkIO, currentTime)
+	recordNetworkDataPoint(mb, networkMetrics.Errors, s, getNetworkErrors, currentTime)
 }
 
-func recordNetworkDataPoint(mb *metadata.MetricsBuilder, r metadata.NetworkMetricsRecorder, s *stats.NetworkStats, currentTime pcommon.Timestamp) {
-	if s.RxBytes == nil && s.TxBytes == nil {
+func recordNetworkDataPoint(mb *metadata.MetricsBuilder, r metadata.NetworkMetricsRecorder, s *stats.NetworkStats, getData getNetworkDataFunc, currentTime pcommon.Timestamp) {
+	rx, tx := getData(s)
+	if rx == nil && tx == nil {
 		return
 	}
 
-	r.RecordReceiveDataPoint(mb, currentTime, int64(*s.RxBytes), s.Name)
-	r.RecordTransmitDataPoint(mb, currentTime, int64(*s.TxBytes), s.Name)
+	r.RecordReceiveDataPoint(mb, currentTime, int64(*rx), s.Name)
+	r.RecordTransmitDataPoint(mb, currentTime, int64(*tx), s.Name)
 }
 
 func addNetworkMetricsWithDirection(mb *metadata.MetricsBuilder, networkMetrics metadata.NetworkMetricsWithDirection, s *stats.NetworkStats, currentTime pcommon.Timestamp) {
@@ -44,15 +47,24 @@ func addNetworkMetricsWithDirection(mb *metadata.MetricsBuilder, networkMetrics 
 		return
 	}
 
-	recordNetworkDataPointWithDirection(mb, networkMetrics.IO, s, currentTime)
-	recordNetworkDataPointWithDirection(mb, networkMetrics.Errors, s, currentTime)
+	recordNetworkDataPointWithDirection(mb, networkMetrics.IO, s, getNetworkIO, currentTime)
+	recordNetworkDataPointWithDirection(mb, networkMetrics.Errors, s, getNetworkErrors, currentTime)
 }
 
-func recordNetworkDataPointWithDirection(mb *metadata.MetricsBuilder, recordDataPoint metadata.RecordIntDataPointWithDirectionFunc, s *stats.NetworkStats, currentTime pcommon.Timestamp) {
-	if s.RxBytes == nil && s.TxBytes == nil {
+func recordNetworkDataPointWithDirection(mb *metadata.MetricsBuilder, recordDataPoint metadata.RecordIntDataPointWithDirectionFunc, s *stats.NetworkStats, getData getNetworkDataFunc, currentTime pcommon.Timestamp) {
+	rx, tx := getData(s)
+	if rx == nil && tx == nil {
 		return
 	}
 
-	recordDataPoint(mb, currentTime, int64(*s.RxBytes), s.Name, metadata.AttributeDirectionReceive)
-	recordDataPoint(mb, currentTime, int64(*s.TxBytes), s.Name, metadata.AttributeDirectionTransmit)
+	recordDataPoint(mb, currentTime, int64(*rx), s.Name, metadata.AttributeDirectionReceive)
+	recordDataPoint(mb, currentTime, int64(*tx), s.Name, metadata.AttributeDirectionTransmit)
+}
+
+func getNetworkIO(s *stats.NetworkStats) (*uint64, *uint64) {
+	return s.RxBytes, s.TxBytes
+}
+
+func getNetworkErrors(s *stats.NetworkStats) (*uint64, *uint64) {
+	return s.RxErrors, s.TxErrors
 }

--- a/receiver/kubeletstatsreceiver/internal/kubelet/network.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/network.go
@@ -34,12 +34,14 @@ func addNetworkMetrics(mb *metadata.MetricsBuilder, networkMetrics metadata.Netw
 
 func recordNetworkDataPoint(mb *metadata.MetricsBuilder, r metadata.NetworkMetricsRecorder, s *stats.NetworkStats, getData getNetworkDataFunc, currentTime pcommon.Timestamp) {
 	rx, tx := getData(s)
-	if rx == nil && tx == nil {
-		return
+
+	if rx != nil {
+		r.RecordReceiveDataPoint(mb, currentTime, int64(*rx), s.Name)
 	}
 
-	r.RecordReceiveDataPoint(mb, currentTime, int64(*rx), s.Name)
-	r.RecordTransmitDataPoint(mb, currentTime, int64(*tx), s.Name)
+	if tx != nil {
+		r.RecordTransmitDataPoint(mb, currentTime, int64(*tx), s.Name)
+	}
 }
 
 func addNetworkMetricsWithDirection(mb *metadata.MetricsBuilder, networkMetrics metadata.NetworkMetricsWithDirection, s *stats.NetworkStats, currentTime pcommon.Timestamp) {
@@ -53,12 +55,14 @@ func addNetworkMetricsWithDirection(mb *metadata.MetricsBuilder, networkMetrics 
 
 func recordNetworkDataPointWithDirection(mb *metadata.MetricsBuilder, recordDataPoint metadata.RecordIntDataPointWithDirectionFunc, s *stats.NetworkStats, getData getNetworkDataFunc, currentTime pcommon.Timestamp) {
 	rx, tx := getData(s)
-	if rx == nil && tx == nil {
-		return
+
+	if rx != nil {
+		recordDataPoint(mb, currentTime, int64(*rx), s.Name, metadata.AttributeDirectionReceive)
 	}
 
-	recordDataPoint(mb, currentTime, int64(*rx), s.Name, metadata.AttributeDirectionReceive)
-	recordDataPoint(mb, currentTime, int64(*tx), s.Name, metadata.AttributeDirectionTransmit)
+	if tx != nil {
+		recordDataPoint(mb, currentTime, int64(*tx), s.Name, metadata.AttributeDirectionTransmit)
+	}
 }
 
 func getNetworkIO(s *stats.NetworkStats) (*uint64, *uint64) {

--- a/unreleased/14318-fix-kubeletstats-network-errors-bug.yaml
+++ b/unreleased/14318-fix-kubeletstats-network-errors-bug.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kubeletstatsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix use network io as network errors bug
+
+# One or more tracking issues related to the change
+issues: [14318]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
fix bug: internal/network.go use network io as network errors
**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14318
**Testing:** <Describe what testing was performed and which tests were added.>
UT
**Documentation:** <Describe the documentation added.>