### PR TITLE
[receiver/mongodbatlas] Add missing audit log fields

### DIFF
--- a/receiver/mongodbatlasreceiver/go.mod
+++ b/receiver/mongodbatlasreceiver/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.4.3 // indirect
-	github.com/kr/text v0.2.0 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -28,7 +28,6 @@ require (
 	github.com/openlyinc/pointy v1.1.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/otel v1.9.0 // indirect
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
@@ -44,7 +43,6 @@ require (
 )
 
 require (
-	github.com/kr/pretty v0.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.60.0
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector/pdata v0.60.0

--- a/receiver/mongodbatlasreceiver/go.mod
+++ b/receiver/mongodbatlasreceiver/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.4.3 // indirect
-	github.com/kr/pretty v0.3.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -28,6 +28,7 @@ require (
 	github.com/openlyinc/pointy v1.1.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/otel v1.9.0 // indirect
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
@@ -43,6 +44,7 @@ require (
 )
 
 require (
+	github.com/kr/pretty v0.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.60.0
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector/pdata v0.60.0

--- a/receiver/mongodbatlasreceiver/internal/model/logs.go
+++ b/receiver/mongodbatlasreceiver/internal/model/logs.go
@@ -49,7 +49,7 @@ func (l LogEntry) RawLog() (string, error) {
 type AuditLog struct {
 	Type      string         `json:"atype"`
 	Timestamp LogTimestamp   `json:"ts"`
-	ID        ID             `json:"uuid"`
+	ID        *ID            `json:"uuid,omitempty"`
 	Local     Address        `json:"local"`
 	Remote    Address        `json:"remote"`
 	Users     []AuditUser    `json:"users"`

--- a/receiver/mongodbatlasreceiver/internal/model/logs.go
+++ b/receiver/mongodbatlasreceiver/internal/model/logs.go
@@ -16,6 +16,8 @@ package model // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"encoding/json"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 // LogEntry represents a MongoDB Atlas JSON log entry
@@ -45,13 +47,15 @@ func (l LogEntry) RawLog() (string, error) {
 
 // AuditLog represents a MongoDB Atlas JSON audit log entry
 type AuditLog struct {
-	AuthType  string       `json:"authenticate"`
-	Timestamp LogTimestamp `json:"ts"`
-	ID        ID           `json:"uuid"`
-	Local     Address      `json:"local"`
-	Remote    Address      `json:"remote"`
-	Result    int          `json:"result"`
-	Param     Param        `json:"param"`
+	Type      string         `json:"atype"`
+	Timestamp LogTimestamp   `json:"ts"`
+	ID        ID             `json:"uuid"`
+	Local     Address        `json:"local"`
+	Remote    Address        `json:"remote"`
+	Users     []AuditUser    `json:"users"`
+	Roles     []AuditRole    `json:"roles"`
+	Result    int            `json:"result"`
+	Param     map[string]any `json:"param"`
 }
 
 // logTimestamp is the structure that represents a Log Timestamp
@@ -69,8 +73,28 @@ type Address struct {
 	Port int    `json:"port"`
 }
 
-type Param struct {
-	User      string `json:"user"`
-	Database  string `json:"db"`
-	Mechanism string `json:"mechanism"`
+type AuditRole struct {
+	Role     string `json:"role"`
+	Database string `json:"db"`
+}
+
+func (ar AuditRole) Pdata() pcommon.Map {
+	m := pcommon.NewMap()
+	m.EnsureCapacity(2)
+	m.PutString("role", ar.Role)
+	m.PutString("db", ar.Database)
+	return m
+}
+
+type AuditUser struct {
+	User     string `json:"user"`
+	Database string `json:"db"`
+}
+
+func (ar AuditUser) Pdata() pcommon.Map {
+	m := pcommon.NewMap()
+	m.EnsureCapacity(2)
+	m.PutString("user", ar.User)
+	m.PutString("db", ar.Database)
+	return m
 }

--- a/receiver/mongodbatlasreceiver/internal/model/logs.go
+++ b/receiver/mongodbatlasreceiver/internal/model/logs.go
@@ -69,8 +69,10 @@ type ID struct {
 }
 
 type Address struct {
-	IP   string `json:"ip"`
-	Port int    `json:"port"`
+	IP         *string `json:"ip,omitempty"`
+	Port       *int    `json:"port,omitempty"`
+	SystemUser *bool   `json:"isSystemUser,omitempty"`
+	UnixSocket *string `json:"unix,omitempty"`
 }
 
 type AuditRole struct {

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -249,7 +249,6 @@ func TestDecodeAudit4_2(t *testing.T) {
 		{
 			Type:      "authenticate",
 			Timestamp: model.LogTimestamp{Date: "2022-09-16T01:38:20.034+0000"},
-			ID:        model.ID{},
 			Local:     model.Address{IP: "127.0.0.1", Port: 27017},
 			Remote:    model.Address{IP: "127.0.0.1", Port: 50722},
 			Users: []model.AuditUser{
@@ -294,7 +293,6 @@ func TestDecodeAudit4_2(t *testing.T) {
 		{
 			Type:      "authenticate",
 			Timestamp: model.LogTimestamp{Date: "2022-09-16T02:37:38.714+0000"},
-			ID:        model.ID{},
 			Local:     model.Address{IP: "192.168.248.5", Port: 27017},
 			Remote:    model.Address{IP: "192.168.248.6", Port: 43714},
 			Users: []model.AuditUser{
@@ -339,7 +337,6 @@ func TestDecodeAudit4_2(t *testing.T) {
 		{
 			Type:      "authenticate",
 			Timestamp: model.LogTimestamp{Date: "2022-09-16T02:38:20.030+0000"},
-			ID:        model.ID{},
 			Local:     model.Address{IP: "127.0.0.1", Port: 27017},
 			Remote:    model.Address{IP: "127.0.0.1", Port: 52216},
 			Users: []model.AuditUser{
@@ -402,7 +399,6 @@ func TestDecodeAudit4_2InvalidLog(t *testing.T) {
 		{
 			Type:      "authenticate",
 			Timestamp: model.LogTimestamp{Date: "2022-09-16T01:38:20.034+0000"},
-			ID:        model.ID{},
 			Local:     model.Address{IP: "127.0.0.1", Port: 27017},
 			Remote:    model.Address{IP: "127.0.0.1", Port: 50722},
 			Users: []model.AuditUser{
@@ -465,7 +461,7 @@ func TestDecodeAudit5_0(t *testing.T) {
 		{
 			Type:      "clientMetadata",
 			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.043+00:00"},
-			ID:        model.ID{Binary: "KXMtAMh9TOOSl9aQBW1Zkg==", Type: "04"},
+			ID:        &model.ID{Binary: "KXMtAMh9TOOSl9aQBW1Zkg==", Type: "04"},
 			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
 			Remote:    model.Address{IP: "192.168.248.2", Port: 34736},
 			Users:     []model.AuditUser{},
@@ -495,7 +491,7 @@ func TestDecodeAudit5_0(t *testing.T) {
 		{
 			Type:      "clientMetadata",
 			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.055+00:00"},
-			ID:        model.ID{Binary: "pWSwWRZvR9CgNsvcDYhiwg==", Type: "04"},
+			ID:        &model.ID{Binary: "pWSwWRZvR9CgNsvcDYhiwg==", Type: "04"},
 			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
 			Remote:    model.Address{IP: "192.168.248.2", Port: 34740},
 			Users:     []model.AuditUser{},
@@ -525,7 +521,7 @@ func TestDecodeAudit5_0(t *testing.T) {
 		{
 			Type:      "logout",
 			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.071+00:00"},
-			ID:        model.ID{Binary: "pWSwWRZvR9CgNsvcDYhiwg==", Type: "04"},
+			ID:        &model.ID{Binary: "pWSwWRZvR9CgNsvcDYhiwg==", Type: "04"},
 			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
 			Remote:    model.Address{IP: "192.168.248.2", Port: 34740},
 			Users:     []model.AuditUser{},
@@ -563,7 +559,7 @@ func TestDecodeAudit5_0InvalidLog(t *testing.T) {
 		{
 			Type:      "clientMetadata",
 			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.043+00:00"},
-			ID:        model.ID{Binary: "KXMtAMh9TOOSl9aQBW1Zkg==", Type: "04"},
+			ID:        &model.ID{Binary: "KXMtAMh9TOOSl9aQBW1Zkg==", Type: "04"},
 			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
 			Remote:    model.Address{IP: "192.168.248.2", Port: 34736},
 			Users:     []model.AuditUser{},

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -227,6 +227,14 @@ func strp(s string) *string {
 	return &s
 }
 
+func intp(i int) *int {
+	return &i
+}
+
+func boolp(b bool) *bool {
+	return &b
+}
+
 func TestDecodeAudit4_2(t *testing.T) {
 	b, err := os.ReadFile(filepath.Join("testdata", "logs", "sample-payloads", "4.2_audit.log"))
 	require.NoError(t, err)
@@ -245,8 +253,8 @@ func TestDecodeAudit4_2(t *testing.T) {
 		{
 			Type:      "authenticate",
 			Timestamp: model.LogTimestamp{Date: "2022-09-16T01:38:20.034+0000"},
-			Local:     model.Address{IP: "127.0.0.1", Port: 27017},
-			Remote:    model.Address{IP: "127.0.0.1", Port: 50722},
+			Local:     model.Address{IP: strp("127.0.0.1"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("127.0.0.1"), Port: intp(50722)},
 			Users: []model.AuditUser{
 				{
 					Database: "admin",
@@ -289,8 +297,8 @@ func TestDecodeAudit4_2(t *testing.T) {
 		{
 			Type:      "authenticate",
 			Timestamp: model.LogTimestamp{Date: "2022-09-16T02:37:38.714+0000"},
-			Local:     model.Address{IP: "192.168.248.5", Port: 27017},
-			Remote:    model.Address{IP: "192.168.248.6", Port: 43714},
+			Local:     model.Address{IP: strp("192.168.248.5"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("192.168.248.6"), Port: intp(43714)},
 			Users: []model.AuditUser{
 				{
 					Database: "admin",
@@ -333,8 +341,8 @@ func TestDecodeAudit4_2(t *testing.T) {
 		{
 			Type:      "authenticate",
 			Timestamp: model.LogTimestamp{Date: "2022-09-16T02:38:20.030+0000"},
-			Local:     model.Address{IP: "127.0.0.1", Port: 27017},
-			Remote:    model.Address{IP: "127.0.0.1", Port: 52216},
+			Local:     model.Address{IP: strp("127.0.0.1"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("127.0.0.1"), Port: intp(52216)},
 			Users: []model.AuditUser{
 				{
 					Database: "admin",
@@ -395,8 +403,8 @@ func TestDecodeAudit4_2InvalidLog(t *testing.T) {
 		{
 			Type:      "authenticate",
 			Timestamp: model.LogTimestamp{Date: "2022-09-16T01:38:20.034+0000"},
-			Local:     model.Address{IP: "127.0.0.1", Port: 27017},
-			Remote:    model.Address{IP: "127.0.0.1", Port: 50722},
+			Local:     model.Address{IP: strp("127.0.0.1"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("127.0.0.1"), Port: intp(50722)},
 			Users: []model.AuditUser{
 				{
 					Database: "admin",
@@ -458,8 +466,8 @@ func TestDecodeAudit5_0(t *testing.T) {
 			Type:      "clientMetadata",
 			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.043+00:00"},
 			ID:        &model.ID{Binary: "KXMtAMh9TOOSl9aQBW1Zkg==", Type: "04"},
-			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
-			Remote:    model.Address{IP: "192.168.248.2", Port: 34736},
+			Local:     model.Address{IP: strp("192.168.248.2"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("192.168.248.2"), Port: intp(34736)},
 			Users:     []model.AuditUser{},
 			Roles:     []model.AuditRole{},
 			Result:    0,
@@ -488,8 +496,8 @@ func TestDecodeAudit5_0(t *testing.T) {
 			Type:      "clientMetadata",
 			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.055+00:00"},
 			ID:        &model.ID{Binary: "pWSwWRZvR9CgNsvcDYhiwg==", Type: "04"},
-			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
-			Remote:    model.Address{IP: "192.168.248.2", Port: 34740},
+			Local:     model.Address{IP: strp("192.168.248.2"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("192.168.248.2"), Port: intp(34740)},
 			Users:     []model.AuditUser{},
 			Roles:     []model.AuditRole{},
 			Result:    0,
@@ -518,8 +526,8 @@ func TestDecodeAudit5_0(t *testing.T) {
 			Type:      "logout",
 			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.071+00:00"},
 			ID:        &model.ID{Binary: "pWSwWRZvR9CgNsvcDYhiwg==", Type: "04"},
-			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
-			Remote:    model.Address{IP: "192.168.248.2", Port: 34740},
+			Local:     model.Address{IP: strp("192.168.248.2"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("192.168.248.2"), Port: intp(34740)},
 			Users:     []model.AuditUser{},
 			Roles:     []model.AuditRole{},
 			Result:    0,
@@ -556,8 +564,8 @@ func TestDecodeAudit5_0InvalidLog(t *testing.T) {
 			Type:      "clientMetadata",
 			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.043+00:00"},
 			ID:        &model.ID{Binary: "KXMtAMh9TOOSl9aQBW1Zkg==", Type: "04"},
-			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
-			Remote:    model.Address{IP: "192.168.248.2", Port: 34736},
+			Local:     model.Address{IP: strp("192.168.248.2"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("192.168.248.2"), Port: intp(34736)},
 			Users:     []model.AuditUser{},
 			Roles:     []model.AuditRole{},
 			Result:    0,

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -144,7 +145,7 @@ func TestDecode5_0(t *testing.T) {
 			ID:        22944,
 			Context:   "conn35107",
 			Message:   "Connection ended",
-			Attributes: map[string]interface{}{
+			Attributes: map[string]any{
 				"remote":          "192.168.248.2:52066",
 				"uuid":            "d3f4641a-14ca-4a24-b5bb-7d7b391a02e7",
 				"connectionId":    float64(35107),
@@ -160,7 +161,7 @@ func TestDecode5_0(t *testing.T) {
 			ID:        22944,
 			Context:   "conn35109",
 			Message:   "Connection ended",
-			Attributes: map[string]interface{}{
+			Attributes: map[string]any{
 				"remote":          "192.168.248.2:52070",
 				"uuid":            "dcdb08ac-981d-41ea-9d6b-f85fe0475bd1",
 				"connectionId":    float64(35109),
@@ -176,8 +177,8 @@ func TestDecode5_0(t *testing.T) {
 			ID:        20997,
 			Context:   "conn9957",
 			Message:   "Refreshed RWC defaults",
-			Attributes: map[string]interface{}{
-				"newDefaults": map[string]interface{}{},
+			Attributes: map[string]any{
+				"newDefaults": map[string]any{},
 			},
 		},
 	}, entries)
@@ -207,7 +208,7 @@ func TestDecode5_0InvalidLog(t *testing.T) {
 			ID:        22944,
 			Context:   "conn35107",
 			Message:   "Connection ended",
-			Attributes: map[string]interface{}{
+			Attributes: map[string]any{
 				"remote":          "192.168.248.2:52066",
 				"uuid":            "d3f4641a-14ca-4a24-b5bb-7d7b391a02e7",
 				"connectionId":    float64(35107),
@@ -241,74 +242,143 @@ func TestDecodeAudit4_2(t *testing.T) {
 	entries, err := decodeAuditJSON(zippedBuffer)
 	require.NoError(t, err)
 
-	t.Logf("%#v", entries)
+	pretty.Printf("%# v", entries)
+	t.Logf("Logs: %#v", entries)
 
 	require.Equal(t, []model.AuditLog{
 		{
-			AuthType: "",
-			Timestamp: model.LogTimestamp{
-				Date: "2022-09-16T01:38:20.034+0000",
+			Type:      "authenticate",
+			Timestamp: model.LogTimestamp{Date: "2022-09-16T01:38:20.034+0000"},
+			ID:        model.ID{},
+			Local:     model.Address{IP: "127.0.0.1", Port: 27017},
+			Remote:    model.Address{IP: "127.0.0.1", Port: 50722},
+			Users: []model.AuditUser{
+				{
+					Database: "admin",
+					User:     "mms-automation",
+				},
 			},
-			ID: model.ID{
-				Binary: "",
-				Type:   "",
-			},
-			Local: model.Address{
-				IP:   "127.0.0.1",
-				Port: 27017,
-			},
-			Remote: model.Address{
-				IP:   "127.0.0.1",
-				Port: 50722,
+			Roles: []model.AuditRole{
+				{
+					Database: "admin",
+					Role:     "clusterAdmin",
+				},
+				{
+					Database: "admin",
+					Role:     "backup",
+				},
+				{
+					Database: "admin",
+					Role:     "dbAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "restore",
+				},
+				{
+					Database: "admin",
+					Role:     "userAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "readWriteAnyDatabase",
+				},
 			},
 			Result: 0,
-			Param: model.Param{
-				User:      "mms-automation",
-				Database:  "admin",
-				Mechanism: "SCRAM-SHA-1",
+			Param: map[string]any{
+				"db":        "admin",
+				"mechanism": "SCRAM-SHA-1",
+				"user":      "mms-automation",
 			},
 		},
 		{
-			AuthType: "",
-			Timestamp: model.LogTimestamp{
-				Date: "2022-09-16T02:37:38.714+0000",
-			}, ID: model.ID{
-				Binary: "",
-				Type:   "",
-			}, Local: model.Address{
-				IP:   "192.168.248.5",
-				Port: 27017,
-			}, Remote: model.Address{
-				IP:   "192.168.248.6",
-				Port: 43714,
-			}, Result: 0,
-			Param: model.Param{
-				User:      "mms-automation",
-				Database:  "admin",
-				Mechanism: "SCRAM-SHA-1",
+			Type:      "authenticate",
+			Timestamp: model.LogTimestamp{Date: "2022-09-16T02:37:38.714+0000"},
+			ID:        model.ID{},
+			Local:     model.Address{IP: "192.168.248.5", Port: 27017},
+			Remote:    model.Address{IP: "192.168.248.6", Port: 43714},
+			Users: []model.AuditUser{
+				{
+					Database: "admin",
+					User:     "mms-automation",
+				},
+			},
+			Roles: []model.AuditRole{
+				{
+					Database: "admin",
+					Role:     "clusterAdmin",
+				},
+				{
+					Database: "admin",
+					Role:     "backup",
+				},
+				{
+					Database: "admin",
+					Role:     "dbAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "restore",
+				},
+				{
+					Database: "admin",
+					Role:     "userAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "readWriteAnyDatabase",
+				},
+			},
+			Result: 0,
+			Param: map[string]any{
+				"db":        "admin",
+				"mechanism": "SCRAM-SHA-1",
+				"user":      "mms-automation",
 			},
 		},
 		{
-			AuthType: "",
-			Timestamp: model.LogTimestamp{
-				Date: "2022-09-16T02:38:20.030+0000",
-			}, ID: model.ID{
-				Binary: "",
-				Type:   "",
+			Type:      "authenticate",
+			Timestamp: model.LogTimestamp{Date: "2022-09-16T02:38:20.030+0000"},
+			ID:        model.ID{},
+			Local:     model.Address{IP: "127.0.0.1", Port: 27017},
+			Remote:    model.Address{IP: "127.0.0.1", Port: 52216},
+			Users: []model.AuditUser{
+				{
+					Database: "admin",
+					User:     "mms-automation",
+				},
 			},
-			Local: model.Address{
-				IP:   "127.0.0.1",
-				Port: 27017,
-			},
-			Remote: model.Address{
-				IP:   "127.0.0.1",
-				Port: 52216,
+			Roles: []model.AuditRole{
+				{
+					Database: "admin",
+					Role:     "clusterAdmin",
+				},
+				{
+					Database: "admin",
+					Role:     "backup",
+				},
+				{
+					Database: "admin",
+					Role:     "dbAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "restore",
+				},
+				{
+					Database: "admin",
+					Role:     "userAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "readWriteAnyDatabase",
+				},
 			},
 			Result: 0,
-			Param: model.Param{
-				User:      "mms-automation",
-				Database:  "admin",
-				Mechanism: "SCRAM-SHA-1",
+			Param: map[string]any{
+				"db":        "admin",
+				"mechanism": "SCRAM-SHA-1",
+				"user":      "mms-automation",
 			},
 		},
 	}, entries)
@@ -330,27 +400,48 @@ func TestDecodeAudit4_2InvalidLog(t *testing.T) {
 
 	require.Equal(t, []model.AuditLog{
 		{
-			AuthType: "",
-			Timestamp: model.LogTimestamp{
-				Date: "2022-09-16T01:38:20.034+0000",
+			Type:      "authenticate",
+			Timestamp: model.LogTimestamp{Date: "2022-09-16T01:38:20.034+0000"},
+			ID:        model.ID{},
+			Local:     model.Address{IP: "127.0.0.1", Port: 27017},
+			Remote:    model.Address{IP: "127.0.0.1", Port: 50722},
+			Users: []model.AuditUser{
+				{
+					Database: "admin",
+					User:     "mms-automation",
+				},
 			},
-			ID: model.ID{
-				Binary: "",
-				Type:   "",
-			},
-			Local: model.Address{
-				IP:   "127.0.0.1",
-				Port: 27017,
-			},
-			Remote: model.Address{
-				IP:   "127.0.0.1",
-				Port: 50722,
+			Roles: []model.AuditRole{
+				{
+					Database: "admin",
+					Role:     "clusterAdmin",
+				},
+				{
+					Database: "admin",
+					Role:     "backup",
+				},
+				{
+					Database: "admin",
+					Role:     "dbAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "restore",
+				},
+				{
+					Database: "admin",
+					Role:     "userAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "readWriteAnyDatabase",
+				},
 			},
 			Result: 0,
-			Param: model.Param{
-				User:      "mms-automation",
-				Database:  "admin",
-				Mechanism: "SCRAM-SHA-1",
+			Param: map[string]any{
+				"db":        "admin",
+				"mechanism": "SCRAM-SHA-1",
+				"user":      "mms-automation",
 			},
 		},
 	}, entries)
@@ -370,74 +461,85 @@ func TestDecodeAudit5_0(t *testing.T) {
 	entries, err := decodeAuditJSON(zippedBuffer)
 	require.NoError(t, err)
 
-	t.Logf("%#v", entries)
-
 	require.Equal(t, []model.AuditLog{
 		{
-			AuthType: "",
-			Timestamp: model.LogTimestamp{
-				Date: "2022-09-15T23:56:28.043+00:00",
+			Type:      "clientMetadata",
+			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.043+00:00"},
+			ID:        model.ID{Binary: "KXMtAMh9TOOSl9aQBW1Zkg==", Type: "04"},
+			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
+			Remote:    model.Address{IP: "192.168.248.2", Port: 34736},
+			Users:     []model.AuditUser{},
+			Roles:     []model.AuditRole{},
+			Result:    0,
+			Param: map[string]any{
+				"clientMetadata": map[string]any{
+					"application": map[string]any{
+						"name": "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)",
+					},
+					"driver": map[string]any{
+						"name":    "mongo-go-driver",
+						"version": "v1.7.2+prerelease",
+					},
+					"os": map[string]any{
+						"architecture": "amd64",
+						"type":         "linux",
+					},
+					"platform": "go1.18.2",
+				},
+				"localEndpoint": map[string]any{
+					"ip":   "192.168.248.2",
+					"port": float64(27017),
+				},
 			},
-			ID: model.ID{
-				Binary: "KXMtAMh9TOOSl9aQBW1Zkg==",
-				Type:   "04",
+		},
+		{
+			Type:      "clientMetadata",
+			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.055+00:00"},
+			ID:        model.ID{Binary: "pWSwWRZvR9CgNsvcDYhiwg==", Type: "04"},
+			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
+			Remote:    model.Address{IP: "192.168.248.2", Port: 34740},
+			Users:     []model.AuditUser{},
+			Roles:     []model.AuditRole{},
+			Result:    0,
+			Param: map[string]any{
+				"clientMetadata": map[string]any{
+					"application": map[string]any{
+						"name": "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)",
+					},
+					"driver": map[string]any{
+						"name":    "mongo-go-driver",
+						"version": "v1.7.2+prerelease",
+					},
+					"os": map[string]any{
+						"architecture": "amd64",
+						"type":         "linux",
+					},
+					"platform": "go1.18.2",
+				},
+				"localEndpoint": map[string]any{
+					"ip":   "192.168.248.2",
+					"port": float64(27017),
+				},
 			},
-			Local: model.Address{
-				IP:   "192.168.248.2",
-				Port: 27017,
-			}, Remote: model.Address{
-				IP:   "192.168.248.2",
-				Port: 34736,
-			},
-			Result: 0,
-			Param: model.Param{
-				User:      "",
-				Database:  "",
-				Mechanism: "",
-			},
-		}, {
-			AuthType: "",
-			Timestamp: model.LogTimestamp{
-				Date: "2022-09-15T23:56:28.055+00:00",
-			},
-			ID: model.ID{
-				Binary: "pWSwWRZvR9CgNsvcDYhiwg==",
-				Type:   "04",
-			},
-			Local: model.Address{
-				IP:   "192.168.248.2",
-				Port: 27017,
-			},
-			Remote: model.Address{
-				IP:   "192.168.248.2",
-				Port: 34740,
-			},
-			Result: 0,
-			Param: model.Param{
-				User:      "",
-				Database:  "",
-				Mechanism: "",
-			},
-		}, {
-			AuthType: "",
-			Timestamp: model.LogTimestamp{
-				Date: "2022-09-15T23:56:28.071+00:00",
-			},
-			ID: model.ID{
-				Binary: "pWSwWRZvR9CgNsvcDYhiwg==",
-				Type:   "04",
-			}, Local: model.Address{
-				IP:   "192.168.248.2",
-				Port: 27017,
-			}, Remote: model.Address{
-				IP:   "192.168.248.2",
-				Port: 34740,
-			},
-			Result: 0,
-			Param: model.Param{
-				User:      "",
-				Database:  "",
-				Mechanism: "",
+		},
+		{
+			Type:      "logout",
+			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.071+00:00"},
+			ID:        model.ID{Binary: "pWSwWRZvR9CgNsvcDYhiwg==", Type: "04"},
+			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
+			Remote:    model.Address{IP: "192.168.248.2", Port: 34740},
+			Users:     []model.AuditUser{},
+			Roles:     []model.AuditRole{},
+			Result:    0,
+			Param: map[string]any{
+				"initialUsers": []any{
+					map[string]any{
+						"db":   "local",
+						"user": "__system",
+					},
+				},
+				"reason":       "Client has disconnected",
+				"updatedUsers": []any{},
 			},
 		},
 	}, entries)
@@ -459,26 +561,33 @@ func TestDecodeAudit5_0InvalidLog(t *testing.T) {
 
 	require.Equal(t, []model.AuditLog{
 		{
-			AuthType: "",
-			Timestamp: model.LogTimestamp{
-				Date: "2022-09-15T23:56:28.043+00:00",
-			},
-			ID: model.ID{
-				Binary: "KXMtAMh9TOOSl9aQBW1Zkg==",
-				Type:   "04",
-			},
-			Local: model.Address{
-				IP:   "192.168.248.2",
-				Port: 27017,
-			}, Remote: model.Address{
-				IP:   "192.168.248.2",
-				Port: 34736,
-			},
-			Result: 0,
-			Param: model.Param{
-				User:      "",
-				Database:  "",
-				Mechanism: "",
+			Type:      "clientMetadata",
+			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.043+00:00"},
+			ID:        model.ID{Binary: "KXMtAMh9TOOSl9aQBW1Zkg==", Type: "04"},
+			Local:     model.Address{IP: "192.168.248.2", Port: 27017},
+			Remote:    model.Address{IP: "192.168.248.2", Port: 34736},
+			Users:     []model.AuditUser{},
+			Roles:     []model.AuditRole{},
+			Result:    0,
+			Param: map[string]any{
+				"clientMetadata": map[string]any{
+					"application": map[string]any{
+						"name": "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)",
+					},
+					"driver": map[string]any{
+						"name":    "mongo-go-driver",
+						"version": "v1.7.2+prerelease",
+					},
+					"os": map[string]any{
+						"architecture": "amd64",
+						"type":         "linux",
+					},
+					"platform": "go1.18.2",
+				},
+				"localEndpoint": map[string]any{
+					"ip":   "192.168.248.2",
+					"port": float64(27017),
+				},
 			},
 		},
 	}, entries)

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -241,9 +240,6 @@ func TestDecodeAudit4_2(t *testing.T) {
 
 	entries, err := decodeAuditJSON(zippedBuffer)
 	require.NoError(t, err)
-
-	pretty.Printf("%# v", entries)
-	t.Logf("Logs: %#v", entries)
 
 	require.Equal(t, []model.AuditLog{
 		{

--- a/receiver/mongodbatlasreceiver/mongodb_event_to_logdata.go
+++ b/receiver/mongodbatlasreceiver/mongodb_event_to_logdata.go
@@ -94,11 +94,37 @@ func mongodbAuditEventToLogData(logger *zap.Logger, logs []model.AuditLog, pc Pr
 
 		attrs.PutString("atype", log.Type)
 
-		attrs.PutString("local.ip", log.Local.IP)
-		attrs.PutInt("local.port", int64(log.Local.Port))
+		if log.Local.IP != nil {
+			attrs.PutString("local.ip", *log.Local.IP)
+		}
 
-		attrs.PutString("remote.ip", log.Remote.IP)
-		attrs.PutInt("remote.port", int64(log.Remote.Port))
+		if log.Local.Port != nil {
+			attrs.PutInt("local.port", int64(*log.Local.Port))
+		}
+
+		if log.Local.SystemUser != nil {
+			attrs.PutBool("local.isSystemUser", *log.Local.SystemUser)
+		}
+
+		if log.Local.UnixSocket != nil {
+			attrs.PutString("local.unix", *log.Local.UnixSocket)
+		}
+
+		if log.Remote.IP != nil {
+			attrs.PutString("remote.ip", *log.Remote.IP)
+		}
+
+		if log.Remote.Port != nil {
+			attrs.PutInt("remote.port", int64(*log.Remote.Port))
+		}
+
+		if log.Remote.SystemUser != nil {
+			attrs.PutBool("remote.isSystemUser", *log.Remote.SystemUser)
+		}
+
+		if log.Remote.UnixSocket != nil {
+			attrs.PutString("remote.unix", *log.Remote.UnixSocket)
+		}
 
 		if log.ID != nil {
 			attrs.PutString("uuid.binary", log.ID.Binary)

--- a/receiver/mongodbatlasreceiver/mongodb_event_to_logdata.go
+++ b/receiver/mongodbatlasreceiver/mongodb_event_to_logdata.go
@@ -29,7 +29,7 @@ const (
 	// Number of log attributes to add to the plog.LogRecordSlice for host logs.
 	totalLogAttributes = 11
 	// Number of log attributes to add to the plog.LogRecordSlice for audit logs.
-	totalAuditLogAttributes = 12
+	totalAuditLogAttributes = 16
 
 	// Number of resource attributes to add to the plog.ResourceLogs.
 	totalResourceAttributes = 4

--- a/receiver/mongodbatlasreceiver/mongodb_event_to_logdata.go
+++ b/receiver/mongodbatlasreceiver/mongodb_event_to_logdata.go
@@ -100,8 +100,10 @@ func mongodbAuditEventToLogData(logger *zap.Logger, logs []model.AuditLog, pc Pr
 		attrs.PutString("remote.ip", log.Remote.IP)
 		attrs.PutInt("remote.port", int64(log.Remote.Port))
 
-		attrs.PutString("uuid.binary", log.ID.Binary)
-		attrs.PutString("uuid.type", log.ID.Type)
+		if log.ID != nil {
+			attrs.PutString("uuid.binary", log.ID.Binary)
+			attrs.PutString("uuid.type", log.ID.Type)
+		}
 
 		attrs.PutInt("result", int64(log.Result))
 

--- a/receiver/mongodbatlasreceiver/mongodb_event_to_logdata_test.go
+++ b/receiver/mongodbatlasreceiver/mongodb_event_to_logdata_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -96,7 +97,7 @@ func TestMongoEventToAuditLogData4_4(t *testing.T) {
 		Project: mongodbatlas.Project{Name: "Project"},
 	}
 
-	ld := mongodbAuditEventToLogData(zap.NewNop(), []model.AuditLog{mongoevent}, pc, "hostname", "clusterName", "logName", "4.4")
+	ld := mongodbAuditEventToLogData(zaptest.NewLogger(t), []model.AuditLog{mongoevent}, pc, "hostname", "logName", "clusterName", "5.0")
 	rl := ld.ResourceLogs().At(0)
 	resourceAttrs := rl.Resource().Attributes()
 	sl := rl.ScopeLogs().At(0)
@@ -105,10 +106,43 @@ func TestMongoEventToAuditLogData4_4(t *testing.T) {
 
 	assert.Equal(t, ld.ResourceLogs().Len(), 1)
 	assert.Equal(t, resourceAttrs.Len(), 4)
-	assert.Equal(t, 12, attrs.Len())
-	assert.Equal(t, pcommon.Timestamp(1663342012563000000), lr.Timestamp())
+	assertString(t, resourceAttrs, "mongodb_atlas.org", "Org")
+	assertString(t, resourceAttrs, "mongodb_atlas.project", "Project")
+	assertString(t, resourceAttrs, "mongodb_atlas.cluster", "clusterName")
+	assertString(t, resourceAttrs, "mongodb_atlas.host.name", "hostname")
 
-	ld = mongodbAuditEventToLogData(zap.NewNop(), []model.AuditLog{mongoevent}, pc, "hostname", "clusterName", "logName", "4.4")
+	assert.Equal(t, 12, attrs.Len())
+	assertString(t, attrs, "atype", "authtype")
+	assertString(t, attrs, "local.ip", "0.0.0.0")
+	assertInt(t, attrs, "local.port", 3000)
+	assertString(t, attrs, "remote.ip", "192.168.1.237")
+	assertInt(t, attrs, "remote.port", 4000)
+	assertString(t, attrs, "uuid.binary", "binary")
+	assertString(t, attrs, "uuid.type", "type")
+	assertString(t, attrs, "log_name", "logName")
+	assertInt(t, attrs, "result", 40)
+
+	roles, ok := attrs.Get("roles")
+	require.True(t, ok, "roles key does not exist")
+	require.Equal(t, roles.SliceVal().Len(), 1)
+	assertString(t, roles.SliceVal().At(0).MapVal(), "role", "test_role")
+	assertString(t, roles.SliceVal().At(0).MapVal(), "db", "test_db")
+
+	users, ok := attrs.Get("users")
+	require.True(t, ok, "users key does not exist")
+	require.Equal(t, users.SliceVal().Len(), 1)
+	assertString(t, users.SliceVal().At(0).MapVal(), "user", "mongo_user")
+	assertString(t, users.SliceVal().At(0).MapVal(), "db", "my_db")
+
+	param, ok := attrs.Get("param")
+	require.True(t, ok, "param key does not exist")
+	assert.Equal(t, mongoevent.Param, param.MapVal().AsRaw())
+
+	assert.Equal(t, pcommon.Timestamp(1663342012563000000), lr.Timestamp())
+	assert.Equal(t, plog.SeverityNumberInfo, lr.SeverityNumber())
+	assert.Equal(t, "INFO", lr.SeverityText())
+
+	ld = mongodbAuditEventToLogData(zap.NewNop(), []model.AuditLog{mongoevent}, pc, "hostname", "clusterName", "logName", "4.2")
 	assert.Equal(t, 12, ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Len())
 }
 
@@ -128,6 +162,7 @@ func TestMongoEventToAuditLogData4_2(t *testing.T) {
 
 	assert.Equal(t, ld.ResourceLogs().Len(), 1)
 	assert.Equal(t, resourceAttrs.Len(), 4)
+
 	assert.Equal(t, 12, attrs.Len())
 	assert.Equal(t, pcommon.Timestamp(1663342012563000000), lr.Timestamp())
 
@@ -166,24 +201,36 @@ func GetTestAuditEvent4_4() model.AuditLog {
 		Timestamp: model.LogTimestamp{
 			Date: "2022-09-16T15:26:52.563+00:00",
 		},
-		AuthType: "authtype",
+		Type: "authtype",
 		ID: model.ID{
 			Type:   "type",
 			Binary: "binary",
 		},
 		Local: model.Address{
-			IP:   "Ip",
-			Port: 12345,
+			IP:   "0.0.0.0",
+			Port: 3000,
 		},
 		Remote: model.Address{
-			IP:   "Ip",
-			Port: 12345,
+			IP:   "192.168.1.237",
+			Port: 4000,
+		},
+		Roles: []model.AuditRole{
+			{
+				Role:     "test_role",
+				Database: "test_db",
+			},
+		},
+		Users: []model.AuditUser{
+			{
+				User:     "mongo_user",
+				Database: "my_db",
+			},
 		},
 		Result: 40,
-		Param: model.Param{
-			User:      "name",
-			Database:  "db",
-			Mechanism: "mechanism",
+		Param: map[string]any{
+			"user":      "name",
+			"db":        "db",
+			"mechanism": "mechanism",
 		},
 	}
 }
@@ -193,7 +240,7 @@ func GetTestEventAuditEvent4_2() model.AuditLog {
 		Timestamp: model.LogTimestamp{
 			Date: "2022-09-16T15:26:52.563+0000",
 		},
-		AuthType: "authtype",
+		Type: "authtype",
 		ID: model.ID{
 			Type:   "type",
 			Binary: "binary",
@@ -207,10 +254,42 @@ func GetTestEventAuditEvent4_2() model.AuditLog {
 			Port: 12345,
 		},
 		Result: 40,
-		Param: model.Param{
-			User:      "name",
-			Database:  "db",
-			Mechanism: "mechanism",
+		Param: map[string]any{
+			"user":      "name",
+			"db":        "db",
+			"mechanism": "mechanism",
 		},
 	}
+}
+
+func assertString(t *testing.T, m pcommon.Map, key, expected string) {
+	t.Helper()
+
+	v, ok := m.Get(key)
+	if !ok {
+		assert.Fail(t, "Couldn't find key %s in map", key)
+		return
+	}
+
+	if v.Type() != pcommon.ValueTypeString {
+		assert.Fail(t, "Value for key %s was expected be STRING but was %s", key, v.Type().String())
+	}
+
+	assert.Equal(t, expected, v.StringVal())
+}
+
+func assertInt(t *testing.T, m pcommon.Map, key string, expected int64) {
+	t.Helper()
+
+	v, ok := m.Get(key)
+	if !ok {
+		assert.Fail(t, "Couldn't find key %s in map", key)
+		return
+	}
+
+	if v.Type() != pcommon.ValueTypeInt {
+		assert.Fail(t, "Value for key %s was expected be INT but was %s", key, v.Type().String())
+	}
+
+	assert.Equal(t, expected, v.IntVal())
 }

--- a/unreleased/mongodb-atlas-add-audit-log-fields.yaml
+++ b/unreleased/mongodb-atlas-add-audit-log-fields.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add missing fields for audit logs
+
+# One or more tracking issues related to the change
+issues: [14177]


### PR DESCRIPTION
**Description:**
* Add missing audit log fields (see: https://www.mongodb.com/docs/v6.0/reference/audit-message/)

**Link to tracking Issue:** Resolves #14177

**Testing:**
* Updated unit tests
* Manual tests with a 4.2 and 5.0 clusters