### PR TITLE
[chore] Change receiver config tests to unmarshal config only for that component. (Part 2)

### DIFF
--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -21,246 +21,224 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.opentelemetry.io/collector/service/servicetest"
-	"go.uber.org/zap"
 )
 
 func TestLoadConfig(t *testing.T) {
-	mockJarVersions()
-	defer unmockJarVersions()
+	t.Parallel()
 
-	testLogger, _ := zap.NewDevelopment()
-	factories, err := componenttest.NopFactories()
-	assert.Nil(t, err)
-
-	factory := NewFactory()
-	factories.Receivers[typeStr] = factory
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
-
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
-	require.NotNil(t, cfg)
-
-	assert.Equal(t, len(cfg.Receivers), 10)
-
-	r0 := cfg.Receivers[config.NewComponentID(typeStr)].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r0))
-	assert.Equal(t, r0, factory.CreateDefaultConfig())
-	err = r0.validate()
-	require.Error(t, err)
-	assert.Equal(t, "jmx missing required fields: `endpoint`, `target_system`", err.Error())
-
-	r1 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "all")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r1))
-	require.NoError(t, r1.validate())
-	assert.Equal(t,
-		&Config{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "all")),
-			JARPath:            "testdata/fake_jmx.jar",
-			Endpoint:           "myendpoint:12345",
-			TargetSystem:       "jvm",
-			CollectionInterval: 15 * time.Second,
-			Username:           "myusername",
-			Password:           "mypassword",
-			LogLevel:           "trace",
-			OTLPExporterConfig: otlpExporterConfig{
-				Endpoint: "myotlpendpoint",
-				Headers: map[string]string{
-					"x-header-1": "value1",
-					"x-header-2": "value2",
+	initSupportedJars()
+	tests := []struct {
+		id          config.ComponentID
+		expected    config.Receiver
+		expectedErr string
+	}{
+		{
+			id:          config.NewComponentIDWithName(typeStr, ""),
+			expectedErr: "missing required fields: `endpoint`, `target_system`",
+			expected:    createDefaultConfig(),
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "all"),
+			expected: &Config{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				JARPath:            "testdata/fake_jmx.jar",
+				Endpoint:           "myendpoint:12345",
+				TargetSystem:       "jvm",
+				CollectionInterval: 15 * time.Second,
+				Username:           "myusername",
+				Password:           "mypassword",
+				LogLevel:           "trace",
+				OTLPExporterConfig: otlpExporterConfig{
+					Endpoint: "myotlpendpoint",
+					Headers: map[string]string{
+						"x-header-1": "value1",
+						"x-header-2": "value2",
+					},
+					TimeoutSettings: exporterhelper.TimeoutSettings{
+						Timeout: 5 * time.Second,
+					},
 				},
-				TimeoutSettings: exporterhelper.TimeoutSettings{
-					Timeout: 5 * time.Second,
+				KeystorePath:       "mykeystorepath",
+				KeystorePassword:   "mykeystorepassword",
+				KeystoreType:       "mykeystoretype",
+				TruststorePath:     "mytruststorepath",
+				TruststorePassword: "mytruststorepassword",
+				RemoteProfile:      "myremoteprofile",
+				Realm:              "myrealm",
+				AdditionalJars: []string{
+					"testdata/fake_additional.jar",
 				},
-			},
-			KeystorePath:       "mykeystorepath",
-			KeystorePassword:   "mykeystorepassword",
-			KeystoreType:       "mykeystoretype",
-			TruststorePath:     "mytruststorepath",
-			TruststorePassword: "mytruststorepassword",
-			RemoteProfile:      "myremoteprofile",
-			Realm:              "myrealm",
-			AdditionalJars: []string{
-				"testdata/fake_additional.jar",
-			},
-			ResourceAttributes: map[string]string{
-				"one": "two",
-			},
-		}, r1)
-
-	assert.Equal(
-		t, []string{"-Dorg.slf4j.simpleLogger.defaultLogLevel=trace"},
-		r1.parseProperties(testLogger),
-	)
-
-	r2 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "missingendpoint")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r2))
-	assert.Equal(t,
-		&Config{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "missingendpoint")),
-			JARPath:            "testdata/fake_jmx.jar",
-			TargetSystem:       "jvm",
-			CollectionInterval: 10 * time.Second,
-			OTLPExporterConfig: otlpExporterConfig{
-				Endpoint: "0.0.0.0:0",
-				TimeoutSettings: exporterhelper.TimeoutSettings{
-					Timeout: 5 * time.Second,
+				ResourceAttributes: map[string]string{
+					"one": "two",
 				},
 			},
-		}, r2)
-	err = r2.validate()
-	require.Error(t, err)
-	assert.Equal(t, "jmx/missingendpoint missing required field: `endpoint`", err.Error())
-
-	// Default log level should set to level of provided zap logger
-	assert.Equal(
-		t, []string{"-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"},
-		r2.parseProperties(testLogger),
-	)
-
-	r3 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "missingtarget")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r3))
-	assert.Equal(t,
-		&Config{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "missingtarget")),
-			JARPath:            "testdata/fake_jmx.jar",
-			Endpoint:           "service:jmx:rmi:///jndi/rmi://host:12345/jmxrmi",
-			CollectionInterval: 10 * time.Second,
-			OTLPExporterConfig: otlpExporterConfig{
-				Endpoint: "0.0.0.0:0",
-				TimeoutSettings: exporterhelper.TimeoutSettings{
-					Timeout: 5 * time.Second,
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "missingendpoint"),
+			expected: &Config{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				JARPath:            "testdata/fake_jmx.jar",
+				TargetSystem:       "jvm",
+				CollectionInterval: 10 * time.Second,
+				OTLPExporterConfig: otlpExporterConfig{
+					Endpoint: "0.0.0.0:0",
+					TimeoutSettings: exporterhelper.TimeoutSettings{
+						Timeout: 5 * time.Second,
+					},
 				},
 			},
-		}, r3)
-	err = r3.validate()
-	require.Error(t, err)
-	assert.Equal(t, "jmx/missingtarget missing required field: `target_system`", err.Error())
-
-	r4 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "invalidinterval")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r4))
-	assert.Equal(t,
-		&Config{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "invalidinterval")),
-			JARPath:            "testdata/fake_jmx.jar",
-			Endpoint:           "myendpoint:23456",
-			TargetSystem:       "jvm",
-			CollectionInterval: -100 * time.Millisecond,
-			OTLPExporterConfig: otlpExporterConfig{
-				Endpoint: "0.0.0.0:0",
-				TimeoutSettings: exporterhelper.TimeoutSettings{
-					Timeout: 5 * time.Second,
+		},
+		{
+			id:          config.NewComponentIDWithName(typeStr, "missingtarget"),
+			expectedErr: "jmx missing required field: `target_system`",
+			expected: &Config{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				JARPath:            "testdata/fake_jmx.jar",
+				Endpoint:           "service:jmx:rmi:///jndi/rmi://host:12345/jmxrmi",
+				CollectionInterval: 10 * time.Second,
+				OTLPExporterConfig: otlpExporterConfig{
+					Endpoint: "0.0.0.0:0",
+					TimeoutSettings: exporterhelper.TimeoutSettings{
+						Timeout: 5 * time.Second,
+					},
 				},
 			},
-		}, r4)
-	err = r4.validate()
-	require.Error(t, err)
-	assert.Equal(t, "jmx/invalidinterval `interval` must be positive: -100ms", err.Error())
-
-	r5 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "invalidotlptimeout")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r5))
-	assert.Equal(t,
-		&Config{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "invalidotlptimeout")),
-			JARPath:            "testdata/fake_jmx.jar",
-			Endpoint:           "myendpoint:34567",
-			TargetSystem:       "jvm",
-			CollectionInterval: 10 * time.Second,
-			OTLPExporterConfig: otlpExporterConfig{
-				Endpoint: "0.0.0.0:0",
-				TimeoutSettings: exporterhelper.TimeoutSettings{
-					Timeout: -100 * time.Millisecond,
+		},
+		{
+			id:          config.NewComponentIDWithName(typeStr, "invalidinterval"),
+			expectedErr: "`interval` must be positive: -100ms",
+			expected: &Config{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				JARPath:            "testdata/fake_jmx.jar",
+				Endpoint:           "myendpoint:23456",
+				TargetSystem:       "jvm",
+				CollectionInterval: -100 * time.Millisecond,
+				OTLPExporterConfig: otlpExporterConfig{
+					Endpoint: "0.0.0.0:0",
+					TimeoutSettings: exporterhelper.TimeoutSettings{
+						Timeout: 5 * time.Second,
+					},
 				},
 			},
-		}, r5)
-	err = r5.validate()
-	require.Error(t, err)
-	assert.Equal(t, "jmx/invalidotlptimeout `otlp.timeout` must be positive: -100ms", err.Error())
-
-	r6 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "nonexistentjar")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r6))
-	assert.Equal(t,
-		&Config{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "nonexistentjar")),
-			JARPath:            "testdata/file_does_not_exist.jar",
-			Endpoint:           "myendpoint:23456",
-			TargetSystem:       "jvm",
-			CollectionInterval: 10 * time.Second,
-			OTLPExporterConfig: otlpExporterConfig{
-				Endpoint: "0.0.0.0:0",
-				TimeoutSettings: exporterhelper.TimeoutSettings{
-					Timeout: 5 * time.Second,
+		},
+		{
+			id:          config.NewComponentIDWithName(typeStr, "invalidotlptimeout"),
+			expectedErr: "`otlp.timeout` must be positive: -100ms",
+			expected: &Config{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				JARPath:            "testdata/fake_jmx.jar",
+				Endpoint:           "myendpoint:34567",
+				TargetSystem:       "jvm",
+				CollectionInterval: 10 * time.Second,
+				OTLPExporterConfig: otlpExporterConfig{
+					Endpoint: "0.0.0.0:0",
+					TimeoutSettings: exporterhelper.TimeoutSettings{
+						Timeout: -100 * time.Millisecond,
+					},
 				},
 			},
-		}, r6)
-	err = r6.validate()
-	require.Error(t, err)
-	// Error is different based on OS, which is why this is contains, not equals
-	assert.Contains(t, err.Error(), "jmx/nonexistentjar error validating `jar_path`: error hashing file: open testdata/file_does_not_exist.jar:")
+		},
 
