### PR TITLE
[pkg/winperfcounters] Add counter name to ScrapeData errors

### DIFF
--- a/pkg/winperfcounters/watcher.go
+++ b/pkg/winperfcounters/watcher.go
@@ -106,12 +106,12 @@ func (pc *perfCounter) Path() string {
 func (pc *perfCounter) ScrapeData() ([]CounterValue, error) {
 	err := pc.query.CollectData()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to collect data for performance counter '%s': %w", pc.path, err)
 	}
 
 	vals, err := pc.query.GetFormattedCounterArrayDouble(pc.handle)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to format data for performance counter '%s': %w", pc.path, err)
 	}
 
 	vals = removeTotalIfMultipleValues(vals)

--- a/unreleased/winperfcounters-add-countername-to-error.yaml
+++ b/unreleased/winperfcounters-add-countername-to-error.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/winperfcounters
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add counter path to error if scraping fails
+
+# One or more tracking issues related to the change
+issues: [14443]


### PR DESCRIPTION
**Description:**
* Add counter path to errors returned when scraping perfcounter data.

**Link to tracking Issue:** Resolves #14443