### PR TITLE
make mute process option more generic + handle parent process error mute

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -104,7 +104,7 @@ process:
   <include|exclude>:
     names: [ <process name>, ... ]
     match_type: <strict|regexp>
-  mute_process_name_error: <true|false>
+  mute_process_errors: <true|false>
   scrape_process_delay: <time>
 ```
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -36,7 +36,13 @@ type Config struct {
 	// MuteProcessNameError is a flag that will mute the error encountered when trying to read a process the
 	// collector does not have permission for.
 	// See https://github.com/open-telemetry/opentelemetry-collector/issues/3004 for more information.
+	// Deprecated: use MuteProcessErrors instead
 	MuteProcessNameError bool `mapstructure:"mute_process_name_error,omitempty"`
+
+	// MuteProcessErrors is a flag that will mute the errors encountered when the collector is trying to read
+	// a process details that it does not have access to.
+	// See https://github.com/open-telemetry/opentelemetry-collector/issues/3004 for more information.
+	MuteProcessErrors bool `mapstructure:"mute_process_errors,omitempty"`
 
 	// ScrapeProcessDelay is used to indicate the minimum amount of time a process must be running
 	// before metrics are scraped for it.  The default value is 0 seconds (0s)


### PR DESCRIPTION
**Description:** Changing config option `MuteProcessNameError` to more generic `MuteProcessErrors` + add handling to parent process and username errors on docker based deployments like k8s, where parent processes are unavailable,

**Link to tracking Issue:** N/A

**Testing:** Unit test added, performed test on k8s environment.

**Documentation:** Configuration documentation was updated.