### PR TITLE
[receiver/hostmetrics] Add optional metric `process.cpu.utilization`

### DIFF
--- a/.chloggen/add-process-cpu-utilization-metric.yaml
+++ b/.chloggen/add-process-cpu-utilization-metric.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a new optional metric `process.cpu.utilization` to the `process` scraper of the `hostmetrics` receiver.
+
+# One or more tracking issues related to the change
+issues: [14084]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
@@ -10,6 +10,7 @@ These are the metrics available for this scraper.
 | ---- | ----------- | ---- | ---- | ---------- |
 | process.context_switches | Number of times the process has been context switched. | {count} | Sum(Int) | <ul> <li>context_switch_type</li> </ul> |
 | **process.cpu.time** | Total CPU seconds broken down by different states. | s | Sum(Double) | <ul> <li>state</li> </ul> |
+| process.cpu.utilization | Percentage of total CPU time used by the process since last scrape, expressed as a value between 0 and 1. On the first scrape, no data point is emitted for this metric. | 1 | Gauge(Double) | <ul> <li>state</li> </ul> |
 | **process.disk.io** | Disk bytes transferred. | By | Sum(Int) | <ul> <li>direction</li> </ul> |
 | **process.memory.physical_usage** | Deprecated: use `process.memory.usage` metric instead. The amount of physical memory in use. | By | Sum(Int) | <ul> </ul> |
 | process.memory.usage | The amount of physical memory in use. | By | Sum(Int) | <ul> </ul> |

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -72,6 +72,17 @@ metrics:
       monotonic: true
     attributes: [state]
 
+  process.cpu.utilization:
+    enabled: false
+    description: >-
+      Percentage of total CPU time used by the process since last scrape,
+      expressed as a value between 0 and 1.
+      On the first scrape, no data point is emitted for this metric.
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [state]
+
   process.memory.physical_usage:
     enabled: true
     description: "Deprecated: use `process.memory.usage` metric instead. The amount of physical memory in use."

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -16,6 +16,7 @@ package processscraper // import "github.com/open-telemetry/opentelemetry-collec
 
 import (
 	"strings"
+	"time"
 
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/process"
@@ -88,6 +89,7 @@ type processHandle interface {
 	Cmdline() (string, error)
 	CmdlineSlice() ([]string, error)
 	Times() (*cpu.TimesStat, error)
+	Percent(time.Duration) (float64, error)
 	MemoryInfo() (*process.MemoryInfoStat, error)
 	IOCounters() (*process.IOCountersStat, error)
 	NumThreads() (int32, error)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_linux.go
@@ -22,12 +22,19 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal"
 )
 
 func (s *scraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {
 	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.User, metadata.AttributeStateUser)
 	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.System, metadata.AttributeStateSystem)
 	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.Iowait, metadata.AttributeStateWait)
