### PR TITLE
[receiver/mongodbatlas]: Retain actual raw log line as Body

### DIFF
--- a/receiver/mongodbatlasreceiver/internal/model/logs.go
+++ b/receiver/mongodbatlasreceiver/internal/model/logs.go
@@ -15,8 +15,6 @@
 package model // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver/internal/model"
 
 import (
-	"encoding/json"
-
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -29,20 +27,8 @@ type LogEntry struct {
 	Context    string                 `json:"ctx"`
 	Message    string                 `json:"msg"`
 	Attributes map[string]interface{} `json:"attr"`
-	// Raw, if it is present, is the original log line. It is not a part of the payload, but transient data added during decoding.
-	Raw *string `json:"-"`
-}
-
-// RawLog returns a raw representation of the log entry.
-// In the case of console logs, this is the actual log line.
-// In the case of JSON logs, it is reconstructed (re-marshaled) after being unmarshalled
-func (l LogEntry) RawLog() (string, error) {
-	if l.Raw != nil {
-		return *l.Raw, nil
-	}
-
-	data, err := json.Marshal(l)
-	return string(data), err
+	// Raw is the original log line. It is not a part of the payload, but transient data added during decoding.
+	Raw string `json:"-"`
 }
 
 // AuditLog represents a MongoDB Atlas JSON audit log entry
@@ -56,6 +42,8 @@ type AuditLog struct {
 	Roles     []AuditRole    `json:"roles"`
 	Result    int            `json:"result"`
 	Param     map[string]any `json:"param"`
+	// Raw is the original log line. It is not a part of the payload, but transient data added during decoding.
+	Raw string `json:"-"`
 }
 
 // logTimestamp is the structure that represents a Log Timestamp

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -51,7 +51,7 @@ func TestDecode4_2(t *testing.T) {
 			Component: "NETWORK",
 			Context:   "listener",
 			Message:   "connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)",
-			Raw:       strp("2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)"),
+			Raw:       "2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)",
 		},
 		{
 			Timestamp: model.LogTimestamp{
@@ -61,7 +61,7 @@ func TestDecode4_2(t *testing.T) {
 			Component: "NETWORK",
 			Context:   "listener",
 			Message:   "connection accepted from 192.168.248.5:51974 #25289 (32 connections now open)",
-			Raw:       strp("2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51974 #25289 (32 connections now open)"),
+			Raw:       "2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51974 #25289 (32 connections now open)",
 		},
 		{
 			Timestamp: model.LogTimestamp{
@@ -71,7 +71,7 @@ func TestDecode4_2(t *testing.T) {
 			Component: "NETWORK",
 			Context:   "conn25289",
 			Message:   `received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`,
-			Raw:       strp(`2022-09-11T18:53:02.563+0000 I  NETWORK  [conn25289] received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`),
+			Raw:       `2022-09-11T18:53:02.563+0000 I  NETWORK  [conn25289] received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`,
 		},
 	}, entries)
 }
@@ -99,7 +99,7 @@ func TestDecode4_2InvalidLog(t *testing.T) {
 			Component: "NETWORK",
 			Context:   "listener",
 			Message:   "connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)",
-			Raw:       strp("2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)"),
+			Raw:       "2022-09-11T18:53:02.541+0000 I  NETWORK  [listener] connection accepted from 192.168.248.5:51972 #25288 (31 connections now open)",
 		},
 		{
 			Timestamp: model.LogTimestamp{
@@ -109,7 +109,7 @@ func TestDecode4_2InvalidLog(t *testing.T) {
 			Component: "NETWORK",
 			Context:   "conn25289",
 			Message:   `received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`,
-			Raw:       strp(`2022-09-11T18:53:02.563+0000 I  NETWORK  [conn25289] received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`),
+			Raw:       `2022-09-11T18:53:02.563+0000 I  NETWORK  [conn25289] received client metadata from 192.168.248.5:51974 conn25289: { driver: { name: "mongo-go-driver", version: "v1.7.2+prerelease" }, os: { type: "linux", architecture: "amd64" }, platform: "go1.18.2", application: { name: "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } }`,
 		},
 	}, entries)
 }
@@ -150,6 +150,7 @@ func TestDecode5_0(t *testing.T) {
 				"connectionId":    float64(35107),
 				"connectionCount": float64(33),
 			},
+			Raw: `{"t":{"$date":"2022-09-11T18:53:14.675+00:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn35107","msg":"Connection ended","attr":{"remote":"192.168.248.2:52066","uuid":"d3f4641a-14ca-4a24-b5bb-7d7b391a02e7","connectionId":35107,"connectionCount":33}}`,
 		},
 		{
 			Timestamp: model.LogTimestamp{
@@ -166,6 +167,7 @@ func TestDecode5_0(t *testing.T) {
 				"connectionId":    float64(35109),
 				"connectionCount": float64(32),
 			},
+			Raw: `{"t":{"$date":"2022-09-11T18:53:14.676+00:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn35109","msg":"Connection ended","attr":{"remote":"192.168.248.2:52070","uuid":"dcdb08ac-981d-41ea-9d6b-f85fe0475bd1","connectionId":35109,"connectionCount":32}}`,
 		},
 		{
 			Timestamp: model.LogTimestamp{
@@ -179,6 +181,7 @@ func TestDecode5_0(t *testing.T) {
 			Attributes: map[string]any{
 				"newDefaults": map[string]any{},
 			},
+			Raw: `{"t":{"$date":"2022-09-11T18:53:37.727+00:00"},"s":"I",  "c":"SHARDING", "id":20997,   "ctx":"conn9957","msg":"Refreshed RWC defaults","attr":{"newDefaults":{}}}`,
 		},
 	}, entries)
 }
