### PR TITLE
[pkg/stanza/fileconsumer] Convert config unmarshal tests to use operatortest

### DIFF
--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -16,6 +16,7 @@ package fileconsumer
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -28,368 +29,332 @@ import (
 )
 
 func TestUnmarshal(t *testing.T) {
-	cases := []operatortest.ConfigUnmarshalTest{
-		{
-			Name:      "include_one",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				return cfg
-			}(),
+	operatortest.ConfigUnmarshalTests{
+		DefaultConfig: newMockOperatorConfig(NewConfig()),
+		TestsFile:     filepath.Join(".", "testdata", "config.yaml"),
+		Tests: []operatortest.ConfigUnmarshalTest{
+			{
+				Name: "include_one",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "one.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "include_multi",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "one.log", "two.log", "three.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "include_glob",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "*.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "include_glob_double_asterisk",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "**.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "include_glob_double_asterisk_nested",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "directory/**/*.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "include_glob_double_asterisk_prefix",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "**/directory/**/*.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "include_inline",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "a.log", "b.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "include_string",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "aString")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "exclude_one",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "*.log")
+					cfg.Exclude = append(cfg.Exclude, "one.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "exclude_multi",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "*.log")
+					cfg.Exclude = append(cfg.Exclude, "one.log", "two.log", "three.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "exclude_glob",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "*.log")
+					cfg.Exclude = append(cfg.Exclude, "not*.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "exclude_glob_double_asterisk",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "*.log")
+					cfg.Exclude = append(cfg.Exclude, "not**.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "exclude_glob_double_asterisk_nested",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "*.log")
+					cfg.Exclude = append(cfg.Exclude, "directory/**/not*.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "exclude_glob_double_asterisk_prefix",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "*.log")
+					cfg.Exclude = append(cfg.Exclude, "**/directory/**/not*.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "exclude_inline",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "*.log")
+					cfg.Exclude = append(cfg.Exclude, "a.log", "b.log")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "exclude_string",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Include = append(cfg.Include, "*.log")
+					cfg.Exclude = append(cfg.Exclude, "aString")
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "poll_interval_no_units",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.PollInterval = time.Second
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "poll_interval_1s",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.PollInterval = time.Second
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "poll_interval_1ms",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.PollInterval = time.Millisecond
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "poll_interval_1000ms",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.PollInterval = time.Second
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "fingerprint_size_no_units",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.FingerprintSize = helper.ByteSize(1000)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "fingerprint_size_1kb_lower",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.FingerprintSize = helper.ByteSize(1000)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "fingerprint_size_1KB",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.FingerprintSize = helper.ByteSize(1000)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "fingerprint_size_1kib_lower",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.FingerprintSize = helper.ByteSize(1024)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "fingerprint_size_1KiB",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.FingerprintSize = helper.ByteSize(1024)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "fingerprint_size_float",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.FingerprintSize = helper.ByteSize(1100)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "multiline_line_start_string",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					newSplit := helper.NewSplitterConfig()
+					newSplit.Multiline.LineStartPattern = "Start"
+					cfg.Splitter = newSplit
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "multiline_line_start_special",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					newSplit := helper.NewSplitterConfig()
+					newSplit.Multiline.LineStartPattern = "%"
+					cfg.Splitter = newSplit
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "multiline_line_end_string",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					newSplit := helper.NewSplitterConfig()
+					newSplit.Multiline.LineEndPattern = "Start"
+					cfg.Splitter = newSplit
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "multiline_line_end_special",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					newSplit := helper.NewSplitterConfig()
+					newSplit.Multiline.LineEndPattern = "%"
+					cfg.Splitter = newSplit
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "start_at_string",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.StartAt = "beginning"
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "max_concurrent_large",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.MaxConcurrentFiles = 9223372036854775807
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "max_log_size_mib_lower",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.MaxLogSize = helper.ByteSize(1048576)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "max_log_size_mib_upper",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.MaxLogSize = helper.ByteSize(1048576)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "max_log_size_mb_upper",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.MaxLogSize = helper.ByteSize(1048576)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "max_log_size_mb_lower",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.MaxLogSize = helper.ByteSize(1048576)
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "encoding_lower",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "utf-16le"}
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
+			{
+				Name: "encoding_upper",
+				Expect: func() *mockOperatorConfig {
+					cfg := NewConfig()
+					cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "UTF-16lE"}
+					return newMockOperatorConfig(cfg)
+				}(),
+			},
 		},
-		{
-			Name:      "include_multi",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log", "two.log", "three.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_glob",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "*.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_glob_double_asterisk",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "**.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_glob_double_asterisk_nested",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "directory/**/*.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_glob_double_asterisk_prefix",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "**/directory/**/*.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_inline",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "a.log", "b.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_invalid",
-			ExpectErr: true,
-			Expect:    nil,
-		},
-		{
-			Name:      "exclude_one",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "*.log")
-				cfg.Exclude = append(cfg.Exclude, "one.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "exclude_multi",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "*.log")
-				cfg.Exclude = append(cfg.Exclude, "one.log", "two.log", "three.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "exclude_glob",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "*.log")
-				cfg.Exclude = append(cfg.Exclude, "not*.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "exclude_glob_double_asterisk",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "*.log")
-				cfg.Exclude = append(cfg.Exclude, "not**.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "exclude_glob_double_asterisk_nested",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "*.log")
-				cfg.Exclude = append(cfg.Exclude, "directory/**/not*.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "exclude_glob_double_asterisk_prefix",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "*.log")
-				cfg.Exclude = append(cfg.Exclude, "**/directory/**/not*.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "exclude_inline",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "*.log")
-				cfg.Exclude = append(cfg.Exclude, "a.log", "b.log")
-				return cfg
-			}(),
-		},
-		{
-			Name:      "exclude_invalid",
-			ExpectErr: true,
-			Expect:    nil,
-		},
-		{
-			Name:      "poll_interval_no_units",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.PollInterval = time.Second
-				return cfg
-			}(),
-		},
-		{
-			Name:      "poll_interval_1s",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.PollInterval = time.Second
-				return cfg
-			}(),
-		},
-		{
-			Name:      "poll_interval_1ms",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.PollInterval = time.Millisecond
-				return cfg
-			}(),
-		},
-		{
-			Name:      "poll_interval_1000ms",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.PollInterval = time.Second
-				return cfg
-			}(),
-		},
-		{
-			Name:      "fingerprint_size_no_units",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.FingerprintSize = helper.ByteSize(1000)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "fingerprint_size_1kb_lower",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.FingerprintSize = helper.ByteSize(1000)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "fingerprint_size_1KB",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.FingerprintSize = helper.ByteSize(1000)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "fingerprint_size_1kib_lower",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.FingerprintSize = helper.ByteSize(1024)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "fingerprint_size_1KiB",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.FingerprintSize = helper.ByteSize(1024)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "fingerprint_size_float",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.FingerprintSize = helper.ByteSize(1100)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "multiline_line_start_string",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				newSplit := helper.NewSplitterConfig()
-				newSplit.Multiline.LineStartPattern = "Start"
-				cfg.Splitter = newSplit
-				return cfg
-			}(),
-		},
-		{
-			Name:      "multiline_line_start_special",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				newSplit := helper.NewSplitterConfig()
-				newSplit.Multiline.LineStartPattern = "%"
-				cfg.Splitter = newSplit
-				return cfg
-			}(),
-		},
-		{
-			Name:      "multiline_line_end_string",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				newSplit := helper.NewSplitterConfig()
-				newSplit.Multiline.LineEndPattern = "Start"
-				cfg.Splitter = newSplit
-				return cfg
-			}(),
-		},
-		{
-			Name:      "multiline_line_end_special",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				newSplit := helper.NewSplitterConfig()
-				newSplit.Multiline.LineEndPattern = "%"
-				cfg.Splitter = newSplit
-				return cfg
-			}(),
-		},
-		{
-			Name:      "multiline_random",
-			ExpectErr: true,
-			Expect:    nil,
-		},
-		{
-			Name:      "start_at_string",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.StartAt = "beginning"
-				return cfg
-			}(),
-		},
-		{
-			Name:      "max_concurrent_large",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.MaxConcurrentFiles = 9223372036854775807
-				return cfg
-			}(),
-		},
-		{
-			Name:      "max_log_size_mib_lower",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.MaxLogSize = helper.ByteSize(1048576)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "max_log_size_mib_upper",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.MaxLogSize = helper.ByteSize(1048576)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "max_log_size_mb_upper",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.MaxLogSize = helper.ByteSize(1048576)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "max_log_size_mb_lower",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.MaxLogSize = helper.ByteSize(1048576)
-				return cfg
-			}(),
-		},
-		{
-			Name:      "encoding_lower",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "utf-16le"}
-				return cfg
-			}(),
-		},
-		{
-			Name:      "encoding_upper",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "UTF-16lE"}
-				return cfg
-			}(),
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.Name, func(t *testing.T) {
-			tc.RunDeprecated(t, NewConfig())
-		})
-	}
+	}.Run(t)
 }
 
 func TestBuild(t *testing.T) {

--- a/pkg/stanza/fileconsumer/testdata/config.yaml
+++ b/pkg/stanza/fileconsumer/testdata/config.yaml
@@ -1,0 +1,156 @@
+encoding_lower:
+  type: mock
+  encoding: "utf-16le"
+encoding_upper:
+  type: mock
+  encoding: "UTF-16lE"
+exclude_glob:
+  type: mock
+  include:
+    - "*.log"
+  exclude:
+    - "not*.log"
+exclude_glob_double_asterisk:
+  type: mock
+  include:
+    - "*.log"
+  exclude:
+    - "not**.log"
+exclude_glob_double_asterisk_nested:
+  type: mock
+  include:
+    - "*.log"
+  exclude:
+    - "directory/**/not*.log"
+exclude_glob_double_asterisk_prefix:
+  type: mock
+  include:
+    - "*.log"
+  exclude:
+    - "**/directory/**/not*.log"
+exclude_inline:
+  type: mock
+  include: [ "*.log" ]
+  exclude: [ "a.log", "b.log" ]
+exclude_string:
+  type: mock
+  include:
+    - "*.log"
+  exclude: "aString"
+exclude_multi:
+  type: mock
+  include:
+    - "*.log"
+  exclude:
+    - one.log
+    - two.log
+    - three.log
+exclude_one:
+  type: mock
+  include:
+    - "*.log"
+  exclude:
+    - one.log
+fingerprint_size_1KB:
+  type: mock
+  fingerprint_size: 1KB
+fingerprint_size_1KiB:
+  type: mock
+  fingerprint_size: 1KiB
+fingerprint_size_1kb_lower:
+  type: mock
+  fingerprint_size: 1kb
+fingerprint_size_1kib_lower:
+  type: mock
+  fingerprint_size: 1kib
+fingerprint_size_float:
+  type: mock
+  fingerprint_size: 1.1kb
+fingerprint_size_no_units:
+  type: mock
+  fingerprint_size: 1000
+include_glob:
+  type: mock
+  include:
+    - "*.log"
+include_glob_double_asterisk:
+  type: mock
+  include:
+    - "**.log"
+include_glob_double_asterisk_nested:
+  type: mock
+  include:
+    - "directory/**/*.log"
+include_glob_double_asterisk_prefix:
+  type: mock
+  include:
+    - "**/directory/**/*.log"
+include_inline:
+  type: mock
+  include: [ "a.log", "b.log" ]
+include_string:
+  type: mock
+  include: "aString"
+include_multi:
+  type: mock
+  include:
+    - one.log
+    - two.log
+    - three.log
+include_one:
+  type: mock
+  include:
+    - one.log
+max_concurrent_large:
+  type: mock
+  max_concurrent_files: 9223372036854775807
+max_log_size_invalid_unit:
+  type: mock
+  max_log_size: 1TOFU
+max_log_size_mb_lower:
+  type: mock
+  max_log_size: 1mib
+max_log_size_mb_upper:
+  type: mock
+  max_log_size: 1MiB
+max_log_size_mib_lower:
+  type: mock
+  max_log_size: 1mib
+max_log_size_mib_upper:
+  type: mock
+  max_log_size: 1MiB
+multiline_extra_field:
+  type: mock
+  multiline:
+    that_random_field: "this should go nowhere"
+multiline_line_end_special:
+  type: mock
+  multiline:
+    line_end_pattern: '%'
+multiline_line_end_string:
+  type: mock
+  multiline:
+    line_end_pattern: 'Start'
+multiline_line_start_special:
+  type: mock
+  multiline:
+    line_start_pattern: '%'
+multiline_line_start_string:
+  type: mock
+  multiline:
+    line_start_pattern: 'Start'
+poll_interval_1000ms:
+  type: mock
+  poll_interval: 1000ms
+poll_interval_1ms:
+  type: mock
+  poll_interval: 1ms
+poll_interval_1s:
+  type: mock
+  poll_interval: 1s
+poll_interval_no_units:
+  type: mock
+  poll_interval: 1000000000
+start_at_string:
+  type: mock
+  start_at: "beginning"

--- a/pkg/stanza/fileconsumer/testdata/encoding_lower.yaml
+++ b/pkg/stanza/fileconsumer/testdata/encoding_lower.yaml
@@ -1,1 +1,0 @@
-encoding: "utf-16le"

--- a/pkg/stanza/fileconsumer/testdata/encoding_upper.yaml
+++ b/pkg/stanza/fileconsumer/testdata/encoding_upper.yaml
@@ -1,1 +1,0 @@
-encoding: "UTF-16lE"

--- a/pkg/stanza/fileconsumer/testdata/exclude_glob.yaml
+++ b/pkg/stanza/fileconsumer/testdata/exclude_glob.yaml
@@ -1,4 +1,0 @@
-include:
-  - "*.log"
-exclude:
-  - "not*.log"

--- a/pkg/stanza/fileconsumer/testdata/exclude_glob_double_asterisk.yaml
+++ b/pkg/stanza/fileconsumer/testdata/exclude_glob_double_asterisk.yaml
@@ -1,4 +1,0 @@
-include:
-  - "*.log"
-exclude:
-  - "not**.log"

--- a/pkg/stanza/fileconsumer/testdata/exclude_glob_double_asterisk_nested.yaml
+++ b/pkg/stanza/fileconsumer/testdata/exclude_glob_double_asterisk_nested.yaml
@@ -1,4 +1,0 @@
-include:
-  - "*.log"
-exclude:
-  - "directory/**/not*.log"

--- a/pkg/stanza/fileconsumer/testdata/exclude_glob_double_asterisk_prefix.yaml
+++ b/pkg/stanza/fileconsumer/testdata/exclude_glob_double_asterisk_prefix.yaml
@@ -1,4 +1,0 @@
-include:
-  - "*.log"
-exclude:
-  - "**/directory/**/not*.log"

--- a/pkg/stanza/fileconsumer/testdata/exclude_inline.yaml
+++ b/pkg/stanza/fileconsumer/testdata/exclude_inline.yaml
@@ -1,2 +1,0 @@
-include: [ "*.log" ]
-exclude: [ "a.log", "b.log" ]

--- a/pkg/stanza/fileconsumer/testdata/exclude_invalid.yaml
+++ b/pkg/stanza/fileconsumer/testdata/exclude_invalid.yaml
@@ -1,3 +1,0 @@
-include:
-  - "*.log"
-exclude: "aRandomString"

--- a/pkg/stanza/fileconsumer/testdata/exclude_multi.yaml
+++ b/pkg/stanza/fileconsumer/testdata/exclude_multi.yaml
@@ -1,6 +1,0 @@
-include:
-  - "*.log"
-exclude:
-  - one.log
-  - two.log
-  - three.log

--- a/pkg/stanza/fileconsumer/testdata/exclude_one.yaml
+++ b/pkg/stanza/fileconsumer/testdata/exclude_one.yaml
@@ -1,4 +1,0 @@
-include:
-  - "*.log"
-exclude:
-  - one.log

--- a/pkg/stanza/fileconsumer/testdata/fingerprint_size_1KB.yaml
+++ b/pkg/stanza/fileconsumer/testdata/fingerprint_size_1KB.yaml
@@ -1,1 +1,0 @@
-fingerprint_size: 1KB

--- a/pkg/stanza/fileconsumer/testdata/fingerprint_size_1KiB.yaml
+++ b/pkg/stanza/fileconsumer/testdata/fingerprint_size_1KiB.yaml
@@ -1,1 +1,0 @@
-fingerprint_size: 1KiB

--- a/pkg/stanza/fileconsumer/testdata/fingerprint_size_1kb_lower.yaml
+++ b/pkg/stanza/fileconsumer/testdata/fingerprint_size_1kb_lower.yaml
@@ -1,1 +1,0 @@
-fingerprint_size: 1kb

--- a/pkg/stanza/fileconsumer/testdata/fingerprint_size_1kib_lower.yaml
+++ b/pkg/stanza/fileconsumer/testdata/fingerprint_size_1kib_lower.yaml
@@ -1,1 +1,0 @@
-fingerprint_size: 1kib

--- a/pkg/stanza/fileconsumer/testdata/fingerprint_size_float.yaml
+++ b/pkg/stanza/fileconsumer/testdata/fingerprint_size_float.yaml
@@ -1,1 +1,0 @@
-fingerprint_size: 1.1kb

--- a/pkg/stanza/fileconsumer/testdata/fingerprint_size_no_units.yaml
+++ b/pkg/stanza/fileconsumer/testdata/fingerprint_size_no_units.yaml
@@ -1,1 +1,0 @@
-fingerprint_size: 1000

--- a/pkg/stanza/fileconsumer/testdata/include_glob.yaml
+++ b/pkg/stanza/fileconsumer/testdata/include_glob.yaml
@@ -1,2 +1,0 @@
-include:
-  - "*.log"

--- a/pkg/stanza/fileconsumer/testdata/include_glob_double_asterisk.yaml
+++ b/pkg/stanza/fileconsumer/testdata/include_glob_double_asterisk.yaml
@@ -1,2 +1,0 @@
-include:
-  - "**.log"

--- a/pkg/stanza/fileconsumer/testdata/include_glob_double_asterisk_nested.yaml
+++ b/pkg/stanza/fileconsumer/testdata/include_glob_double_asterisk_nested.yaml
@@ -1,2 +1,0 @@
-include:
-  - "directory/**/*.log"

--- a/pkg/stanza/fileconsumer/testdata/include_glob_double_asterisk_prefix.yaml
+++ b/pkg/stanza/fileconsumer/testdata/include_glob_double_asterisk_prefix.yaml
@@ -1,2 +1,0 @@
-include:
-  - "**/directory/**/*.log"

--- a/pkg/stanza/fileconsumer/testdata/include_inline.yaml
+++ b/pkg/stanza/fileconsumer/testdata/include_inline.yaml
@@ -1,1 +1,0 @@
-include: [ "a.log", "b.log" ]

--- a/pkg/stanza/fileconsumer/testdata/include_invalid.yaml
+++ b/pkg/stanza/fileconsumer/testdata/include_invalid.yaml
@@ -1,1 +1,0 @@
-include: "justwords"

--- a/pkg/stanza/fileconsumer/testdata/include_multi.yaml
+++ b/pkg/stanza/fileconsumer/testdata/include_multi.yaml
@@ -1,4 +1,0 @@
-include:
-  - one.log
-  - two.log
-  - three.log

--- a/pkg/stanza/fileconsumer/testdata/include_one.yaml
+++ b/pkg/stanza/fileconsumer/testdata/include_one.yaml
@@ -1,2 +1,0 @@
-include:
-  - one.log

--- a/pkg/stanza/fileconsumer/testdata/max_concurrent_large.yaml
+++ b/pkg/stanza/fileconsumer/testdata/max_concurrent_large.yaml
@@ -1,1 +1,0 @@
-max_concurrent_files: 9223372036854775807

--- a/pkg/stanza/fileconsumer/testdata/max_log_size_invalid_unit.yaml
+++ b/pkg/stanza/fileconsumer/testdata/max_log_size_invalid_unit.yaml
@@ -1,1 +1,0 @@
-max_log_size: 1TOFU

--- a/pkg/stanza/fileconsumer/testdata/max_log_size_mb_lower.yaml
+++ b/pkg/stanza/fileconsumer/testdata/max_log_size_mb_lower.yaml
@@ -1,1 +1,0 @@
-max_log_size: 1mib

--- a/pkg/stanza/fileconsumer/testdata/max_log_size_mb_upper.yaml
+++ b/pkg/stanza/fileconsumer/testdata/max_log_size_mb_upper.yaml
@@ -1,1 +1,0 @@
-max_log_size: 1MiB

--- a/pkg/stanza/fileconsumer/testdata/max_log_size_mib_lower.yaml
+++ b/pkg/stanza/fileconsumer/testdata/max_log_size_mib_lower.yaml
@@ -1,1 +1,0 @@
-max_log_size: 1mib

--- a/pkg/stanza/fileconsumer/testdata/max_log_size_mib_upper.yaml
+++ b/pkg/stanza/fileconsumer/testdata/max_log_size_mib_upper.yaml
@@ -1,1 +1,0 @@
-max_log_size: 1MiB

--- a/pkg/stanza/fileconsumer/testdata/multiline_extra_field.yaml
+++ b/pkg/stanza/fileconsumer/testdata/multiline_extra_field.yaml
@@ -1,2 +1,0 @@
-multiline:
-  that_random_field: "this should go nowhere"

--- a/pkg/stanza/fileconsumer/testdata/multiline_line_end_special.yaml
+++ b/pkg/stanza/fileconsumer/testdata/multiline_line_end_special.yaml
@@ -1,2 +1,0 @@
-multiline:
-  line_end_pattern: '%'

--- a/pkg/stanza/fileconsumer/testdata/multiline_line_end_string.yaml
+++ b/pkg/stanza/fileconsumer/testdata/multiline_line_end_string.yaml
@@ -1,2 +1,0 @@
-multiline:
-  line_end_pattern: 'Start'

--- a/pkg/stanza/fileconsumer/testdata/multiline_line_start_special.yaml
+++ b/pkg/stanza/fileconsumer/testdata/multiline_line_start_special.yaml
@@ -1,2 +1,0 @@
-multiline:
-  line_start_pattern: '%'

--- a/pkg/stanza/fileconsumer/testdata/multiline_line_start_string.yaml
+++ b/pkg/stanza/fileconsumer/testdata/multiline_line_start_string.yaml
@@ -1,2 +1,0 @@
-multiline:
-  line_start_pattern: 'Start'

--- a/pkg/stanza/fileconsumer/testdata/poll_interval_1000ms.yaml
+++ b/pkg/stanza/fileconsumer/testdata/poll_interval_1000ms.yaml
@@ -1,1 +1,0 @@
-poll_interval: 1000ms

--- a/pkg/stanza/fileconsumer/testdata/poll_interval_1ms.yaml
+++ b/pkg/stanza/fileconsumer/testdata/poll_interval_1ms.yaml
@@ -1,1 +1,0 @@
-poll_interval: 1ms

--- a/pkg/stanza/fileconsumer/testdata/poll_interval_1s.yaml
+++ b/pkg/stanza/fileconsumer/testdata/poll_interval_1s.yaml
@@ -1,1 +1,0 @@
-poll_interval: 1s

--- a/pkg/stanza/fileconsumer/testdata/poll_interval_no_units.yaml
+++ b/pkg/stanza/fileconsumer/testdata/poll_interval_no_units.yaml
@@ -1,1 +1,0 @@
-poll_interval: 1000000000

--- a/pkg/stanza/fileconsumer/testdata/start_at_string.yaml
+++ b/pkg/stanza/fileconsumer/testdata/start_at_string.yaml
@@ -1,1 +1,0 @@
-start_at: "beginning"

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -26,7 +26,10 @@ import (
 
 	"github.com/observiq/nanojack"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -172,4 +175,28 @@ func expectNoTokensUntil(t *testing.T, c chan *emitParams, d time.Duration) {
 		require.FailNow(t, "Received unexpected message", "Message: %s", token)
 	case <-time.After(d):
 	}
+}
+
+const mockOperatorType = "mock"
+
+func init() {
+	operator.Register(mockOperatorType, func() operator.Builder { return newMockOperatorConfig(NewConfig()) })
+}
+
+type mockOperatorConfig struct {
+	helper.BasicConfig `mapstructure:",squash"`
+	*Config            `mapstructure:",squash"`
+}
+
+func newMockOperatorConfig(cfg *Config) *mockOperatorConfig {
+	return &mockOperatorConfig{
+		BasicConfig: helper.NewBasicConfig(mockOperatorType, mockOperatorType),
+		Config:      cfg,
+	}
+}
+
+// This function is impelmented for compatibility with operatortest
+// but is not meant to be used directly
+func (h *mockOperatorConfig) Build(*zap.SugaredLogger) (operator.Operator, error) {
+	panic("not impelemented")
 }


### PR DESCRIPTION
This required implementation of an operator.Builder to hold the struct. The same pattern has been used in the helper package.