### PR TITLE
[chore] update issue template to fix render bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -21,7 +21,6 @@ body:
 
         ## Actual Result
 
-      render: Markdown
     validations:
       required: true
   - type: input
@@ -38,7 +37,7 @@ body:
         ## Environment
         OS: (e.g., "Ubuntu 20.04")
         Compiler(if manually compiled): (e.g., "go 14.2")
-      render: Markdown
+
   - type: textarea
     attributes:
       label: OpenTelemetry Collector configuration
@@ -73,5 +72,3 @@ body:
     attributes:
       label: Additional context
       description: Any additional information you think may be relevant to this issue.
-      render: Markdown
-


### PR DESCRIPTION
The current bug template is causing content to be rendered inside a textarea which makes it hard to read. Updating the template to render it as it was originally intended (as markdown).

See the difference below in an issue created in this repo (before the change) and an issue created in the js repo (without the `render: Markdown` config option)

![Screen Shot 2022-09-22 at 9 11 32 AM](https://user-images.githubusercontent.com/223565/191799499-24033e6e-3f8e-4478-8ed8-fd3f4501e9a8.png)
![Screen Shot 2022-09-22 at 9 11 45 AM](https://user-images.githubusercontent.com/223565/191799510-37d67ee5-4d08-4210-92e3-d06aee7f83f5.png)