@@ -195,7 +198,7 @@ func TestDecode5_0InvalidLog(t *testing.T) {
 	require.NoError(t, gzipWriter.Close())
 
 	entries, err := decodeLogs(zaptest.NewLogger(t), "5.0", zippedBuffer)
-	assert.ErrorContains(t, err, "entry could not be decoded into LogEntry")
+	assert.NoError(t, err)
 
 	assert.Equal(t, []model.LogEntry{
 		{
@@ -213,6 +216,21 @@ func TestDecode5_0InvalidLog(t *testing.T) {
 				"connectionId":    float64(35107),
 				"connectionCount": float64(33),
 			},
+			Raw: `{"t":{"$date":"2022-09-11T18:53:14.675+00:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn35107","msg":"Connection ended","attr":{"remote":"192.168.248.2:52066","uuid":"d3f4641a-14ca-4a24-b5bb-7d7b391a02e7","connectionId":35107,"connectionCount":33}}`,
+		},
+		{
+			Timestamp: model.LogTimestamp{
+				Date: "2022-09-11T18:53:37.727+00:00",
+			},
+			Severity:  "I",
+			Component: "SHARDING",
+			ID:        20997,
+			Context:   "conn9957",
+			Message:   "Refreshed RWC defaults",
+			Attributes: map[string]any{
+				"newDefaults": map[string]any{},
+			},
+			Raw: `{"t":{"$date":"2022-09-11T18:53:37.727+00:00"},"s":"I",  "c":"SHARDING", "id":20997,   "ctx":"conn9957","msg":"Refreshed RWC defaults","attr":{"newDefaults":{}}}`,
 		},
 	}, entries)
 }
@@ -246,7 +264,7 @@ func TestDecodeAudit4_2(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, gzipWriter.Close())
 