-	r7 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "invalidjar")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r7))
-	assert.Equal(t,
-		&Config{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "invalidjar")),
-			JARPath:            "testdata/fake_jmx_wrong.jar",
-			Endpoint:           "myendpoint:23456",
-			TargetSystem:       "jvm",
-			CollectionInterval: 10 * time.Second,
-			OTLPExporterConfig: otlpExporterConfig{
-				Endpoint: "0.0.0.0:0",
-				TimeoutSettings: exporterhelper.TimeoutSettings{
-					Timeout: 5 * time.Second,
+		{
+			id: config.NewComponentIDWithName(typeStr, "nonexistentjar"),
+			// Error is different based on OS, which is why this is contains, not equals
+			expectedErr: "error validating `jar_path`: error hashing file: open testdata/file_does_not_exist.jar:",
+			expected: &Config{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				JARPath:            "testdata/file_does_not_exist.jar",
+				Endpoint:           "myendpoint:23456",
+				TargetSystem:       "jvm",
+				CollectionInterval: 10 * time.Second,
+				OTLPExporterConfig: otlpExporterConfig{
+					Endpoint: "0.0.0.0:0",
+					TimeoutSettings: exporterhelper.TimeoutSettings{
+						Timeout: 5 * time.Second,
+					},
 				},
 			},
-		}, r7)
-	err = r7.validate()
-	require.Error(t, err)
-	assert.Equal(t, "jmx/invalidjar error validating `jar_path`: jar hash does not match known versions", err.Error())
-
-	r8 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "invalidloglevel")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r8))
-	assert.Equal(t,
-		&Config{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "invalidloglevel")),
-			JARPath:            "testdata/fake_jmx.jar",
-			Endpoint:           "myendpoint:55555",
-			TargetSystem:       "jvm",
-			LogLevel:           "truth",
-			CollectionInterval: 10 * time.Second,
-			OTLPExporterConfig: otlpExporterConfig{
-				Endpoint: "0.0.0.0:0",
-				TimeoutSettings: exporterhelper.TimeoutSettings{
-					Timeout: 5 * time.Second,
+		},
+		{
+			id:          config.NewComponentIDWithName(typeStr, "invalidjar"),
+			expectedErr: "error validating `jar_path`: jar hash does not match known versions",
+			expected: &Config{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				JARPath:            "testdata/fake_jmx_wrong.jar",
+				Endpoint:           "myendpoint:23456",
+				TargetSystem:       "jvm",
+				CollectionInterval: 10 * time.Second,
+				OTLPExporterConfig: otlpExporterConfig{
+					Endpoint: "0.0.0.0:0",
+					TimeoutSettings: exporterhelper.TimeoutSettings{
+						Timeout: 5 * time.Second,
+					},
 				},
 			},
-		}, r8)
-	err = r8.validate()
-	require.Error(t, err)
-	assert.Equal(t, "jmx/invalidloglevel `log_level` must be one of 'debug', 'error', 'info', 'off', 'trace', 'warn'", err.Error())
-
-	r9 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "invalidtargetsystem")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r9))
-	assert.Equal(t,
-		&Config{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "invalidtargetsystem")),
-			JARPath:            "testdata/fake_jmx.jar",
-			Endpoint:           "myendpoint:55555",
-			TargetSystem:       "jvm,fakejvmtechnology",
-			CollectionInterval: 10 * time.Second,
-			OTLPExporterConfig: otlpExporterConfig{
-				Endpoint: "0.0.0.0:0",
-				TimeoutSettings: exporterhelper.TimeoutSettings{
-					Timeout: 5 * time.Second,
+		},
+		{
+			id:          config.NewComponentIDWithName(typeStr, "invalidloglevel"),
+			expectedErr: "jmx `log_level` must be one of 'debug', 'error', 'info', 'off', 'trace', 'warn'",
+			expected: &Config{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				JARPath:            "testdata/fake_jmx.jar",
+				Endpoint:           "myendpoint:55555",
+				TargetSystem:       "jvm",
+				LogLevel:           "truth",
+				CollectionInterval: 10 * time.Second,
+				OTLPExporterConfig: otlpExporterConfig{
+					Endpoint: "0.0.0.0:0",
+					TimeoutSettings: exporterhelper.TimeoutSettings{
+						Timeout: 5 * time.Second,
+					},
 				},
 			},
-		}, r9)
-	err = r9.validate()
-	require.Error(t, err)
-	assert.Equal(t, "jmx/invalidtargetsystem `target_system` list may only be a subset of 'activemq', 'cassandra', 'hadoop', 'hbase', 'jetty', 'jvm', 'kafka', 'kafka-consumer', 'kafka-producer', 'solr', 'tomcat', 'wildfly'", err.Error())
+		},
+		{
+			id:          config.NewComponentIDWithName(typeStr, "invalidtargetsystem"),
+			expectedErr: "`target_system` list may only be a subset of 'activemq', 'cassandra', 'hadoop', 'hbase', 'jetty', 'jvm', 'kafka', 'kafka-consumer', 'kafka-producer', 'solr', 'tomcat', 'wildfly'",
+			expected: &Config{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				JARPath:            "testdata/fake_jmx.jar",
+				Endpoint:           "myendpoint:55555",
+				TargetSystem:       "jvm,fakejvmtechnology",
+				CollectionInterval: 10 * time.Second,
+				OTLPExporterConfig: otlpExporterConfig{
+					Endpoint: "0.0.0.0:0",
+					TimeoutSettings: exporterhelper.TimeoutSettings{
+						Timeout: 5 * time.Second,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			mockJarVersions()
+			t.Cleanup(func() {
+				unmockJarVersions()
+			})
+
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
+
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, config.UnmarshalReceiver(sub, cfg))
+
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, cfg.(*Config).validate(), tt.expectedErr)
+				assert.Equal(t, tt.expected, cfg)
+				return
+			}
+			assert.NoError(t, cfg.Validate())
+			assert.Equal(t, tt.expected, cfg)
+		})
+	}
 }
 
 func TestCustomMetricsGathererConfig(t *testing.T) {
@@ -269,37 +247,38 @@ func TestCustomMetricsGathererConfig(t *testing.T) {
 		version: "2.3.4",
 	}
 
-	factories, err := componenttest.NopFactories()
-	assert.Nil(t, err)
-
-	factory := NewFactory()
-	factories.Receivers[typeStr] = factory
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
-
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
-	require.NotNil(t, cfg)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
 
-	assert.Equal(t, len(cfg.Receivers), 10)
+	sub, err := cm.Sub(config.NewComponentIDWithName(typeStr, "invalidtargetsystem").String())
+	require.NoError(t, err)
+	require.NoError(t, config.UnmarshalReceiver(sub, cfg))
 
-	r1 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "invalidtargetsystem")].(*Config)
-	require.NoError(t, configtest.CheckConfigStruct(r1))
-	err = r1.validate()
+	conf := cfg.(*Config)
+
+	err = conf.validate()
 	require.Error(t, err)
