### PR TITLE
[exporter/instanaexporter] Config requires HTTPS endpoint URL

### DIFF
--- a/exporter/instanaexporter/config.go
+++ b/exporter/instanaexporter/config.go
@@ -47,8 +47,8 @@ func (cfg *Config) Validate() error {
 		return errors.New("no Instana agent key set")
 	}
 
-	if !(strings.HasPrefix(cfg.Endpoint, "http://") || strings.HasPrefix(cfg.Endpoint, "https://")) {
-		return errors.New("endpoint must start with http:// or https://")
+	if !strings.HasPrefix(cfg.Endpoint, "https://") {
+		return errors.New("endpoint must start with https://")
 	}
 	_, err := url.Parse(cfg.Endpoint)
 	if err != nil {

--- a/exporter/instanaexporter/config_test.go
+++ b/exporter/instanaexporter/config_test.go
@@ -28,27 +28,27 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("Valid configuration", func(t *testing.T) {
-		c := &Config{Endpoint: "http://example.com/", AgentKey: "key1"}
+		c := &Config{Endpoint: "https://example.com/", AgentKey: "key1"}
 		err := c.Validate()
 		assert.NoError(t, err)
-
-		assert.Equal(t, "http://example.com/", c.Endpoint, "no Instana endpoint set")
 	})
 
 	t.Run("Invalid Endpoint Invalid URL", func(t *testing.T) {
-		c := &Config{Endpoint: "http://example.}~", AgentKey: "key1"}
+		c := &Config{Endpoint: "http://example.~}", AgentKey: "key1"}
 		err := c.Validate()
 		assert.Error(t, err)
-
-		assert.Equal(t, "http://example.}~", c.Endpoint, "endpoint must be a valid URL")
 	})
 
 	t.Run("Invalid Endpoint No Protocol", func(t *testing.T) {
 		c := &Config{Endpoint: "example.com", AgentKey: "key1"}
 		err := c.Validate()
 		assert.Error(t, err)
+	})
 
-		assert.Equal(t, "example.com", c.Endpoint, "endpoint must start with http:// or https://")
+	t.Run("Invalid Endpoint No https:// Protocol", func(t *testing.T) {
+		c := &Config{Endpoint: "http://example.com", AgentKey: "key1"}
+		err := c.Validate()
+		assert.Error(t, err, "endpoint must start with https://")
 	})
 
 	t.Run("No Agent key", func(t *testing.T) {

--- a/exporter/instanaexporter/factory_test.go
+++ b/exporter/instanaexporter/factory_test.go
@@ -66,12 +66,12 @@ func TestLoadConfig(t *testing.T) {
 		assert.Equal(t, &Config{
 			ExporterSettings: config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "valid")),
 			HTTPClientSettings: confighttp.HTTPClientSettings{
-				Endpoint:        "http://example.com/api/",
+				Endpoint:        "https://example.com/api/",
 				Timeout:         30 * time.Second,
 				Headers:         map[string]string{},
 				WriteBufferSize: 512 * 1024,
 			},
-			Endpoint: "http://example.com/api/",
+			Endpoint: "https://example.com/api/",
 			AgentKey: "key1",
 		}, validConfig)
 	})
@@ -79,6 +79,12 @@ func TestLoadConfig(t *testing.T) {
 	t.Run("bad endpoint", func(t *testing.T) {
 		badEndpointConfig := cfg.Exporters[config.NewComponentIDWithName(typeStr, "bad_endpoint")].(*Config)
 		err = badEndpointConfig.Validate()
+		require.Error(t, err)
+	})
+
+	t.Run("non https endpoint", func(t *testing.T) {
+		nonHTTPSEndpointConfig := cfg.Exporters[config.NewComponentIDWithName(typeStr, "non_https_endpoint")].(*Config)
+		err = nonHTTPSEndpointConfig.Validate()
 		require.Error(t, err)
 	})
 

--- a/exporter/instanaexporter/testdata/config.yml
+++ b/exporter/instanaexporter/testdata/config.yml
@@ -8,10 +8,13 @@ exporters:
   instana/bad_endpoint:
     endpoint: never a url
     agent_key: key1
+  instana/non_https_endpoint:
+    endpoint: http://example.com/api/
+    agent_key: key1
   instana/missing_agent_key:
-    endpoint: http://example.com/api/
+    endpoint: https://example.com/api/
   instana/valid:
-    endpoint: http://example.com/api/
+    endpoint: https://example.com/api/
     agent_key: key1
 
 
@@ -20,4 +23,4 @@ service:
     metrics:
       receivers: [nop]
       processors: [nop]
-      exporters: [instana/bad_endpoint, instana/valid, instana/missing_agent_key]
+      exporters: [instana/bad_endpoint, instana/non_https_endpoint, instana/valid, instana/missing_agent_key]

--- a/unreleased/instana-exporter-https-option.yaml
+++ b/unreleased/instana-exporter-https-option.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporterconfig
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The exporter config options expects the endpoint URL to be https://
+
+# One or more tracking issues related to the change
+issues: [14323]


### PR DESCRIPTION
**Description:** The config expects an endpoint URL with HTTPS, opposed to accepting both HTTP and HTTPS
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14323

**Testing:** The config was tested against the changes, as well as specific tests regarding HTTPS validation were added. Tests are made both via API and against a config.yaml file.

**Documentation:** The endpoint URL is restricted to have HTTPS protocol