### PR TITLE
[pkg/ottl] Use generics to avoid context cast in getters and funcs

### DIFF
--- a/pkg/ottl/boolean_value_test.go
+++ b/pkg/ottl/boolean_value_test.go
@@ -85,45 +85,43 @@ func Test_newComparisonEvaluator(t *testing.T) {
 		componenttest.NewNopTelemetrySettings(),
 	)
 
-	tests := []struct {
+	var tests = []struct {
 		name string
 		l    any
 		r    any
 		op   string
-		item interface{}
+		item string
 		want bool
 	}{
-		{"literals match", "hello", "hello", "==", nil, true},
-		{"literals don't match", "hello", "goodbye", "!=", nil, true},
-		{"path expression matches", "NAME", "bear", "==", "bear", true},
-		{"path expression not matches", "NAME", "cat", "!=", "bear", true},
-		{"compare Enum to int", "TEST_ENUM", int(0), "==", nil, true},
-		{"compare int to Enum", int(2), "TEST_ENUM_TWO", "==", nil, true},
-		{"2 > Enum 0", int(2), "TEST_ENUM", ">", nil, true},
-		{"not 2 < Enum 0", int(2), "TEST_ENUM", "<", nil, false},
-		{"not 6 == 3.14", 6, 3.14, "==", nil, false},
-		{"6 != 3.14", 6, 3.14, "!=", nil, true},
-		{"6 > 3.14", 6, 3.14, ">", nil, true},
-		{"6 >= 3.14", 6, 3.14, ">=", nil, true},
-		{"not 6 < 3.14", 6, 3.14, "<", nil, false},
-		{"not 6 <= 3.14", 6, 3.14, "<=", nil, false},
-		{"'foo' > 'bar'", "foo", "bar", ">", nil, true},
-		{"'foo' > bear", "foo", "NAME", ">", "bear", true},
-		{"true > false", true, false, ">", nil, true},
-		{"not true > 0", true, 0, ">", nil, false},
-		{"not 'true' == true", "true", true, "==", nil, false},
-		{"[]byte('a') < []byte('b')", []byte("a"), []byte("b"), "<", nil, true},
-		{"nil == nil", nil, nil, "==", nil, true},
-		{"nil == []byte(nil)", nil, []byte(nil), "==", nil, true},
+		{name: "literals match", l: "hello", r: "hello", op: "==", want: true},
+		{name: "literals don't match", l: "hello", r: "goodbye", op: "!=", want: true},
+		{name: "path expression matches", l: "NAME", r: "bear", op: "==", item: "bear", want: true},
+		{name: "path expression not matches", l: "NAME", r: "cat", op: "!=", item: "bear", want: true},
+		{name: "compare Enum to int", l: "TEST_ENUM", r: 0, op: "==", want: true},
+		{name: "compare int to Enum", l: 2, r: "TEST_ENUM_TWO", op: "==", want: true},
+		{name: "2 > Enum 0", l: 2, r: "TEST_ENUM", op: ">", want: true},
+		{name: "not 2 < Enum 0", l: 2, r: "TEST_ENUM", op: "<"},
+		{name: "not 6 == 3.14", l: 6, r: 3.14, op: "=="},
+		{name: "6 != 3.14", l: 6, r: 3.14, op: "!=", want: true},
+		{name: "6 > 3.14", l: 6, r: 3.14, op: ">", want: true},
+		{name: "6 >= 3.14", l: 6, r: 3.14, op: ">=", want: true},
+		{name: "not 6 < 3.14", l: 6, r: 3.14, op: "<"},
+		{name: "not 6 <= 3.14", l: 6, r: 3.14, op: "<="},
+		{name: "'foo' > 'bar'", l: "foo", r: "bar", op: ">", want: true},
+		{name: "'foo' > bear", l: "foo", r: "NAME", op: ">", item: "bear", want: true},
+		{name: "true > false", l: true, r: false, op: ">", want: true},
+		{name: "not true > 0", l: true, r: 0, op: ">"},
+		{name: "not 'true' == true", l: "true", r: true, op: "=="},
+		{name: "[]byte('a') < []byte('b')", l: []byte("a"), r: []byte("b"), op: "<", want: true},
+		{name: "nil == nil", op: "==", want: true},
+		{name: "nil == []byte(nil)", r: []byte(nil), op: "==", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			comp := comparison(tt.l, tt.r, tt.op)
 			evaluate, err := p.newComparisonEvaluator(comp)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want, evaluate(ottltest.TestTransformContext{
-				Item: tt.item,
-			}))
+			assert.Equal(t, tt.want, evaluate(tt.item))
 		})
 	}
 }
@@ -353,9 +351,7 @@ func Test_newBooleanExpressionEvaluator(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluate, err := p.newBooleanExpressionEvaluator(tt.expr)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want, evaluate(ottltest.TestTransformContext{
-				Item: nil,
-			}))
+			assert.Equal(t, tt.want, evaluate(nil))
 		})
 	}
 }