-	assert.Equal(t, "jmx/invalidtargetsystem error validating `jar_path`: jar hash does not match known versions", err.Error())
+	assert.Equal(t, "jmx error validating `jar_path`: jar hash does not match known versions", err.Error())
 
 	MetricsGathererHash = "5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5"
 	initSupportedJars()
 
-	err = r1.validate()
+	err = conf.validate()
 	require.Error(t, err)
-	assert.Equal(t, "jmx/invalidtargetsystem `target_system` list may only be a subset of 'activemq', 'cassandra', 'hadoop', 'hbase', 'jetty', 'jvm', 'kafka', 'kafka-consumer', 'kafka-producer', 'solr', 'tomcat', 'wildfly'", err.Error())
+	assert.Equal(t, "jmx `target_system` list may only be a subset of 'activemq', 'cassandra', 'hadoop', 'hbase', 'jetty', 'jvm', 'kafka', 'kafka-consumer', 'kafka-producer', 'solr', 'tomcat', 'wildfly'", err.Error())
 
 	AdditionalTargetSystems = "fakejvmtechnology,anothertechnology"
+	t.Cleanup(func() {
+		delete(validTargetSystems, "fakejvmtechnology")
+		delete(validTargetSystems, "anothertechnology")
+	})
 	initAdditionalTargetSystems()
 
-	r1.TargetSystem = "jvm,fakejvmtechnology,anothertechnology"
+	conf.TargetSystem = "jvm,fakejvmtechnology,anothertechnology"
 
-	require.NoError(t, r1.validate())
+	require.NoError(t, conf.validate())
 }
 
 func TestClassPathParse(t *testing.T) {

--- a/receiver/jmxreceiver/testdata/config.yaml
+++ b/receiver/jmxreceiver/testdata/config.yaml
@@ -1,74 +1,60 @@
-receivers:
-  jmx:
-  jmx/all:
-    jar_path: testdata/fake_jmx.jar
-    endpoint: myendpoint:12345
-    target_system: jvm
-    collection_interval: 15s
-    username: myusername
-    password: mypassword
-    otlp:
-      endpoint: myotlpendpoint
-      headers:
-        x-header-1: value1
-        x-header-2: value2
-      timeout: 5s
-    keystore_path: mykeystorepath
-    keystore_password: mykeystorepassword
-    keystore_type: mykeystoretype
-    truststore_path: mytruststorepath
-    truststore_password: mytruststorepassword
-    remote_profile: myremoteprofile
-    realm: myrealm
-    log_level: trace
-    resource_attributes:
-      one: two
-    additional_jars:
-      - testdata/fake_additional.jar
-  jmx/missingendpoint:
-    jar_path: testdata/fake_jmx.jar
-    target_system: jvm
-  jmx/missingtarget:
-    jar_path: testdata/fake_jmx.jar
-    endpoint: service:jmx:rmi:///jndi/rmi://host:12345/jmxrmi
-  jmx/invalidinterval:
-    jar_path: testdata/fake_jmx.jar
-    endpoint: myendpoint:23456
-    target_system: jvm
-    collection_interval: -100ms
-  jmx/invalidotlptimeout:
-    jar_path: testdata/fake_jmx.jar
-    endpoint: myendpoint:34567
-    target_system: jvm
-    otlp:
-      timeout: -100ms
-  jmx/nonexistentjar:
-    jar_path: testdata/file_does_not_exist.jar
-    endpoint: myendpoint:23456
-    target_system: jvm
-  jmx/invalidjar:
-    jar_path: testdata/fake_jmx_wrong.jar
-    endpoint: myendpoint:23456
-    target_system: jvm
-  jmx/invalidloglevel:
-    jar_path: testdata/fake_jmx.jar
-    endpoint: myendpoint:55555
-    target_system: jvm
-    log_level: truth
-  jmx/invalidtargetsystem:
-    jar_path: testdata/fake_jmx.jar
-    endpoint: myendpoint:55555
-    target_system: jvm,fakejvmtechnology
-
-processors:
-  nop:
-
-exporters:
-  nop:
-
-service:
-  pipelines:
-    metrics:
-      receivers: [jmx, jmx/all]
-      processors: [nop]
-      exporters: [nop]
+jmx:
+jmx/all:
+  jar_path: testdata/fake_jmx.jar
+  endpoint: myendpoint:12345
+  target_system: jvm
+  collection_interval: 15s
+  username: myusername
+  password: mypassword
+  otlp:
+    endpoint: myotlpendpoint
+    headers:
+      x-header-1: value1
+      x-header-2: value2
+    timeout: 5s
+  keystore_path: mykeystorepath
+  keystore_password: mykeystorepassword
+  keystore_type: mykeystoretype
+  truststore_path: mytruststorepath
+  truststore_password: mytruststorepassword
+  remote_profile: myremoteprofile
+  realm: myrealm
+  log_level: trace
+  resource_attributes:
+    one: two
+  additional_jars:
+    - testdata/fake_additional.jar
+jmx/missingendpoint:
+  jar_path: testdata/fake_jmx.jar
+  target_system: jvm
+jmx/missingtarget:
+  jar_path: testdata/fake_jmx.jar
+  endpoint: service:jmx:rmi:///jndi/rmi://host:12345/jmxrmi
+jmx/invalidinterval:
+  jar_path: testdata/fake_jmx.jar
+  endpoint: myendpoint:23456
+  target_system: jvm
+  collection_interval: -100ms
+jmx/invalidotlptimeout:
+  jar_path: testdata/fake_jmx.jar
+  endpoint: myendpoint:34567
+  target_system: jvm
+  otlp:
+    timeout: -100ms
+jmx/nonexistentjar:
+  jar_path: testdata/file_does_not_exist.jar
+  endpoint: myendpoint:23456
+  target_system: jvm
+jmx/invalidjar:
+  jar_path: testdata/fake_jmx_wrong.jar
+  endpoint: myendpoint:23456
+  target_system: jvm
+jmx/invalidloglevel:
+  jar_path: testdata/fake_jmx.jar
+  endpoint: myendpoint:55555
+  target_system: jvm
+  log_level: truth
+jmx/invalidtargetsystem:
+  jar_path: testdata/fake_jmx.jar
+  endpoint: myendpoint:55555
+  target_system: jvm,fakejvmtechnology

--- a/receiver/journaldreceiver/journald_test.go
+++ b/receiver/journaldreceiver/journald_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/service/servicetest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -35,18 +35,16 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := componenttest.NopFactories()
-	assert.Nil(t, err)
-
-	factory := NewFactory()
-	factories.Receivers[typeStr] = factory
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
-	require.NotNil(t, cfg)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
 
-	assert.Equal(t, len(cfg.Receivers), 1)
+	sub, err := cm.Sub(config.NewComponentIDWithName(typeStr, "").String())
+	require.NoError(t, err)
+	require.NoError(t, config.UnmarshalReceiver(sub, cfg))
 
-	assert.Equal(t, testdataConfigYaml(), cfg.Receivers[config.NewComponentID("journald")])
+	assert.Equal(t, testdataConfigYaml(), cfg)
 }
 
 func TestInputConfigFailure(t *testing.T) {

--- a/receiver/journaldreceiver/testdata/config.yaml
+++ b/receiver/journaldreceiver/testdata/config.yaml
@@ -1,19 +1,5 @@
-receivers:
-  journald:
-    units:
-      - ssh
-    priority: info
-    directory: /run/log/journal
-
-processors:
-  nop:
-
-exporters:
-  nop:
-
-service:
-  pipelines:
-    logs:
-      receivers: [journald]
-      processors: [nop]
-      exporters: [nop]
+journald:
+  units:
+    - ssh
+  priority: info
+  directory: /run/log/journal

--- a/receiver/k8sclusterreceiver/config_test.go
+++ b/receiver/k8sclusterreceiver/config_test.go
@@ -21,55 +21,68 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/service/servicetest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := componenttest.NopFactories()
-	assert.Nil(t, err)
+	t.Parallel()
 
-	factory := NewFactory()
-	receiverType := "k8s_cluster"
-	factories.Receivers[config.Type(receiverType)] = factory
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
-
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
-	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Receivers), 3)
-
-	r1 := cfg.Receivers[config.NewComponentID(typeStr)]
-	assert.Equal(t, r1, factory.CreateDefaultConfig())
-
-	r2 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "all_settings")].(*Config)
-	assert.Equal(t, r2,
-		&Config{
-			ReceiverSettings:           config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "all_settings")),
-			Distribution:               distributionKubernetes,
-			CollectionInterval:         30 * time.Second,
-			NodeConditionTypesToReport: []string{"Ready", "MemoryPressure"},
-			AllocatableTypesToReport:   []string{"cpu", "memory"},
-			MetadataExporters:          []string{"nop"},
-			APIConfig: k8sconfig.APIConfig{
-				AuthType: k8sconfig.AuthTypeServiceAccount,
+	tests := []struct {
+		id          config.ComponentID
+		expected    config.Receiver
+		expectedErr error
+	}{
+		{
+			id:       config.NewComponentIDWithName(typeStr, ""),
+			expected: createDefaultConfig(),
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "all_settings"),
+			expected: &Config{
+				ReceiverSettings:           config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				Distribution:               distributionKubernetes,
+				CollectionInterval:         30 * time.Second,
+				NodeConditionTypesToReport: []string{"Ready", "MemoryPressure"},
+				AllocatableTypesToReport:   []string{"cpu", "memory"},
+				MetadataExporters:          []string{"nop"},
+				APIConfig: k8sconfig.APIConfig{
+					AuthType: k8sconfig.AuthTypeServiceAccount,
+				},
 			},
-		})
-
-	r3 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "partial_settings")].(*Config)
-	assert.Equal(t, r3,
-		&Config{
-			ReceiverSettings:           config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "partial_settings")),
-			Distribution:               distributionOpenShift,
-			CollectionInterval:         30 * time.Second,
-			NodeConditionTypesToReport: []string{"Ready"},
-			APIConfig: k8sconfig.APIConfig{
-				AuthType: k8sconfig.AuthTypeServiceAccount,
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "partial_settings"),
+			expected: &Config{
+				ReceiverSettings:           config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				Distribution:               distributionOpenShift,
+				CollectionInterval:         30 * time.Second,
+				NodeConditionTypesToReport: []string{"Ready"},
+				APIConfig: k8sconfig.APIConfig{
+					AuthType: k8sconfig.AuthTypeServiceAccount,
+				},
 			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
+
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, config.UnmarshalReceiver(sub, cfg))
+
+			assert.NoError(t, cfg.Validate())
+			assert.Equal(t, tt.expected, cfg)
 		})