-	entries, err := decodeAuditJSON(zippedBuffer)
+	entries, err := decodeAuditJSON(zaptest.NewLogger(t), zippedBuffer)
 	require.NoError(t, err)
 
 	require.Equal(t, []model.AuditLog{
@@ -293,6 +311,7 @@ func TestDecodeAudit4_2(t *testing.T) {
 				"mechanism": "SCRAM-SHA-1",
 				"user":      "mms-automation",
 			},
+			Raw: `{ "atype" : "authenticate", "ts" : { "$date" : "2022-09-16T01:38:20.034+0000" }, "local" : { "ip" : "127.0.0.1", "port" : 27017 }, "remote" : { "ip" : "127.0.0.1", "port" : 50722 }, "users" : [ { "user" : "mms-automation", "db" : "admin" } ], "roles" : [ { "role" : "clusterAdmin", "db" : "admin" }, { "role" : "backup", "db" : "admin" }, { "role" : "dbAdminAnyDatabase", "db" : "admin" }, { "role" : "restore", "db" : "admin" }, { "role" : "userAdminAnyDatabase", "db" : "admin" }, { "role" : "readWriteAnyDatabase", "db" : "admin" } ], "param" : { "user" : "mms-automation", "db" : "admin", "mechanism" : "SCRAM-SHA-1" }, "result" : 0 }`,
 		},
 		{
 			Type:      "authenticate",
@@ -337,6 +356,7 @@ func TestDecodeAudit4_2(t *testing.T) {
 				"mechanism": "SCRAM-SHA-1",
 				"user":      "mms-automation",
 			},
+			Raw: `{ "atype" : "authenticate", "ts" : { "$date" : "2022-09-16T02:37:38.714+0000" }, "local" : { "ip" : "192.168.248.5", "port" : 27017 }, "remote" : { "ip" : "192.168.248.6", "port" : 43714 }, "users" : [ { "user" : "mms-automation", "db" : "admin" } ], "roles" : [ { "role" : "clusterAdmin", "db" : "admin" }, { "role" : "backup", "db" : "admin" }, { "role" : "dbAdminAnyDatabase", "db" : "admin" }, { "role" : "restore", "db" : "admin" }, { "role" : "userAdminAnyDatabase", "db" : "admin" }, { "role" : "readWriteAnyDatabase", "db" : "admin" } ], "param" : { "user" : "mms-automation", "db" : "admin", "mechanism" : "SCRAM-SHA-1" }, "result" : 0 }`,
 		},
 		{
 			Type:      "authenticate",
@@ -381,6 +401,7 @@ func TestDecodeAudit4_2(t *testing.T) {
 				"mechanism": "SCRAM-SHA-1",
 				"user":      "mms-automation",
 			},
+			Raw: `{ "atype" : "authenticate", "ts" : { "$date" : "2022-09-16T02:38:20.030+0000" }, "local" : { "ip" : "127.0.0.1", "port" : 27017 }, "remote" : { "ip" : "127.0.0.1", "port" : 52216 }, "users" : [ { "user" : "mms-automation", "db" : "admin" } ], "roles" : [ { "role" : "clusterAdmin", "db" : "admin" }, { "role" : "backup", "db" : "admin" }, { "role" : "dbAdminAnyDatabase", "db" : "admin" }, { "role" : "restore", "db" : "admin" }, { "role" : "userAdminAnyDatabase", "db" : "admin" }, { "role" : "readWriteAnyDatabase", "db" : "admin" } ], "param" : { "user" : "mms-automation", "db" : "admin", "mechanism" : "SCRAM-SHA-1" }, "result" : 0 }`,
 		},
 	}, entries)
 }
@@ -396,8 +417,8 @@ func TestDecodeAudit4_2InvalidLog(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, gzipWriter.Close())
 
-	entries, err := decodeAuditJSON(zippedBuffer)
-	assert.ErrorContains(t, err, "entry could not be decoded into AuditLog")
+	entries, err := decodeAuditJSON(zaptest.NewLogger(t), zippedBuffer)
+	assert.NoError(t, err)
 
 	require.Equal(t, []model.AuditLog{
 		{
@@ -443,6 +464,52 @@ func TestDecodeAudit4_2InvalidLog(t *testing.T) {
 				"mechanism": "SCRAM-SHA-1",
 				"user":      "mms-automation",
 			},
+			Raw: `{ "atype" : "authenticate", "ts" : { "$date" : "2022-09-16T01:38:20.034+0000" }, "local" : { "ip" : "127.0.0.1", "port" : 27017 }, "remote" : { "ip" : "127.0.0.1", "port" : 50722 }, "users" : [ { "user" : "mms-automation", "db" : "admin" } ], "roles" : [ { "role" : "clusterAdmin", "db" : "admin" }, { "role" : "backup", "db" : "admin" }, { "role" : "dbAdminAnyDatabase", "db" : "admin" }, { "role" : "restore", "db" : "admin" }, { "role" : "userAdminAnyDatabase", "db" : "admin" }, { "role" : "readWriteAnyDatabase", "db" : "admin" } ], "param" : { "user" : "mms-automation", "db" : "admin", "mechanism" : "SCRAM-SHA-1" }, "result" : 0 }`,
+		},
+		{
+			Type:      "authenticate",
+			Timestamp: model.LogTimestamp{Date: "2022-09-16T02:38:20.030+0000"},
+			Local:     model.Address{IP: strp("127.0.0.1"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("127.0.0.1"), Port: intp(52216)},
+			Users: []model.AuditUser{
+				{
+					Database: "admin",
+					User:     "mms-automation",
+				},
+			},
+			Roles: []model.AuditRole{
+				{
+					Database: "admin",
+					Role:     "clusterAdmin",
+				},
+				{
+					Database: "admin",
+					Role:     "backup",
+				},
+				{
+					Database: "admin",
+					Role:     "dbAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "restore",
+				},
+				{
+					Database: "admin",
+					Role:     "userAdminAnyDatabase",
+				},
+				{
+					Database: "admin",
+					Role:     "readWriteAnyDatabase",
+				},
+			},
+			Result: 0,
+			Param: map[string]any{
+				"db":        "admin",
+				"mechanism": "SCRAM-SHA-1",
+				"user":      "mms-automation",
+			},
+			Raw: `{ "atype" : "authenticate", "ts" : { "$date" : "2022-09-16T02:38:20.030+0000" }, "local" : { "ip" : "127.0.0.1", "port" : 27017 }, "remote" : { "ip" : "127.0.0.1", "port" : 52216 }, "users" : [ { "user" : "mms-automation", "db" : "admin" } ], "roles" : [ { "role" : "clusterAdmin", "db" : "admin" }, { "role" : "backup", "db" : "admin" }, { "role" : "dbAdminAnyDatabase", "db" : "admin" }, { "role" : "restore", "db" : "admin" }, { "role" : "userAdminAnyDatabase", "db" : "admin" }, { "role" : "readWriteAnyDatabase", "db" : "admin" } ], "param" : { "user" : "mms-automation", "db" : "admin", "mechanism" : "SCRAM-SHA-1" }, "result" : 0 }`,
 		},
 	}, entries)
 }