--- a/pkg/ottl/compare.go
+++ b/pkg/ottl/compare.go
@@ -28,7 +28,7 @@ import (
 // invalidComparison returns false for everything except NE (where it returns true to indicate that the
 // objects were definitely not equivalent).
 // It also gives us an opportunity to log something.
-func (p *Parser) invalidComparison(msg string, op CompareOp) bool {
+func (p *Parser[K]) invalidComparison(msg string, op CompareOp) bool {
 	p.telemetrySettings.Logger.Debug(msg, zap.Any("op", op))
 	return op == NE
 }
@@ -92,7 +92,7 @@ func compareBytes(a []byte, b []byte, op CompareOp) bool {
 	}
 }
 
-func (p *Parser) compareBool(a bool, b any, op CompareOp) bool {
+func (p *Parser[K]) compareBool(a bool, b any, op CompareOp) bool {
 	switch v := b.(type) {
 	case bool:
 		return compareBools(a, v, op)
@@ -101,7 +101,7 @@ func (p *Parser) compareBool(a bool, b any, op CompareOp) bool {
 	}
 }
 
-func (p *Parser) compareString(a string, b any, op CompareOp) bool {
+func (p *Parser[K]) compareString(a string, b any, op CompareOp) bool {
 	switch v := b.(type) {
 	case string:
 		return comparePrimitives(a, v, op)
@@ -110,7 +110,7 @@ func (p *Parser) compareString(a string, b any, op CompareOp) bool {
 	}
 }
 
-func (p *Parser) compareByte(a []byte, b any, op CompareOp) bool {
+func (p *Parser[K]) compareByte(a []byte, b any, op CompareOp) bool {
 	switch v := b.(type) {
 	case nil:
 		return op == NE
@@ -124,7 +124,7 @@ func (p *Parser) compareByte(a []byte, b any, op CompareOp) bool {
 	}
 }
 
-func (p *Parser) compareInt64(a int64, b any, op CompareOp) bool {
+func (p *Parser[K]) compareInt64(a int64, b any, op CompareOp) bool {
 	switch v := b.(type) {
 	case int64:
 		return comparePrimitives(a, v, op)
@@ -135,7 +135,7 @@ func (p *Parser) compareInt64(a int64, b any, op CompareOp) bool {
 	}
 }
 
-func (p *Parser) compareFloat64(a float64, b any, op CompareOp) bool {
+func (p *Parser[K]) compareFloat64(a float64, b any, op CompareOp) bool {
 	switch v := b.(type) {
 	case int64:
 		return comparePrimitives(a, float64(v), op)
@@ -148,7 +148,7 @@ func (p *Parser) compareFloat64(a float64, b any, op CompareOp) bool {
 
 // a and b are the return values from a Getter; we try to compare them
 // according to the given operator.
-func (p *Parser) compare(a any, b any, op CompareOp) bool {
+func (p *Parser[K]) compare(a any, b any, op CompareOp) bool {
 	// nils are equal to each other and never equal to anything else,
 	// so if they're both nil, report equality.
 	if a == nil && b == nil {

--- a/pkg/ottl/compare_test.go
+++ b/pkg/ottl/compare_test.go
@@ -116,7 +116,7 @@ func Test_compare(t *testing.T) {
 	for _, tt := range tests {
 		for _, op := range ops {
 			t.Run(fmt.Sprintf("%s %v", tt.name, op), func(t *testing.T) {
-				p := NewParser(nil, nil, nil, componenttest.NewNopTelemetrySettings())
+				p := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
 				if got := p.compare(tt.a, tt.b, op); got != tt.want[op] {
 					t.Errorf("compare(%v, %v, %v) = %v, want %v", tt.a, tt.b, op, got, tt.want[op])
 				}
@@ -125,70 +125,113 @@ func Test_compare(t *testing.T) {
 	}
 }
 
-var testParser = NewParser(nil, nil, nil, componenttest.NewNopTelemetrySettings())
-
 // Benchmarks -- these benchmarks compare the performance of comparisons of a variety of data types.
 // It's not attempting to be exhaustive, but again, it hits most of the major types and combinations.
 // The summary is that they're pretty fast; all the calls to compare are 12 ns/op or less on a 2019 intel
 // mac pro laptop, and none of them have any allocations.
 func BenchmarkCompareEQInt64(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(i64a, i64b, EQ)
 	}
 }
 
 func BenchmarkCompareEQFloat(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(f64a, f64b, EQ)
 	}
 }
+
 func BenchmarkCompareEQString(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(sa, sb, EQ)
 	}
 }
+
 func BenchmarkCompareEQPString(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(&sa, &sb, EQ)
 	}
 }
+
 func BenchmarkCompareEQBytes(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(ba, bb, EQ)
 	}
 }
+
 func BenchmarkCompareEQNil(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(nil, nil, EQ)
 	}
 }
+
 func BenchmarkCompareNEInt(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(i64a, i64b, NE)
 	}
 }
 
 func BenchmarkCompareNEFloat(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(f64a, f64b, NE)
 	}
 }
+
 func BenchmarkCompareNEString(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(sa, sb, NE)
 	}
 }
+
 func BenchmarkCompareLTFloat(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(f64a, f64b, LT)
 	}
 }
+
 func BenchmarkCompareLTString(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(sa, sb, LT)
 	}
 }
+
 func BenchmarkCompareLTNil(b *testing.B) {
+	testParser := NewParser[interface{}](nil, nil, nil, componenttest.NewNopTelemetrySettings())
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testParser.compare(nil, nil, LT)
 	}

--- a/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
@@ -230,7 +230,7 @@ func TestResourcePathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := ResourcePathGetSetter(tt.path)
+			accessor, err := ResourcePathGetSetter[*resourceContext](tt.path)
 			assert.NoError(t, err)
 
 			resource := createResource()
@@ -289,18 +289,10 @@ type resourceContext struct {
 	resource pcommon.Resource
 }
 
-func (r *resourceContext) GetItem() interface{} {
-	return nil
-}
-
-func (r *resourceContext) GetInstrumentationScope() pcommon.InstrumentationScope {
-	return pcommon.InstrumentationScope{}
-}
-
 func (r *resourceContext) GetResource() pcommon.Resource {
 	return r.resource
 }
 
-func newResourceContext(resource pcommon.Resource) ottl.TransformContext {
+func newResourceContext(resource pcommon.Resource) *resourceContext {
 	return &resourceContext{resource: resource}
 }

--- a/pkg/ottl/contexts/internal/ottlcommon/scope.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope.go
@@ -22,33 +22,37 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func ScopePathGetSetter(path []ottl.Field) (ottl.GetSetter, error) {
+type InstrumentationScopeContext interface {
+	GetInstrumentationScope() pcommon.InstrumentationScope
+}
+
+func ScopePathGetSetter[K InstrumentationScopeContext](path []ottl.Field) (ottl.GetSetter[K], error) {
 	if len(path) == 0 {
-		return accessInstrumentationScope(), nil
+		return accessInstrumentationScope[K](), nil
 	}
 
 	switch path[0].Name {
 	case "name":
-		return accessInstrumentationScopeName(), nil
+		return accessInstrumentationScopeName[K](), nil
 	case "version":
-		return accessInstrumentationScopeVersion(), nil
+		return accessInstrumentationScopeVersion[K](), nil
 	case "attributes":
 		mapKey := path[0].MapKey
 		if mapKey == nil {
-			return accessInstrumentationScopeAttributes(), nil
+			return accessInstrumentationScopeAttributes[K](), nil
 		}
-		return accessInstrumentationScopeAttributesKey(mapKey), nil
+		return accessInstrumentationScopeAttributesKey[K](mapKey), nil
 	}
 
 	return nil, fmt.Errorf("invalid scope path expression %v", path)
 }
 
-func accessInstrumentationScope() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
+func accessInstrumentationScope[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx K) interface{} {
 			return ctx.GetInstrumentationScope()
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx K, val interface{}) {
 			if newIl, ok := val.(pcommon.InstrumentationScope); ok {
 				newIl.CopyTo(ctx.GetInstrumentationScope())
 			}
@@ -56,12 +60,12 @@ func accessInstrumentationScope() ottl.StandardGetSetter {
 	}
 }
 
-func accessInstrumentationScopeAttributes() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
+func accessInstrumentationScopeAttributes[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx K) interface{} {
 			return ctx.GetInstrumentationScope().Attributes()
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx K, val interface{}) {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(ctx.GetInstrumentationScope().Attributes())
 			}
@@ -69,23 +73,23 @@ func accessInstrumentationScopeAttributes() ottl.StandardGetSetter {
 	}
 }
 
-func accessInstrumentationScopeAttributesKey(mapKey *string) ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
+func accessInstrumentationScopeAttributesKey[K InstrumentationScopeContext](mapKey *string) ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx K) interface{} {
 			return GetMapValue(ctx.GetInstrumentationScope().Attributes(), *mapKey)
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx K, val interface{}) {
 			SetMapValue(ctx.GetInstrumentationScope().Attributes(), *mapKey, val)
 		},
 	}
 }
 
-func accessInstrumentationScopeName() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
+func accessInstrumentationScopeName[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx K) interface{} {
 			return ctx.GetInstrumentationScope().Name()
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx K, val interface{}) {
 			if str, ok := val.(string); ok {
 				ctx.GetInstrumentationScope().SetName(str)
 			}
@@ -93,12 +97,12 @@ func accessInstrumentationScopeName() ottl.StandardGetSetter {
 	}
 }
 
-func accessInstrumentationScopeVersion() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
+func accessInstrumentationScopeVersion[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx K) interface{} {
 			return ctx.GetInstrumentationScope().Version()
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx K, val interface{}) {
 			if str, ok := val.(string); ok {
 				ctx.GetInstrumentationScope().SetVersion(str)
 			}

--- a/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
@@ -247,7 +247,7 @@ func TestScopePathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := ScopePathGetSetter(tt.path)
+			accessor, err := ScopePathGetSetter[*instrumentationScopeContext](tt.path)
 			assert.NoError(t, err)
 
 			is := createInstrumentationScope()
@@ -303,18 +303,10 @@ type instrumentationScopeContext struct {
 	is pcommon.InstrumentationScope
 }
 
-func (r *instrumentationScopeContext) GetItem() interface{} {
-	return nil
-}
-
 func (r *instrumentationScopeContext) GetInstrumentationScope() pcommon.InstrumentationScope {
 	return r.is
 }
 
-func (r *instrumentationScopeContext) GetResource() pcommon.Resource {
-	return pcommon.Resource{}
-}
-
-func newInstrumentationScopeContext(is pcommon.InstrumentationScope) ottl.TransformContext {
+func newInstrumentationScopeContext(is pcommon.InstrumentationScope) *instrumentationScopeContext {
 	return &instrumentationScopeContext{is: is}
 }

--- a/pkg/ottl/contexts/ottldatapoints/datapoints.go
+++ b/pkg/ottl/contexts/ottldatapoints/datapoints.go
@@ -26,6 +26,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
 )
 
+var _ ottlcommon.ResourceContext = TransformContext{}
+var _ ottlcommon.InstrumentationScopeContext = TransformContext{}
+
 type TransformContext struct {
 	dataPoint            interface{}
 	metric               pmetric.Metric
@@ -44,7 +47,7 @@ func NewTransformContext(dataPoint interface{}, metric pmetric.Metric, metrics p
 	}
 }
 
-func (ctx TransformContext) GetItem() interface{} {
+func (ctx TransformContext) GetDataPoint() interface{} {
 	return ctx.dataPoint
 }
 
@@ -88,19 +91,19 @@ func ParseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, fmt.Errorf("enum symbol not provided")
 }
 
-func ParsePath(val *ottl.Path) (ottl.GetSetter, error) {
+func ParsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
 	if val != nil && len(val.Fields) > 0 {
 		return newPathGetSetter(val.Fields)
 	}
 	return nil, fmt.Errorf("bad path %v", val)
 }
 
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter, error) {
+func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
 	switch path[0].Name {
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter(path[1:])
+		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter(path[1:])
+		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
 	case "metric":
 		if len(path) == 1 {
 			return accessMetric(), nil
@@ -175,74 +178,74 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter, error) {
 	return nil, fmt.Errorf("invalid path expression %v", path)
 }
 
-func accessMetric() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.(TransformContext).GetMetric()
+func accessMetric() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			return ctx.GetMetric()
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newMetric, ok := val.(pmetric.Metric); ok {
-				newMetric.CopyTo(ctx.(TransformContext).GetMetric())
+				newMetric.CopyTo(ctx.GetMetric())
 			}
 		},
 	}
 }
 
-func accessMetricName() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.(TransformContext).GetMetric().Name()
+func accessMetricName() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			return ctx.GetMetric().Name()
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if str, ok := val.(string); ok {
-				ctx.(TransformContext).GetMetric().SetName(str)
+				ctx.GetMetric().SetName(str)
 			}
 		},
 	}
 }
 
-func accessMetricDescription() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.(TransformContext).GetMetric().Description()
+func accessMetricDescription() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			return ctx.GetMetric().Description()
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if str, ok := val.(string); ok {
-				ctx.(TransformContext).GetMetric().SetDescription(str)
+				ctx.GetMetric().SetDescription(str)
 			}
 		},
 	}
 }
 
-func accessMetricUnit() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.(TransformContext).GetMetric().Unit()
+func accessMetricUnit() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			return ctx.GetMetric().Unit()
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if str, ok := val.(string); ok {
-				ctx.(TransformContext).GetMetric().SetUnit(str)
+				ctx.GetMetric().SetUnit(str)
 			}
 		},
 	}
 }
 
-func accessMetricType() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return int64(ctx.(TransformContext).GetMetric().Type())
+func accessMetricType() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			return int64(ctx.GetMetric().Type())
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			// TODO Implement methods so correctly convert data types.
 			// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10130
 		},
 	}
 }
 
