### PR TITLE
[processor/servicegraph] Fix metric names to match the specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,6 @@ wavefront-sdk-go library.
  (#13417)
 - `transformprocessor`: Fixes panic of transformprocessor handling Gauge types (#13905)
 - `vcenterreceiver`: Fix incorrect KBy and MBy units, updating them to KiBy and MiBy (#13935)
-- `servicegraphprocessor`: Fixed metric names to match the specification (#14324)
 
 # v0.59.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ wavefront-sdk-go library.
  (#13417)
 - `transformprocessor`: Fixes panic of transformprocessor handling Gauge types (#13905)
 - `vcenterreceiver`: Fix incorrect KBy and MBy units, updating them to KiBy and MiBy (#13935)
+- `servicegraphprocessor`: Fixed metric names to match the specification (#14324)
 
 # v0.59.0
 

--- a/processor/servicegraphprocessor/processor.go
+++ b/processor/servicegraphprocessor/processor.go
@@ -346,7 +346,7 @@ func buildDimensions(e *store.Edge) pcommon.Map {
 func (p *processor) buildMetrics() (pmetric.Metrics, error) {
 	m := pmetric.NewMetrics()
 	ilm := m.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
-	ilm.Scope().SetName("servicegraphprocessor")
+	ilm.Scope().SetName("traces_service_graph_servicegraphprocessor")
 
 	// Obtain write lock to reset data
 	p.seriesMutex.Lock()
@@ -366,7 +366,7 @@ func (p *processor) buildMetrics() (pmetric.Metrics, error) {
 func (p *processor) collectCountMetrics(ilm pmetric.ScopeMetrics) error {
 	for key, c := range p.reqTotal {
 		mCount := ilm.Metrics().AppendEmpty()
-		mCount.SetName("request_total")
+		mCount.SetName("traces_service_graph_request_total")
 		mCount.SetEmptySum().SetIsMonotonic(true)
 		// TODO: Support other aggregation temporalities
 		mCount.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -386,7 +386,7 @@ func (p *processor) collectCountMetrics(ilm pmetric.ScopeMetrics) error {
 
 	for key, c := range p.reqFailedTotal {
 		mCount := ilm.Metrics().AppendEmpty()
-		mCount.SetName("request_failed_total")
+		mCount.SetName("traces_service_graph_request_failed_total")
 		mCount.SetEmptySum().SetIsMonotonic(true)
 		// TODO: Support other aggregation temporalities
 		mCount.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
@@ -410,7 +410,7 @@ func (p *processor) collectCountMetrics(ilm pmetric.ScopeMetrics) error {
 func (p *processor) collectLatencyMetrics(ilm pmetric.ScopeMetrics) error {
 	for key := range p.reqDurationSecondsCount {
 		mDuration := ilm.Metrics().AppendEmpty()
-		mDuration.SetName("request_duration_seconds")
+		mDuration.SetName("traces_service_graph_request_duration_seconds")
 		// TODO: Support other aggregation temporalities
 		mDuration.SetEmptyHistogram().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 

--- a/processor/servicegraphprocessor/processor_test.go
+++ b/processor/servicegraphprocessor/processor_test.go
@@ -155,7 +155,7 @@ func verifyMetrics(t *testing.T, md pmetric.Metrics) error {
 }
 
 func verifyCount(t *testing.T, m pmetric.Metric) {
-	assert.Equal(t, "request_total", m.Name())
+	assert.Equal(t, "traces_service_graph_request_total", m.Name())
 
 	assert.Equal(t, pmetric.MetricDataTypeSum, m.DataType())
 	dps := m.Sum().DataPoints()
@@ -174,7 +174,7 @@ func verifyCount(t *testing.T, m pmetric.Metric) {
 }
 
 func verifyDuration(t *testing.T, m pmetric.Metric) {
-	assert.Equal(t, "request_duration_seconds", m.Name())
+	assert.Equal(t, "traces_service_graph_request_duration_seconds", m.Name())
 
 	assert.Equal(t, pmetric.MetricDataTypeHistogram, m.DataType())
 	dps := m.Histogram().DataPoints()

--- a/unreleased/fix_metrics_service_graph_processor.yaml
+++ b/unreleased/fix_metrics_service_graph_processor.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: servicegraphprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed metric names to match the specification.
+
+
+# One or more tracking issues related to the change
+issues: [14187]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** Add `traces_service_graph` prefix to metrics to match the specification. This is the spec used by Grafana and Tempo.

**Link to tracking Issue:** #14187

**Testing:** Updated tests accordingly