### PR TITLE
[receiver/dockerstats] Disable container.cpu.usage.system by default, and expand description

### DIFF
--- a/receiver/dockerstatsreceiver/documentation.md
+++ b/receiver/dockerstatsreceiver/documentation.md
@@ -22,7 +22,7 @@ These are the metrics available for this scraper.
 | container.cpu.throttling_data.throttled_time | Aggregate time the container was throttled. | ns | Sum(Int) | <ul> </ul> |
 | **container.cpu.usage.kernelmode** | Time spent by tasks of the cgroup in kernel mode (Linux).  Time spent by all container processes in kernel mode (Windows). | ns | Sum(Int) | <ul> </ul> |
 | container.cpu.usage.percpu | Per-core CPU usage by the container. | ns | Sum(Int) | <ul> <li>core</li> </ul> |
-| **container.cpu.usage.system** | System CPU usage. | ns | Sum(Int) | <ul> </ul> |
+| container.cpu.usage.system | System CPU usage, as reported by docker. Note this is the usage for the system, not the container. | ns | Sum(Int) | <ul> </ul> |
 | **container.cpu.usage.total** | Total CPU time consumed. | ns | Sum(Int) | <ul> </ul> |
 | **container.cpu.usage.usermode** | Time spent by tasks of the cgroup in user mode (Linux).  Time spent by all container processes in user mode (Windows). | ns | Sum(Int) | <ul> </ul> |
 | container.memory.active_anon | The amount of anonymous memory that has been identified as active by the kernel. | By | Sum(Int) | <ul> </ul> |

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -128,7 +128,7 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: false,
 		},
 		ContainerCPUUsageSystem: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ContainerCPUUsageTotal: MetricSettings{
 			Enabled: true,
@@ -1032,7 +1032,7 @@ type metricContainerCPUUsageSystem struct {
 // init fills container.cpu.usage.system metric with initial data.
 func (m *metricContainerCPUUsageSystem) init() {
 	m.data.SetName("container.cpu.usage.system")
-	m.data.SetDescription("System CPU usage.")
+	m.data.SetDescription("System CPU usage, as reported by docker.")
 	m.data.SetUnit("ns")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -40,8 +40,9 @@ attributes:
 metrics:
   # CPU
   container.cpu.usage.system:
-    enabled: true
-    description: "System CPU usage."
+    enabled: false
+    description: "System CPU usage, as reported by docker."
+    extended_documentation: "Note this is the usage for the system, not the container."
     unit: ns
     sum:
       value_type: int

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.json
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.json
@@ -374,7 +374,7 @@
               "unit": "{operations}"
             },
             {
-              "description": "System CPU usage.",
+              "description": "System CPU usage, as reported by docker.",
               "name": "container.cpu.usage.system",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",

--- a/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.json
+++ b/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.json
@@ -374,7 +374,7 @@
               "unit": "{operations}"
             },
             {
-              "description": "System CPU usage.",
+              "description": "System CPU usage, as reported by docker.",
               "name": "container.cpu.usage.system",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -1591,7 +1591,7 @@
               "unit": "{operations}"
             },
             {
-              "description": "System CPU usage.",
+              "description": "System CPU usage, as reported by docker.",
               "name": "container.cpu.usage.system",
               "sum": {
                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",

--- a/unreleased/system-usage-tweak.yaml
+++ b/unreleased/system-usage-tweak.yaml
@@ -1,0 +1,5 @@
+change_type: breaking
+component: dockerstatsreceiver
+note: "`container.cpu.usage.system` is no longer a default metric. Added more description for the metric."
+issues: [9794, 14558]
+subtext: "Change is not breaking unless you are have enabled the featuregate `receiver.dockerstats.useScraperV2` and are using the specified metric."


### PR DESCRIPTION
**Description:**
* `container.cpu.usage.system` is no longer a default metric. 
* Added more description for the metric, since I believe it had the possibility to mislead users. 

My rationale behind disabling this as a default metric, is that it has the potential to be misleading unless the user has explicitly read the description. It also duplicates system CPU metrics emitted by the `hostmetricsreceiver`. I thought about completely removing it, but I thought I better leave it in since it is something that docker reports. 

Change is technically breaking, but only behind the non-default featuregate. I don't expect it will impact any users. 

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9794

**Testing:** 

Tests were updated to test for the updated description

**Documentation:**

Go generate / mdatagen updates the docs. 