@@ -458,7 +525,7 @@ func TestDecodeAudit5_0(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, gzipWriter.Close())
 
-	entries, err := decodeAuditJSON(zippedBuffer)
+	entries, err := decodeAuditJSON(zaptest.NewLogger(t), zippedBuffer)
 	require.NoError(t, err)
 
 	require.Equal(t, []model.AuditLog{
@@ -491,6 +558,7 @@ func TestDecodeAudit5_0(t *testing.T) {
 					"port": float64(27017),
 				},
 			},
+			Raw: `{ "atype" : "clientMetadata", "ts" : { "$date" : "2022-09-15T23:56:28.043+00:00" }, "uuid" : { "$binary" : "KXMtAMh9TOOSl9aQBW1Zkg==", "$type" : "04" }, "local" : { "ip" : "192.168.248.2", "port" : 27017 }, "remote" : { "ip" : "192.168.248.2", "port" : 34736 }, "users" : [], "roles" : [], "param" : { "localEndpoint" : { "ip" : "192.168.248.2", "port" : 27017 }, "clientMetadata" : { "driver" : { "name" : "mongo-go-driver", "version" : "v1.7.2+prerelease" }, "os" : { "type" : "linux", "architecture" : "amd64" }, "platform" : "go1.18.2", "application" : { "name" : "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } } }, "result" : 0 }`,
 		},
 		{
 			Type:      "clientMetadata",
@@ -521,6 +589,7 @@ func TestDecodeAudit5_0(t *testing.T) {
 					"port": float64(27017),
 				},
 			},
+			Raw: `{ "atype" : "clientMetadata", "ts" : { "$date" : "2022-09-15T23:56:28.055+00:00" }, "uuid" : { "$binary" : "pWSwWRZvR9CgNsvcDYhiwg==", "$type" : "04" }, "local" : { "ip" : "192.168.248.2", "port" : 27017 }, "remote" : { "ip" : "192.168.248.2", "port" : 34740 }, "users" : [], "roles" : [], "param" : { "localEndpoint" : { "ip" : "192.168.248.2", "port" : 27017 }, "clientMetadata" : { "driver" : { "name" : "mongo-go-driver", "version" : "v1.7.2+prerelease" }, "os" : { "type" : "linux", "architecture" : "amd64" }, "platform" : "go1.18.2", "application" : { "name" : "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } } }, "result" : 0 }`,
 		},
 		{
 			Type:      "logout",
@@ -541,6 +610,7 @@ func TestDecodeAudit5_0(t *testing.T) {
 				"reason":       "Client has disconnected",
 				"updatedUsers": []any{},
 			},
+			Raw: `{ "atype" : "logout", "ts" : { "$date" : "2022-09-15T23:56:28.071+00:00" }, "uuid" : { "$binary" : "pWSwWRZvR9CgNsvcDYhiwg==", "$type" : "04" }, "local" : { "ip" : "192.168.248.2", "port" : 27017 }, "remote" : { "ip" : "192.168.248.2", "port" : 34740 }, "users" : [], "roles" : [], "param" : { "reason" : "Client has disconnected", "initialUsers" : [ { "user" : "__system", "db" : "local" } ], "updatedUsers" : [] }, "result" : 0 }`,
 		},
 	}, entries)
 }
@@ -556,8 +626,8 @@ func TestDecodeAudit5_0InvalidLog(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, gzipWriter.Close())
 
