### PR TITLE
[receiver/splunkhecreceiver] Updates Splunk receiver http status codes in order to be compliant with SplunkCloud

### DIFF
--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -276,7 +276,7 @@ func (r *splunkReceiver) handleRawReq(resp http.ResponseWriter, req *http.Reques
 	if consumerErr != nil {
 		r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, sl.LogRecords().Len(), consumerErr)
 	} else {
-		resp.WriteHeader(http.StatusAccepted)
+		resp.WriteHeader(http.StatusOK)
 		r.obsrecv.EndLogsOp(ctx, typeStr, sl.LogRecords().Len(), nil)
 	}
 }
@@ -359,7 +359,7 @@ func (r *splunkReceiver) consumeMetrics(ctx context.Context, events []*splunk.Ev
 	if decodeErr != nil {
 		r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, len(events), decodeErr)
 	} else {
-		resp.WriteHeader(http.StatusAccepted)
+		resp.WriteHeader(http.StatusOK)
 		_, err := resp.Write(okRespBody)
 		if err != nil {
 			r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, len(events), err)
@@ -380,7 +380,7 @@ func (r *splunkReceiver) consumeLogs(ctx context.Context, events []*splunk.Event
 	if decodeErr != nil {
 		r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, len(events), decodeErr)
 	} else {
-		resp.WriteHeader(http.StatusAccepted)
+		resp.WriteHeader(http.StatusOK)
 		if _, err := resp.Write(okRespBody); err != nil {
 			r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, len(events), err)
 		}

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -254,7 +254,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {
-				assert.Equal(t, http.StatusAccepted, status)
+				assert.Equal(t, http.StatusOK, status)
 				assert.Equal(t, responseOK, body)
 			},
 		},
@@ -275,7 +275,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {
-				assert.Equal(t, http.StatusAccepted, status)
+				assert.Equal(t, http.StatusOK, status)
 				assert.Equal(t, responseOK, body)
 			},
 		},
@@ -439,7 +439,7 @@ func Test_splunkhecReceiver_TLS(t *testing.T) {
 
 	resp, err := client.Do(req)
 	require.NoErrorf(t, err, "should not have failed when sending to splunk HEC receiver %v", err)
-	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	t.Log("Splunk HEC Request Received")
 
 	got := sink.AllLogs()
@@ -519,7 +519,7 @@ func Test_splunkhecReceiver_AccessTokenPassthrough(t *testing.T) {
 			endServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				_, err := io.Copy(io.Discard, req.Body)
 				assert.NoError(t, err)
-				rw.WriteHeader(http.StatusAccepted)
+				rw.WriteHeader(http.StatusOK)
 				accessTokensChan <- req.Header.Get("Authorization")
 			}))
 			defer endServer.Close()
@@ -619,7 +619,7 @@ func Test_Logs_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 			endServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				body, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
-				rw.WriteHeader(http.StatusAccepted)
+				rw.WriteHeader(http.StatusOK)
 				receivedSplunkLogs <- body
 			}))
 			defer endServer.Close()
@@ -671,7 +671,7 @@ func Test_Logs_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 			assert.NoError(t, err)
 			var bodyStr string
 			assert.NoError(t, json.Unmarshal(respBytes, &bodyStr))
-			assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			assert.Equal(t, responseOK, bodyStr)
 			select {
 			case <-done:
@@ -712,7 +712,7 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 			endServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				body, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
-				rw.WriteHeader(http.StatusAccepted)
+				rw.WriteHeader(http.StatusOK)
 				receivedSplunkMetrics <- body
 			}))
 			defer endServer.Close()
@@ -765,7 +765,7 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 			assert.NoError(t, err)
 			var bodyStr string
 			assert.NoError(t, json.Unmarshal(respBytes, &bodyStr))
-			assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			assert.Equal(t, responseOK, bodyStr)
 			select {
 			case <-done:
@@ -899,7 +899,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {
-				assert.Equal(t, http.StatusAccepted, status)
+				assert.Equal(t, http.StatusOK, status)
 			},
 		},
 		{
@@ -911,7 +911,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {
-				assert.Equal(t, http.StatusAccepted, status)
+				assert.Equal(t, http.StatusOK, status)
 			},
 		},
 		{
@@ -931,7 +931,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {
-				assert.Equal(t, http.StatusAccepted, status)
+				assert.Equal(t, http.StatusOK, status)
 			},
 		},
 		{

--- a/unreleased/splunkhecreceiver-http-status-code-return.yaml
+++ b/unreleased/splunkhecreceiver-http-status-code-return.yaml
@@ -8,9 +8,4 @@ component: splunkhecreceiver
 note: Updates Splunk receiver http status codes in order to be compliant with SplunkCloud
 
 # One or more tracking issues related to the change
-issues: []
-
-# (Optional) One or more lines of additional information to render under the primary note.
-# These lines will be padded with 2 spaces and then inserted directly into the document.
-# Use pipe (|) for multiline entries.
-subtext:
+issues: [14469]

--- a/unreleased/splunkhecreceiver-http-status-code-return.yaml
+++ b/unreleased/splunkhecreceiver-http-status-code-return.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updates Splunk receiver http status codes in order to be compliant with SplunkCloud
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
TL;DR
This Pull Request makes Splunk receiver returns the same HTTP Status code as Splunk Cloud service

*Problem*: 
SplunkCloud returns `200 OK` when you send requests to `/{raw/events}` HTTP routes.
Splunk receiver in the other hand returns `202 Accepted`. Based on that, consider a scenario
where you are migrating from sending logs to SplunkCloud directly and starting to add one
Open Telemetry Splunk Receiver in between in order to modify data before proceeding towards SplunkCloud.

The observed side effects were that all clients stopped working because the response Status Code 
was different from SplunkCloud itself. Thus, such migration wouldn't be transparent.


**Link to tracking Issue:** N/A

**Testing:**
No new tests were added. Although, all previous tests were updated to use `StatusOK` on its assertions.

**Documentation:**
I didn't find any documentation regarding returning statuses codes for this particular receiver.

**Examples**

Event sent to Splunk Cloud directly
```bash
$> curl -v -X POST 'https://{SplunkCloudDNS}/services/collector/event' -H 'Authorization: Splunk {TOKEN}' -d '{data}'
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=UTF-8
< Date: Sat, 24 Sep 2022 19:39:22 GMT
< Server: Splunkd
< Vary: Authorization
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< Content-Length: 27
< Connection: keep-alive 
```

Same event sent to Splunk Receiver
```bash
$> curl -v -X POST 'https://{SplunkReceiverDNS}/services/collector/event' -H 'Authorization: Splunk {TOKEN}' -d '{data}'
< HTTP/1.1 202 Accepted
< date: Sat, 24 Sep 2022 19:44:36 GMT
< content-length: 4
< content-type: text/plain; charset=utf-8
< x-envoy-upstream-service-time: 11
< server: istio-envoy
```