+	}
 }
 
 func TestInvalidConfig(t *testing.T) {

--- a/receiver/k8sclusterreceiver/testdata/config.yaml
+++ b/receiver/k8sclusterreceiver/testdata/config.yaml
@@ -1,24 +1,9 @@
-receivers:
-  k8s_cluster:
-  k8s_cluster/all_settings:
-    collection_interval: 30s
-    node_conditions_to_report: ["Ready", "MemoryPressure"]
-    allocatable_types_to_report: ["cpu","memory"]
-    metadata_exporters: [nop]
-  k8s_cluster/partial_settings:
-    collection_interval: 30s
-    distribution: openshift
-
-
-processors:
-  nop:
-
-exporters:
-  nop:
-
-service:
-  pipelines:
-    metrics:
-      receivers: [k8s_cluster]
-      processors: [nop]
-      exporters: [nop]
+k8s_cluster:
+k8s_cluster/all_settings:
+  collection_interval: 30s
+  node_conditions_to_report: [ "Ready", "MemoryPressure" ]
+  allocatable_types_to_report: [ "cpu","memory" ]
+  metadata_exporters: [ nop ]
+k8s_cluster/partial_settings:
+  collection_interval: 30s
+  distribution: openshift

--- a/receiver/k8seventsreceiver/config_test.go
+++ b/receiver/k8seventsreceiver/config_test.go
@@ -20,37 +20,50 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/service/servicetest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := componenttest.NopFactories()
+	t.Parallel()
+
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 
-	factory := NewFactory()
-	receiverType := "k8s_events"
-	factories.Receivers[config.Type(receiverType)] = factory
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
-
-	require.NoError(t, err)
-	require.NotNil(t, cfg)
-
-	require.Equal(t, len(cfg.Receivers), 2)
-
-	r1 := cfg.Receivers[config.NewComponentID(typeStr)]
-	assert.Equal(t, r1, factory.CreateDefaultConfig())
-
-	r2 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "all_settings")].(*Config)
-	assert.Equal(t, r2,
-		&Config{
-			ReceiverSettings: config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "all_settings")),
-			Namespaces:       []string{"default", "my_namespace"},
-			APIConfig: k8sconfig.APIConfig{
-				AuthType: k8sconfig.AuthTypeServiceAccount,
+	tests := []struct {
+		id          config.ComponentID
+		expected    config.Receiver
+		expectedErr error
+	}{
+		{
+			id:       config.NewComponentIDWithName(typeStr, ""),
+			expected: createDefaultConfig(),
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "all_settings"),
+			expected: &Config{
+				ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				Namespaces:       []string{"default", "my_namespace"},
+				APIConfig: k8sconfig.APIConfig{
+					AuthType: k8sconfig.AuthTypeServiceAccount,
+				},
 			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
+
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, config.UnmarshalReceiver(sub, cfg))
+
+			assert.NoError(t, cfg.Validate())
+			assert.Equal(t, tt.expected, cfg)
 		})
+	}
 }

--- a/receiver/k8seventsreceiver/testdata/config.yaml
+++ b/receiver/k8seventsreceiver/testdata/config.yaml
@@ -1,17 +1,3 @@
-receivers:
-  k8s_events:
-  k8s_events/all_settings:
-    namespaces: [default, my_namespace]
-
-processors:
-  nop:
-
-exporters:
-  nop:
-
-service:
-  pipelines:
-    logs:
-      receivers: [k8s_events]
-      processors: [nop]
-      exporters: [nop]
+k8s_events:
+k8s_events/all_settings:
+  namespaces: [ default, my_namespace ]

--- a/receiver/kafkametricsreceiver/config_test.go
+++ b/receiver/kafkametricsreceiver/config_test.go
@@ -20,27 +20,25 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
-	"go.opentelemetry.io/collector/service/servicetest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver/internal/metadata"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := componenttest.NopFactories()
-	assert.NoError(t, err)
-
-	factory := NewFactory()
-	factories.Receivers[typeStr] = factory
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
-	require.Equal(t, 1, len(cfg.Receivers))
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
 
