### PR TITLE
[pkg/winperfcounters] Retry collection when rolloever error is detected

### DIFF
--- a/.chloggen/winperf-retry-rollover.yaml
+++ b/.chloggen/winperf-retry-rollover.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: windowsperfcountersreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Retry counter retrieval once, when error indicates possible rollover
+
+# One or more tracking issues related to the change
+issues: [14343]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -65,7 +65,6 @@ func mockPerfCounterFactory(mpc mockPerfCounter) newWatcherFunc {
 }
 
 func Test_WindowsPerfCounterScraper(t *testing.T) {
-	t.Skip("Flaky Test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11445")
 	type testCase struct {
 		name string
 		cfg  *Config


### PR DESCRIPTION
Based on documentation, I believe this resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11445. However, I'm not sure how to test it as it occurs very infrequently.