### PR TITLE
[pkg/stanza] Remove unused json and yaml tags from operators

### DIFF
--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -37,7 +37,7 @@ func init() {
 
 // UnstartableConfig is the configuration of an unstartable mock operator
 type UnstartableConfig struct {
-	helper.OutputConfig `yaml:",inline"`
+	helper.OutputConfig `mapstructure:",squash"`
 }
 
 // UnstartableOperator is an operator that will build but not start

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -47,17 +47,17 @@ func NewConfig() *Config {
 
 // Config is the configuration of a file input operator
 type Config struct {
-	Finder                  `mapstructure:",squash" yaml:",inline"`
-	IncludeFileName         bool                  `mapstructure:"include_file_name,omitempty"              json:"include_file_name,omitempty"             yaml:"include_file_name,omitempty"`
-	IncludeFilePath         bool                  `mapstructure:"include_file_path,omitempty"              json:"include_file_path,omitempty"             yaml:"include_file_path,omitempty"`
-	IncludeFileNameResolved bool                  `mapstructure:"include_file_name_resolved,omitempty"     json:"include_file_name_resolved,omitempty"    yaml:"include_file_name_resolved,omitempty"`
-	IncludeFilePathResolved bool                  `mapstructure:"include_file_path_resolved,omitempty"     json:"include_file_path_resolved,omitempty"    yaml:"include_file_path_resolved,omitempty"`
-	PollInterval            time.Duration         `mapstructure:"poll_interval,omitempty"                  json:"poll_interval,omitempty"                 yaml:"poll_interval,omitempty"`
-	StartAt                 string                `mapstructure:"start_at,omitempty"                       json:"start_at,omitempty"                      yaml:"start_at,omitempty"`
-	FingerprintSize         helper.ByteSize       `mapstructure:"fingerprint_size,omitempty"               json:"fingerprint_size,omitempty"              yaml:"fingerprint_size,omitempty"`
-	MaxLogSize              helper.ByteSize       `mapstructure:"max_log_size,omitempty"                   json:"max_log_size,omitempty"                  yaml:"max_log_size,omitempty"`
-	MaxConcurrentFiles      int                   `mapstructure:"max_concurrent_files,omitempty"           json:"max_concurrent_files,omitempty"          yaml:"max_concurrent_files,omitempty"`
-	Splitter                helper.SplitterConfig `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
+	Finder                  `mapstructure:",squash"`
+	IncludeFileName         bool                  `mapstructure:"include_file_name,omitempty"`
+	IncludeFilePath         bool                  `mapstructure:"include_file_path,omitempty"`
+	IncludeFileNameResolved bool                  `mapstructure:"include_file_name_resolved,omitempty"`
+	IncludeFilePathResolved bool                  `mapstructure:"include_file_path_resolved,omitempty"`
+	PollInterval            time.Duration         `mapstructure:"poll_interval,omitempty"`
+	StartAt                 string                `mapstructure:"start_at,omitempty"`
+	FingerprintSize         helper.ByteSize       `mapstructure:"fingerprint_size,omitempty"`
+	MaxLogSize              helper.ByteSize       `mapstructure:"max_log_size,omitempty"`
+	MaxConcurrentFiles      int                   `mapstructure:"max_concurrent_files,omitempty"`
+	Splitter                helper.SplitterConfig `mapstructure:",squash,omitempty"`
 }
 
 // Build will build a file input operator from the supplied configuration

--- a/pkg/stanza/fileconsumer/finder.go
+++ b/pkg/stanza/fileconsumer/finder.go
@@ -19,8 +19,8 @@ import (
 )
 
 type Finder struct {
-	Include []string `mapstructure:"include,omitempty" json:"include,omitempty" yaml:"include,omitempty"`
-	Exclude []string `mapstructure:"exclude,omitempty" json:"exclude,omitempty" yaml:"exclude,omitempty"`
+	Include []string `mapstructure:"include,omitempty"`
+	Exclude []string `mapstructure:"exclude,omitempty"`
 }
 
 // FindFiles gets a list of paths given an array of glob patterns to include and exclude

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -32,7 +32,7 @@ type readerConfig struct {
 
 // Reader manages a single file
 type Reader struct {
-	*zap.SugaredLogger `json:"-"`
+	*zap.SugaredLogger `json:"-"` // json tag excludes embedded fields from storage
 	*readerConfig
 	splitter *helper.Splitter
 

--- a/pkg/stanza/operator/helper/attributer.go
+++ b/pkg/stanza/operator/helper/attributer.go
@@ -27,7 +27,7 @@ func NewAttributerConfig() AttributerConfig {
 
 // AttributerConfig is the configuration of a attributer
 type AttributerConfig struct {
-	Attributes map[string]ExprStringConfig `mapstructure:"attributes" json:"attributes" yaml:"attributes"`
+	Attributes map[string]ExprStringConfig `mapstructure:"attributes"`
 }
 
 // Build will build a attributer from the supplied configuration

--- a/pkg/stanza/operator/helper/bytesize.go
+++ b/pkg/stanza/operator/helper/bytesize.go
@@ -24,41 +24,31 @@ import (
 
 type ByteSize int64
 
-func (h *ByteSize) UnmarshalJSON(raw []byte) error {
-	return h.unmarshalShared(func(i interface{}) error {
-		return json.Unmarshal(raw, &i)
-	})
-}
-
-func (h *ByteSize) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	return h.unmarshalShared(unmarshal)
-}
+var byteSizeRegex = regexp.MustCompile(`^([0-9]+\.?[0-9]*)\s*([kKmMgGtTpP]i?[bB])?$`)
 
 func (h *ByteSize) UnmarshalText(text []byte) (err error) {
 	slice := make([]byte, 1, 2+len(text))
 	slice[0] = byte('"')
 	slice = append(slice, text...)
 	slice = append(slice, byte('"'))
-	return h.UnmarshalJSON(slice)
-}
+	unmarshal := func(i interface{}) error {
+		return json.Unmarshal(slice, &i)
+	}
 
-var byteSizeRegex = regexp.MustCompile(`^([0-9]+\.?[0-9]*)\s*([kKmMgGtTpP]i?[bB])?$`)
-
-func (h *ByteSize) unmarshalShared(unmarshal func(interface{}) error) error {
 	var intType int64
-	if err := unmarshal(&intType); err == nil {
+	if err = unmarshal(&intType); err == nil {
 		*h = ByteSize(intType)
 		return nil
 	}
 
 	var floatType float64
-	if err := unmarshal(&floatType); err == nil {
+	if err = unmarshal(&floatType); err == nil {
 		*h = ByteSize(int64(floatType))
 		return nil
 	}
 
 	var stringType string
-	if err := unmarshal(&stringType); err != nil {
+	if err = unmarshal(&stringType); err != nil {
 		return fmt.Errorf("failed to unmarshal to int64, float64, or string: %w", err)
 	}
 

--- a/pkg/stanza/operator/helper/encoding.go
+++ b/pkg/stanza/operator/helper/encoding.go
@@ -34,7 +34,7 @@ func NewEncodingConfig() EncodingConfig {
 
 // EncodingConfig is the configuration of a Encoding helper
 type EncodingConfig struct {
-	Encoding string `mapstructure:"encoding,omitempty"              json:"encoding,omitempty"             yaml:"encoding,omitempty"`
+	Encoding string `mapstructure:"encoding,omitempty"`
 }
 
 // Build will build an Encoding operator.

--- a/pkg/stanza/operator/helper/identifier.go
+++ b/pkg/stanza/operator/helper/identifier.go
@@ -27,7 +27,7 @@ func NewIdentifierConfig() IdentifierConfig {
 
 // IdentifierConfig is the configuration of a resource identifier
 type IdentifierConfig struct {
-	Resource map[string]ExprStringConfig `mapstructure:"resource" json:"resource" yaml:"resource"`
+	Resource map[string]ExprStringConfig `mapstructure:"resource"`
 }
 
 // Build will build an identifier from the supplied configuration

--- a/pkg/stanza/operator/helper/input.go
+++ b/pkg/stanza/operator/helper/input.go
@@ -34,9 +34,9 @@ func NewInputConfig(operatorID, operatorType string) InputConfig {
 
 // InputConfig provides a basic implementation of an input operator config.
 type InputConfig struct {
-	AttributerConfig `mapstructure:",squash" yaml:",inline"`
-	IdentifierConfig `mapstructure:",squash" yaml:",inline"`
-	WriterConfig     `mapstructure:",squash" yaml:",inline"`
+	AttributerConfig `mapstructure:",squash"`
+	IdentifierConfig `mapstructure:",squash"`
+	WriterConfig     `mapstructure:",squash"`
 }
 
 // Build will build a base producer.

--- a/pkg/stanza/operator/helper/multiline.go
+++ b/pkg/stanza/operator/helper/multiline.go
@@ -26,7 +26,7 @@ import (
 
 // FlusherConfig is a configuration of Flusher helper
 type FlusherConfig struct {
-	Period time.Duration `mapstructure:"force_flush_period"  json:"force_flush_period" yaml:"force_flush_period"`
+	Period time.Duration `mapstructure:"force_flush_period"`
 }
 
 // NewFlusherConfig creates a default Flusher config
@@ -131,8 +131,8 @@ func NewMultilineConfig() MultilineConfig {
 
 // MultilineConfig is the configuration of a multiline helper
 type MultilineConfig struct {
-	LineStartPattern string `mapstructure:"line_start_pattern"  json:"line_start_pattern" yaml:"line_start_pattern"`
-	LineEndPattern   string `mapstructure:"line_end_pattern"    json:"line_end_pattern"   yaml:"line_end_pattern"`
+	LineStartPattern string `mapstructure:"line_start_pattern"`
+	LineEndPattern   string `mapstructure:"line_end_pattern"`
 }
 
 // Build will build a Multiline operator.
@@ -348,9 +348,9 @@ func trimWhitespaces(data []byte) []byte {
 
 // SplitterConfig consolidates MultilineConfig and FlusherConfig
 type SplitterConfig struct {
-	EncodingConfig EncodingConfig  `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
-	Multiline      MultilineConfig `mapstructure:"multiline,omitempty"                      json:"multiline,omitempty"                     yaml:"multiline,omitempty"`
-	Flusher        FlusherConfig   `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
+	EncodingConfig EncodingConfig  `mapstructure:",squash,omitempty"`
+	Multiline      MultilineConfig `mapstructure:"multiline,omitempty"`
+	Flusher        FlusherConfig   `mapstructure:",squash,omitempty"`
 }
 
 // NewSplitterConfig returns default SplitterConfig

--- a/pkg/stanza/operator/helper/operator.go
+++ b/pkg/stanza/operator/helper/operator.go
@@ -31,8 +31,8 @@ func NewBasicConfig(operatorID, operatorType string) BasicConfig {
 
 // BasicConfig provides a basic implemention for an operator config.
 type BasicConfig struct {
-	OperatorID   string `mapstructure:"id"   json:"id"   yaml:"id"`
-	OperatorType string `mapstructure:"type" json:"type" yaml:"type"`
+	OperatorID   string `mapstructure:"id"`
+	OperatorType string `mapstructure:"type"`
 }
 
 // ID will return the operator id.

--- a/pkg/stanza/operator/helper/output.go
+++ b/pkg/stanza/operator/helper/output.go
@@ -30,7 +30,7 @@ func NewOutputConfig(operatorID, operatorType string) OutputConfig {
 
 // OutputConfig provides a basic implementation of an output operator config.
 type OutputConfig struct {
-	BasicConfig `mapstructure:",squash" yaml:",inline"`
+	BasicConfig `mapstructure:",squash"`
 }
 
 // Build will build an output operator.

--- a/pkg/stanza/operator/helper/parser.go
+++ b/pkg/stanza/operator/helper/parser.go
@@ -35,14 +35,14 @@ func NewParserConfig(operatorID, operatorType string) ParserConfig {
 
 // ParserConfig provides the basic implementation of a parser config.
 type ParserConfig struct {
-	TransformerConfig `mapstructure:",squash" yaml:",inline"`
-	ParseFrom         entry.Field         `mapstructure:"parse_from"          json:"parse_from"          yaml:"parse_from"`
-	ParseTo           entry.RootableField `mapstructure:"parse_to"            json:"parse_to"            yaml:"parse_to"`
-	BodyField         *entry.Field        `mapstructure:"body"                json:"body"                yaml:"body"`
-	TimeParser        *TimeParser         `mapstructure:"timestamp,omitempty" json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
-	SeverityConfig    *SeverityConfig     `mapstructure:"severity,omitempty"  json:"severity,omitempty"  yaml:"severity,omitempty"`
-	TraceParser       *TraceParser        `mapstructure:"trace,omitempty"     json:"trace,omitempty"     yaml:"trace,omitempty"`
-	ScopeNameParser   *ScopeNameParser    `mapstructure:"scope_name,omitempty"     json:"scope_name,omitempty"     yaml:"scope_name,omitempty"`
+	TransformerConfig `mapstructure:",squash"`
+	ParseFrom         entry.Field         `mapstructure:"parse_from"`
+	ParseTo           entry.RootableField `mapstructure:"parse_to"`
+	BodyField         *entry.Field        `mapstructure:"body"`
+	TimeParser        *TimeParser         `mapstructure:"timestamp,omitempty"`
+	SeverityConfig    *SeverityConfig     `mapstructure:"severity,omitempty"`
+	TraceParser       *TraceParser        `mapstructure:"trace,omitempty"`
+	ScopeNameParser   *ScopeNameParser    `mapstructure:"scope_name,omitempty"`
 }
 
 // Build will build a parser operator.

--- a/pkg/stanza/operator/helper/scope_name.go
+++ b/pkg/stanza/operator/helper/scope_name.go
@@ -21,7 +21,7 @@ import (
 
 // ScopeNameParser is a helper that parses severity onto an entry.
 type ScopeNameParser struct {
-	ParseFrom entry.Field `mapstructure:"parse_from,omitempty"  json:"parse_from,omitempty"  yaml:"parse_from,omitempty"`
+	ParseFrom entry.Field `mapstructure:"parse_from,omitempty"`
 }
 
 // NewScopeNameParser creates a new scope parser with default values

--- a/pkg/stanza/operator/helper/severity_builder.go
+++ b/pkg/stanza/operator/helper/severity_builder.go
@@ -149,9 +149,9 @@ func NewSeverityConfig() SeverityConfig {
 
 // SeverityConfig allows users to specify how to parse a severity from a field.
 type SeverityConfig struct {
-	ParseFrom *entry.Field                `mapstructure:"parse_from,omitempty"  json:"parse_from,omitempty"  yaml:"parse_from,omitempty"`
-	Preset    string                      `mapstructure:"preset,omitempty"      json:"preset,omitempty"      yaml:"preset,omitempty"`
-	Mapping   map[interface{}]interface{} `mapstructure:"mapping,omitempty"     json:"mapping,omitempty"     yaml:"mapping,omitempty"`
+	ParseFrom *entry.Field                `mapstructure:"parse_from,omitempty"`
+	Preset    string                      `mapstructure:"preset,omitempty"`
+	Mapping   map[interface{}]interface{} `mapstructure:"mapping,omitempty"`
 }
 
 // Build builds a SeverityParser from a SeverityConfig

--- a/pkg/stanza/operator/helper/time.go
+++ b/pkg/stanza/operator/helper/time.go
@@ -48,10 +48,10 @@ func NewTimeParser() TimeParser {
 
 // TimeParser is a helper that parses time onto an entry.
 type TimeParser struct {
-	ParseFrom  *entry.Field `mapstructure:"parse_from"  json:"parse_from"  yaml:"parse_from"`
-	Layout     string       `mapstructure:"layout"      json:"layout"      yaml:"layout"`
-	LayoutType string       `mapstructure:"layout_type" json:"layout_type" yaml:"layout_type"`
-	Location   string       `mapstructure:"location"    json:"location"    yaml:"location"`
+	ParseFrom  *entry.Field `mapstructure:"parse_from"`
+	Layout     string       `mapstructure:"layout"`
+	LayoutType string       `mapstructure:"layout_type"`
+	Location   string       `mapstructure:"location"`
 
 	location *time.Location
 }

--- a/pkg/stanza/operator/helper/trace.go
+++ b/pkg/stanza/operator/helper/trace.go
@@ -42,21 +42,21 @@ func NewTraceParser() TraceParser {
 
 // TraceParser is a helper that parses trace spans (and flags) onto an entry.
 type TraceParser struct {
-	TraceID    *TraceIDConfig    `mapstructure:"trace_id,omitempty"    json:"trace_id,omitempty"    yaml:"trace_id,omitempty"`
-	SpanID     *SpanIDConfig     `mapstructure:"span_id,omitempty"     json:"span_id,omitempty"     yaml:"span_id,omitempty"`
-	TraceFlags *TraceFlagsConfig `mapstructure:"trace_flags,omitempty" json:"trace_flags,omitempty" yaml:"trace_flags,omitempty"`
+	TraceID    *TraceIDConfig    `mapstructure:"trace_id,omitempty"`
+	SpanID     *SpanIDConfig     `mapstructure:"span_id,omitempty"`
+	TraceFlags *TraceFlagsConfig `mapstructure:"trace_flags,omitempty"`
 }
 
 type TraceIDConfig struct {
-	ParseFrom *entry.Field `mapstructure:"parse_from,omitempty"  json:"parse_from,omitempty"  yaml:"parse_from,omitempty"`
+	ParseFrom *entry.Field `mapstructure:"parse_from,omitempty"`
 }
 
 type SpanIDConfig struct {
-	ParseFrom *entry.Field `mapstructure:"parse_from,omitempty"  json:"parse_from,omitempty"  yaml:"parse_from,omitempty"`
+	ParseFrom *entry.Field `mapstructure:"parse_from,omitempty"`
 }
 
 type TraceFlagsConfig struct {
-	ParseFrom *entry.Field `mapstructure:"parse_from,omitempty"  json:"parse_from,omitempty"  yaml:"parse_from,omitempty"`
+	ParseFrom *entry.Field `mapstructure:"parse_from,omitempty"`
 }
 
 // Validate validates a TraceParser, and reconfigures it if necessary

--- a/pkg/stanza/operator/helper/transformer.go
+++ b/pkg/stanza/operator/helper/transformer.go
@@ -36,9 +36,9 @@ func NewTransformerConfig(operatorID, operatorType string) TransformerConfig {
 
 // TransformerConfig provides a basic implementation of a transformer config.
 type TransformerConfig struct {
-	WriterConfig `mapstructure:",squash"  yaml:",inline"`
-	OnError      string `mapstructure:"on_error" json:"on_error" yaml:"on_error"`
-	IfExpr       string `mapstructure:"if"       json:"if"       yaml:"if"`
+	WriterConfig `mapstructure:",squash"`
+	OnError      string `mapstructure:"on_error"`
+	IfExpr       string `mapstructure:"if"`
 }
 
 // Build will build a transformer operator.

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -43,8 +43,8 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a file input operator
 type Config struct {
-	helper.InputConfig  `mapstructure:",squash" yaml:",inline"`
-	fileconsumer.Config `mapstructure:",squash" yaml:",inline"`
+	helper.InputConfig  `mapstructure:",squash"`
+	fileconsumer.Config `mapstructure:",squash"`
 }
 
 // Build will build a file input operator from the supplied configuration

--- a/pkg/stanza/operator/input/generate/generate.go
+++ b/pkg/stanza/operator/input/generate/generate.go
@@ -40,10 +40,10 @@ func NewConfig(operatorID string) *Config {
 
 // Config is the configuration of a generate input operator.
 type Config struct {
-	helper.InputConfig `yaml:",inline"`
-	Entry              entry.Entry `json:"entry"           yaml:"entry"`
-	Count              int         `json:"count,omitempty" yaml:"count,omitempty"`
-	Static             bool        `json:"static"          yaml:"static,omitempty"`
+	helper.InputConfig `mapstructure:",squash"`
+	Entry              entry.Entry `mapstructure:"entry"`
+	Count              int         `mapstructure:"count"`
+	Static             bool        `mapstructure:"static"`
 }
 
 // Build will build a generate input operator.

--- a/pkg/stanza/operator/input/journald/journald.go
+++ b/pkg/stanza/operator/input/journald/journald.go
@@ -58,13 +58,13 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a journald input operator
 type Config struct {
-	helper.InputConfig `mapstructure:",squash" yaml:",inline"`
+	helper.InputConfig `mapstructure:",squash"`
 
-	Directory *string  `mapstructure:"directory,omitempty" json:"directory,omitempty" yaml:"directory,omitempty"`
-	Files     []string `mapstructure:"files,omitempty"     json:"files,omitempty"     yaml:"files,omitempty"`
-	StartAt   string   `mapstructure:"start_at,omitempty"  json:"start_at,omitempty"  yaml:"start_at,omitempty"`
-	Units     []string `mapstructure:"units,omitempty"     json:"units,omitempty"     yaml:"units,omitempty"`
-	Priority  string   `mapstructure:"priority,omitempty"  json:"priority,omitempty"  yaml:"priority,omitempty"`
+	Directory *string  `mapstructure:"directory,omitempty"`
+	Files     []string `mapstructure:"files,omitempty"`
+	StartAt   string   `mapstructure:"start_at,omitempty"`
+	Units     []string `mapstructure:"units,omitempty"`
+	Priority  string   `mapstructure:"priority,omitempty"`
 }
 
 // Build will build a journald input operator from the supplied configuration

--- a/pkg/stanza/operator/input/stdin/stdin.go
+++ b/pkg/stanza/operator/input/stdin/stdin.go
@@ -41,7 +41,7 @@ func NewConfig(operatorID string) *Config {
 
 // Config is the configuration of a stdin input operator.
 type Config struct {
-	helper.InputConfig `yaml:",inline"`
+	helper.InputConfig `mapstructure:",squash"`
 }
 
 // Build will build a stdin input operator.

--- a/pkg/stanza/operator/input/syslog/syslog.go
+++ b/pkg/stanza/operator/input/syslog/syslog.go
@@ -45,10 +45,10 @@ func NewConfigWithID(operatorID string) *Config {
 }
 
 type Config struct {
-	helper.InputConfig `mapstructure:",squash" yaml:",inline"`
-	syslog.BaseConfig  `mapstructure:",squash" yaml:",inline"`
-	TCP                *tcp.BaseConfig `mapstructure:"tcp" json:"tcp" yaml:"tcp"`
-	UDP                *udp.BaseConfig `mapstructure:"udp" json:"udp" yaml:"udp"`
+	helper.InputConfig `mapstructure:",squash"`
+	syslog.BaseConfig  `mapstructure:",squash"`
+	TCP                *tcp.BaseConfig `mapstructure:"tcp"`
+	UDP                *udp.BaseConfig `mapstructure:"udp"`
 }
 
 func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {

--- a/pkg/stanza/operator/input/syslog/syslog_test.go
+++ b/pkg/stanza/operator/input/syslog/syslog_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/tcp"
@@ -143,34 +142,4 @@ func NewConfigWithUDP(syslogCfg *syslog.BaseConfig) *Config {
 	cfg.UDP.ListenAddress = ":12032"
 	cfg.OutputIDs = []string{"fake"}
 	return cfg
-}
-
-func TestConfigYamlUnmarshalUDP(t *testing.T) {
-	base := `type: syslog_input
-protocol: rfc5424
-udp:
-  listen_address: localhost:1234
-`
-	var cfg Config
-	err := yaml.Unmarshal([]byte(base), &cfg)
-	require.NoError(t, err)
-	require.Equal(t, syslog.RFC5424, cfg.Protocol)
-	require.Nil(t, cfg.TCP)
-	require.NotNil(t, cfg.UDP)
-	require.Equal(t, "localhost:1234", cfg.UDP.ListenAddress)
-}
-
-func TestConfigYamlUnmarshalTCP(t *testing.T) {
-	base := `type: syslog_input
-protocol: rfc5424
-tcp:
-  listen_address: localhost:1234
-`
-	var cfg Config
-	err := yaml.Unmarshal([]byte(base), &cfg)
-	require.NoError(t, err)
-	require.Equal(t, syslog.RFC5424, cfg.Protocol)
-	require.Nil(t, cfg.UDP)
-	require.NotNil(t, cfg.TCP)
-	require.Equal(t, "localhost:1234", cfg.TCP.ListenAddress)
 }

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -67,18 +67,18 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a tcp input operator.
 type Config struct {
-	helper.InputConfig `mapstructure:",squash" yaml:",inline"`
-	BaseConfig         `mapstructure:",squash" yaml:",inline"`
+	helper.InputConfig `mapstructure:",squash"`
+	BaseConfig         `mapstructure:",squash"`
 }
 
 // BaseConfig is the detailed configuration of a tcp input operator.
 type BaseConfig struct {
-	MaxLogSize    helper.ByteSize             `mapstructure:"max_log_size,omitempty"          json:"max_log_size,omitempty"         yaml:"max_log_size,omitempty"`
-	ListenAddress string                      `mapstructure:"listen_address,omitempty"        json:"listen_address,omitempty"       yaml:"listen_address,omitempty"`
-	TLS           *configtls.TLSServerSetting `mapstructure:"tls,omitempty"                   json:"tls,omitempty"                  yaml:"tls,omitempty"`
-	AddAttributes bool                        `mapstructure:"add_attributes,omitempty"        json:"add_attributes,omitempty"       yaml:"add_attributes,omitempty"`
-	Encoding      helper.EncodingConfig       `mapstructure:",squash,omitempty"               json:",inline,omitempty"              yaml:",inline,omitempty"`
-	Multiline     helper.MultilineConfig      `mapstructure:"multiline,omitempty"             json:"multiline,omitempty"            yaml:"multiline,omitempty"`
+	MaxLogSize    helper.ByteSize             `mapstructure:"max_log_size,omitempty"`
+	ListenAddress string                      `mapstructure:"listen_address,omitempty"`
+	TLS           *configtls.TLSServerSetting `mapstructure:"tls,omitempty"`
+	AddAttributes bool                        `mapstructure:"add_attributes,omitempty"`
+	Encoding      helper.EncodingConfig       `mapstructure:",squash,omitempty"`
+	Multiline     helper.MultilineConfig      `mapstructure:"multiline,omitempty"`
 }
 
 // Build will build a tcp input operator.

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -61,16 +61,16 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a udp input operator.
 type Config struct {
-	helper.InputConfig `mapstructure:",squash" yaml:",inline"`
-	BaseConfig         `mapstructure:",squash" yaml:",inline"`
+	helper.InputConfig `mapstructure:",squash"`
+	BaseConfig         `mapstructure:",squash"`
 }
 
 // BaseConfig is the details configuration of a udp input operator.
 type BaseConfig struct {
-	ListenAddress string                 `mapstructure:"listen_address,omitempty"        json:"listen_address,omitempty"       yaml:"listen_address,omitempty"`
-	AddAttributes bool                   `mapstructure:"add_attributes,omitempty"        json:"add_attributes,omitempty"       yaml:"add_attributes,omitempty"`
-	Encoding      helper.EncodingConfig  `mapstructure:",squash,omitempty"               json:",inline,omitempty"              yaml:",inline,omitempty"`
-	Multiline     helper.MultilineConfig `mapstructure:"multiline,omitempty"             json:"multiline,omitempty"            yaml:"multiline,omitempty"`
+	ListenAddress string                 `mapstructure:"listen_address,omitempty"`
+	AddAttributes bool                   `mapstructure:"add_attributes,omitempty"`
+	Encoding      helper.EncodingConfig  `mapstructure:",squash,omitempty"`
+	Multiline     helper.MultilineConfig `mapstructure:"multiline,omitempty"`
 }
 
 // Build will build a udp input operator.

--- a/pkg/stanza/operator/input/windows/operator.go
+++ b/pkg/stanza/operator/input/windows/operator.go
@@ -52,11 +52,11 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a windows event log operator.
 type Config struct {
-	helper.InputConfig `mapstructure:",squash" yaml:",inline"`
-	Channel            string        `mapstructure:"channel" json:"channel" yaml:"channel"`
-	MaxReads           int           `mapstructure:"max_reads,omitempty" json:"max_reads,omitempty" yaml:"max_reads,omitempty"`
-	StartAt            string        `mapstructure:"start_at,omitempty" json:"start_at,omitempty" yaml:"start_at,omitempty"`
-	PollInterval       time.Duration `mapstructure:"poll_interval,omitempty" json:"poll_interval,omitempty" yaml:"poll_interval,omitempty"`
+	helper.InputConfig `mapstructure:",squash"`
+	Channel            string        `mapstructure:"channel"`
+	MaxReads           int           `mapstructure:"max_reads,omitempty"`
+	StartAt            string        `mapstructure:"start_at,omitempty"`
+	PollInterval       time.Duration `mapstructure:"poll_interval,omitempty"`
 }
 
 // Build will build a windows event log operator.

--- a/pkg/stanza/operator/output/drop/drop.go
+++ b/pkg/stanza/operator/output/drop/drop.go
@@ -37,7 +37,7 @@ func NewConfig(operatorID string) *Config {
 
 // Config is the configuration of a drop output operator.
 type Config struct {
-	helper.OutputConfig `yaml:",inline"`
+	helper.OutputConfig `mapstructure:",squash"`
 }
 
 // Build will build a drop output operator.

--- a/pkg/stanza/operator/output/file/file.go
+++ b/pkg/stanza/operator/output/file/file.go
@@ -42,10 +42,10 @@ func NewConfig(operatorID string) *Config {
 
 // Config is the configuration of a file output operatorn.
 type Config struct {
-	helper.OutputConfig `yaml:",inline"`
+	helper.OutputConfig `mapstructure:",squash"`
 
-	Path   string `json:"path" yaml:"path"`
-	Format string `json:"format,omitempty" path:"format,omitempty"`
+	Path   string `mapstructure:"path"`
+	Format string `mapstructure:"format"`
 }
 
 // Build will build a file output operator.

--- a/pkg/stanza/operator/output/stdout/stdout.go
+++ b/pkg/stanza/operator/output/stdout/stdout.go
@@ -44,7 +44,7 @@ func NewConfig(operatorID string) *Config {
 
 // Config is the configuration of the Stdout operator
 type Config struct {
-	helper.OutputConfig `yaml:",inline"`
+	helper.OutputConfig `mapstructure:",squash"`
 }
 
 // Build will build a stdout operator.

--- a/pkg/stanza/operator/parser/csv/csv.go
+++ b/pkg/stanza/operator/parser/csv/csv.go
@@ -48,13 +48,13 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a csv parser operator.
 type Config struct {
-	helper.ParserConfig `mapstructure:",squash" yaml:",inline"`
+	helper.ParserConfig `mapstructure:",squash"`
 
-	Header          string `mapstructure:"header" json:"header" yaml:"header"`
-	HeaderAttribute string `mapstructure:"header_attribute" json:"header_attribute" yaml:"header_attribute"`
-	FieldDelimiter  string `mapstructure:"delimiter" json:"delimiter,omitempty" yaml:"delimiter,omitempty"`
-	LazyQuotes      bool   `mapstructure:"lazy_quotes" json:"lazy_quotes,omitempty" yaml:"lazy_quotes,omitempty"`
-	IgnoreQuotes    bool   `mapstructure:"ignore_quotes" json:"ignore_quotes,omitempty" yaml:"ignore_quotes,omitempty"`
+	Header          string `mapstructure:"header"`
+	HeaderAttribute string `mapstructure:"header_attribute"`
+	FieldDelimiter  string `mapstructure:"delimiter"`
+	LazyQuotes      bool   `mapstructure:"lazy_quotes"`
+	IgnoreQuotes    bool   `mapstructure:"ignore_quotes"`
 }
 
 // Build will build a csv parser operator.

--- a/pkg/stanza/operator/parser/json/json.go
+++ b/pkg/stanza/operator/parser/json/json.go
@@ -46,7 +46,7 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a JSON parser operator.
 type Config struct {
-	helper.ParserConfig `mapstructure:",squash" yaml:",inline"`
+	helper.ParserConfig `mapstructure:",squash"`
 }
 
 // Build will build a JSON parser operator.

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue.go
@@ -49,10 +49,10 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a key value parser operator.
 type Config struct {
-	helper.ParserConfig `mapstructure:",squash" yaml:",inline"`
+	helper.ParserConfig `mapstructure:",squash"`
 
-	Delimiter     string `mapstructure:"delimiter" yaml:"delimiter"`
-	PairDelimiter string `mapstructure:"pair_delimiter" yaml:"pair_delimiter"`
+	Delimiter     string `mapstructure:"delimiter"`
+	PairDelimiter string `mapstructure:"pair_delimiter"`
 }
 
 // Build will build a key value parser operator.

--- a/pkg/stanza/operator/parser/regex/regex.go
+++ b/pkg/stanza/operator/parser/regex/regex.go
@@ -47,13 +47,13 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a regex parser operator.
 type Config struct {
-	helper.ParserConfig `mapstructure:",squash" yaml:",inline"`
+	helper.ParserConfig `mapstructure:",squash"`
 
-	Regex string `mapstructure:"regex" json:"regex" yaml:"regex"`
+	Regex string `mapstructure:"regex"`
 
 	Cache struct {
-		Size uint16 `json:"size" yaml:"size"`
-	} `mapstructure:"cache" json:"cache" yaml:"cache"`
+		Size uint16 `mapstructure:"size"`
+	} `mapstructure:"cache"`
 }
 
 // Build will build a regex parser operator.

--- a/pkg/stanza/operator/parser/scope/scope_name.go
+++ b/pkg/stanza/operator/parser/scope/scope_name.go
@@ -45,8 +45,8 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a logger name parser operator.
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash"           yaml:",inline"`
-	helper.ScopeNameParser   `mapstructure:",omitempty,squash" yaml:",omitempty,inline"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	helper.ScopeNameParser   `mapstructure:",omitempty,squash"`
 }
 
 // Build will build a logger name parser operator.

--- a/pkg/stanza/operator/parser/severity/severity.go
+++ b/pkg/stanza/operator/parser/severity/severity.go
@@ -45,8 +45,8 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a severity parser operator.
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash" yaml:",inline"`
-	helper.SeverityConfig    `mapstructure:",omitempty,squash" yaml:",omitempty,inline"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	helper.SeverityConfig    `mapstructure:",omitempty,squash"`
 }
 
 // Build will build a severity parser operator.

--- a/pkg/stanza/operator/parser/syslog/syslog.go
+++ b/pkg/stanza/operator/parser/syslog/syslog.go
@@ -54,14 +54,14 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a syslog parser operator.
 type Config struct {
-	helper.ParserConfig `mapstructure:",squash" yaml:",inline"`
-	BaseConfig          `mapstructure:",squash" yaml:",inline"`
+	helper.ParserConfig `mapstructure:",squash"`
+	BaseConfig          `mapstructure:",squash"`
 }
 
 // BaseConfig is the detailed configuration of a syslog parser.
 type BaseConfig struct {
-	Protocol string `mapstructure:"protocol,omitempty" json:"protocol,omitempty" yaml:"protocol,omitempty"`
-	Location string `mapstructure:"location,omitempty" json:"location,omitempty" yaml:"location,omitempty"`
+	Protocol string `mapstructure:"protocol,omitempty"`
+	Location string `mapstructure:"location,omitempty"`
 }
 
 // Build will build a JSON parser operator.

--- a/pkg/stanza/operator/parser/time/time.go
+++ b/pkg/stanza/operator/parser/time/time.go
@@ -45,8 +45,8 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a time parser operator.
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash" yaml:",inline"`
-	helper.TimeParser        `mapstructure:",omitempty,squash" yaml:",omitempty,inline"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	helper.TimeParser        `mapstructure:",omitempty,squash"`
 }
 
 // Build will build a time parser operator.

--- a/pkg/stanza/operator/parser/trace/trace.go
+++ b/pkg/stanza/operator/parser/trace/trace.go
@@ -45,8 +45,8 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a trace parser operator.
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash"           yaml:",inline"`
-	helper.TraceParser       `mapstructure:",omitempty,squash" yaml:",omitempty,inline"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	helper.TraceParser       `mapstructure:",omitempty,squash"`
 }
 
 // Build will build a trace parser operator.

--- a/pkg/stanza/operator/parser/uri/uri.go
+++ b/pkg/stanza/operator/parser/uri/uri.go
@@ -47,7 +47,7 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a uri parser operator.
 type Config struct {
-	helper.ParserConfig `mapstructure:",squash" yaml:",inline"`
+	helper.ParserConfig `mapstructure:",squash"`
 }
 
 // Build will build a uri parser operator.

--- a/pkg/stanza/operator/transformer/add/add.go
+++ b/pkg/stanza/operator/transformer/add/add.go
@@ -48,9 +48,9 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of an add operator
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash" yaml:",inline"`
-	Field                    entry.Field `mapstructure:"field" json:"field" yaml:"field"`
-	Value                    interface{} `mapstructure:"value,omitempty" json:"value,omitempty" yaml:"value,omitempty"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	Field                    entry.Field `mapstructure:"field"`
+	Value                    interface{} `mapstructure:"value,omitempty"`
 }
 
 // Build will build an add operator from the supplied configuration

--- a/pkg/stanza/operator/transformer/copy/copy.go
+++ b/pkg/stanza/operator/transformer/copy/copy.go
@@ -45,9 +45,9 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a copy operator
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash" yaml:",inline"`
-	From                     entry.Field `mapstructure:"from" json:"from" yaml:"from"`
-	To                       entry.Field `mapstructure:"to" json:"to" yaml:"to"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	From                     entry.Field `mapstructure:"from"`
+	To                       entry.Field `mapstructure:"to"`
 }
 
 // Build will build a copy operator from the supplied configuration

--- a/pkg/stanza/operator/transformer/filter/filter.go
+++ b/pkg/stanza/operator/transformer/filter/filter.go
@@ -55,9 +55,9 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a filter operator
 type Config struct {
-	helper.TransformerConfig `yaml:",inline"`
-	Expression               string  `json:"expr"   yaml:"expr"`
-	DropRatio                float64 `json:"drop_ratio"   yaml:"drop_ratio"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	Expression               string  `mapstructure:"expr"`
+	DropRatio                float64 `mapstructure:"drop_ratio"`
 }
 
 // Build will build a filter operator from the supplied configuration

--- a/pkg/stanza/operator/transformer/flatten/flatten.go
+++ b/pkg/stanza/operator/transformer/flatten/flatten.go
@@ -47,8 +47,8 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a flatten operator
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash" yaml:",inline"`
-	Field                    entry.BodyField `mapstructure:"field" json:"field" yaml:"field"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	Field                    entry.BodyField `mapstructure:"field"`
 }
 
 // Build will build a Flatten operator from the supplied configuration

--- a/pkg/stanza/operator/transformer/move/move.go
+++ b/pkg/stanza/operator/transformer/move/move.go
@@ -45,9 +45,9 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a move operator
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash" yaml:",inline"`
-	From                     entry.Field `mapstructure:"from" yaml:"from"`
-	To                       entry.Field `mapstructure:"to" yaml:"to"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	From                     entry.Field `mapstructure:"from"`
+	To                       entry.Field `mapstructure:"to"`
 }
 
 // Build will build a Move operator from the supplied configuration

--- a/pkg/stanza/operator/transformer/noop/noop.go
+++ b/pkg/stanza/operator/transformer/noop/noop.go
@@ -44,7 +44,7 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a noop operator.
 type Config struct {
-	helper.TransformerConfig `yaml:",inline"`
+	helper.TransformerConfig `mapstructure:",squash"`
 }
 
 // Build will build a noop operator.

--- a/pkg/stanza/operator/transformer/recombine/recombine.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine.go
@@ -59,16 +59,16 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a recombine operator
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash" yaml:",inline"`
-	IsFirstEntry             string        `mapstructure:"is_first_entry"     json:"is_first_entry"     yaml:"is_first_entry"`
-	IsLastEntry              string        `mapstructure:"is_last_entry"      json:"is_last_entry"      yaml:"is_last_entry"`
-	MaxBatchSize             int           `mapstructure:"max_batch_size"     json:"max_batch_size"     yaml:"max_batch_size"`
-	CombineField             entry.Field   `mapstructure:"combine_field"      json:"combine_field"      yaml:"combine_field"`
-	CombineWith              string        `mapstructure:"combine_with"       json:"combine_with"       yaml:"combine_with"`
-	SourceIdentifier         entry.Field   `mapstructure:"source_identifier"  json:"source_identifier"  yaml:"source_identifier"`
-	OverwriteWith            string        `mapstructure:"overwrite_with"     json:"overwrite_with"     yaml:"overwrite_with"`
-	ForceFlushTimeout        time.Duration `mapstructure:"force_flush_period" json:"force_flush_period" yaml:"force_flush_period"`
-	MaxSources               int           `mapstructure:"max_sources"        json:"max_sources"        yaml:"max_sources"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	IsFirstEntry             string        `mapstructure:"is_first_entry"`
+	IsLastEntry              string        `mapstructure:"is_last_entry"`
+	MaxBatchSize             int           `mapstructure:"max_batch_size"`
+	CombineField             entry.Field   `mapstructure:"combine_field"`
+	CombineWith              string        `mapstructure:"combine_with"`
+	SourceIdentifier         entry.Field   `mapstructure:"source_identifier"`
+	OverwriteWith            string        `mapstructure:"overwrite_with"`
+	ForceFlushTimeout        time.Duration `mapstructure:"force_flush_period"`
+	MaxSources               int           `mapstructure:"max_sources"`
 }
 
 // Build creates a new Transformer from a config

--- a/pkg/stanza/operator/transformer/remove/remove.go
+++ b/pkg/stanza/operator/transformer/remove/remove.go
@@ -45,9 +45,9 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a remove operator
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash" yaml:",inline"`
+	helper.TransformerConfig `mapstructure:",squash"`
 
-	Field rootableField `mapstructure:"field"  json:"field" yaml:"field"`
+	Field rootableField `mapstructure:"field"`
 }
 
 // Build will build a Remove operator from the supplied configuration

--- a/pkg/stanza/operator/transformer/retain/retain.go
+++ b/pkg/stanza/operator/transformer/retain/retain.go
@@ -46,8 +46,8 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a retain operator
 type Config struct {
-	helper.TransformerConfig `mapstructure:",squash" yaml:",inline"`
-	Fields                   []entry.Field `mapstructure:"fields" json:"fields" yaml:"fields"`
+	helper.TransformerConfig `mapstructure:",squash"`
+	Fields                   []entry.Field `mapstructure:"fields"`
 }
 
 // Build will build a retain operator from the supplied configuration

--- a/pkg/stanza/operator/transformer/router/router.go
+++ b/pkg/stanza/operator/transformer/router/router.go
@@ -47,16 +47,16 @@ func NewConfigWithID(operatorID string) *Config {
 
 // Config is the configuration of a router operator
 type Config struct {
-	helper.BasicConfig `mapstructure:",squash" yaml:",inline"`
-	Routes             []*RouteConfig `mapstructure:"routes" json:"routes" yaml:"routes"`
-	Default            []string       `mapstructure:"default" json:"default" yaml:"default"`
+	helper.BasicConfig `mapstructure:",squash"`
+	Routes             []*RouteConfig `mapstructure:"routes"`
+	Default            []string       `mapstructure:"default"`
 }
 
 // RouteConfig is the configuration of a route on a router operator
 type RouteConfig struct {
-	helper.AttributerConfig `mapstructure:",squash" yaml:",inline"`
-	Expression              string   `mapstructure:"expr" json:"expr"   yaml:"expr"`
-	OutputIDs               []string `mapstructure:"output" json:"output" yaml:"output"`
+	helper.AttributerConfig `mapstructure:",squash"`
+	Expression              string   `mapstructure:"expr"`
+	OutputIDs               []string `mapstructure:"output"`
 }
 
 // Build will build a router operator from the supplied configuration


### PR DESCRIPTION
Operators are no longer unmarshaled based on json or yaml libaries,
so do not require the associated tags.