-func accessMetricAggTemporality() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			metric := ctx.(TransformContext).GetMetric()
+func accessMetricAggTemporality() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			metric := ctx.GetMetric()
 			switch metric.Type() {
 			case pmetric.MetricTypeSum:
 				return int64(metric.Sum().AggregationTemporality())
@@ -253,9 +256,9 @@ func accessMetricAggTemporality() ottl.StandardGetSetter {
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newAggTemporality, ok := val.(int64); ok {
-				metric := ctx.(TransformContext).GetMetric()
+				metric := ctx.GetMetric()
 				switch metric.Type() {
 				case pmetric.MetricTypeSum:
 					metric.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporality(newAggTemporality))
@@ -269,19 +272,19 @@ func accessMetricAggTemporality() ottl.StandardGetSetter {
 	}
 }
 
-func accessMetricIsMonotonic() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			metric := ctx.(TransformContext).GetMetric()
+func accessMetricIsMonotonic() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			metric := ctx.GetMetric()
 			switch metric.Type() {
 			case pmetric.MetricTypeSum:
 				return metric.Sum().IsMonotonic()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newIsMonotonic, ok := val.(bool); ok {
-				metric := ctx.(TransformContext).GetMetric()
+				metric := ctx.GetMetric()
 				switch metric.Type() {
 				case pmetric.MetricTypeSum:
 					metric.Sum().SetIsMonotonic(newIsMonotonic)
@@ -291,508 +294,508 @@ func accessMetricIsMonotonic() ottl.StandardGetSetter {
 	}
 }
 
-func accessAttributes() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessAttributes() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetItem().(pmetric.NumberDataPoint).Attributes()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).Attributes()
 			case pmetric.HistogramDataPoint:
-				return ctx.GetItem().(pmetric.HistogramDataPoint).Attributes()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes()
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Attributes()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes()
 			case pmetric.SummaryDataPoint:
-				return ctx.GetItem().(pmetric.SummaryDataPoint).Attributes()
+				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
-			switch ctx.GetItem().(type) {
+		Setter: func(ctx TransformContext, val interface{}) {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
-					attrs.CopyTo(ctx.GetItem().(pmetric.NumberDataPoint).Attributes())
+					attrs.CopyTo(ctx.GetDataPoint().(pmetric.NumberDataPoint).Attributes())
 				}
 			case pmetric.HistogramDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
-					attrs.CopyTo(ctx.GetItem().(pmetric.HistogramDataPoint).Attributes())
+					attrs.CopyTo(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes())
 				}
 			case pmetric.ExponentialHistogramDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
-					attrs.CopyTo(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Attributes())
+					attrs.CopyTo(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes())
 				}
 			case pmetric.SummaryDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
-					attrs.CopyTo(ctx.GetItem().(pmetric.SummaryDataPoint).Attributes())
+					attrs.CopyTo(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes())
 				}
 			}
 		},
 	}
 }
 
-func accessAttributesKey(mapKey *string) ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessAttributesKey(mapKey *string) ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ottlcommon.GetMapValue(ctx.GetItem().(pmetric.NumberDataPoint).Attributes(), *mapKey)
+				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.NumberDataPoint).Attributes(), *mapKey)
 			case pmetric.HistogramDataPoint:
-				return ottlcommon.GetMapValue(ctx.GetItem().(pmetric.HistogramDataPoint).Attributes(), *mapKey)
+				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes(), *mapKey)
 			case pmetric.ExponentialHistogramDataPoint:
-				return ottlcommon.GetMapValue(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Attributes(), *mapKey)
+				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes(), *mapKey)
 			case pmetric.SummaryDataPoint:
-				return ottlcommon.GetMapValue(ctx.GetItem().(pmetric.SummaryDataPoint).Attributes(), *mapKey)
+				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes(), *mapKey)
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
-			switch ctx.GetItem().(type) {
+		Setter: func(ctx TransformContext, val interface{}) {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				ottlcommon.SetMapValue(ctx.GetItem().(pmetric.NumberDataPoint).Attributes(), *mapKey, val)
+				ottlcommon.SetMapValue(ctx.GetDataPoint().(pmetric.NumberDataPoint).Attributes(), *mapKey, val)
 			case pmetric.HistogramDataPoint:
-				ottlcommon.SetMapValue(ctx.GetItem().(pmetric.HistogramDataPoint).Attributes(), *mapKey, val)
+				ottlcommon.SetMapValue(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes(), *mapKey, val)
 			case pmetric.ExponentialHistogramDataPoint:
-				ottlcommon.SetMapValue(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Attributes(), *mapKey, val)
+				ottlcommon.SetMapValue(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes(), *mapKey, val)
 			case pmetric.SummaryDataPoint:
-				ottlcommon.SetMapValue(ctx.GetItem().(pmetric.SummaryDataPoint).Attributes(), *mapKey, val)
+				ottlcommon.SetMapValue(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes(), *mapKey, val)
 			}
 		},
 	}
 }
 
-func accessStartTimeUnixNano() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessStartTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetItem().(pmetric.NumberDataPoint).StartTimestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).StartTimestamp().AsTime().UnixNano()
 			case pmetric.HistogramDataPoint:
-				return ctx.GetItem().(pmetric.HistogramDataPoint).StartTimestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).StartTimestamp().AsTime().UnixNano()
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).StartTimestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).StartTimestamp().AsTime().UnixNano()
 			case pmetric.SummaryDataPoint:
-				return ctx.GetItem().(pmetric.SummaryDataPoint).StartTimestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).StartTimestamp().AsTime().UnixNano()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newTime, ok := val.(int64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
-					ctx.GetItem().(pmetric.NumberDataPoint).SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+					ctx.GetDataPoint().(pmetric.NumberDataPoint).SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				case pmetric.HistogramDataPoint:
-					ctx.GetItem().(pmetric.HistogramDataPoint).SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+					ctx.GetDataPoint().(pmetric.HistogramDataPoint).SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				case pmetric.SummaryDataPoint:
-					ctx.GetItem().(pmetric.SummaryDataPoint).SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				}
 			}
 		},
 	}
 }
 
-func accessTimeUnixNano() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetItem().(pmetric.NumberDataPoint).Timestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).Timestamp().AsTime().UnixNano()
 			case pmetric.HistogramDataPoint:
-				return ctx.GetItem().(pmetric.HistogramDataPoint).Timestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Timestamp().AsTime().UnixNano()
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Timestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Timestamp().AsTime().UnixNano()
 			case pmetric.SummaryDataPoint:
-				return ctx.GetItem().(pmetric.SummaryDataPoint).Timestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).Timestamp().AsTime().UnixNano()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newTime, ok := val.(int64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
-					ctx.GetItem().(pmetric.NumberDataPoint).SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+					ctx.GetDataPoint().(pmetric.NumberDataPoint).SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				case pmetric.HistogramDataPoint:
-					ctx.GetItem().(pmetric.HistogramDataPoint).SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+					ctx.GetDataPoint().(pmetric.HistogramDataPoint).SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				case pmetric.SummaryDataPoint:
-					ctx.GetItem().(pmetric.SummaryDataPoint).SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				}
 			}
 		},
 	}
 }
 
-func accessDoubleValue() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessDoubleValue() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetItem().(pmetric.NumberDataPoint).DoubleValue()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).DoubleValue()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newDouble, ok := val.(float64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
-					ctx.GetItem().(pmetric.NumberDataPoint).SetDoubleValue(newDouble)
+					ctx.GetDataPoint().(pmetric.NumberDataPoint).SetDoubleValue(newDouble)
 				}
 			}
 		},
 	}
 }
 
-func accessIntValue() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessIntValue() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetItem().(pmetric.NumberDataPoint).IntValue()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).IntValue()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newInt, ok := val.(int64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
-					ctx.GetItem().(pmetric.NumberDataPoint).SetIntValue(newInt)
+					ctx.GetDataPoint().(pmetric.NumberDataPoint).SetIntValue(newInt)
 				}
 			}
 		},
 	}
 }
 
-func accessExemplars() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessExemplars() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetItem().(pmetric.NumberDataPoint).Exemplars()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).Exemplars()
 			case pmetric.HistogramDataPoint:
-				return ctx.GetItem().(pmetric.HistogramDataPoint).Exemplars()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Exemplars()
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Exemplars()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Exemplars()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newExemplars, ok := val.(pmetric.ExemplarSlice); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
-					newExemplars.CopyTo(ctx.GetItem().(pmetric.NumberDataPoint).Exemplars())
+					newExemplars.CopyTo(ctx.GetDataPoint().(pmetric.NumberDataPoint).Exemplars())
 				case pmetric.HistogramDataPoint:
-					newExemplars.CopyTo(ctx.GetItem().(pmetric.HistogramDataPoint).Exemplars())
+					newExemplars.CopyTo(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Exemplars())
 				case pmetric.ExponentialHistogramDataPoint:
-					newExemplars.CopyTo(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Exemplars())
+					newExemplars.CopyTo(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Exemplars())
 				}
 			}
 		},
 	}
 }
 
-func accessFlags() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessFlags() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return int64(ctx.GetItem().(pmetric.NumberDataPoint).Flags())
+				return int64(ctx.GetDataPoint().(pmetric.NumberDataPoint).Flags())
 			case pmetric.HistogramDataPoint:
-				return int64(ctx.GetItem().(pmetric.HistogramDataPoint).Flags())
+				return int64(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Flags())
 			case pmetric.ExponentialHistogramDataPoint:
-				return int64(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Flags())
+				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Flags())
 			case pmetric.SummaryDataPoint:
-				return int64(ctx.GetItem().(pmetric.SummaryDataPoint).Flags())
+				return int64(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Flags())
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newFlags, ok := val.(int64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
-					ctx.GetItem().(pmetric.NumberDataPoint).SetFlags(pmetric.MetricDataPointFlags(newFlags))
+					ctx.GetDataPoint().(pmetric.NumberDataPoint).SetFlags(pmetric.MetricDataPointFlags(newFlags))
 				case pmetric.HistogramDataPoint:
-					ctx.GetItem().(pmetric.HistogramDataPoint).SetFlags(pmetric.MetricDataPointFlags(newFlags))
+					ctx.GetDataPoint().(pmetric.HistogramDataPoint).SetFlags(pmetric.MetricDataPointFlags(newFlags))
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).SetFlags(pmetric.MetricDataPointFlags(newFlags))
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).SetFlags(pmetric.MetricDataPointFlags(newFlags))
 				case pmetric.SummaryDataPoint:
-					ctx.GetItem().(pmetric.SummaryDataPoint).SetFlags(pmetric.MetricDataPointFlags(newFlags))
+					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetFlags(pmetric.MetricDataPointFlags(newFlags))
 				}
 			}
 		},
 	}
 }
 
-func accessCount() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessCount() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.HistogramDataPoint:
-				return int64(ctx.GetItem().(pmetric.HistogramDataPoint).Count())
+				return int64(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Count())
 			case pmetric.ExponentialHistogramDataPoint:
-				return int64(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Count())
+				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Count())
 			case pmetric.SummaryDataPoint:
