### PR TITLE
[extension/bearertokenauthextension] support reading tokens from file

### DIFF
--- a/extension/bearertokenauthextension/README.md
+++ b/extension/bearertokenauthextension/README.md
@@ -13,19 +13,26 @@ The authenticator type has to be set to `bearertokenauth`.
 
 ## Configuration
 
-The following is the only setting and is required:
+One of the following two options is required. If a token **and** a tokenfile are specified, the token is **ignored**:
 
 - `token`: static authorization token that needs to be sent on every gRPC client call as metadata.
   This token is prepended by "Bearer " before being sent as a value of "authorization" key in
   RPC metadata.
-  
-  **Note**: bearertokenauth requires transport layer security enabled on the exporter.
+
+- `tokenfile`: filename of file that contains a authorization token that needs to be sent on every
+  gRPC client call as metadata.
+  This token is prepended by "Bearer " before being sent as a value of "authorization" key in
+  RPC metadata.
+
+
+**Note**: bearertokenauth requires transport layer security enabled on the exporter.
 
 
 ```yaml
 extensions:
   bearertokenauth:
     token: "somerandomtoken"
+    token_filename: "file-containing.token"
 
 receivers:
   hostmetrics:

--- a/extension/bearertokenauthextension/README.md
+++ b/extension/bearertokenauthextension/README.md
@@ -19,7 +19,7 @@ One of the following two options is required. If a token **and** a tokenfile are
   This token is prepended by "Bearer " before being sent as a value of "authorization" key in
   RPC metadata.
 
-- `tokenfile`: filename of file that contains a authorization token that needs to be sent on every
+- `filename`: filename of file that contains a authorization token that needs to be sent on every
   gRPC client call as metadata.
   This token is prepended by "Bearer " before being sent as a value of "authorization" key in
   RPC metadata.
@@ -32,7 +32,7 @@ One of the following two options is required. If a token **and** a tokenfile are
 extensions:
   bearertokenauth:
     token: "somerandomtoken"
-    token_filename: "file-containing.token"
+    filename: "file-containing.token"
 
 receivers:
   hostmetrics:

--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -114,9 +114,13 @@ func (b *BearerTokenAuth) startWatcher(ctx context.Context, watcher *fsnotify.Wa
 			// SEE: https://martensson.io/go-fsnotify-and-kubernetes-configmaps/
 			if event.Op == fsnotify.Remove || event.Op == fsnotify.Chmod {
 				// remove the watcher since the file is removed
-				watcher.Remove(event.Name)
+				if err := watcher.Remove(event.Name); err != nil {
+					b.logger.Error(err.Error())
+				}
 				// add a new watcher pointing to the new symlink/file
-				watcher.Add(b.filename)
+				if err := watcher.Add(b.filename); err != nil {
+					b.logger.Error(err.Error())
+				}
 				b.refreshToken()
 			}
 			// also allow normal files to be modified and reloaded.

--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -135,6 +135,7 @@ func (b *BearerTokenAuth) startWatcher(ctx context.Context, watcher *fsnotify.Wa
 }
 
 func (b *BearerTokenAuth) refreshToken() {
+	b.logger.Info("refresh token", zap.Field{Key: "filename", String: b.filename})
 	token, err := os.ReadFile(b.filename)
 	if err != nil {
 		b.logger.Error(err.Error())

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestPerRPCAuth(t *testing.T) {
@@ -111,7 +112,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Filename = "test.token"
 
-	bauth := newBearerTokenAuth(cfg, nil)
+	bauth := newBearerTokenAuth(cfg, zaptest.NewLogger(t))
 	assert.NotNil(t, bauth)
 
 	assert.Nil(t, bauth.Start(context.Background(), componenttest.NewNopHost()))

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -109,7 +109,7 @@ func TestBearerAuthenticator(t *testing.T) {
 
 func TestBearerStartWatchStop(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.BearerTokenFilename = "test.token"
+	cfg.Filename = "test.token"
 
 	bauth := newBearerTokenAuth(cfg, nil)
 	assert.NotNil(t, bauth)
@@ -121,7 +121,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, credential)
 
-	token, err := os.ReadFile(bauth.tokenFilename)
+	token, err := os.ReadFile(bauth.filename)
 	assert.NoError(t, err)
 
 	tokenStr := fmt.Sprintf("Bearer %s", token)
@@ -134,7 +134,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	assert.True(t, credential.RequireTransportSecurity())
 
 	// change file content once
-	assert.Nil(t, os.WriteFile(bauth.tokenFilename, []byte(fmt.Sprintf("%stest", token)), 0600))
+	assert.Nil(t, os.WriteFile(bauth.filename, []byte(fmt.Sprintf("%stest", token)), 0600))
 	time.Sleep(5 * time.Second)
 	credential, _ = bauth.PerRPCCredentials()
 	md, err = credential.GetRequestMetadata(context.Background())
@@ -143,7 +143,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	assert.NoError(t, err)
 
 	// change file content back
-	assert.Nil(t, os.WriteFile(bauth.tokenFilename, token, 0600))
+	assert.Nil(t, os.WriteFile(bauth.filename, token, 0600))
 	time.Sleep(5 * time.Second)
 	credential, _ = bauth.PerRPCCredentials()
 	md, err = credential.GetRequestMetadata(context.Background())

--- a/extension/bearertokenauthextension/config.go
+++ b/extension/bearertokenauthextension/config.go
@@ -26,6 +26,9 @@ type Config struct {
 
 	// BearerToken specifies the bearer token to use for every RPC.
 	BearerToken string `mapstructure:"token,omitempty"`
+
+	// BearerTokenFile points to a file that contains the bearer token to use for every RPC.
+	BearerTokenFilename string `mapstructure:"tokenfile,omitempty"`
 }
 
 var _ config.Extension = (*Config)(nil)

--- a/extension/bearertokenauthextension/config.go
+++ b/extension/bearertokenauthextension/config.go
@@ -36,7 +36,7 @@ var errNoTokenProvided = errors.New("no bearer token provided")
 
 // Validate checks if the extension configuration is valid
 func (cfg *Config) Validate() error {
-	if cfg.BearerToken == "" {
+	if cfg.BearerToken == "" && cfg.Filename == "" {
 		return errNoTokenProvided
 	}
 	return nil

--- a/extension/bearertokenauthextension/config.go
+++ b/extension/bearertokenauthextension/config.go
@@ -27,8 +27,8 @@ type Config struct {
 	// BearerToken specifies the bearer token to use for every RPC.
 	BearerToken string `mapstructure:"token,omitempty"`
 
-	// BearerTokenFile points to a file that contains the bearer token to use for every RPC.
-	BearerTokenFilename string `mapstructure:"tokenfile,omitempty"`
+	// Filename points to a file that contains the bearer token to use for every RPC.
+	Filename string `mapstructure:"filename,omitempty"`
 }
 
 var _ config.Extension = (*Config)(nil)

--- a/extension/bearertokenauthextension/go.mod
+++ b/extension/bearertokenauthextension/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/extension/bearertokenauthextension/go.mod
+++ b/extension/bearertokenauthextension/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/beare
 go 1.18
 
 require (
+	github.com/fsnotify/fsnotify v1.5.4
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.60.1-0.20220916163348-84621e483dfb
 	go.uber.org/zap v1.23.0
@@ -11,7 +12,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/extension/bearertokenauthextension/go.sum
+++ b/extension/bearertokenauthextension/go.sum
@@ -23,6 +23,7 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+
 github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21TfrhJ8AEMzVybRNSb/b4g=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/extension/bearertokenauthextension/test.token
+++ b/extension/bearertokenauthextension/test.token
@@ -1,0 +1,1 @@
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...+file+

--- a/unreleased/bearertokenauthextension_support_token_from_file.yaml
+++ b/unreleased/bearertokenauthextension_support_token_from_file.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: bearertokenauthextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: support reading tokens from file
+
+# One or more tracking issues related to the change
+issues: [14325]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This pr extends the bearer token extension by the possibility to read tokens from a file. If a token file has been specified, this file is read once when the extension is started and overwrites the old token. Only if the content of the token changes again, the transferred token will be overwritten again.

**Link to tracking Issue:** #14325

**Testing:**
- starting the extension while its already running
- stopping the extension
- make sure the token is updated when the file content changed

**Documentation:**
Updated extension Readme