### PR TITLE
[chore] remove unused replace

### DIFF
--- a/internal/scrapertest/go.mod
+++ b/internal/scrapertest/go.mod
@@ -27,5 +27,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/scraperhelper => ../../receiver/scraperhelper


### PR DESCRIPTION
scraperhelper is in the core repo, this replace statement is not used.