-				return int64(ctx.GetItem().(pmetric.SummaryDataPoint).Count())
+				return int64(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Count())
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newCount, ok := val.(int64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.HistogramDataPoint:
-					ctx.GetItem().(pmetric.HistogramDataPoint).SetCount(uint64(newCount))
+					ctx.GetDataPoint().(pmetric.HistogramDataPoint).SetCount(uint64(newCount))
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).SetCount(uint64(newCount))
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).SetCount(uint64(newCount))
 				case pmetric.SummaryDataPoint:
-					ctx.GetItem().(pmetric.SummaryDataPoint).SetCount(uint64(newCount))
+					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetCount(uint64(newCount))
 				}
 			}
 		},
 	}
 }
 
-func accessSum() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessSum() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.HistogramDataPoint:
-				return ctx.GetItem().(pmetric.HistogramDataPoint).Sum()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Sum()
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Sum()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Sum()
 			case pmetric.SummaryDataPoint:
-				return ctx.GetItem().(pmetric.SummaryDataPoint).Sum()
+				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).Sum()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newSum, ok := val.(float64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.HistogramDataPoint:
-					ctx.GetItem().(pmetric.HistogramDataPoint).SetSum(newSum)
+					ctx.GetDataPoint().(pmetric.HistogramDataPoint).SetSum(newSum)
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).SetSum(newSum)
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).SetSum(newSum)
 				case pmetric.SummaryDataPoint:
-					ctx.GetItem().(pmetric.SummaryDataPoint).SetSum(newSum)
+					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetSum(newSum)
 				}
 			}
 		},
 	}
 }
 
-func accessExplicitBounds() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessExplicitBounds() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.HistogramDataPoint:
-				return ctx.GetItem().(pmetric.HistogramDataPoint).ExplicitBounds().AsRaw()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).ExplicitBounds().AsRaw()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newExplicitBounds, ok := val.([]float64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.HistogramDataPoint:
-					ctx.GetItem().(pmetric.HistogramDataPoint).ExplicitBounds().FromRaw(newExplicitBounds)
+					ctx.GetDataPoint().(pmetric.HistogramDataPoint).ExplicitBounds().FromRaw(newExplicitBounds)
 				}
 			}
 		},
 	}
 }
 
-func accessBucketCounts() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessBucketCounts() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.HistogramDataPoint:
-				return ctx.GetItem().(pmetric.HistogramDataPoint).BucketCounts().AsRaw()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).BucketCounts().AsRaw()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newBucketCount, ok := val.([]uint64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.HistogramDataPoint:
-					ctx.GetItem().(pmetric.HistogramDataPoint).BucketCounts().FromRaw(newBucketCount)
+					ctx.GetDataPoint().(pmetric.HistogramDataPoint).BucketCounts().FromRaw(newBucketCount)
 				}
 			}
 		},
 	}
 }
 
-func accessScale() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessScale() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.ExponentialHistogramDataPoint:
-				return int64(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Scale())
+				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Scale())
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newScale, ok := val.(int64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).SetScale(int32(newScale))
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).SetScale(int32(newScale))
 				}
 			}
 		},
 	}
 }
 
-func accessZeroCount() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessZeroCount() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.ExponentialHistogramDataPoint:
-				return int64(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).ZeroCount())
+				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).ZeroCount())
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newZeroCount, ok := val.(int64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).SetZeroCount(uint64(newZeroCount))
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).SetZeroCount(uint64(newZeroCount))
 				}
 			}
 		},
 	}
 }
 
-func accessPositive() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessPositive() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Positive()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Positive()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newPositive, ok := val.(pmetric.Buckets); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.ExponentialHistogramDataPoint:
-					newPositive.CopyTo(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Positive())
+					newPositive.CopyTo(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Positive())
 				}
 			}
 		},
 	}
 }
 
-func accessPositiveOffset() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessPositiveOffset() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.ExponentialHistogramDataPoint:
-				return int64(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Positive().Offset())
+				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Positive().Offset())
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newPositiveOffset, ok := val.(int64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Positive().SetOffset(int32(newPositiveOffset))
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Positive().SetOffset(int32(newPositiveOffset))
 				}
 			}
 		},
 	}
 }
 
-func accessPositiveBucketCounts() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessPositiveBucketCounts() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Positive().BucketCounts().AsRaw()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Positive().BucketCounts().AsRaw()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newPositiveBucketCounts, ok := val.([]uint64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Positive().BucketCounts().FromRaw(newPositiveBucketCounts)
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Positive().BucketCounts().FromRaw(newPositiveBucketCounts)
 				}
 			}
 		},
 	}
 }
 
-func accessNegative() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessNegative() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Negative()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Negative()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newNegative, ok := val.(pmetric.Buckets); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.ExponentialHistogramDataPoint:
-					newNegative.CopyTo(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Negative())
+					newNegative.CopyTo(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Negative())
 				}
 			}
 		},
 	}
 }
 
-func accessNegativeOffset() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessNegativeOffset() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.ExponentialHistogramDataPoint:
-				return int64(ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Negative().Offset())
+				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Negative().Offset())
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newNegativeOffset, ok := val.(int64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Negative().SetOffset(int32(newNegativeOffset))
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Negative().SetOffset(int32(newNegativeOffset))
 				}
 			}
 		},
 	}
 }
 
-func accessNegativeBucketCounts() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessNegativeBucketCounts() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Negative().BucketCounts().AsRaw()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Negative().BucketCounts().AsRaw()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newNegativeBucketCounts, ok := val.([]uint64); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.ExponentialHistogramDataPoint:
-					ctx.GetItem().(pmetric.ExponentialHistogramDataPoint).Negative().BucketCounts().FromRaw(newNegativeBucketCounts)
+					ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Negative().BucketCounts().FromRaw(newNegativeBucketCounts)
 				}
 			}
 		},
 	}
 }
 
-func accessQuantileValues() ottl.StandardGetSetter {
-	return ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			switch ctx.GetItem().(type) {
+func accessQuantileValues() ottl.StandardGetSetter[TransformContext] {
+	return ottl.StandardGetSetter[TransformContext]{
+		Getter: func(ctx TransformContext) interface{} {
+			switch ctx.GetDataPoint().(type) {
 			case pmetric.SummaryDataPoint:
-				return ctx.GetItem().(pmetric.SummaryDataPoint).QuantileValues()
+				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).QuantileValues()
 			}
 			return nil
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) {
 			if newQuantileValues, ok := val.(pmetric.ValueAtQuantileSlice); ok {
-				switch ctx.GetItem().(type) {
+				switch ctx.GetDataPoint().(type) {
 				case pmetric.SummaryDataPoint:
-					newQuantileValues.CopyTo(ctx.GetItem().(pmetric.SummaryDataPoint).QuantileValues())
+					newQuantileValues.CopyTo(ctx.GetDataPoint().(pmetric.SummaryDataPoint).QuantileValues())
 				}
 			}
 		},

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -540,111 +540,111 @@ func Test_NewFunctionCall(t *testing.T) {
 	}
 }
 
-func functionWithStringSlice(_ []string) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithStringSlice(_ []string) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithFloatSlice(_ []float64) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithFloatSlice(_ []float64) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithIntSlice(_ []int64) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithIntSlice(_ []int64) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithByteSlice(_ []byte) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithByteSlice([]byte) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithGetterSlice(_ []Getter) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithGetterSlice([]Getter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithSetter(_ Setter) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithSetter(Setter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithGetSetter(_ GetSetter) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithGetSetter(GetSetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithGetter(_ Getter) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithGetter(Getter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithString(_ string) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithString(string) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithFloat(_ float64) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithFloat(float64) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithInt(_ int64) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithInt(int64) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithBool(_ bool) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithBool(bool) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithMultipleArgs(_ GetSetter, _ string, _ float64, _ int64, _ []string) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithMultipleArgs(GetSetter[interface{}], string, float64, int64, []string) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionThatHasAnError() (ExprFunc, error) {
+func functionThatHasAnError() (ExprFunc[interface{}], error) {
 	err := errors.New("testing")
-	return func(ctx TransformContext) interface{} {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, err
 }
 
-func functionWithEnum(_ Enum) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithEnum(_ Enum) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithTelemetrySettingsFirst(_ component.TelemetrySettings, _ string, _ string, _ int64) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithTelemetrySettingsFirst(_ component.TelemetrySettings, _ string, _ string, _ int64) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithTelemetrySettingsMiddle(_ string, _ string, _ component.TelemetrySettings, _ int64) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithTelemetrySettingsMiddle(_ string, _ string, _ component.TelemetrySettings, _ int64) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }
 
-func functionWithTelemetrySettingsLast(_ string, _ string, _ int64, _ component.TelemetrySettings) (ExprFunc, error) {
-	return func(ctx TransformContext) interface{} {
+func functionWithTelemetrySettingsLast(_ string, _ string, _ int64, _ component.TelemetrySettings) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
 		return "anything"
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_concat.go
+++ b/pkg/ottl/ottlfuncs/func_concat.go
@@ -21,8 +21,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func Concat(delimiter string, vals []ottl.Getter) (ottl.ExprFunc, error) {
-	return func(ctx ottl.TransformContext) interface{} {
+func Concat[K any](delimiter string, vals []ottl.Getter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx K) interface{} {
 		builder := strings.Builder{}
 		for i, rv := range vals {
 			switch val := rv.Get(ctx).(type) {

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -18,29 +18,29 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func Test_concat(t *testing.T) {
 	tests := []struct {
 		name      string
 		delimiter string
-		vals      []ottl.StandardGetSetter
+		vals      []ottl.StandardGetSetter[interface{}]
 		expected  string
 	}{
 		{
 			name:      "concat strings",
 			delimiter: " ",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "hello"
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "world"
 					},
 				},
@@ -50,19 +50,19 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "nil",
 			delimiter: "",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "hello"
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return nil
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "world"
 					},
 				},
@@ -72,14 +72,14 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "integers",
 			delimiter: "",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "hello"
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return int64(1)
 					},
 				},
@@ -89,14 +89,14 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "floats",
 			delimiter: "",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "hello"
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return 3.14159
 					},
 				},
@@ -106,14 +106,14 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "booleans",
 			delimiter: " ",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "hello"
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return true
 					},
 				},
@@ -123,9 +123,9 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "byte slices",
 			delimiter: "",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8}
 					},
 				},
@@ -135,9 +135,9 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "non-byte slices",
 			delimiter: "",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
 					},
 				},
@@ -147,9 +147,9 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "maps",
 			delimiter: "",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return map[string]string{"key": "value"}
 					},
 				},
@@ -159,19 +159,19 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "unprintable value in the middle",
 			delimiter: "-",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "hello"
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return map[string]string{"key": "value"}
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "world"
 					},
 				},
