### PR TITLE
[translator/jaeger] Add refType as attribute to link when translating Jaeger spans to OTEL

### DIFF
--- a/.chloggen/adn_jaeger-reftype.yaml
+++ b/.chloggen/adn_jaeger-reftype.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: translator/jaeger
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add refType as attribute to link when translating Jaeger span references to OTEL.
+
+# One or more tracking issues related to the change
+issues: [14465]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The attribute is used to set the proper refType when translating back from OTEL to Jager.
+
+  In the case of a span with multiple parents, which Jaeger supports, all the refType are properly translated.

--- a/pkg/translator/jaeger/jaegerproto_to_traces.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces.go
@@ -26,7 +26,7 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/idutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
@@ -423,6 +423,7 @@ func jReferencesToSpanLinks(refs []model.SpanRef, excludeParentID model.SpanID, 
 		link := dest.AppendEmpty()
 		link.SetTraceID(idutils.UInt64ToTraceID(ref.TraceID.High, ref.TraceID.Low))
 		link.SetSpanID(idutils.UInt64ToSpanID(uint64(ref.SpanID)))
+		link.Attributes().PutStr(conventions.AttributeOpentracingRefType, jRefTypeToAttribute(ref.RefType))
 	}
 }
 
@@ -456,4 +457,11 @@ func getAndDeleteTag(span *model.Span, key string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func jRefTypeToAttribute(ref model.SpanRefType) string {
+	if ref == model.ChildOf {
+		return conventions.AttributeOpentracingRefTypeChildOf
+	}
+	return conventions.AttributeOpentracingRefTypeFollowsFrom
 }

--- a/pkg/translator/jaeger/jaegerthrift_to_traces.go
+++ b/pkg/translator/jaeger/jaegerthrift_to_traces.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/idutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
@@ -180,10 +180,18 @@ func jThriftReferencesToSpanLinks(refs []*jaeger.SpanRef, excludeParentID int64,
 		link := dest.AppendEmpty()
 		link.SetTraceID(idutils.UInt64ToTraceID(uint64(ref.TraceIdHigh), uint64(ref.TraceIdLow)))
 		link.SetSpanID(idutils.UInt64ToSpanID(uint64(ref.SpanId)))
+		link.Attributes().PutStr(conventions.AttributeOpentracingRefType, jThriftRefTypeToAttribute(ref.RefType))
 	}
 }
 
 // microsecondsToUnixNano converts epoch microseconds to pcommon.Timestamp
 func microsecondsToUnixNano(ms int64) pcommon.Timestamp {
 	return pcommon.Timestamp(uint64(ms) * 1000)
+}
+
+func jThriftRefTypeToAttribute(ref jaeger.SpanRefType) string {
+	if ref == jaeger.SpanRefType_CHILD_OF {
+		return conventions.AttributeOpentracingRefTypeChildOf
+	}
+	return conventions.AttributeOpentracingRefTypeFollowsFrom
 }

--- a/pkg/translator/jaeger/jaegerthrift_to_traces_test.go
+++ b/pkg/translator/jaeger/jaegerthrift_to_traces_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
@@ -116,6 +116,17 @@ func TestThriftBatchToInternalTraces(t *testing.T) {
 			td: generateTracesTwoSpansChildParent(),
 		},
 
+		{
+			name: "a-spans-with-two-parent",
+			jb: &jaeger.Batch{
+				Spans: []*jaeger.Span{
+					generateThriftSpan(),
+					generateThriftFollowerSpan(),
+					generateThriftTwoParentsSpan(),
+				},
+			},
+			td: generateTracesSpanWithTwoParents(),
+		},
 		{
 			name: "two-spans-with-follower",
 			jb: &jaeger.Batch{
@@ -284,6 +295,48 @@ func generateThriftFollowerSpan() *jaeger.Span {
 	}
 }
 
+func generateThriftTwoParentsSpan() *jaeger.Span {
+	spanStartTs := unixNanoToMicroseconds(testSpanStartTimestamp)
+	spanEndTs := unixNanoToMicroseconds(testSpanEndTimestamp)
+	statusCode := statusOk
+	statusMsg := "status-ok"
+	kind := string(tracetranslator.OpenTracingSpanKindConsumer)
+
+	return &jaeger.Span{
+		TraceIdHigh:   int64(binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8})),
+		TraceIdLow:    int64(binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80})),
+		SpanId:        int64(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x20})),
+		OperationName: "operationD",
+		StartTime:     spanStartTs,
+		Duration:      spanEndTs - spanStartTs,
+		ParentSpanId:  int64(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+		Tags: []*jaeger.Tag{
+			{
+				Key:   conventions.OtelStatusCode,
+				VType: jaeger.TagType_STRING,
+				VStr:  &statusCode,
+			},
+			{
+				Key:   conventions.OtelStatusDescription,
+				VType: jaeger.TagType_STRING,
+				VStr:  &statusMsg,
+			},
+			{
+				Key:   tracetranslator.TagSpanKind,
+				VType: jaeger.TagType_STRING,
+				VStr:  &kind,
+			},
+		},
+		References: []*jaeger.SpanRef{
+			{
+				TraceIdHigh: int64(binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8})),
+				TraceIdLow:  int64(binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80})),
+				SpanId:      int64(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})),
+				RefType:     jaeger.SpanRefType_CHILD_OF,
+			},
+		},
+	}
+}
 func unixNanoToMicroseconds(ns pcommon.Timestamp) int64 {
 	return int64(ns / 1000)
 }

--- a/pkg/translator/jaeger/traces_to_jaegerproto_test.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/goldendataset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
@@ -322,6 +322,20 @@ func TestInternalTracesToJaegerProto(t *testing.T) {
 				},
 			},
 			err: nil,
+		},
+		{
+			name: "a-spans-with-two-parent",
+			jb: &model.Batch{
+				Process: &model.Process{
+					ServiceName: tracetranslator.ResourceNoServiceName,
+				},
+				Spans: []*model.Span{
+					generateProtoSpan(),
+					generateProtoFollowerSpan(),
+					generateProtoTwoParentsSpan(),
+				},
+			},
+			td: generateTracesSpanWithTwoParents(),
 		},
 	}
 


### PR DESCRIPTION
Following OTEL's trace semantic conventions for Opentracing traces. When creating a link the attribute `opentracing.ref_type` will be set with one of the accepted values, either `child_of` or `follows_from`.

This enables the translator to maintain reference context that enable features. For example, Jaeger multiple parents for spans.

https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/compatibility/#opentracing

**Testing:** <Describe what testing was performed and which tests were added.>

Unittest have been up updated to include the case when a span has 2 parent spans. Assertions are made for:

- refType  is added as an Attribute to the link.
- When translating links with attributes containing the `opentracing.ref_type` to Jaeger traces the correct refType is created.

The usage of these attributes and the multiple parents use case was discussed with the Jaeger maintainers, see https://github.com/jaegertracing/jaeger/pull/3919#discussion_r977892362 for more context.

resolves #14465 