-	r := cfg.Receivers[config.NewComponentID(typeStr)].(*Config)
+	sub, err := cm.Sub(config.NewComponentIDWithName(typeStr, "").String())
+	require.NoError(t, err)
+	require.NoError(t, config.UnmarshalReceiver(sub, cfg))
+
 	assert.Equal(t, &Config{
 		ScraperControllerSettings: scraperhelper.NewDefaultScraperControllerSettings(typeStr),
 		Brokers:                   []string{"10.10.10.10:9092"},
@@ -59,5 +57,5 @@ func TestLoadConfig(t *testing.T) {
 		ClientID: defaultClientID,
 		Scrapers: []string{"brokers", "topics", "consumers"},
 		Metrics:  metadata.DefaultMetricsSettings(),
-	}, r)
+	}, cfg)
 }

--- a/receiver/kafkametricsreceiver/testdata/config.yaml
+++ b/receiver/kafkametricsreceiver/testdata/config.yaml
@@ -1,28 +1,14 @@
-receivers:
-  kafkametrics:
-    brokers: 10.10.10.10:9092
-    protocol_version: 2.0.0
-    scrapers:
-      - brokers
-      - topics
-      - consumers
-    auth:
-      tls:
-        ca_file: ca.pem
-        cert_file: cert.pem
-        key_file: key.pem
-    topic_match: test_\w+
-    group_match: test_\w+
-
-processors:
-  nop:
-
-exporters:
-  nop:
-
-service:
-  pipelines:
-    metrics:
-      receivers: [ kafkametrics ]
-      processors: [ nop ]
-      exporters: [ nop ]
+kafkametrics:
+  brokers: 10.10.10.10:9092
+  protocol_version: 2.0.0
+  scrapers:
+    - brokers
+    - topics
+    - consumers
+  auth:
+    tls:
+      ca_file: ca.pem
+      cert_file: cert.pem
+      key_file: key.pem
+  topic_match: test_\w+
+  group_match: test_\w+

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -21,81 +21,100 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtls"
-	"go.opentelemetry.io/collector/service/servicetest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := componenttest.NopFactories()
-	assert.NoError(t, err)
+	t.Parallel()
 
-	factory := NewFactory()
-	factories.Receivers[typeStr] = factory
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
-	require.Equal(t, 2, len(cfg.Receivers))
 
-	r1 := cfg.Receivers[config.NewComponentID(typeStr)].(*Config)
-	r2 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "logs")].(*Config)
-	assert.Equal(t, &Config{
-		ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
-		Topic:            "spans",
-		Encoding:         "otlp_proto",
-		Brokers:          []string{"foo:123", "bar:456"},
-		ClientID:         "otel-collector",
-		GroupID:          "otel-collector",
-		Authentication: kafkaexporter.Authentication{
-			TLS: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
-					CAFile:   "ca.pem",
-					CertFile: "cert.pem",
-					KeyFile:  "key.pem",
+	tests := []struct {
+		id          config.ComponentID
+		expected    config.Receiver
+		expectedErr error
+	}{
+		{
+			id: config.NewComponentIDWithName(typeStr, ""),
+			expected: &Config{
+				ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				Topic:            "spans",
+				Encoding:         "otlp_proto",
+				Brokers:          []string{"foo:123", "bar:456"},
+				ClientID:         "otel-collector",
+				GroupID:          "otel-collector",
+				Authentication: kafkaexporter.Authentication{
+					TLS: &configtls.TLSClientSetting{
+						TLSSetting: configtls.TLSSetting{
+							CAFile:   "ca.pem",
+							CertFile: "cert.pem",
+							KeyFile:  "key.pem",
+						},
+					},
+				},
+				Metadata: kafkaexporter.Metadata{
+					Full: true,
+					Retry: kafkaexporter.MetadataRetry{
+						Max:     10,
+						Backoff: time.Second * 5,
+					},
+				},
+				AutoCommit: AutoCommit{
+					Enable:   true,
+					Interval: 1 * time.Second,
 				},
 			},
 		},
-		Metadata: kafkaexporter.Metadata{
-			Full: true,
-			Retry: kafkaexporter.MetadataRetry{
-				Max:     10,
-				Backoff: time.Second * 5,
-			},
-		},
-		AutoCommit: AutoCommit{
-			Enable:   true,
-			Interval: 1 * time.Second,
-		},
-	}, r1)
+		{
 
-	assert.Equal(t, &Config{
-		ReceiverSettings: config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "logs")),
-		Topic:            "logs",
-		Encoding:         "direct",
-		Brokers:          []string{"coffee:123", "foobar:456"},
-		ClientID:         "otel-collector",
-		GroupID:          "otel-collector",
-		Authentication: kafkaexporter.Authentication{
-			TLS: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
-					CAFile:   "ca.pem",
-					CertFile: "cert.pem",
-					KeyFile:  "key.pem",
+			id: config.NewComponentIDWithName(typeStr, "logs"),
+			expected: &Config{
+				ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				Topic:            "logs",
+				Encoding:         "direct",
+				Brokers:          []string{"coffee:123", "foobar:456"},
+				ClientID:         "otel-collector",
+				GroupID:          "otel-collector",
+				Authentication: kafkaexporter.Authentication{
+					TLS: &configtls.TLSClientSetting{
+						TLSSetting: configtls.TLSSetting{
+							CAFile:   "ca.pem",
+							CertFile: "cert.pem",
+							KeyFile:  "key.pem",
+						},
+					},
+				},
+				Metadata: kafkaexporter.Metadata{
+					Full: true,
+					Retry: kafkaexporter.MetadataRetry{
+						Max:     10,
+						Backoff: time.Second * 5,
+					},
+				},
+				AutoCommit: AutoCommit{
+					Enable:   true,
+					Interval: 1 * time.Second,
 				},
 			},
 		},
-		Metadata: kafkaexporter.Metadata{
-			Full: true,
-			Retry: kafkaexporter.MetadataRetry{
-				Max:     10,
-				Backoff: time.Second * 5,
-			},
-		},
-		AutoCommit: AutoCommit{
-			Enable:   true,
-			Interval: 1 * time.Second,
-		},
-	}, r2)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
+
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, config.UnmarshalReceiver(sub, cfg))
+
+			assert.NoError(t, cfg.Validate())
+			assert.Equal(t, tt.expected, cfg)
+		})
+	}
 }

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -1,51 +1,33 @@
-receivers:
-  kafka:
-    topic: spans
-    brokers:
-      - "foo:123"
-      - "bar:456"
-    client_id: otel-collector
-    group_id: otel-collector
-    auth:
-      tls:
-        ca_file: ca.pem
-        cert_file: cert.pem
-        key_file: key.pem
-    metadata:
-      retry:
-        max: 10
-        backoff: 5s
-  kafka/logs:
-    topic: logs
-    encoding: direct
-    brokers:
-      - "coffee:123"
-      - "foobar:456"
-    client_id: otel-collector
-    group_id: otel-collector
-    auth:
-      tls:
-        ca_file: ca.pem
-        cert_file: cert.pem
-        key_file: key.pem
-    metadata:
-      retry:
-        max: 10
-        backoff: 5s
-
-processors:
-  nop:
-
-exporters:
-  nop:
-
-service:
-  pipelines:
-    traces:
-      receivers: [kafka]
-      processors: [nop]
-      exporters: [nop]
-    logs:
-      receivers: [kafka/logs]
-      processors: [nop]
-      exporters: [nop]
+kafka:
+  topic: spans
+  brokers:
+    - "foo:123"
+    - "bar:456"
+  client_id: otel-collector
+  group_id: otel-collector
+  auth:
+    tls:
+      ca_file: ca.pem
+      cert_file: cert.pem
+      key_file: key.pem
+  metadata:
+    retry:
+      max: 10
+      backoff: 5s
+kafka/logs:
+  topic: logs
+  encoding: direct
+  brokers:
+    - "coffee:123"
+    - "foobar:456"
+  client_id: otel-collector
+  group_id: otel-collector
+  auth:
+    tls:
+      ca_file: ca.pem
+      cert_file: cert.pem
+      key_file: key.pem
+  metadata:
+    retry:
+      max: 10
+      backoff: 5s