@@ -181,19 +181,19 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "empty string values",
 			delimiter: "__",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return ""
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return ""
 					},
 				},
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return ""
 					},
 				},
@@ -203,9 +203,9 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "single argument",
 			delimiter: "-",
-			vals: []ottl.StandardGetSetter{
+			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx ottl.TransformContext) interface{} {
+					Getter: func(ctx interface{}) interface{} {
 						return "hello"
 					},
 				},
@@ -215,30 +215,27 @@ func Test_concat(t *testing.T) {
 		{
 			name:      "no arguments",
 			delimiter: "-",
-			vals:      []ottl.StandardGetSetter{},
+			vals:      []ottl.StandardGetSetter[interface{}]{},
 			expected:  "",
 		},
 		{
 			name:      "no arguments with an empty delimiter",
 			delimiter: "",
-			vals:      []ottl.StandardGetSetter{},
+			vals:      []ottl.StandardGetSetter[interface{}]{},
 			expected:  "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := ottltest.TestTransformContext{}
-
-			getters := make([]ottl.Getter, len(tt.vals))
+			getters := make([]ottl.Getter[interface{}], len(tt.vals))
 
 			for i, val := range tt.vals {
 				getters[i] = val
 			}
 
-			exprFunc, _ := Concat(tt.delimiter, getters)
-			actual := exprFunc(ctx)
-
-			assert.Equal(t, tt.expected, actual)
+			exprFunc, err := Concat(tt.delimiter, getters)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, exprFunc(nil))
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_delete_key.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key.go
@@ -20,8 +20,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func DeleteKey(target ottl.Getter, key string) (ottl.ExprFunc, error) {
-	return func(ctx ottl.TransformContext) interface{} {
+func DeleteKey[K any](target ottl.Getter[K], key string) (ottl.ExprFunc[K], error) {
+	return func(ctx K) interface{} {
 		val := target.Get(ctx)
 		if val == nil {
 			return nil

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -18,10 +18,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func Test_deleteKey(t *testing.T) {
@@ -30,15 +30,15 @@ func Test_deleteKey(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.GetItem()
+	target := &ottl.StandardGetSetter[pcommon.Map]{
+		Getter: func(ctx pcommon.Map) interface{} {
+			return ctx
 		},
 	}
 
 	tests := []struct {
 		name   string
-		target ottl.Getter
+		target ottl.Getter[pcommon.Map]
 		key    string
 		want   func(pcommon.Map)
 	}{
@@ -79,12 +79,9 @@ func Test_deleteKey(t *testing.T) {
 			scenarioMap := pcommon.NewMap()
 			input.CopyTo(scenarioMap)
 
-			ctx := ottltest.TestTransformContext{
-				Item: scenarioMap,
-			}
-
-			exprFunc, _ := DeleteKey(tt.target, tt.key)
-			exprFunc(ctx)
+			exprFunc, err := DeleteKey(tt.target, tt.key)
+			require.NoError(t, err)
+			exprFunc(scenarioMap)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -96,43 +93,36 @@ func Test_deleteKey(t *testing.T) {
 
 func Test_deleteKey_bad_input(t *testing.T) {
 	input := pcommon.NewValueString("not a map")
-	ctx := ottltest.TestTransformContext{
-		Item: input,
-	}
-
-	target := &ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.GetItem()
+	target := &ottl.StandardGetSetter[interface{}]{
+		Getter: func(ctx interface{}) interface{} {
+			return ctx
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) {
 			t.Errorf("nothing should be set in this scenario")
 		},
 	}
 
 	key := "anything"
 
-	exprFunc, _ := DeleteKey(target, key)
-	exprFunc(ctx)
-
+	exprFunc, err := DeleteKey[interface{}](target, key)
+	require.NoError(t, err)
+	assert.Nil(t, exprFunc(input))
 	assert.Equal(t, pcommon.NewValueString("not a map"), input)
 }
 
 func Test_deleteKey_get_nil(t *testing.T) {
-	ctx := ottltest.TestTransformContext{
-		Item: nil,
-	}
-
-	target := &ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.GetItem()
+	target := &ottl.StandardGetSetter[interface{}]{
+		Getter: func(ctx interface{}) interface{} {
+			return ctx
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) {
 			t.Errorf("nothing should be set in this scenario")
 		},
 	}
 
 	key := "anything"
 
-	exprFunc, _ := DeleteKey(target, key)
-	exprFunc(ctx)
+	exprFunc, err := DeleteKey[interface{}](target, key)
+	require.NoError(t, err)
+	assert.Nil(t, exprFunc(nil))
 }

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
@@ -23,12 +23,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func DeleteMatchingKeys(target ottl.Getter, pattern string) (ottl.ExprFunc, error) {
+func DeleteMatchingKeys[K any](target ottl.Getter[K], pattern string) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to delete_matching_keys is not a valid pattern: %w", err)
 	}
-	return func(ctx ottl.TransformContext) interface{} {
+	return func(ctx K) interface{} {
 		val := target.Get(ctx)
 		if val == nil {
 			return nil

--- a/pkg/ottl/ottlfuncs/func_int.go
+++ b/pkg/ottl/ottlfuncs/func_int.go
@@ -20,8 +20,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func Int(target ottl.Getter) (ottl.ExprFunc, error) {
-	return func(ctx ottl.TransformContext) interface{} {
+func Int[K any](target ottl.Getter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx K) interface{} {
 		value := target.Get(ctx)
 		switch value := value.(type) {
 		case int64:

--- a/pkg/ottl/ottlfuncs/func_int_test.go
+++ b/pkg/ottl/ottlfuncs/func_int_test.go
@@ -18,9 +18,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func Test_Int(t *testing.T) {
@@ -82,16 +82,13 @@ func Test_Int(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := ottltest.TestTransformContext{}
-
-			exprFunc, _ := Int(&ottl.StandardGetSetter{
-				Getter: func(_ ottl.TransformContext) interface{} {
+			exprFunc, err := Int[interface{}](&ottl.StandardGetSetter[interface{}]{
+				Getter: func(interface{}) interface{} {
 					return tt.value
 				},
 			})
-			actual := exprFunc(ctx)
-
-			assert.Equal(t, tt.expected, actual)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, exprFunc(nil))
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_is_match.go
+++ b/pkg/ottl/ottlfuncs/func_is_match.go
@@ -21,15 +21,15 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func IsMatch(target ottl.Getter, pattern string) (ottl.ExprFunc, error) {
-	regexp, err := regexp.Compile(pattern)
+func IsMatch[K any](target ottl.Getter[K], pattern string) (ottl.ExprFunc[K], error) {
+	compiledPattern, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to IsMatch is not a valid regexp pattern: %w", err)
 	}
-	return func(ctx ottl.TransformContext) interface{} {
+	return func(ctx K) interface{} {
 		if val := target.Get(ctx); val != nil {
 			if valStr, ok := val.(string); ok {
-				return regexp.MatchString(valStr)
+				return compiledPattern.MatchString(valStr)
 			}
 		}
 		return false

--- a/pkg/ottl/ottlfuncs/func_keep_keys.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys.go
@@ -20,13 +20,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func KeepKeys(target ottl.GetSetter, keys []string) (ottl.ExprFunc, error) {
+func KeepKeys[K any](target ottl.GetSetter[K], keys []string) (ottl.ExprFunc[K], error) {
 	keySet := make(map[string]struct{}, len(keys))
 	for _, key := range keys {
 		keySet[key] = struct{}{}
 	}
 
-	return func(ctx ottl.TransformContext) interface{} {
+	return func(ctx K) interface{} {
 		val := target.Get(ctx)
 		if val == nil {
 			return nil

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -18,10 +18,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func Test_keepKeys(t *testing.T) {
@@ -30,19 +30,19 @@ func Test_keepKeys(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.GetItem()
+	target := &ottl.StandardGetSetter[pcommon.Map]{
+		Getter: func(ctx pcommon.Map) interface{} {
+			return ctx
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
-			ctx.GetItem().(pcommon.Map).Clear()
-			val.(pcommon.Map).CopyTo(ctx.GetItem().(pcommon.Map))
+		Setter: func(ctx pcommon.Map, val interface{}) {
+			ctx.Clear()
+			val.(pcommon.Map).CopyTo(ctx)
 		},
 	}
 
 	tests := []struct {
 		name   string
-		target ottl.GetSetter
+		target ottl.GetSetter[pcommon.Map]
 		keys   []string
 		want   func(pcommon.Map)
 	}{
@@ -95,12 +95,9 @@ func Test_keepKeys(t *testing.T) {
 			scenarioMap := pcommon.NewMap()
 			input.CopyTo(scenarioMap)
 
-			ctx := ottltest.TestTransformContext{
-				Item: scenarioMap,
-			}
-
-			exprFunc, _ := KeepKeys(tt.target, tt.keys)
-			exprFunc(ctx)
+			exprFunc, err := KeepKeys(tt.target, tt.keys)
+			require.NoError(t, err)
+			exprFunc(scenarioMap)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -112,43 +109,37 @@ func Test_keepKeys(t *testing.T) {
 
 func Test_keepKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueString("not a map")
-	ctx := ottltest.TestTransformContext{
-		Item: input,
-	}
-
-	target := &ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.GetItem()
+	target := &ottl.StandardGetSetter[interface{}]{
+		Getter: func(ctx interface{}) interface{} {
+			return ctx
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) {
 			t.Errorf("nothing should be set in this scenario")
 		},
 	}
 
 	keys := []string{"anything"}
 
-	exprFunc, _ := KeepKeys(target, keys)
-	exprFunc(ctx)
+	exprFunc, err := KeepKeys[interface{}](target, keys)
+	require.NoError(t, err)
+	exprFunc(input)
 
 	assert.Equal(t, pcommon.NewValueString("not a map"), input)
 }
 
 func Test_keepKeys_get_nil(t *testing.T) {
-	ctx := ottltest.TestTransformContext{
-		Item: nil,
-	}
-
-	target := &ottl.StandardGetSetter{
-		Getter: func(ctx ottl.TransformContext) interface{} {
-			return ctx.GetItem()
+	target := &ottl.StandardGetSetter[interface{}]{
+		Getter: func(ctx interface{}) interface{} {
+			return ctx
 		},
-		Setter: func(ctx ottl.TransformContext, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) {
 			t.Errorf("nothing should be set in this scenario")
 		},
 	}
 
 	keys := []string{"anything"}
 
-	exprFunc, _ := KeepKeys(target, keys)
-	exprFunc(ctx)
+	exprFunc, err := KeepKeys[interface{}](target, keys)
+	require.NoError(t, err)
+	assert.Nil(t, exprFunc(nil))
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -23,27 +23,29 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func ReplaceAllMatches(target ottl.GetSetter, pattern string, replacement string) (ottl.ExprFunc, error) {
+func ReplaceAllMatches[K any](target ottl.GetSetter[K], pattern string, replacement string) (ottl.ExprFunc[K], error) {
 	glob, err := glob.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
-	return func(ctx ottl.TransformContext) interface{} {
+	return func(ctx K) interface{} {
 		val := target.Get(ctx)
 		if val == nil {
 			return nil
 		}
-		if attrs, ok := val.(pcommon.Map); ok {
-			updated := pcommon.NewMap()
-			attrs.CopyTo(updated)
-			updated.Range(func(key string, value pcommon.Value) bool {
-				if glob.Match(value.Str()) {
-					value.SetStr(replacement)
-				}
-				return true
-			})
-			target.Set(ctx, updated)
+		attrs, ok := val.(pcommon.Map)
+		if !ok {
+			return nil
 		}
+		updated := pcommon.NewMap()
+		attrs.CopyTo(updated)
+		updated.Range(func(key string, value pcommon.Value) bool {
+			if glob.Match(value.Str()) {
+				value.SetStr(replacement)
+			}
+			return true
+		})
+		target.Set(ctx, updated)
 		return nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_match.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match.go
@@ -22,12 +22,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func ReplaceMatch(target ottl.GetSetter, pattern string, replacement string) (ottl.ExprFunc, error) {
+func ReplaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement string) (ottl.ExprFunc[K], error) {
 	glob, err := glob.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
-	return func(ctx ottl.TransformContext) interface{} {
+	return func(ctx K) interface{} {
 		val := target.Get(ctx)
 		if val == nil {
 			return nil

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -21,12 +21,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func ReplacePattern(target ottl.GetSetter, regexPattern string, replacement string) (ottl.ExprFunc, error) {
+func ReplacePattern[K any](target ottl.GetSetter[K], regexPattern string, replacement string) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(regexPattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to replace_pattern is not a valid pattern: %w", err)
 	}
-	return func(ctx ottl.TransformContext) interface{} {
+	return func(ctx K) interface{} {
 		originalVal := target.Get(ctx)
 		if originalVal == nil {
 			return nil

--- a/pkg/ottl/ottlfuncs/func_set.go
+++ b/pkg/ottl/ottlfuncs/func_set.go
@@ -16,8 +16,8 @@ package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-c
 
 import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 
-func Set(target ottl.Setter, value ottl.Getter) (ottl.ExprFunc, error) {
-	return func(ctx ottl.TransformContext) interface{} {
+func Set[K any](target ottl.Setter[K], value ottl.Getter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx K) interface{} {
 		val := value.Get(ctx)
 
 		// No fields currently support `null` as a valid type.

--- a/pkg/ottl/ottlfuncs/func_span_id.go
+++ b/pkg/ottl/ottlfuncs/func_span_id.go
@@ -22,14 +22,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func SpanID(bytes []byte) (ottl.ExprFunc, error) {
+func SpanID[K any](bytes []byte) (ottl.ExprFunc[K], error) {
 	if len(bytes) != 8 {
 		return nil, errors.New("span ids must be 8 bytes")
 	}
 	var idArr [8]byte
 	copy(idArr[:8], bytes)
 	id := pcommon.SpanID(idArr)
-	return func(ctx ottl.TransformContext) interface{} {
+	return func(K) interface{} {
 		return id
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_span_id_test.go
+++ b/pkg/ottl/ottlfuncs/func_span_id_test.go
@@ -18,9 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func Test_spanID(t *testing.T) {
@@ -37,13 +36,9 @@ func Test_spanID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			ctx := ottltest.TestTransformContext{}
-
-			exprFunc, _ := SpanID(tt.bytes)
-			actual := exprFunc(ctx)
-
-			assert.Equal(t, tt.want, actual)
+			exprFunc, err := SpanID[interface{}](tt.bytes)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, exprFunc(nil))
 		})
 	}
 }
@@ -64,8 +59,9 @@ func Test_spanID_validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := TraceID(tt.bytes)
-			assert.Error(t, err, "span ids must be 8 bytes")
+			_, err := SpanID[interface{}](tt.bytes)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "span ids must be 8 bytes")
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_split.go
+++ b/pkg/ottl/ottlfuncs/func_split.go
@@ -20,8 +20,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func Split(target ottl.Getter, delimiter string) (ottl.ExprFunc, error) {
-	return func(ctx ottl.TransformContext) interface{} {
+func Split[K any](target ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], error) {
+	return func(ctx K) interface{} {
 		if val := target.Get(ctx); val != nil {
 			if valStr, ok := val.(string); ok {
 				return strings.Split(valStr, delimiter)

--- a/pkg/ottl/ottlfuncs/func_split_test.go
+++ b/pkg/ottl/ottlfuncs/func_split_test.go
@@ -18,22 +18,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func Test_split(t *testing.T) {
 	tests := []struct {
 		name      string
-		target    ottl.Getter
+		target    ottl.Getter[interface{}]
 		delimiter string
 		expected  interface{}
 	}{
 		{
 			name: "split string",
-			target: &ottl.StandardGetSetter{
-				Getter: func(ctx ottl.TransformContext) interface{} {
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx interface{}) interface{} {
 					return "A|B|C"
 				},
 			},
@@ -42,8 +42,8 @@ func Test_split(t *testing.T) {
 		},
 		{
 			name: "split empty string",
-			target: &ottl.StandardGetSetter{
-				Getter: func(ctx ottl.TransformContext) interface{} {
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx interface{}) interface{} {
 					return ""
 				},
 			},
@@ -52,8 +52,8 @@ func Test_split(t *testing.T) {
 		},
 		{
 			name: "split empty delimiter",
-			target: &ottl.StandardGetSetter{
-				Getter: func(ctx ottl.TransformContext) interface{} {
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx interface{}) interface{} {
 					return "A|B|C"
 				},
 			},
@@ -62,8 +62,8 @@ func Test_split(t *testing.T) {
 		},
 		{
 			name: "split empty string and empty delimiter",
-			target: &ottl.StandardGetSetter{
-				Getter: func(ctx ottl.TransformContext) interface{} {
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx interface{}) interface{} {
 					return ""
 				},
 			},
@@ -72,8 +72,8 @@ func Test_split(t *testing.T) {
 		},
 		{
 			name: "split non-string",
-			target: &ottl.StandardGetSetter{
-				Getter: func(ctx ottl.TransformContext) interface{} {
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx interface{}) interface{} {
 					return 123
 				},
 			},
@@ -83,12 +83,9 @@ func Test_split(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := ottltest.TestTransformContext{}
-
-			exprFunc, _ := Split(tt.target, tt.delimiter)
-			actual := exprFunc(ctx)
-
-			assert.Equal(t, tt.expected, actual)
+			exprFunc, err := Split(tt.target, tt.delimiter)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, exprFunc(nil))
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_trace_id.go
+++ b/pkg/ottl/ottlfuncs/func_trace_id.go
@@ -22,14 +22,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func TraceID(bytes []byte) (ottl.ExprFunc, error) {
+func TraceID[K any](bytes []byte) (ottl.ExprFunc[K], error) {
 	if len(bytes) != 16 {
 		return nil, errors.New("traces ids must be 16 bytes")
 	}
 	var idArr [16]byte
 	copy(idArr[:16], bytes)
 	id := pcommon.TraceID(idArr)
-	return func(ctx ottl.TransformContext) interface{} {
+	return func(K) interface{} {
 		return id
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_trace_id_test.go
+++ b/pkg/ottl/ottlfuncs/func_trace_id_test.go
@@ -18,9 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func Test_traceID(t *testing.T) {
@@ -37,13 +36,9 @@ func Test_traceID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			ctx := ottltest.TestTransformContext{}
-
-			exprFunc, _ := TraceID(tt.bytes)
-			actual := exprFunc(ctx)
-
-			assert.Equal(t, tt.want, actual)
+			exprFunc, err := TraceID[interface{}](tt.bytes)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, exprFunc(nil))
 		})
 	}
 }
@@ -64,8 +59,9 @@ func Test_traceID_validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := TraceID(tt.bytes)
-			assert.Error(t, err, "traces ids must be 16 bytes")
+			_, err := TraceID[interface{}](tt.bytes)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "traces ids must be 16 bytes")
 		})
 	}
 }

--- a/pkg/ottl/ottltest/ottltest.go
+++ b/pkg/ottl/ottltest/ottltest.go
@@ -14,10 +14,6 @@
 
 package ottltest // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 
-import (
-	"go.opentelemetry.io/collector/pdata/pcommon"
-)
-
 func Strp(s string) *string {
 	return &s
 }
@@ -32,20 +28,4 @@ func Intp(i int64) *int64 {
 
 func Boolp(b bool) *bool {
 	return &b
-}
-
-type TestTransformContext struct {
-	Item interface{}
-}
-
-func (ctx TestTransformContext) GetItem() interface{} {
-	return ctx.Item
-}
-
-func (ctx TestTransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
-	return pcommon.InstrumentationScope{}
-}
-
-func (ctx TestTransformContext) GetResource() pcommon.Resource {
-	return pcommon.Resource{}
 }

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -157,9 +157,9 @@ type Field struct {
 
 // Statement holds a top level Statement for processing telemetry data. A Statement is a combination of a function
 // invocation and the expression to match telemetry for invoking the function.
-type Statement struct {
-	Function  ExprFunc
-	Condition boolExpressionEvaluator
+type Statement[K any] struct {
+	Function  ExprFunc[K]
+	Condition boolExpressionEvaluator[K]
 }
 
 // Bytes type for capturing byte arrays
@@ -193,15 +193,15 @@ func (n *IsNil) Capture(_ []string) error {
 
 type EnumSymbol string
 
-type Parser struct {
+type Parser[K any] struct {
 	functions         map[string]interface{}
-	pathParser        PathExpressionParser
+	pathParser        PathExpressionParser[K]
 	enumParser        EnumParser
 	telemetrySettings component.TelemetrySettings
 }
 
-func NewParser(functions map[string]interface{}, pathParser PathExpressionParser, enumParser EnumParser, telemetrySettings component.TelemetrySettings) Parser {
-	return Parser{
+func NewParser[K any](functions map[string]interface{}, pathParser PathExpressionParser[K], enumParser EnumParser, telemetrySettings component.TelemetrySettings) Parser[K] {
+	return Parser[K]{
 		functions:         functions,
 		pathParser:        pathParser,
 		enumParser:        enumParser,
@@ -209,8 +209,8 @@ func NewParser(functions map[string]interface{}, pathParser PathExpressionParser
 	}
 }
 
-func (p *Parser) ParseStatements(statements []string) ([]Statement, error) {
-	var queries []Statement
+func (p *Parser[K]) ParseStatements(statements []string) ([]Statement[K], error) {
+	var queries []Statement[K]
 	var errors error
 
 	for _, statement := range statements {
@@ -229,7 +229,7 @@ func (p *Parser) ParseStatements(statements []string) ([]Statement, error) {
 			errors = multierr.Append(errors, err)
 			continue
 		}
-		queries = append(queries, Statement{
+		queries = append(queries, Statement[K]{
 			Function:  function,
 			Condition: expression,
 		})

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -16,6 +16,7 @@ package ottl
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -466,14 +467,14 @@ func Test_parse_failure(t *testing.T) {
 	}
 }
 
-func testParsePath(val *Path) (GetSetter, error) {
+func testParsePath(val *Path) (GetSetter[interface{}], error) {
 	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "name" {
-		return &testGetSetter{
-			getter: func(ctx TransformContext) interface{} {
-				return ctx.GetItem()
+		return &StandardGetSetter[interface{}]{
+			Getter: func(ctx interface{}) interface{} {
+				return ctx
 			},
-			setter: func(ctx TransformContext, val interface{}) {
-				ctx.GetItem()
+			Setter: func(ctx interface{}, val interface{}) {
+				reflect.DeepEqual(ctx, val)
 			},
 		}, nil
 	}

--- a/processor/routingprocessor/internal/common/functions.go
+++ b/processor/routingprocessor/internal/common/functions.go
@@ -19,19 +19,17 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-var registry = map[string]interface{}{
-	"IsMatch":              ottlfuncs.IsMatch,
-	"delete_key":           ottlfuncs.DeleteKey,
-	"delete_matching_keys": ottlfuncs.DeleteMatchingKeys,
-	// noop function, it is required since the parsing of conditions is not implemented yet,
-	// see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545
-	"route": func(_ []string) (ottl.ExprFunc, error) {
-		return func(ctx ottl.TransformContext) interface{} {
-			return true
-		}, nil
-	},
-}
-
-func Functions() map[string]interface{} {
-	return registry
+func Functions[K any]() map[string]interface{} {
+	return map[string]interface{}{
+		"IsMatch":              ottlfuncs.IsMatch[K],
+		"delete_key":           ottlfuncs.DeleteKey[K],
+		"delete_matching_keys": ottlfuncs.DeleteMatchingKeys[K],
+		// noop function, it is required since the parsing of conditions is not implemented yet,
+		// see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545
+		"route": func(_ []string) (ottl.ExprFunc[K], error) {
+			return func(K) interface{} {
+				return true
+			}, nil
+		},
+	}
 }

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -41,35 +41,35 @@ var _ config.Processor = (*Config)(nil)
 func (c *Config) Validate() error {
 	var errors error
 
-	ottlp := ottl.NewParser(
+	ottltracesp := ottl.NewParser[ottltraces.TransformContext](
 		traces.Functions(),
 		ottltraces.ParsePath,
 		ottltraces.ParseEnum,
 		component.TelemetrySettings{Logger: zap.NewNop()},
 	)
-	_, err := ottlp.ParseStatements(c.Traces.Queries)
+	_, err := ottltracesp.ParseStatements(c.Traces.Queries)
 	if err != nil {
 		errors = multierr.Append(errors, err)
 	}
 
-	ottlp = ottl.NewParser(
+	ottlmetricsp := ottl.NewParser[ottldatapoints.TransformContext](
 		metrics.Functions(),
 		ottldatapoints.ParsePath,
 		ottldatapoints.ParseEnum,
 		component.TelemetrySettings{Logger: zap.NewNop()},
 	)
-	_, err = ottlp.ParseStatements(c.Metrics.Queries)
+	_, err = ottlmetricsp.ParseStatements(c.Metrics.Queries)
 	if err != nil {
 		errors = multierr.Append(errors, err)
 	}
 
-	ottlp = ottl.NewParser(
+	ottllogsp := ottl.NewParser[ottllogs.TransformContext](
 		logs.Functions(),
 		ottllogs.ParsePath,
 		ottllogs.ParseEnum,
 		component.TelemetrySettings{Logger: zap.NewNop()},
 	)
-	_, err = ottlp.ParseStatements(c.Logs.Queries)
+	_, err = ottllogsp.ParseStatements(c.Logs.Queries)
 	if err != nil {
 		errors = multierr.Append(errors, err)
 	}

--- a/processor/transformprocessor/internal/common/functions.go
+++ b/processor/transformprocessor/internal/common/functions.go
@@ -18,25 +18,23 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-var registry = map[string]interface{}{
-	"TraceID":              ottlfuncs.TraceID,
-	"SpanID":               ottlfuncs.SpanID,
-	"IsMatch":              ottlfuncs.IsMatch,
-	"Concat":               ottlfuncs.Concat,
-	"Split":                ottlfuncs.Split,
-	"Int":                  ottlfuncs.Int,
-	"keep_keys":            ottlfuncs.KeepKeys,
-	"set":                  ottlfuncs.Set,
-	"truncate_all":         ottlfuncs.TruncateAll,
-	"limit":                ottlfuncs.Limit,
-	"replace_match":        ottlfuncs.ReplaceMatch,
-	"replace_all_matches":  ottlfuncs.ReplaceAllMatches,
-	"replace_pattern":      ottlfuncs.ReplacePattern,
-	"replace_all_patterns": ottlfuncs.ReplaceAllPatterns,
-	"delete_key":           ottlfuncs.DeleteKey,
-	"delete_matching_keys": ottlfuncs.DeleteMatchingKeys,
-}
-
-func Functions() map[string]interface{} {
-	return registry
+func Functions[K any]() map[string]interface{} {
+	return map[string]interface{}{
+		"TraceID":              ottlfuncs.TraceID[K],
+		"SpanID":               ottlfuncs.SpanID[K],
+		"IsMatch":              ottlfuncs.IsMatch[K],
+		"Concat":               ottlfuncs.Concat[K],
+		"Split":                ottlfuncs.Split[K],
+		"Int":                  ottlfuncs.Int[K],
+		"keep_keys":            ottlfuncs.KeepKeys[K],
+		"set":                  ottlfuncs.Set[K],
+		"truncate_all":         ottlfuncs.TruncateAll[K],
+		"limit":                ottlfuncs.Limit[K],
+		"replace_match":        ottlfuncs.ReplaceMatch[K],
+		"replace_all_matches":  ottlfuncs.ReplaceAllMatches[K],
+		"replace_pattern":      ottlfuncs.ReplacePattern[K],
+		"replace_all_patterns": ottlfuncs.ReplaceAllPatterns[K],
+		"delete_key":           ottlfuncs.DeleteKey[K],
+		"delete_matching_keys": ottlfuncs.DeleteMatchingKeys[K],
+	}
 }

--- a/processor/transformprocessor/internal/logs/functions.go
+++ b/processor/transformprocessor/internal/logs/functions.go
@@ -15,10 +15,11 @@
 package logs // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/logs"
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllogs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
 func Functions() map[string]interface{} {
 	// No logs-only functions yet.
-	return common.Functions()
+	return common.Functions[ottllogs.TransformContext]()
 }

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -18,10 +18,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllogs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
 func Test_DefaultFunctions(t *testing.T) {
-	assert.Equal(t, common.Functions(), Functions())
+	expected := common.Functions[ottllogs.TransformContext]()
+	actual := Functions()
+	require.Equal(t, len(expected), len(actual))
+	for k := range actual {
+		assert.Contains(t, expected, k)
+	}
 }

--- a/processor/transformprocessor/internal/logs/processor.go
+++ b/processor/transformprocessor/internal/logs/processor.go
@@ -26,7 +26,7 @@ import (
 )
 
 type Processor struct {
-	queries []ottl.Statement
+	queries []ottl.Statement[ottllogs.TransformContext]
 	logger  *zap.Logger
 }
 

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
@@ -23,7 +23,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoints"
 )
 
-func convertGaugeToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc, error) {
+func convertGaugeToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc[ottldatapoints.TransformContext], error) {
 	var aggTemp pmetric.MetricAggregationTemporality
 	switch stringAggTemp {
 	case "delta":
@@ -34,13 +34,8 @@ func convertGaugeToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc, err
 		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
 	}
 
-	return func(ctx ottl.TransformContext) interface{} {
-		mtc, ok := ctx.(ottldatapoints.TransformContext)
-		if !ok {
-			return nil
-		}
-
-		metric := mtc.GetMetric()
+	return func(ctx ottldatapoints.TransformContext) interface{} {
+		metric := ctx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeGauge {
 			return nil
 		}

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge.go
@@ -21,14 +21,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoints"
 )
 
-func convertSumToGauge() (ottl.ExprFunc, error) {
-	return func(ctx ottl.TransformContext) interface{} {
-		mtc, ok := ctx.(ottldatapoints.TransformContext)
-		if !ok {
-			return nil
-		}
-
-		metric := mtc.GetMetric()
+func convertSumToGauge() (ottl.ExprFunc[ottldatapoints.TransformContext], error) {
+	return func(ctx ottldatapoints.TransformContext) interface{} {
+		metric := ctx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSum {
 			return nil
 		}

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
@@ -23,7 +23,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoints"
 )
 
-func convertSummaryCountValToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc, error) {
+func convertSummaryCountValToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc[ottldatapoints.TransformContext], error) {
 	var aggTemp pmetric.MetricAggregationTemporality
 	switch stringAggTemp {
 	case "delta":
@@ -33,18 +33,13 @@ func convertSummaryCountValToSum(stringAggTemp string, monotonic bool) (ottl.Exp
 	default:
 		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
 	}
-	return func(ctx ottl.TransformContext) interface{} {
-		mtc, ok := ctx.(ottldatapoints.TransformContext)
-		if !ok {
-			return nil
-		}
-
-		metric := mtc.GetMetric()
+	return func(ctx ottldatapoints.TransformContext) interface{} {
+		metric := ctx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSummary {
 			return nil
 		}
 
-		sumMetric := mtc.GetMetrics().AppendEmpty()
+		sumMetric := ctx.GetMetrics().AppendEmpty()
 		sumMetric.SetDescription(metric.Description())
 		sumMetric.SetName(metric.Name() + "_count")
 		sumMetric.SetUnit(metric.Unit())

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
@@ -23,7 +23,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoints"
 )
 
-func convertSummarySumValToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc, error) {
+func convertSummarySumValToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc[ottldatapoints.TransformContext], error) {
 	var aggTemp pmetric.MetricAggregationTemporality
 	switch stringAggTemp {
 	case "delta":
@@ -33,18 +33,13 @@ func convertSummarySumValToSum(stringAggTemp string, monotonic bool) (ottl.ExprF
 	default:
 		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
 	}
-	return func(ctx ottl.TransformContext) interface{} {
-		mtc, ok := ctx.(ottldatapoints.TransformContext)
-		if !ok {
-			return nil
-		}
-
-		metric := mtc.GetMetric()
+	return func(ctx ottldatapoints.TransformContext) interface{} {
+		metric := ctx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSummary {
 			return nil
 		}
 
-		sumMetric := mtc.GetMetrics().AppendEmpty()
+		sumMetric := ctx.GetMetrics().AppendEmpty()
 		sumMetric.SetDescription(metric.Description())
 		sumMetric.SetName(metric.Name() + "_sum")
 		sumMetric.SetUnit(metric.Unit())

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -15,6 +15,7 @@
 package metrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoints"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
@@ -28,7 +29,7 @@ var registry = map[string]interface{}{
 
 func init() {
 	// Init metrics registry with default functions common to all signals
-	for k, v := range common.Functions() {
+	for k, v := range common.Functions[ottldatapoints.TransformContext]() {
 		registry[k] = v
 	}
 }

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -18,25 +18,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoints"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
 func Test_DefaultFunctions(t *testing.T) {
-	expectedFunctions := common.Functions()
-	expectedFunctions["convert_sum_to_gauge"] = convertSumToGauge
-	expectedFunctions["convert_gauge_to_sum"] = convertGaugeToSum
-	expectedFunctions["convert_summary_sum_val_to_sum"] = convertSummarySumValToSum
-	expectedFunctions["convert_summary_count_val_to_sum"] = convertSummaryCountValToSum
+	expected := common.Functions[ottldatapoints.TransformContext]()
+	expected["convert_sum_to_gauge"] = convertSumToGauge
+	expected["convert_gauge_to_sum"] = convertGaugeToSum
+	expected["convert_summary_sum_val_to_sum"] = convertSummarySumValToSum
+	expected["convert_summary_count_val_to_sum"] = convertSummaryCountValToSum
 
 	actual := Functions()
 
-	assert.NotNil(t, actual)
-	assert.Equal(t, len(expectedFunctions), len(actual))
-
+	require.Equal(t, len(expected), len(actual))
 	for k := range actual {
-		if _, ok := expectedFunctions[k]; !ok {
-			assert.FailNowf(t, "%v is not an expected function", k)
-		}
+		assert.Contains(t, expected, k)
 	}
 }

--- a/processor/transformprocessor/internal/metrics/processor.go
+++ b/processor/transformprocessor/internal/metrics/processor.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Processor struct {
-	queries []ottl.Statement
+	queries []ottl.Statement[ottldatapoints.TransformContext]
 	logger  *zap.Logger
 }
 
@@ -102,7 +102,7 @@ func (p *Processor) handleSummaryDataPoints(dps pmetric.SummaryDataPointSlice, m
 	}
 }
 
-func (p *Processor) callFunctions(ctx ottl.TransformContext) {
+func (p *Processor) callFunctions(ctx ottldatapoints.TransformContext) {
 	for _, statement := range p.queries {
 		if statement.Condition(ctx) {
 			statement.Function(ctx)

--- a/processor/transformprocessor/internal/traces/functions.go
+++ b/processor/transformprocessor/internal/traces/functions.go
@@ -15,10 +15,11 @@
 package traces // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/traces"
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottltraces"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
 func Functions() map[string]interface{} {
 	// No trace-only functions yet.
-	return common.Functions()
+	return common.Functions[ottltraces.TransformContext]()
 }

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -18,10 +18,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottltraces"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
 func Test_DefaultFunctions(t *testing.T) {
-	assert.Equal(t, common.Functions(), Functions())
+	expected := common.Functions[ottltraces.TransformContext]()
+	actual := Functions()
+	require.Equal(t, len(expected), len(actual))
+	for k := range actual {
+		assert.Contains(t, expected, k)
+	}
 }

--- a/processor/transformprocessor/internal/traces/processor.go
+++ b/processor/transformprocessor/internal/traces/processor.go
@@ -26,7 +26,7 @@ import (
 )
 
 type Processor struct {
-	queries []ottl.Statement
+	queries []ottl.Statement[ottltraces.TransformContext]
 	logger  *zap.Logger
 }
 

--- a/unreleased/ottl-generics.yaml
+++ b/unreleased/ottl-generics.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use generics to avoid context cast in getters and funcs.
+
+# One or more tracking issues related to the change
+issues: [14482]


### PR DESCRIPTION
This PR also improves number of allocations (by 2, if I am not wrong is because of the removing of the ottl.TransformContext interface use, which requires a heap allocation) and overall performance of the transform processor.

**Before:**

```shell
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/traces
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkTwoSpans
BenchmarkTwoSpans/no_processing
BenchmarkTwoSpans/no_processing-16         	  783144	      1394 ns/op	    1528 B/op	      31 allocs/op
BenchmarkTwoSpans/set_attribute
BenchmarkTwoSpans/set_attribute-16         	  713299	      1691 ns/op	    1832 B/op	      35 allocs/op
BenchmarkTwoSpans/keep_keys_attribute
BenchmarkTwoSpans/keep_keys_attribute-16   	  789517	      1626 ns/op	    1560 B/op	      33 allocs/op
BenchmarkTwoSpans/no_match
BenchmarkTwoSpans/no_match-16              	  799210	      1520 ns/op	    1560 B/op	      33 allocs/op
BenchmarkTwoSpans/inner_field
BenchmarkTwoSpans/inner_field-16           	  737241	      1566 ns/op	    1560 B/op	      33 allocs/op
BenchmarkTwoSpans/inner_field_both_spans
BenchmarkTwoSpans/inner_field_both_spans-16         	  763725	      1622 ns/op	    1592 B/op	      35 allocs/op
```

**After:**

```shell
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/traces
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkTwoSpans
BenchmarkTwoSpans/no_processing
BenchmarkTwoSpans/no_processing-16         	  868864	      1296 ns/op	    1480 B/op	      29 allocs/op
BenchmarkTwoSpans/set_attribute
BenchmarkTwoSpans/set_attribute-16         	  738514	      1609 ns/op	    1784 B/op	      33 allocs/op
BenchmarkTwoSpans/keep_keys_attribute
BenchmarkTwoSpans/keep_keys_attribute-16   	  800833	      1450 ns/op	    1512 B/op	      31 allocs/op
BenchmarkTwoSpans/no_match
BenchmarkTwoSpans/no_match-16              	  835160	      1394 ns/op	    1512 B/op	      31 allocs/op
BenchmarkTwoSpans/inner_field
BenchmarkTwoSpans/inner_field-16           	  796388	      1445 ns/op	    1512 B/op	      31 allocs/op
BenchmarkTwoSpans/inner_field_both_spans
BenchmarkTwoSpans/inner_field_both_spans-16         	  798840	      1539 ns/op	    1544 B/op	      33 allocs/op
```