### PR TITLE
prometheusreceiver: Don't ignore instance labels for internal metrics

### DIFF
--- a/.chloggen/prom_federated_internal_metrics.yaml
+++ b/.chloggen/prom_federated_internal_metrics.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: prometheusreceiver
+note: Don't ignore instance, job, or metric path labels for internal metrics
+issues: [14453]

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -129,7 +129,7 @@ func (t *transaction) Append(ref storage.SeriesRef, ls labels.Labels, atMs int64
 
 	curMF := t.getOrCreateMetricFamily(metricName)
 
-	return 0, curMF.addSeries(t.getSeriesRef(ls, curMF.mtype), metricName, ls, atMs, val)
+	return 0, curMF.addSeries(t.getSeriesRef(ls, curMF.mtype, metricName), metricName, ls, atMs, val)
 }
 
 func (t *transaction) getOrCreateMetricFamily(mn string) *metricFamily {
@@ -174,14 +174,14 @@ func (t *transaction) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e e
 	}
 
 	mf := t.getOrCreateMetricFamily(mn)
-	mf.addExemplar(t.getSeriesRef(l, mf.mtype), e)
+	mf.addExemplar(t.getSeriesRef(l, mf.mtype, mf.name), e)
 
 	return 0, nil
 }
 
-func (t *transaction) getSeriesRef(ls labels.Labels, mtype pmetric.MetricType) uint64 {
+func (t *transaction) getSeriesRef(ls labels.Labels, mtype pmetric.MetricType, mname string) uint64 {
 	var hash uint64
-	hash, t.bufBytes = getSeriesRef(t.bufBytes, ls, mtype)
+	hash, t.bufBytes = getSeriesRef(t.bufBytes, ls, mtype, mname)
 	return hash
 }
 
@@ -273,6 +273,6 @@ func (t *transaction) AddTargetInfo(labels labels.Labels) error {
 	return nil
 }
 
-func getSeriesRef(bytes []byte, ls labels.Labels, mtype pmetric.MetricType) (uint64, []byte) {
-	return ls.HashWithoutLabels(bytes, getSortedNotUsefulLabels(mtype)...)
+func getSeriesRef(bytes []byte, ls labels.Labels, mtype pmetric.MetricType, name string) (uint64, []byte) {
+	return ls.HashWithoutLabels(bytes, getSortedNotUsefulLabels(mtype, name)...)
 }

--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -53,6 +53,7 @@ var (
 	notUsefulLabelsHistogram = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel, model.BucketLabel})
 	notUsefulLabelsSummary   = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel, model.QuantileLabel})
 	notUsefulLabelsOther     = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel})
+	notUsefulLabelsInternal  = sortString([]string{model.MetricNameLabel, model.SchemeLabel})
 )
 
 func sortString(strs []string) []string {
@@ -60,7 +61,14 @@ func sortString(strs []string) []string {
 	return strs
 }
 
-func getSortedNotUsefulLabels(mType pmetric.MetricType) []string {
+func getSortedNotUsefulLabels(mType pmetric.MetricType, mName string) []string {
+	if _, ok := internalMetricMetadata[mName]; ok {
+		// For internal time series don't filter instance, job, or metrics path labels as these
+		// differentiate federated instances in cases of otherwise equivalent labels.
+		// Internal metrics are all gauges.
+		return notUsefulLabelsInternal
+	}
+
 	switch mType {
 	case pmetric.MetricTypeHistogram:
 		return notUsefulLabelsHistogram


### PR DESCRIPTION
**Description:**
Fixing a bug - In federated endpoint scraping cases internal labels are required to differentiate scraped metrics and receiver-internal ones. These changes take the metric name into consideration when establishing "not useful" labels for metric group identity.

**Link to tracking Issue:**
#14453

**Testing:**
~~ongoing - I'm having issues w/ my dev environment and running these tests reliably.~~
Added basic unit tests for internal metric attributes.