--- a/receiver/kubeletstatsreceiver/config_test.go
+++ b/receiver/kubeletstatsreceiver/config_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
-	"go.opentelemetry.io/collector/service/servicetest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 	kube "github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet"
@@ -35,146 +35,171 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := componenttest.NopFactories()
+	t.Parallel()
+
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
-	factory := NewFactory()
-	factories.Receivers[typeStr] = factory
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
-	require.NoError(t, err)
-	require.NotNil(t, cfg)
 
 	duration := 10 * time.Second
-	defaultCfg := cfg.Receivers[config.NewComponentIDWithName(typeStr, "default")].(*Config)
-	require.Equal(t, &Config{
-		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "default")),
-			CollectionInterval: duration,
-		},
-		ClientConfig: kube.ClientConfig{
-			APIConfig: k8sconfig.APIConfig{
-				AuthType: "tls",
-			},
-		},
-		MetricGroupsToCollect: []kubelet.MetricGroup{
-			kubelet.ContainerMetricGroup,
-			kubelet.PodMetricGroup,
-			kubelet.NodeMetricGroup,
-		},
-		Metrics: metadata.DefaultMetricsSettings(),
-	}, defaultCfg)
 
-	tlsCfg := cfg.Receivers[config.NewComponentIDWithName(typeStr, "tls")].(*Config)
-	require.Equal(t, &Config{
-		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "tls")),
-			CollectionInterval: duration,
-		},
-		TCPAddr: confignet.TCPAddr{
-			Endpoint: "1.2.3.4:5555",
-		},
-		ClientConfig: kube.ClientConfig{
-			APIConfig: k8sconfig.APIConfig{
-				AuthType: "tls",
+	tests := []struct {
+		id          config.ComponentID
+		expected    config.Receiver
+		expectedErr error
+	}{
+		{
+			id: config.NewComponentIDWithName(typeStr, "default"),
+			expected: &Config{
+				ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
+					ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+					CollectionInterval: duration,
+				},
+				ClientConfig: kube.ClientConfig{
+					APIConfig: k8sconfig.APIConfig{
+						AuthType: "tls",
+					},
+				},
+				MetricGroupsToCollect: []kubelet.MetricGroup{
+					kubelet.ContainerMetricGroup,
+					kubelet.PodMetricGroup,
+					kubelet.NodeMetricGroup,
+				},
+				Metrics: metadata.DefaultMetricsSettings(),
 			},
-			TLSSetting: configtls.TLSSetting{
-				CAFile:   "/path/to/ca.crt",
-				CertFile: "/path/to/apiserver.crt",
-				KeyFile:  "/path/to/apiserver.key",
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "tls"),
+			expected: &Config{
+				ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
+					ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+					CollectionInterval: duration,
+				},
+				TCPAddr: confignet.TCPAddr{
+					Endpoint: "1.2.3.4:5555",
+				},
+				ClientConfig: kube.ClientConfig{
+					APIConfig: k8sconfig.APIConfig{
+						AuthType: "tls",
+					},
+					TLSSetting: configtls.TLSSetting{
+						CAFile:   "/path/to/ca.crt",
+						CertFile: "/path/to/apiserver.crt",
+						KeyFile:  "/path/to/apiserver.key",
+					},
+					InsecureSkipVerify: true,
+				},
+				MetricGroupsToCollect: []kubelet.MetricGroup{
+					kubelet.ContainerMetricGroup,
+					kubelet.PodMetricGroup,
+					kubelet.NodeMetricGroup,
+				},
+				Metrics: metadata.DefaultMetricsSettings(),
 			},
-			InsecureSkipVerify: true,
 		},
-		MetricGroupsToCollect: []kubelet.MetricGroup{
-			kubelet.ContainerMetricGroup,
-			kubelet.PodMetricGroup,
-			kubelet.NodeMetricGroup,
+		{
+			id: config.NewComponentIDWithName(typeStr, "sa"),
+			expected: &Config{
+				ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
+					ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+					CollectionInterval: duration,
+				},
+				ClientConfig: kube.ClientConfig{
+					APIConfig: k8sconfig.APIConfig{
+						AuthType: "serviceAccount",
+					},
+					InsecureSkipVerify: true,
+				},
+				MetricGroupsToCollect: []kubelet.MetricGroup{
+					kubelet.ContainerMetricGroup,
+					kubelet.PodMetricGroup,
+					kubelet.NodeMetricGroup,
+				},
+				Metrics: metadata.DefaultMetricsSettings(),
+			},
 		},
-		Metrics: metadata.DefaultMetricsSettings(),
-	}, tlsCfg)
+		{
+			id: config.NewComponentIDWithName(typeStr, "metadata"),
+			expected: &Config{
+				ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
+					ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+					CollectionInterval: duration,
+				},
+				ClientConfig: kube.ClientConfig{
+					APIConfig: k8sconfig.APIConfig{
+						AuthType: "serviceAccount",
+					},
+				},
+				ExtraMetadataLabels: []kubelet.MetadataLabel{
+					kubelet.MetadataLabelContainerID,
+					kubelet.MetadataLabelVolumeType,
+				},
+				MetricGroupsToCollect: []kubelet.MetricGroup{
+					kubelet.ContainerMetricGroup,
+					kubelet.PodMetricGroup,
+					kubelet.NodeMetricGroup,
+				},
+				Metrics: metadata.DefaultMetricsSettings(),
+			},
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "metric_groups"),
+			expected: &Config{
+				ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
+					ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+					CollectionInterval: 20 * time.Second,
+				},
+				ClientConfig: kube.ClientConfig{
+					APIConfig: k8sconfig.APIConfig{
+						AuthType: "serviceAccount",
+					},
+				},
+				MetricGroupsToCollect: []kubelet.MetricGroup{
+					kubelet.PodMetricGroup,
+					kubelet.NodeMetricGroup,
+					kubelet.VolumeMetricGroup,
+				},
+				Metrics: metadata.DefaultMetricsSettings(),
+			},
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "metadata_with_k8s_api"),
+			expected: &Config{
+				ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
+					ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
+					CollectionInterval: duration,
+				},
+				ClientConfig: kube.ClientConfig{
+					APIConfig: k8sconfig.APIConfig{
+						AuthType: "serviceAccount",
+					},
+				},
+				ExtraMetadataLabels: []kubelet.MetadataLabel{
+					kubelet.MetadataLabelVolumeType,
+				},
+				MetricGroupsToCollect: []kubelet.MetricGroup{
+					kubelet.ContainerMetricGroup,
+					kubelet.PodMetricGroup,
+					kubelet.NodeMetricGroup,
+				},
+				K8sAPIConfig: &k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeKubeConfig},
+				Metrics:      metadata.DefaultMetricsSettings(),
+			},
+		},
+	}
 
-	saCfg := cfg.Receivers[config.NewComponentIDWithName(typeStr, "sa")].(*Config)
-	require.Equal(t, &Config{
-		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "sa")),
-			CollectionInterval: duration,
-		},
-		ClientConfig: kube.ClientConfig{
-			APIConfig: k8sconfig.APIConfig{
-				AuthType: "serviceAccount",
-			},
-			InsecureSkipVerify: true,
-		},
-		MetricGroupsToCollect: []kubelet.MetricGroup{
-			kubelet.ContainerMetricGroup,
-			kubelet.PodMetricGroup,
-			kubelet.NodeMetricGroup,
-		},
-		Metrics: metadata.DefaultMetricsSettings(),
-	}, saCfg)
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
 
-	metadataCfg := cfg.Receivers[config.NewComponentIDWithName(typeStr, "metadata")].(*Config)
-	require.Equal(t, &Config{
-		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "metadata")),
-			CollectionInterval: duration,
-		},
-		ClientConfig: kube.ClientConfig{
-			APIConfig: k8sconfig.APIConfig{
-				AuthType: "serviceAccount",
-			},
-		},
-		ExtraMetadataLabels: []kubelet.MetadataLabel{
-			kubelet.MetadataLabelContainerID,
-			kubelet.MetadataLabelVolumeType,
-		},
-		MetricGroupsToCollect: []kubelet.MetricGroup{
-			kubelet.ContainerMetricGroup,
-			kubelet.PodMetricGroup,
-			kubelet.NodeMetricGroup,
-		},
-		Metrics: metadata.DefaultMetricsSettings(),
-	}, metadataCfg)
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, config.UnmarshalReceiver(sub, cfg))
 
