### PR TITLE
[receiver/hostmetrics] Add `process.uptime` metric

### DIFF
--- a/.chloggen/add-process-uptime-metric.yaml
+++ b/.chloggen/add-process-uptime-metric.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a new optional metric `process.uptime` to the `process` scraper of the `hostmetrics` receiver.
+
+# One or more tracking issues related to the change
+issues: [14130]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
@@ -156,6 +156,14 @@ Process threads count.
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | {threads} | Sum | Int | Cumulative | false |
 
+### process.uptime
+
+Number of seconds that the process has been running.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| s | Sum | Int | Cumulative | true |
+
 ## Resource Attributes
 
 | Name | Description | Values |

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -192,3 +192,12 @@ metrics:
       aggregation: cumulative
       monotonic: true
     attributes: [context_switch_type]
+
+  process.uptime:
+    enabled: false
+    description: Number of seconds that the process has been running.
+    unit: s
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: true

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -94,6 +94,7 @@ type processHandle interface {
 	MemoryPercent() (float32, error)
 	IOCounters() (*process.IOCountersStat, error)
 	NumThreads() (int32, error)
+	// CreateTime returns process start time in milliseconds since the epoch, in UTC.
 	CreateTime() (int64, error)
 	Parent() (*process.Process, error)
 	PageFaults() (*process.PageFaultsStat, error)


### PR DESCRIPTION
**Description:** 

Adds a new optional metric called `process.uptime` to the `process` scraper of the `hostmetrics` receiver.

**Link to tracking Issue:**

Here's the original issue about `system.uptime` that resulted in this pull request: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14130

I'm going to create a PR adding `system.uptime` as a next step.

Here's the PR to add the metric names to semantic conventions: https://github.com/open-telemetry/opentelemetry-specification/pull/2824.

There's also a related issue proposing a "process create time" metric https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14084, which resulted in a proposal to add a `process.create_time` resource attribute: https://github.com/open-telemetry/opentelemetry-specification/pull/2825.