-	entries, err := decodeAuditJSON(zippedBuffer)
-	assert.ErrorContains(t, err, "entry could not be decoded into AuditLog")
+	entries, err := decodeAuditJSON(zaptest.NewLogger(t), zippedBuffer)
+	assert.NoError(t, err)
 
 	require.Equal(t, []model.AuditLog{
 		{
@@ -589,12 +659,34 @@ func TestDecodeAudit5_0InvalidLog(t *testing.T) {
 					"port": float64(27017),
 				},
 			},
+			Raw: `{ "atype" : "clientMetadata", "ts" : { "$date" : "2022-09-15T23:56:28.043+00:00" }, "uuid" : { "$binary" : "KXMtAMh9TOOSl9aQBW1Zkg==", "$type" : "04" }, "local" : { "ip" : "192.168.248.2", "port" : 27017 }, "remote" : { "ip" : "192.168.248.2", "port" : 34736 }, "users" : [], "roles" : [], "param" : { "localEndpoint" : { "ip" : "192.168.248.2", "port" : 27017 }, "clientMetadata" : { "driver" : { "name" : "mongo-go-driver", "version" : "v1.7.2+prerelease" }, "os" : { "type" : "linux", "architecture" : "amd64" }, "platform" : "go1.18.2", "application" : { "name" : "MongoDB Automation Agent v12.3.4.7674 (git: 4c7df3ac1d15ef3269d44aa38b17376ca00147eb)" } } }, "result" : 0 }`,
+		},
+		{
+			Type:      "logout",
+			Timestamp: model.LogTimestamp{Date: "2022-09-15T23:56:28.071+00:00"},
+			ID:        &model.ID{Binary: "pWSwWRZvR9CgNsvcDYhiwg==", Type: "04"},
+			Local:     model.Address{IP: strp("192.168.248.2"), Port: intp(27017)},
+			Remote:    model.Address{IP: strp("192.168.248.2"), Port: intp(34740)},
+			Users:     []model.AuditUser{},
+			Roles:     []model.AuditRole{},
+			Result:    0,
+			Param: map[string]any{
+				"initialUsers": []any{
+					map[string]any{
+						"db":   "local",
+						"user": "__system",
+					},
+				},
+				"reason":       "Client has disconnected",
+				"updatedUsers": []any{},
+			},
+			Raw: `{ "atype" : "logout", "ts" : { "$date" : "2022-09-15T23:56:28.071+00:00" }, "uuid" : { "$binary" : "pWSwWRZvR9CgNsvcDYhiwg==", "$type" : "04" }, "local" : { "ip" : "192.168.248.2", "port" : 27017 }, "remote" : { "ip" : "192.168.248.2", "port" : 34740 }, "users" : [], "roles" : [], "param" : { "reason" : "Client has disconnected", "initialUsers" : [ { "user" : "__system", "db" : "local" } ], "updatedUsers" : [] }, "result" : 0 }`,
 		},
 	}, entries)
 }
 
 func TestDecodeAuditNotGzip(t *testing.T) {
-	entries, err := decodeAuditJSON(bytes.NewBuffer([]byte("Not compressed log")))
+	entries, err := decodeAuditJSON(zaptest.NewLogger(t), bytes.NewBuffer([]byte("Not compressed log")))
 	require.ErrorContains(t, err, "gzip: invalid header")
 	require.Nil(t, entries)
 }

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -218,7 +218,7 @@ func (s *logsReceiver) getHostAuditLogs(groupID, hostname, logName string) ([]mo
 		return nil, err
 	}
 
-	return decodeAuditJSON(buf)
+	return decodeAuditJSON(s.log, buf)
 }
 
 func (s *logsReceiver) collectLogs(pc ProjectContext, hostname, logName, clusterName, clusterMajorVersion string) {

--- a/unreleased/mongodb-atlas-actual-raw-logs.yaml
+++ b/unreleased/mongodb-atlas-actual-raw-logs.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "breaking"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Retain actual raw log line as Body. The `raw` attribute is now removed. Use Body instead for the raw log line."
+
+# One or more tracking issues related to the change
+issues: [14178]


### PR DESCRIPTION
**Description:**
* Retain the actual raw, original log line as the Body, instead of reconstructing it and saving it as an attribute and on Body.
* Remove `raw` attribute on log

**Link to tracking Issue:** Resolves #14178

**Testing:**
* Updated existing unit tests for log decoding and pdata conversion
* Manually tested on 4.2 and 5.0 clusters