### PR TITLE
[chore] Consistent copyright first line

### DIFF
--- a/exporter/datadogexporter/internal/utils/retrier.go
+++ b/exporter/datadogexporter/internal/utils/retrier.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/kafkaexporter/authentication.go
+++ b/exporter/kafkaexporter/authentication.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/kafkaexporter/authentication_test.go
+++ b/exporter/kafkaexporter/authentication_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/kafkaexporter/internal/awsmsk/doc.go
+++ b/exporter/kafkaexporter/internal/awsmsk/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/kafkaexporter/internal/awsmsk/iam_scram_client.go
+++ b/exporter/kafkaexporter/internal/awsmsk/iam_scram_client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/kafkaexporter/internal/awsmsk/iam_scram_client_test.go
+++ b/exporter/kafkaexporter/internal/awsmsk/iam_scram_client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/kafkaexporter/jaeger_marshaler.go
+++ b/exporter/kafkaexporter/jaeger_marshaler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/kafkaexporter/jaeger_marshaler_test.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/kafkaexporter/marshaler_test.go
+++ b/exporter/kafkaexporter/marshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/exporter/kafkaexporter/scram_client.go
+++ b/exporter/kafkaexporter/scram_client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/logzioexporter/jsonlog.go
+++ b/exporter/logzioexporter/jsonlog.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/logzioexporter/jsonlog_test.go
+++ b/exporter/logzioexporter/jsonlog_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/logzioexporter/logzioservice.go
+++ b/exporter/logzioexporter/logzioservice.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/logzioexporter/logziospan.go
+++ b/exporter/logzioexporter/logziospan.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/logzioexporter/logziospan_test.go
+++ b/exporter/logzioexporter/logziospan_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/mezmoexporter/config.go
+++ b/exporter/mezmoexporter/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/mezmoexporter/config_test.go
+++ b/exporter/mezmoexporter/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/mezmoexporter/doc.go
+++ b/exporter/mezmoexporter/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/mezmoexporter/exporter.go
+++ b/exporter/mezmoexporter/exporter.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/mezmoexporter/exporter_test.go
+++ b/exporter/mezmoexporter/exporter_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/mezmoexporter/factory.go
+++ b/exporter/mezmoexporter/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/mezmoexporter/factory_test.go
+++ b/exporter/mezmoexporter/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/mezmoexporter/utils.go
+++ b/exporter/mezmoexporter/utils.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/mezmoexporter/utils_test.go
+++ b/exporter/mezmoexporter/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/pulsarexporter/jaeger_marshaler.go
+++ b/exporter/pulsarexporter/jaeger_marshaler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/pulsarexporter/jaeger_marshaler_test.go
+++ b/exporter/pulsarexporter/jaeger_marshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/pulsarexporter/marshaler_test.go
+++ b/exporter/pulsarexporter/marshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/extension/asapauthextension/config.go
+++ b/extension/asapauthextension/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/asapauthextension/config_test.go
+++ b/extension/asapauthextension/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/asapauthextension/extension.go
+++ b/extension/asapauthextension/extension.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/asapauthextension/extension_test.go
+++ b/extension/asapauthextension/extension_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/asapauthextension/factory.go
+++ b/extension/asapauthextension/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/asapauthextension/factory_test.go
+++ b/extension/asapauthextension/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/observer/ecstaskobserver/config.go
+++ b/extension/observer/ecstaskobserver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/observer/ecstaskobserver/config_test.go
+++ b/extension/observer/ecstaskobserver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/observer/ecstaskobserver/extension.go
+++ b/extension/observer/ecstaskobserver/extension.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/observer/ecstaskobserver/extension_test.go
+++ b/extension/observer/ecstaskobserver/extension_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/observer/ecstaskobserver/factory.go
+++ b/extension/observer/ecstaskobserver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/observer/ecstaskobserver/factory_test.go
+++ b/extension/observer/ecstaskobserver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/aws/ecsutil/ecsutiltest/testutil.go
+++ b/internal/aws/ecsutil/ecsutiltest/testutil.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/docker/images.go
+++ b/internal/common/docker/images.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/docker/images_test.go
+++ b/internal/common/docker/images_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/coreinternal/attraction/type_converter.go
+++ b/internal/coreinternal/attraction/type_converter.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/coreinternal/processor/filterconfig/config_test.go
+++ b/internal/coreinternal/processor/filterconfig/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/coreinternal/processor/filterlog/severity_matcher.go
+++ b/internal/coreinternal/processor/filterlog/severity_matcher.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/coreinternal/processor/filterlog/severity_matcher_test.go
+++ b/internal/coreinternal/processor/filterlog/severity_matcher_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/coreinternal/processor/filtermatcher/attributematcher.go
+++ b/internal/coreinternal/processor/filtermatcher/attributematcher.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/coreinternal/processor/filtermatcher/filtermatcher.go
+++ b/internal/coreinternal/processor/filtermatcher/filtermatcher.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/coreinternal/timeutils/ticker_test.go
+++ b/internal/coreinternal/timeutils/ticker_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/scrapertest/compare.go
+++ b/internal/scrapertest/compare.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/scrapertest/compare_test.go
+++ b/internal/scrapertest/compare_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/scrapertest/golden/golden.go
+++ b/internal/scrapertest/golden/golden.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/scrapertest/golden/golden_test.go
+++ b/internal/scrapertest/golden/golden_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/scrapertest/mask.go
+++ b/internal/scrapertest/mask.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/scrapertest/util.go
+++ b/internal/scrapertest/util.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/boolean_value.go
+++ b/pkg/ottl/boolean_value.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/boolean_value_test.go
+++ b/pkg/ottl/boolean_value_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/compare.go
+++ b/pkg/ottl/compare.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/compare_test.go
+++ b/pkg/ottl/compare_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/internal/ottlcommon/map.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/map.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/internal/ottlcommon/resource.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/internal/ottlcommon/scope.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/internal/ottlcommon/value.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/value.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/ottldatapoints/datapoints.go
+++ b/pkg/ottl/contexts/ottldatapoints/datapoints.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
+++ b/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/ottllogs/logs.go
+++ b/pkg/ottl/contexts/ottllogs/logs.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/ottllogs/logs_test.go
+++ b/pkg/ottl/contexts/ottllogs/logs_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/ottltraces/traces.go
+++ b/pkg/ottl/contexts/ottltraces/traces.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/contexts/ottltraces/traces_test.go
+++ b/pkg/ottl/contexts/ottltraces/traces_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/lexer_test.go
+++ b/pkg/ottl/lexer_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlconfig/config.go
+++ b/pkg/ottl/ottlconfig/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_concat.go
+++ b/pkg/ottl/ottlfuncs/func_concat.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_delete_key.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_int.go
+++ b/pkg/ottl/ottlfuncs/func_int.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_int_test.go
+++ b/pkg/ottl/ottlfuncs/func_int_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_is_match.go
+++ b/pkg/ottl/ottlfuncs/func_is_match.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_is_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_match_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_keep_keys.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_limit.go
+++ b/pkg/ottl/ottlfuncs/func_limit.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_limit_test.go
+++ b/pkg/ottl/ottlfuncs/func_limit_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_replace_match.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_replace_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_set.go
+++ b/pkg/ottl/ottlfuncs/func_set.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_set_test.go
+++ b/pkg/ottl/ottlfuncs/func_set_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_span_id.go
+++ b/pkg/ottl/ottlfuncs/func_span_id.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_span_id_test.go
+++ b/pkg/ottl/ottlfuncs/func_span_id_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_split.go
+++ b/pkg/ottl/ottlfuncs/func_split.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_split_test.go
+++ b/pkg/ottl/ottlfuncs/func_split_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_trace_id.go
+++ b/pkg/ottl/ottlfuncs/func_trace_id.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_trace_id_test.go
+++ b/pkg/ottl/ottlfuncs/func_trace_id_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottlfuncs/func_truncate_all_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/ottltest/ottltest.go
+++ b/pkg/ottl/ottltest/ottltest.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/stanza/adapter/integration_test.go
+++ b/pkg/stanza/adapter/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/stanza/operator/operatortest/mapstructure.go
+++ b/pkg/stanza/operator/operatortest/mapstructure.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/translator/prometheus/normalize_label.go
+++ b/pkg/translator/prometheus/normalize_label.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/attributesprocessor/attributes_metric_test.go
+++ b/processor/attributesprocessor/attributes_metric_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/resourcedetectionprocessor/internal/context.go
+++ b/processor/resourcedetectionprocessor/internal/context.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/routingprocessor/internal/common/functions.go
+++ b/processor/routingprocessor/internal/common/functions.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/config.go
+++ b/processor/schemaprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/config_test.go
+++ b/processor/schemaprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/factory.go
+++ b/processor/schemaprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/factory_test.go
+++ b/processor/schemaprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/internal/alias/alias.go
+++ b/processor/schemaprocessor/internal/alias/alias.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/internal/fixture/parallel.go
+++ b/processor/schemaprocessor/internal/fixture/parallel.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/internal/race/disable.go
+++ b/processor/schemaprocessor/internal/race/disable.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/internal/race/doc.go
+++ b/processor/schemaprocessor/internal/race/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/internal/race/enable.go
+++ b/processor/schemaprocessor/internal/race/enable.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/internal/translation/version.go
+++ b/processor/schemaprocessor/internal/translation/version.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/internal/translation/version_test.go
+++ b/processor/schemaprocessor/internal/translation/version_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/transformer.go
+++ b/processor/schemaprocessor/transformer.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/schemaprocessor/transformer_test.go
+++ b/processor/schemaprocessor/transformer_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/spanmetricsprocessor/internal/cache/cache.go
+++ b/processor/spanmetricsprocessor/internal/cache/cache.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/spanmetricsprocessor/internal/cache/cache_test.go
+++ b/processor/spanmetricsprocessor/internal/cache/cache_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/and_helper.go
+++ b/processor/tailsamplingprocessor/and_helper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/and_helper_test.go
+++ b/processor/tailsamplingprocessor/and_helper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/composite_helper_test.go
+++ b/processor/tailsamplingprocessor/composite_helper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/internal/sampling/and.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/internal/sampling/and_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/internal/sampling/latency_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/internal/sampling/probabilistic_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/probabilistic_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/internal/sampling/status_code_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/status_code_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/tailsamplingprocessor/internal/sampling/time_provider_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/time_provider_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/config_test.go
+++ b/processor/transformprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/doc.go
+++ b/processor/transformprocessor/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/common/functions.go
+++ b/processor/transformprocessor/internal/common/functions.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/common/parser.go
+++ b/processor/transformprocessor/internal/common/parser.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/logs/functions.go
+++ b/processor/transformprocessor/internal/logs/functions.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/logs/processor.go
+++ b/processor/transformprocessor/internal/logs/processor.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/processor.go
+++ b/processor/transformprocessor/internal/metrics/processor.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/traces/functions.go
+++ b/processor/transformprocessor/internal/traces/functions.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/traces/processor.go
+++ b/processor/transformprocessor/internal/traces/processor.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/config.go
+++ b/receiver/activedirectorydsreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/config_test.go
+++ b/receiver/activedirectorydsreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/counters.go
+++ b/receiver/activedirectorydsreceiver/counters.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/counters_test.go
+++ b/receiver/activedirectorydsreceiver/counters_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/factory.go
+++ b/receiver/activedirectorydsreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/factory_others.go
+++ b/receiver/activedirectorydsreceiver/factory_others.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/factory_others_test.go
+++ b/receiver/activedirectorydsreceiver/factory_others_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/factory_test.go
+++ b/receiver/activedirectorydsreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/factory_windows.go
+++ b/receiver/activedirectorydsreceiver/factory_windows.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/factory_windows_test.go
+++ b/receiver/activedirectorydsreceiver/factory_windows_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/integration_test.go
+++ b/receiver/activedirectorydsreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/scraper.go
+++ b/receiver/activedirectorydsreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/activedirectorydsreceiver/scraper_test.go
+++ b/receiver/activedirectorydsreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/aerospikereceiver/cluster/cluster_test.go
+++ b/receiver/aerospikereceiver/cluster/cluster_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/aerospikereceiver/cluster/node_test.go
+++ b/receiver/aerospikereceiver/cluster/node_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/aerospikereceiver/cluster/subset_cluster_test.go
+++ b/receiver/aerospikereceiver/cluster/subset_cluster_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/aerospikereceiver/doc.go
+++ b/receiver/aerospikereceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/apachereceiver/doc.go
+++ b/receiver/apachereceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/apachereceiver/integration_test.go
+++ b/receiver/apachereceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/config.go
+++ b/receiver/awsfirehosereceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/config_test.go
+++ b/receiver/awsfirehosereceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/doc.go
+++ b/receiver/awsfirehosereceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/factory.go
+++ b/receiver/awsfirehosereceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/factory_test.go
+++ b/receiver/awsfirehosereceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/cwmetric.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/cwmetric.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_unmarshaler.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_unmarshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/metrics_receiver.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/metrics_receiver_test.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/client.go
+++ b/receiver/bigipreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/client_test.go
+++ b/receiver/bigipreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/config.go
+++ b/receiver/bigipreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/config_test.go
+++ b/receiver/bigipreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/doc.go
+++ b/receiver/bigipreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/factory.go
+++ b/receiver/bigipreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/factory_test.go
+++ b/receiver/bigipreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/integration_test.go
+++ b/receiver/bigipreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/internal/models/nodes.go
+++ b/receiver/bigipreceiver/internal/models/nodes.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/internal/models/pool_members.go
+++ b/receiver/bigipreceiver/internal/models/pool_members.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/internal/models/pools.go
+++ b/receiver/bigipreceiver/internal/models/pools.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/internal/models/tokens.go
+++ b/receiver/bigipreceiver/internal/models/tokens.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/internal/models/virtual_servers.go
+++ b/receiver/bigipreceiver/internal/models/virtual_servers.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/scraper.go
+++ b/receiver/bigipreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/bigipreceiver/scraper_test.go
+++ b/receiver/bigipreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/config.go
+++ b/receiver/chronyreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/config_test.go
+++ b/receiver/chronyreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/doc.go
+++ b/receiver/chronyreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/factory.go
+++ b/receiver/chronyreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/factory_test.go
+++ b/receiver/chronyreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/internal/chrony/client.go
+++ b/receiver/chronyreceiver/internal/chrony/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/internal/chrony/client_test.go
+++ b/receiver/chronyreceiver/internal/chrony/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/internal/chrony/types.go
+++ b/receiver/chronyreceiver/internal/chrony/types.go
@@ -9,7 +9,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/internal/chrony/util.go
+++ b/receiver/chronyreceiver/internal/chrony/util.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/internal/chrony/util_test.go
+++ b/receiver/chronyreceiver/internal/chrony/util_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/scraper.go
+++ b/receiver/chronyreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/chronyreceiver/scraper_test.go
+++ b/receiver/chronyreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/couchdbreceiver/client.go
+++ b/receiver/couchdbreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/couchdbreceiver/client_test.go
+++ b/receiver/couchdbreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/couchdbreceiver/config.go
+++ b/receiver/couchdbreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/couchdbreceiver/config_test.go
+++ b/receiver/couchdbreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/couchdbreceiver/factory.go
+++ b/receiver/couchdbreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/couchdbreceiver/factory_test.go
+++ b/receiver/couchdbreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/couchdbreceiver/metrics.go
+++ b/receiver/couchdbreceiver/metrics.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/couchdbreceiver/scraper.go
+++ b/receiver/couchdbreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/dockerstatsreceiver/doc.go
+++ b/receiver/dockerstatsreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/dockerstatsreceiver/receiver_v2.go
+++ b/receiver/dockerstatsreceiver/receiver_v2.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/client_test.go
+++ b/receiver/elasticsearchreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/config.go
+++ b/receiver/elasticsearchreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/config_test.go
+++ b/receiver/elasticsearchreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/factory.go
+++ b/receiver/elasticsearchreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/factory_test.go
+++ b/receiver/elasticsearchreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/integration_test.go
+++ b/receiver/elasticsearchreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/internal/model/clusterhealth.go
+++ b/receiver/elasticsearchreceiver/internal/model/clusterhealth.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/internal/model/nodestats.go
+++ b/receiver/elasticsearchreceiver/internal/model/nodestats.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/internal/model/version.go
+++ b/receiver/elasticsearchreceiver/internal/model/version.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/expvarreceiver/config.go
+++ b/receiver/expvarreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/expvarreceiver/config_test.go
+++ b/receiver/expvarreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/expvarreceiver/doc.go
+++ b/receiver/expvarreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/expvarreceiver/factory.go
+++ b/receiver/expvarreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/expvarreceiver/factory_test.go
+++ b/receiver/expvarreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/expvarreceiver/scraper.go
+++ b/receiver/expvarreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/expvarreceiver/scraper_test.go
+++ b/receiver/expvarreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/client.go
+++ b/receiver/flinkmetricsreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/client_test.go
+++ b/receiver/flinkmetricsreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/config.go
+++ b/receiver/flinkmetricsreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/config_test.go
+++ b/receiver/flinkmetricsreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/doc.go
+++ b/receiver/flinkmetricsreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/factory.go
+++ b/receiver/flinkmetricsreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/factory_test.go
+++ b/receiver/flinkmetricsreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/integration_test.go
+++ b/receiver/flinkmetricsreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/internal/models/model.go
+++ b/receiver/flinkmetricsreceiver/internal/models/model.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/internal/models/response_model.go
+++ b/receiver/flinkmetricsreceiver/internal/models/response_model.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/process.go
+++ b/receiver/flinkmetricsreceiver/process.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/scraper.go
+++ b/receiver/flinkmetricsreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/flinkmetricsreceiver/scraper_test.go
+++ b/receiver/flinkmetricsreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/config.go
+++ b/receiver/googlecloudspannerreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/config_test.go
+++ b/receiver/googlecloudspannerreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/doc.go
+++ b/receiver/googlecloudspannerreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/factory.go
+++ b/receiver/googlecloudspannerreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/factory_test.go
+++ b/receiver/googlecloudspannerreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/datasource/database.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/database.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/datasource/databaseid.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/databaseid.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/datasource/databaseid_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/databaseid_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filter/testhelpers_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/testhelpers_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/itemfilterfactory.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/itemfilterfactory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/itemfilterfactory_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/itemfilterfactory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/testhelpers_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/testhelpers_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metadata_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricdatatype.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricdatatype.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricdatatype_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricdatatype_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/valuemetadata.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/valuemetadata.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata_yaml_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata_yaml_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/label.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/label.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/label_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/label_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataconfig.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataconfig.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metric.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metric.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metric_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metric_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/currentstatsreader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/currentstatsreader.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/currentstatsreader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/currentstatsreader_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/statements.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/statements.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/statements_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/statements_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/statsreaders_mockedspanner_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/statsreaders_mockedspanner_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/receiver.go
+++ b/receiver/googlecloudspannerreceiver/receiver.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/googlecloudspannerreceiver/receiver_test.go
+++ b/receiver/googlecloudspannerreceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper_errors.go
+++ b/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper_errors.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/iisreceiver/integration_test.go
+++ b/receiver/iisreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/journaldreceiver/journald_nonlinux.go
+++ b/receiver/journaldreceiver/journald_nonlinux.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkametricsreceiver/broker_scraper.go
+++ b/receiver/kafkametricsreceiver/broker_scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkametricsreceiver/broker_scraper_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkametricsreceiver/doc.go
+++ b/receiver/kafkametricsreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkametricsreceiver/factory.go
+++ b/receiver/kafkametricsreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkametricsreceiver/receiver.go
+++ b/receiver/kafkametricsreceiver/receiver.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkametricsreceiver/receiver_test.go
+++ b/receiver/kafkametricsreceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkametricsreceiver/scraper_test_helper.go
+++ b/receiver/kafkametricsreceiver/scraper_test_helper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkareceiver/jaeger_unmarshaler.go
+++ b/receiver/kafkareceiver/jaeger_unmarshaler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkareceiver/jaeger_unmarshaler_test.go
+++ b/receiver/kafkareceiver/jaeger_unmarshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kafkareceiver/zipkin_unmarshaler_test.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/kubeletstatsreceiver/doc.go
+++ b/receiver/kubeletstatsreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/memcachedreceiver/client.go
+++ b/receiver/memcachedreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/memcachedreceiver/client_mock_test.go
+++ b/receiver/memcachedreceiver/client_mock_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/memcachedreceiver/doc.go
+++ b/receiver/memcachedreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/alerts.go
+++ b/receiver/mongodbatlasreceiver/alerts.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/alerts_integration_test.go
+++ b/receiver/mongodbatlasreceiver/alerts_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/alerts_test.go
+++ b/receiver/mongodbatlasreceiver/alerts_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/combined_logs.go
+++ b/receiver/mongodbatlasreceiver/combined_logs.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/config_test.go
+++ b/receiver/mongodbatlasreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/doc.go
+++ b/receiver/mongodbatlasreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/internal/model/alerts.go
+++ b/receiver/mongodbatlasreceiver/internal/model/alerts.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/internal/model/logs.go
+++ b/receiver/mongodbatlasreceiver/internal/model/logs.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/log_decoder.go
+++ b/receiver/mongodbatlasreceiver/log_decoder.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbatlasreceiver/logs_test.go
+++ b/receiver/mongodbatlasreceiver/logs_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbreceiver/client.go
+++ b/receiver/mongodbreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbreceiver/client_test.go
+++ b/receiver/mongodbreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbreceiver/config.go
+++ b/receiver/mongodbreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbreceiver/config_test.go
+++ b/receiver/mongodbreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbreceiver/factory.go
+++ b/receiver/mongodbreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbreceiver/factory_test.go
+++ b/receiver/mongodbreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbreceiver/integration_test.go
+++ b/receiver/mongodbreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mysqlreceiver/doc.go
+++ b/receiver/mysqlreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/mysqlreceiver/integration_test.go
+++ b/receiver/mysqlreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nginxreceiver/doc.go
+++ b/receiver/nginxreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/client.go
+++ b/receiver/nsxtreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/client_mock_test.go
+++ b/receiver/nsxtreceiver/client_mock_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/client_test.go
+++ b/receiver/nsxtreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/config.go
+++ b/receiver/nsxtreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/config_test.go
+++ b/receiver/nsxtreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/doc.go
+++ b/receiver/nsxtreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/factory.go
+++ b/receiver/nsxtreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/factory_test.go
+++ b/receiver/nsxtreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/internal/model/interface.go
+++ b/receiver/nsxtreceiver/internal/model/interface.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/internal/model/node.go
+++ b/receiver/nsxtreceiver/internal/model/node.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/scraper.go
+++ b/receiver/nsxtreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/nsxtreceiver/scraper_test.go
+++ b/receiver/nsxtreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/podmanreceiver/libpod_client_test.go
+++ b/receiver/podmanreceiver/libpod_client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/podmanreceiver/libpod_data.go
+++ b/receiver/podmanreceiver/libpod_data.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/config.go
+++ b/receiver/postgresqlreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/config_test.go
+++ b/receiver/postgresqlreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/doc.go
+++ b/receiver/postgresqlreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/factory.go
+++ b/receiver/postgresqlreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/factory_test.go
+++ b/receiver/postgresqlreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/internal/metadata/custom.go
+++ b/receiver/postgresqlreceiver/internal/metadata/custom.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/prometheusreceiver/metrics_receiver_target_allocator_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_target_allocator_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pulsarreceiver/jaeger_unmarshaler.go
+++ b/receiver/pulsarreceiver/jaeger_unmarshaler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pulsarreceiver/jaeger_unmarshaler_test.go
+++ b/receiver/pulsarreceiver/jaeger_unmarshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pulsarreceiver/zipkin_unmarshaler_test.go
+++ b/receiver/pulsarreceiver/zipkin_unmarshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/client.go
+++ b/receiver/rabbitmqreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/client_test.go
+++ b/receiver/rabbitmqreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/config.go
+++ b/receiver/rabbitmqreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/config_test.go
+++ b/receiver/rabbitmqreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/doc.go
+++ b/receiver/rabbitmqreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/factory.go
+++ b/receiver/rabbitmqreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/factory_test.go
+++ b/receiver/rabbitmqreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/integration_test.go
+++ b/receiver/rabbitmqreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/internal/models/models.go
+++ b/receiver/rabbitmqreceiver/internal/models/models.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/scraper.go
+++ b/receiver/rabbitmqreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/rabbitmqreceiver/scraper_test.go
+++ b/receiver/rabbitmqreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/redisreceiver/doc.go
+++ b/receiver/redisreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/client.go
+++ b/receiver/riakreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/client_test.go
+++ b/receiver/riakreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/config.go
+++ b/receiver/riakreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/config_test.go
+++ b/receiver/riakreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/doc.go
+++ b/receiver/riakreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/factory.go
+++ b/receiver/riakreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/factory_test.go
+++ b/receiver/riakreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/internal/model/model.go
+++ b/receiver/riakreceiver/internal/model/model.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/scraper.go
+++ b/receiver/riakreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/riakreceiver/scraper_test.go
+++ b/receiver/riakreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/saphanareceiver/client_test.go
+++ b/receiver/saphanareceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/saphanareceiver/config_test.go
+++ b/receiver/saphanareceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/saphanareceiver/factory_test.go
+++ b/receiver/saphanareceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/saphanareceiver/scraper_test.go
+++ b/receiver/saphanareceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sqlserverreceiver/doc.go
+++ b/receiver/sqlserverreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/client_test.go
+++ b/receiver/vcenterreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/config.go
+++ b/receiver/vcenterreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/config_test.go
+++ b/receiver/vcenterreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/factory_test.go
+++ b/receiver/vcenterreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/integration_test.go
+++ b/receiver/vcenterreceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/internal/mockserver/client_mock.go
+++ b/receiver/vcenterreceiver/internal/mockserver/client_mock.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/scraper.go
+++ b/receiver/vcenterreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/vcenterreceiver/scraper_test.go
+++ b/receiver/vcenterreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/zookeeperreceiver/doc.go
+++ b/receiver/zookeeperreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Remove year, we don't have that in majority of the files
* Remove double space between "Copyright" and "The"
