### PR TITLE
[pkg/stanza] Remove helper.OutputIDs type

### DIFF
--- a/pkg/stanza/operator/helper/helper_test.go
+++ b/pkg/stanza/operator/helper/helper_test.go
@@ -27,6 +27,7 @@ func init() {
 
 type helpersConfig struct {
 	BasicConfig `mapstructure:",squash"`
+	Writer      WriterConfig    `mapstructure:"writer"`
 	Time        TimeParser      `mapstructure:"time"`
 	Severity    SeverityConfig  `mapstructure:"severity"`
 	Scope       ScopeNameParser `mapstructure:"scope"`
@@ -36,6 +37,7 @@ type helpersConfig struct {
 func newHelpersConfig() *helpersConfig {
 	return &helpersConfig{
 		BasicConfig: NewBasicConfig(helpersTestType, helpersTestType),
+		Writer:      NewWriterConfig(helpersTestType, helpersTestType),
 		Time:        NewTimeParser(),
 		Severity:    NewSeverityConfig(),
 		Scope:       NewScopeNameParser(),

--- a/pkg/stanza/operator/helper/testdata/writer.yaml
+++ b/pkg/stanza/operator/helper/testdata/writer.yaml
@@ -1,0 +1,13 @@
+string:
+  type: helpers_test
+  writer:
+    output: test
+slice:
+  type: helpers_test
+  writer:
+    output: [test1, test2]
+invalid:
+  type: helpers_test
+  writer:
+    output:
+      foo: bar

--- a/pkg/stanza/operator/transformer/router/router.go
+++ b/pkg/stanza/operator/transformer/router/router.go
@@ -48,15 +48,15 @@ func NewConfigWithID(operatorID string) *Config {
 // Config is the configuration of a router operator
 type Config struct {
 	helper.BasicConfig `mapstructure:",squash" yaml:",inline"`
-	Routes             []*RouteConfig   `mapstructure:"routes" json:"routes" yaml:"routes"`
-	Default            helper.OutputIDs `mapstructure:"default" json:"default" yaml:"default"`
+	Routes             []*RouteConfig `mapstructure:"routes" json:"routes" yaml:"routes"`
+	Default            []string       `mapstructure:"default" json:"default" yaml:"default"`
 }
 
 // RouteConfig is the configuration of a route on a router operator
 type RouteConfig struct {
 	helper.AttributerConfig `mapstructure:",squash" yaml:",inline"`
-	Expression              string           `mapstructure:"expr" json:"expr"   yaml:"expr"`
-	OutputIDs               helper.OutputIDs `mapstructure:"output" json:"output" yaml:"output"`
+	Expression              string   `mapstructure:"expr" json:"expr"   yaml:"expr"`
+	OutputIDs               []string `mapstructure:"output" json:"output" yaml:"output"`
 }
 
 // Build will build a router operator from the supplied configuration
@@ -110,7 +110,7 @@ type Transformer struct {
 type Route struct {
 	helper.Attributer
 	Expression      *vm.Program
-	OutputIDs       helper.OutputIDs
+	OutputIDs       []string
 	OutputOperators []operator.Operator
 }
 

--- a/pkg/stanza/operator/transformer/router/router_test.go
+++ b/pkg/stanza/operator/transformer/router/router_test.go
@@ -43,7 +43,7 @@ func TestTransformer(t *testing.T) {
 		name               string
 		input              *entry.Entry
 		routes             []*RouteConfig
-		defaultOutput      helper.OutputIDs
+		defaultOutput      []string
 		expectedCounts     map[string]int
 		expectedAttributes map[string]interface{}
 	}{


### PR DESCRIPTION
This struct was originally introduced to allow for custom unmarshaling behavior (specifically to unmarshal either a string or []string). However, this is already default behavior in the collector due to the decode hooks used. Therefore, this struct is unnecessary and can be replaced by []string.