-	metricGroupsCfg := cfg.Receivers[config.NewComponentIDWithName(typeStr, "metric_groups")].(*Config)
-	require.Equal(t, &Config{
-		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "metric_groups")),
-			CollectionInterval: 20 * time.Second,
-		},
-		ClientConfig: kube.ClientConfig{
-			APIConfig: k8sconfig.APIConfig{
-				AuthType: "serviceAccount",
-			},
-		},
-		MetricGroupsToCollect: []kubelet.MetricGroup{
-			kubelet.PodMetricGroup,
-			kubelet.NodeMetricGroup,
-			kubelet.VolumeMetricGroup,
-		},
-		Metrics: metadata.DefaultMetricsSettings(),
-	}, metricGroupsCfg)
-
-	metadataWithK8sAPICfg := cfg.Receivers[config.NewComponentIDWithName(typeStr, "metadata_with_k8s_api")].(*Config)
-	require.Equal(t, &Config{
-		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
-			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "metadata_with_k8s_api")),
-			CollectionInterval: duration,
-		},
-		ClientConfig: kube.ClientConfig{
-			APIConfig: k8sconfig.APIConfig{
-				AuthType: "serviceAccount",
-			},
-		},
-		ExtraMetadataLabels: []kubelet.MetadataLabel{
-			kubelet.MetadataLabelVolumeType,
-		},
-		MetricGroupsToCollect: []kubelet.MetricGroup{
-			kubelet.ContainerMetricGroup,
-			kubelet.PodMetricGroup,
-			kubelet.NodeMetricGroup,
-		},
-		K8sAPIConfig: &k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeKubeConfig},
-		Metrics:      metadata.DefaultMetricsSettings(),
-	}, metadataWithK8sAPICfg)
+			assert.NoError(t, cfg.Validate())
+			assert.Equal(t, tt.expected, cfg)
+		})
+	}
 }
 
 func TestGetReceiverOptions(t *testing.T) {

--- a/receiver/kubeletstatsreceiver/testdata/config.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/config.yaml
@@ -1,38 +1,30 @@
-receivers:
-  kubeletstats/default:
-  kubeletstats/tls:
-    collection_interval: 10s
-    auth_type: "tls"
-    ca_file: "/path/to/ca.crt"
-    key_file: "/path/to/apiserver.key"
-    cert_file: "/path/to/apiserver.crt"
-    endpoint: "1.2.3.4:5555"
-    insecure_skip_verify: true
-  kubeletstats/sa:
-    collection_interval: 10s
-    auth_type: "serviceAccount"
-    insecure_skip_verify: true
-  kubeletstats/metadata:
-    collection_interval: 10s
-    auth_type: "serviceAccount"
-    extra_metadata_labels:
+kubeletstats/default:
+kubeletstats/tls:
+  collection_interval: 10s
+  auth_type: "tls"
+  ca_file: "/path/to/ca.crt"
+  key_file: "/path/to/apiserver.key"
+  cert_file: "/path/to/apiserver.crt"
+  endpoint: "1.2.3.4:5555"
+  insecure_skip_verify: true
+kubeletstats/sa:
+  collection_interval: 10s
+  auth_type: "serviceAccount"
+  insecure_skip_verify: true
+kubeletstats/metadata:
+  collection_interval: 10s
+  auth_type: "serviceAccount"
+  extra_metadata_labels:
     - container.id
     - k8s.volume.type
-  kubeletstats/metadata_with_k8s_api:
-    collection_interval: 10s
-    auth_type: "serviceAccount"
-    extra_metadata_labels:
-      - k8s.volume.type
-    k8s_api_config:
-      auth_type: kubeConfig
-  kubeletstats/metric_groups:
-    collection_interval: 20s
-    auth_type: "serviceAccount"
-    metric_groups: [pod, node, volume]
-exporters:
-  nop:
-service:
-  pipelines:
-    metrics:
-      receivers: [kubeletstats/sa]
-      exporters: [nop]
+kubeletstats/metadata_with_k8s_api:
+  collection_interval: 10s
+  auth_type: "serviceAccount"
+  extra_metadata_labels:
+    - k8s.volume.type
+  k8s_api_config:
+    auth_type: kubeConfig
+kubeletstats/metric_groups:
+  collection_interval: 20s
+  auth_type: "serviceAccount"
+  metric_groups: [ pod, node, volume ]

--- a/receiver/prometheusexecreceiver/config_test.go
+++ b/receiver/prometheusexecreceiver/config_test.go
@@ -20,91 +20,96 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/collector/component/componenttest"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/service/servicetest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver/subprocessmanager"
 )
 
-var (
-	wantReceiver2 = &Config{
-		ReceiverSettings: config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "test")),
-		ScrapeInterval:   60 * time.Second,
-		ScrapeTimeout:    10 * time.Second,
-		Port:             9104,
-		SubprocessConfig: subprocessmanager.SubprocessConfig{
-			Command: "mysqld_exporter",
-			Env:     []subprocessmanager.EnvConfig{},
-		},
-	}
+func TestLoadConfig(t *testing.T) {
+	t.Parallel()
 
-	wantReceiver3 = &Config{
-		ReceiverSettings: config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "test2")),
-		ScrapeInterval:   90 * time.Second,
-		ScrapeTimeout:    10 * time.Second,
-		SubprocessConfig: subprocessmanager.SubprocessConfig{
-			Command: "postgres_exporter",
-			Env:     []subprocessmanager.EnvConfig{},
-		},
-	}
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
 
-	wantReceiver4 = &Config{
-		ReceiverSettings: config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "end_to_end_test/1")),
-		ScrapeInterval:   1 * time.Second,
-		ScrapeTimeout:    1 * time.Second,
-		Port:             9999,
-		SubprocessConfig: subprocessmanager.SubprocessConfig{
-			Command: "go run ./testdata/end_to_end_metrics_test/test_prometheus_exporter.go {{port}}",
-			Env: []subprocessmanager.EnvConfig{
-				{
-					Name:  "DATA_SOURCE_NAME",
-					Value: "user:password@(hostname:port)/dbname",
+	tests := []struct {
+		id          config.ComponentID
+		expected    config.Receiver
+		expectedErr error
+	}{
+		{
+			id: config.NewComponentIDWithName(typeStr, "test"),
+			expected: &Config{
+				ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				ScrapeInterval:   60 * time.Second,
+				ScrapeTimeout:    10 * time.Second,
+				Port:             9104,
+				SubprocessConfig: subprocessmanager.SubprocessConfig{
+					Command: "mysqld_exporter",
+					Env:     []subprocessmanager.EnvConfig{},
 				},
-				{
-					Name:  "SECONDARY_PORT",
-					Value: "1234",
+			},
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "test2"),
+			expected: &Config{
+				ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				ScrapeInterval:   90 * time.Second,
+				ScrapeTimeout:    10 * time.Second,
+				SubprocessConfig: subprocessmanager.SubprocessConfig{
+					Command: "postgres_exporter",
+					Env:     []subprocessmanager.EnvConfig{},
+				},
+			},
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "end_to_end_test/1"),
+			expected: &Config{
+				ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				ScrapeInterval:   1 * time.Second,
+				ScrapeTimeout:    1 * time.Second,
+				Port:             9999,
+				SubprocessConfig: subprocessmanager.SubprocessConfig{
+					Command: "go run ./testdata/end_to_end_metrics_test/test_prometheus_exporter.go {{port}}",
+					Env: []subprocessmanager.EnvConfig{
+						{
+							Name:  "DATA_SOURCE_NAME",
+							Value: "user:password@(hostname:port)/dbname",
+						},
+						{
+							Name:  "SECONDARY_PORT",
+							Value: "1234",
+						},
+					},
+				},
+			},
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "end_to_end_test/2"),
+			expected: &Config{
+				ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
+				ScrapeInterval:   1 * time.Second,
+				ScrapeTimeout:    1 * time.Second,
+				SubprocessConfig: subprocessmanager.SubprocessConfig{
+					Command: "go run ./testdata/end_to_end_metrics_test/test_prometheus_exporter.go {{port}}",
+					Env:     []subprocessmanager.EnvConfig{},
 				},
 			},
 		},
 	}
 
-	wantReceiver5 = &Config{
-		ReceiverSettings: config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "end_to_end_test/2")),
-		ScrapeInterval:   1 * time.Second,
-		ScrapeTimeout:    1 * time.Second,
-		SubprocessConfig: subprocessmanager.SubprocessConfig{
-			Command: "go run ./testdata/end_to_end_metrics_test/test_prometheus_exporter.go {{port}}",
-			Env:     []subprocessmanager.EnvConfig{},
-		},
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
+
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, config.UnmarshalReceiver(sub, cfg))
+
+			assert.NoError(t, cfg.Validate())
+			assert.Equal(t, tt.expected, cfg)
+		})
 	}
