### PR TITLE
[receiver/otlpjsonfilereceiver]logs receive operations should use StartLogsOp/EndLogsOp

### DIFF
--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -85,7 +85,7 @@ func createLogsReceiver(_ context.Context, settings component.ReceiverCreateSett
 	})
 	cfg := configuration.(*Config)
 	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, attrs *fileconsumer.FileAttributes, token []byte) {
-		ctx = obsrecv.StartMetricsOp(ctx)
+		ctx = obsrecv.StartLogsOp(ctx)
 		l, err := logsUnmarshaler.UnmarshalLogs(token)
 		if err != nil {
 			obsrecv.EndLogsOp(ctx, typeStr, 0, err)

--- a/unreleased/otlpjsonfilereceiver-obsreport.yaml
+++ b/unreleased/otlpjsonfilereceiver-obsreport.yaml
@@ -7,3 +7,4 @@ component: otlpjsonfilereceiver
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note:  logs receive operations should use StartLogsOp/EndLogsOp
 
+issues: [14535]

--- a/unreleased/otlpjsonfilereceiver-obsreport.yaml
+++ b/unreleased/otlpjsonfilereceiver-obsreport.yaml
@@ -1,0 +1,9 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: otlpjsonfilereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  logs receive operations should use StartLogsOp/EndLogsOp
+


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fix bug: logs receive operations should use StartLogsOp/EndLogsOp.


**Testing:** <Describe what testing was performed and which tests were added.>
Unit test

issue: #14535 
