### PR TITLE
[receiver/mysql]: add endpoint resource attribute

### DIFF
--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -35,6 +35,12 @@ metrics:
     enabled: <true|false>
 ```
 
+## Resource attributes
+
+| Name | Description | Type |
+| ---- | ----------- | ---- |
+| mysql.instance.endpoint | Endpoint of the MySQL instance. | String |
+
 ## Metric attributes
 
 | Name | Description | Values |

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -1574,6 +1574,13 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 // ResourceMetricsOption applies changes to provided resource metrics.
 type ResourceMetricsOption func(pmetric.ResourceMetrics)
 
+// WithMysqlInstanceEndpoint sets provided value as "mysql.instance.endpoint" attribute for current resource.
+func WithMysqlInstanceEndpoint(val string) ResourceMetricsOption {
+	return func(rm pmetric.ResourceMetrics) {
+		rm.Resource().Attributes().PutString("mysql.instance.endpoint", val)
+	}
+}
+
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -1,5 +1,10 @@
 name: mysqlreceiver
 
+resource_attributes:
+  mysql.instance.endpoint:
+    description: Endpoint of the MySQL instance.
+    type: string
+
 attributes:
   buffer_pool_pages:
     value: kind

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -271,6 +271,8 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 		}
 	}
 
+	m.mb.EmitForResource(metadata.WithMysqlInstanceEndpoint(m.config.Endpoint))
+
 	return m.mb.Emit(), errs.Combine()
 }
 

--- a/receiver/mysqlreceiver/testdata/scraper/expected.json
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.json
@@ -1048,7 +1048,16 @@
                ]
             }
          ],
-         "resource": {}
+         "resource": {
+            "attributes": [
+               {
+                  "key": "mysql.instance.endpoint",
+                  "value": {
+                     "stringValue": "localhost:3306"
+                  }
+               }
+            ]
+         }
       }
    ]
 }

--- a/receiver/mysqlreceiver/testdata/scraper/expected_partial.json
+++ b/receiver/mysqlreceiver/testdata/scraper/expected_partial.json
@@ -1,7 +1,16 @@
 {
    "resourceMetrics": [
       {
-         "resource": {},
+         "resource": {
+            "attributes": [
+               {
+                  "key": "mysql.instance.endpoint",
+                  "value": {
+                     "stringValue": "localhost:3306"
+                  }
+               }
+            ]
+         },
          "scopeMetrics": [
             {
                "metrics": [

--- a/unreleased/mysql-add-endpoint-attribute.yaml
+++ b/unreleased/mysql-add-endpoint-attribute.yaml
@@ -1,0 +1,5 @@
+change_type: breaking
+component: mysqlreceiver
+note: The metrics are now being emitted with a resource attribute marking the endpoint of the database.
+issues: [14138]
+subtext:


### PR DESCRIPTION
**Description:** 
Add mysql.instance.endpoint resource attribute.

**Link to tracking Issue:** 
#14138 

**Testing:**
Unit tests have their expected results modified.
Integration tests have not been modified, because it seems that they don't compare resources anyway (I tested that and the tests were passing even with wrong expected result).

**Documentation:**
Documentation automatically generated my `mdatagen`.