-)
-
-func TestLoadConfig(t *testing.T) {
-	factories, err := componenttest.NopFactories()
-	assert.NoError(t, err)
-
-	factory := NewFactory()
-	factories.Receivers[typeStr] = factory
-
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
-	assert.NoError(t, err)
-	assert.NotNil(t, cfg)
-
-	assert.Equal(t, 5, len(cfg.Receivers))
-
-	receiver1 := cfg.Receivers[config.NewComponentID(typeStr)]
-	assert.Equal(t, factory.CreateDefaultConfig(), receiver1)
-
-	receiver2 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "test")]
-	assert.Equal(t, wantReceiver2, receiver2)
-
-	receiver3 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "test2")]
-	assert.Equal(t, wantReceiver3, receiver3)
-
-	receiver4 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "end_to_end_test/1")]
-	assert.Equal(t, wantReceiver4, receiver4)
-
-	receiver5 := cfg.Receivers[config.NewComponentIDWithName(typeStr, "end_to_end_test/2")]
-	assert.Equal(t, wantReceiver5, receiver5)
 }

--- a/receiver/prometheusexecreceiver/factory_test.go
+++ b/receiver/prometheusexecreceiver/factory_test.go
@@ -23,10 +23,11 @@ import (
 	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/service/servicetest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver/subprocessmanager"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
@@ -38,40 +39,41 @@ func TestCreateTraceAndMetricsReceiver(t *testing.T) {
 		metricReceiver component.MetricsReceiver
 	)
 
-	factories, err := componenttest.NopFactories()
-	assert.NoError(t, err)
-
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
 	factory := NewFactory()
-	factories.Receivers[typeStr] = factory
+	cfg := factory.CreateDefaultConfig()
 
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
+	sub, err := cm.Sub(config.NewComponentIDWithName(typeStr, "").String())
+	require.NoError(t, err)
+	require.NoError(t, config.UnmarshalReceiver(sub, cfg))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg)
 
-	receiver := cfg.Receivers[config.NewComponentID(typeStr)]
-
 	// Test CreateTracesReceiver
-	traceReceiver, err = factory.CreateTracesReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), receiver, nil)
+	traceReceiver, err = factory.CreateTracesReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, nil)
 
 	assert.Equal(t, nil, traceReceiver)
 	assert.ErrorIs(t, err, component.ErrDataTypeIsNotSupported)
 
 	// Test CreateMetricsReceiver error because of lack of command
-	_, err = factory.CreateMetricsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), receiver, nil)
+	_, err = factory.CreateMetricsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, nil)
 	assert.NotNil(t, err)
 
 	// Test CreateMetricsReceiver
-	receiver = cfg.Receivers[config.NewComponentIDWithName(typeStr, "test")]
-	metricReceiver, err = factory.CreateMetricsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), receiver, nil)
+	sub, err = cm.Sub(config.NewComponentIDWithName(typeStr, "test").String())
+	require.NoError(t, err)
+	require.NoError(t, config.UnmarshalReceiver(sub, cfg))
+	metricReceiver, err = factory.CreateMetricsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, nil)
 	assert.Equal(t, nil, err)
 
 	wantPer := &prometheusExecReceiver{
 		params:   componenttest.NewNopReceiverCreateSettings(),
-		config:   receiver.(*Config),
+		config:   cfg.(*Config),
 		consumer: nil,
 		promReceiverConfig: &prometheusreceiver.Config{
-			ReceiverSettings: config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "test")),
+			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			PrometheusConfig: &promconfig.Config{
 				ScrapeConfigs: []*promconfig.ScrapeConfig{
 					{
@@ -79,7 +81,7 @@ func TestCreateTraceAndMetricsReceiver(t *testing.T) {
 						ScrapeTimeout:   model.Duration(defaultTimeoutInterval),
 						Scheme:          "http",
 						MetricsPath:     "/metrics",
-						JobName:         "test",
+						JobName:         typeStr,
 						HonorLabels:     false,
 						HonorTimestamps: true,
 						ServiceDiscoveryConfigs: discovery.Configs{

--- a/receiver/prometheusexecreceiver/testdata/config.yaml
+++ b/receiver/prometheusexecreceiver/testdata/config.yaml
@@ -1,37 +1,23 @@
-receivers:
-  prometheus_exec:
-  prometheus_exec/test:
-    exec: mysqld_exporter
-    port: 9104
-    scrape_timeout: 10s
-  prometheus_exec/test2:
-    exec: postgres_exporter
-    scrape_interval: 90s
-    scrape_timeout: 10s
-  prometheus_exec/end_to_end_test/1:
-    exec: go run ./testdata/end_to_end_metrics_test/test_prometheus_exporter.go {{port}}
-    port: 9999
-    scrape_interval: 1s
-    scrape_timeout: 1s
-    env: 
-      - name: "DATA_SOURCE_NAME"
-        value: user:password@(hostname:port)/dbname
-      - name: SECONDARY_PORT
-        value: "1234"
-  prometheus_exec/end_to_end_test/2:
-    exec: go run ./testdata/end_to_end_metrics_test/test_prometheus_exporter.go {{port}}
-    scrape_interval: 1s
-    scrape_timeout: 1s
-
-processors:
-  nop:
-
-exporters:
-  nop:
-
-service:
-  pipelines:
-    metrics:
-      receivers: [prometheus_exec, prometheus_exec/test, prometheus_exec/end_to_end_test/1, prometheus_exec/end_to_end_test/2]
-      processors: [nop]
-      exporters: [nop]
+prometheus_exec:
+prometheus_exec/test:
+  exec: mysqld_exporter
+  port: 9104
+  scrape_timeout: 10s
+prometheus_exec/test2:
+  exec: postgres_exporter
+  scrape_interval: 90s
+  scrape_timeout: 10s
+prometheus_exec/end_to_end_test/1:
+  exec: go run ./testdata/end_to_end_metrics_test/test_prometheus_exporter.go {{port}}
+  port: 9999
+  scrape_interval: 1s
+  scrape_timeout: 1s
+  env:
+    - name: "DATA_SOURCE_NAME"
+      value: user:password@(hostname:port)/dbname
+    - name: SECONDARY_PORT
+      value: "1234"
+prometheus_exec/end_to_end_test/2:
+  exec: go run ./testdata/end_to_end_metrics_test/test_prometheus_exporter.go {{port}}
+  scrape_interval: 1s
+  scrape_timeout: 1s


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Change receivers config tests to unmarshal config only for that component.
Part 1 - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13383

- [x] hostmetricsreceiver
- [x] iisreceiver
- [x] influxdbreceiver
- [x] jmxreceiver
- [x] journaldreceiver
- [x] k8sclusterreceiver
- [x] k8seventsreceiver
- [x] kafkametricsreceiver
- [x] kafkareceiver
- [x] kubeletstatsreceiver
- [x] prometheusexecreceive

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13224