+}
+
+func (s *scraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.User, metadata.AttributeStateUser)
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.System, metadata.AttributeStateSystem)
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.Iowait, metadata.AttributeStateWait)
 }
 
 func getProcessExecutable(proc processHandle) (*executableMetadata, error) {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
@@ -20,9 +20,13 @@ package processscraper // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"github.com/shirou/gopsutil/v3/cpu"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal"
 )
 
 func (s *scraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {}
+
+func (s *scraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {}
 
 func getProcessExecutable(processHandle) (*executableMetadata, error) {
 	return nil, nil

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_windows.go
@@ -25,11 +25,17 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal"
 )
 
 func (s *scraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {
 	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.User, metadata.AttributeStateUser)
 	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.System, metadata.AttributeStateSystem)
+}
+
+func (s *scraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.User, metadata.AttributeStateUser)
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.System, metadata.AttributeStateSystem)
 }
 
 func getProcessExecutable(proc processHandle) (*executableMetadata, error) {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal/cpu_utilization_calculator.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal/cpu_utilization_calculator.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ucal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal"
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// CPUUtilization stores the utilization percents [0-1] for the different cpu states
+type CPUUtilization struct {
+	User   float64
+	System float64
+	Iowait float64
+}
+
+// CPUUtilizationCalculator calculates the cpu utilization percents for the different cpu states
+// It requires 2 []cpu.TimesStat and spend time to be able to calculate the difference
+type CPUUtilizationCalculator struct {
+	previousCPUStats *cpu.TimesStat
+	previousReadTime pcommon.Timestamp
+}
+
+// CalculateAndRecord calculates the cpu utilization for the different cpu states comparing previously
+// stored []cpu.TimesStat and time.Time and current []cpu.TimesStat and current time.Time
+// If no previous data is stored it will return empty slice of CPUUtilization and no error
+func (c *CPUUtilizationCalculator) CalculateAndRecord(now pcommon.Timestamp, currentCPUStats *cpu.TimesStat, recorder func(pcommon.Timestamp, CPUUtilization)) error {
+	if c.previousCPUStats != nil {
+		recorder(now, cpuUtilization(c.previousCPUStats, c.previousReadTime, currentCPUStats, now))
+	}
+	c.previousCPUStats = currentCPUStats
+	c.previousReadTime = now
+
+	return nil
+}
+
+// cpuUtilization calculates the difference between 2 cpu.TimesStat using spent time between them
+func cpuUtilization(startStats *cpu.TimesStat, startTime pcommon.Timestamp, endStats *cpu.TimesStat, endTime pcommon.Timestamp) CPUUtilization {
+	elapsedTime := time.Duration(endTime - startTime)
+	if elapsedTime <= 0 {
+		return CPUUtilization{}
+	}
+	return CPUUtilization{
+		User:   (endStats.User - startStats.User) / elapsedTime.Seconds(),
+		System: (endStats.System - startStats.System) / elapsedTime.Seconds(),
+		Iowait: (endStats.Iowait - startStats.Iowait) / elapsedTime.Seconds(),
+	}
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal/cpu_utilization_calculator_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal/cpu_utilization_calculator_test.go
@@ -1,0 +1,127 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ucal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type inMemoryRecorder struct {
+	cpuUtilization CPUUtilization
+}
+
+func (r *inMemoryRecorder) record(_ pcommon.Timestamp, utilization CPUUtilization) {
+	r.cpuUtilization = utilization
+}
+
+func TestCpuUtilizationCalculator_Calculate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name                string
+		currentReadTime     pcommon.Timestamp
+		currentCPUStat      *cpu.TimesStat
+		previousReadTime    pcommon.Timestamp
+		previousCPUStat     *cpu.TimesStat
+		expectedUtilization *CPUUtilization
+	}{
+		{
+			name: "no previous times",
+			currentCPUStat: &cpu.TimesStat{
+				User: 8260.4,
+			},
+			expectedUtilization: &CPUUtilization{},
+		},
+		{
+			name:             "no delta time should return utilization=0",
+			previousReadTime: 1640097430772858000,
+			currentReadTime:  1640097430772858000,
+			previousCPUStat: &cpu.TimesStat{
+				User: 8259.4,
+			},
+			currentCPUStat: &cpu.TimesStat{
+				User: 8259.5,
+			},
+			expectedUtilization: &CPUUtilization{},
+		},
+		{
+			name:             "one second time delta",
+			previousReadTime: 1640097430772858000,
+			currentReadTime:  1640097431772858000,
+			previousCPUStat: &cpu.TimesStat{
+				User:   8258.4,
+				System: 6193.3,
+				Iowait: 34.201,
+			},
+			currentCPUStat: &cpu.TimesStat{
+				User:   8258.5,
+				System: 6193.6,
+				Iowait: 34.202,
+			},
+			expectedUtilization: &CPUUtilization{
+				User:   0.1,
+				System: 0.3,
+				Iowait: 0.001,
+			},
+		},
+	}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			recorder := inMemoryRecorder{}
+			calculator := CPUUtilizationCalculator{
+				previousReadTime: test.previousReadTime,
+				previousCPUStats: test.previousCPUStat,
+			}
+			err := calculator.CalculateAndRecord(test.currentReadTime, test.currentCPUStat, recorder.record)
+			assert.NoError(t, err)
+			assert.InDelta(t, test.expectedUtilization.System, recorder.cpuUtilization.System, 0.00001)
+			assert.InDelta(t, test.expectedUtilization.User, recorder.cpuUtilization.User, 0.00001)
+			assert.InDelta(t, test.expectedUtilization.Iowait, recorder.cpuUtilization.Iowait, 0.00001)
+		})
+	}
+}
+
+func Test_cpuUtilization(t *testing.T) {
+
+	startTime := pcommon.Timestamp(1640097435776827000)
+	halfSecondLater := pcommon.Timestamp(uint64(startTime) + uint64(time.Second.Nanoseconds()/2))
+	startStat := &cpu.TimesStat{
+		User:   1.5,
+		System: 2.702,
+		Iowait: 0.888,
+	}
+	endStat := &cpu.TimesStat{
+		User:   1.5124,
+		System: 3.004,
+		Iowait: 0.9,
+	}
+	expectedUtilization := CPUUtilization{
+		User:   0.0248,
+		System: 0.604,
+		Iowait: 0.024,
+	}
+
+	actualUtilization := cpuUtilization(startStat, startTime, endStat, halfSecondLater)
+	assert.InDelta(t, expectedUtilization.User, actualUtilization.User, 0.00001)
+	assert.InDelta(t, expectedUtilization.System, actualUtilization.System, 0.00001)
+	assert.InDelta(t, expectedUtilization.Iowait, actualUtilization.Iowait, 0.00001)
+
+}


### PR DESCRIPTION
**Description:**

This pull request adds an optional metric named `process.cpu.utilization`, as described in the [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.13.0/specification/metrics/semantic_conventions/process-metrics.md), to the metrics scraped by the `process` scraper of the `hostmetrics` receiver.

**Link to tracking Issue:** 

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14084

**Context:**

This metric has an equivalent in Telegraf as `procstat.cpu_usage`.