### PR TITLE
[receiver/hostmetrics] Add optional metric `process.disk.operations`

### DIFF
--- a/.chloggen/add-process-disk-operations-metric.yaml
+++ b/.chloggen/add-process-disk-operations-metric.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a new optional metric `process.disk.operations` to the `process` scraper of the `hostmetrics` receiver.
+
+# One or more tracking issues related to the change
+issues: [14084]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
@@ -94,6 +94,20 @@ Percentage of total CPU time used by the process since last scrape, expressed as
 | ---- | ----------- | ------ |
 | state | Breakdown of CPU usage by type. | Str: ``system``, ``user``, ``wait`` |
 
+### process.disk.operations
+
+Number of disk operations performed by the process.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {operations} | Sum | Int | Cumulative | true |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | Direction of flow of bytes (read or write). | Str: ``read``, ``write`` |
+
 ### process.memory.usage
 
 The amount of physical memory in use.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
@@ -30,6 +30,8 @@ func TestDefaultMetrics(t *testing.T) {
 	enabledMetrics["process.disk.io"] = true
 	mb.RecordProcessDiskIoDataPoint(ts, 1, AttributeDirection(1))
 
+	mb.RecordProcessDiskOperationsDataPoint(ts, 1, AttributeDirection(1))
+
 	enabledMetrics["process.memory.physical_usage"] = true
 	mb.RecordProcessMemoryPhysicalUsageDataPoint(ts, 1)
 
@@ -73,6 +75,7 @@ func TestAllMetrics(t *testing.T) {
 		ProcessCPUTime:             MetricSettings{Enabled: true},
 		ProcessCPUUtilization:      MetricSettings{Enabled: true},
 		ProcessDiskIo:              MetricSettings{Enabled: true},
+		ProcessDiskOperations:      MetricSettings{Enabled: true},
 		ProcessMemoryPhysicalUsage: MetricSettings{Enabled: true},
 		ProcessMemoryUsage:         MetricSettings{Enabled: true},
 		ProcessMemoryUtilization:   MetricSettings{Enabled: true},
@@ -94,6 +97,7 @@ func TestAllMetrics(t *testing.T) {
 	mb.RecordProcessCPUTimeDataPoint(ts, 1, AttributeState(1))
 	mb.RecordProcessCPUUtilizationDataPoint(ts, 1, AttributeState(1))
 	mb.RecordProcessDiskIoDataPoint(ts, 1, AttributeDirection(1))
+	mb.RecordProcessDiskOperationsDataPoint(ts, 1, AttributeDirection(1))
 	mb.RecordProcessMemoryPhysicalUsageDataPoint(ts, 1)
 	mb.RecordProcessMemoryUsageDataPoint(ts, 1)
 	mb.RecordProcessMemoryUtilizationDataPoint(ts, 1)
@@ -208,6 +212,22 @@ func TestAllMetrics(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, "read", attrVal.Str())
 			validatedMetrics["process.disk.io"] = struct{}{}
+		case "process.disk.operations":
+			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+			assert.Equal(t, "Number of disk operations performed by the process.", ms.At(i).Description())
+			assert.Equal(t, "{operations}", ms.At(i).Unit())
+			assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
+			assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+			dp := ms.At(i).Sum().DataPoints().At(0)
+			assert.Equal(t, start, dp.StartTimestamp())
+			assert.Equal(t, ts, dp.Timestamp())
+			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+			assert.Equal(t, int64(1), dp.IntValue())
+			attrVal, ok := dp.Attributes().Get("direction")
+			assert.True(t, ok)
+			assert.Equal(t, "read", attrVal.Str())
+			validatedMetrics["process.disk.operations"] = struct{}{}
 		case "process.memory.physical_usage":
 			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
@@ -339,6 +359,7 @@ func TestNoMetrics(t *testing.T) {
 		ProcessCPUTime:             MetricSettings{Enabled: false},
 		ProcessCPUUtilization:      MetricSettings{Enabled: false},
 		ProcessDiskIo:              MetricSettings{Enabled: false},
+		ProcessDiskOperations:      MetricSettings{Enabled: false},
 		ProcessMemoryPhysicalUsage: MetricSettings{Enabled: false},
 		ProcessMemoryUsage:         MetricSettings{Enabled: false},
 		ProcessMemoryUtilization:   MetricSettings{Enabled: false},
@@ -359,6 +380,7 @@ func TestNoMetrics(t *testing.T) {
 	mb.RecordProcessCPUTimeDataPoint(ts, 1, AttributeState(1))
 	mb.RecordProcessCPUUtilizationDataPoint(ts, 1, AttributeState(1))
 	mb.RecordProcessDiskIoDataPoint(ts, 1, AttributeDirection(1))
+	mb.RecordProcessDiskOperationsDataPoint(ts, 1, AttributeDirection(1))
 	mb.RecordProcessMemoryPhysicalUsageDataPoint(ts, 1)
 	mb.RecordProcessMemoryUsageDataPoint(ts, 1)
 	mb.RecordProcessMemoryUtilizationDataPoint(ts, 1)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -192,3 +192,13 @@ metrics:
       aggregation: cumulative
       monotonic: true
     attributes: [context_switch_type]
+
+  process.disk.operations:
+    enabled: false
+    description: Number of disk operations performed by the process.
+    unit: "{operations}"
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: true
+    attributes: [direction]

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -129,7 +129,12 @@ func TestScrape(t *testing.T) {
 				assertMetricMissing(t, md.ResourceMetrics(), "process.cpu.utilization")
 			}
 			assertMemoryUsageMetricValid(t, md.ResourceMetrics(), expectedStartTime)
-			assertOldDiskIOMetricValid(t, md.ResourceMetrics(), expectedStartTime)
+			assertDiskIoMetricValid(t, md.ResourceMetrics(), expectedStartTime)
+			if metricsSettings.ProcessDiskOperations.Enabled {
+				assertDiskOperationsMetricValid(t, md.ResourceMetrics(), expectedStartTime)
+			} else {
+				assertMetricMissing(t, md.ResourceMetrics(), "process.disk.operations")
+			}
 			if metricsSettings.ProcessPagingFaults.Enabled {
 				assertPagingMetricValid(t, md.ResourceMetrics(), expectedStartTime)
 			}
@@ -259,15 +264,26 @@ func assertMetricMissing(t *testing.T, resourceMetrics pmetric.ResourceMetricsSl
 	}
 }
 
-func assertOldDiskIOMetricValid(t *testing.T, resourceMetrics pmetric.ResourceMetricsSlice,
+func assertDiskIoMetricValid(t *testing.T, resourceMetrics pmetric.ResourceMetricsSlice,
 	startTime pcommon.Timestamp) {
-	diskIOMetric := getMetric(t, "process.disk.io", resourceMetrics)
+	diskIoMetric := getMetric(t, "process.disk.io", resourceMetrics)
 	if startTime != 0 {
-		internal.AssertSumMetricStartTimeEquals(t, diskIOMetric, startTime)
+		internal.AssertSumMetricStartTimeEquals(t, diskIoMetric, startTime)
 	}
-	internal.AssertSumMetricHasAttributeValue(t, diskIOMetric, 0, "direction",
+	internal.AssertSumMetricHasAttributeValue(t, diskIoMetric, 0, "direction",
 		pcommon.NewValueStr(metadata.AttributeDirectionRead.String()))
-	internal.AssertSumMetricHasAttributeValue(t, diskIOMetric, 1, "direction",
+	internal.AssertSumMetricHasAttributeValue(t, diskIoMetric, 1, "direction",
+		pcommon.NewValueStr(metadata.AttributeDirectionWrite.String()))
+}
+
+func assertDiskOperationsMetricValid(t *testing.T, resourceMetrics pmetric.ResourceMetricsSlice, startTime pcommon.Timestamp) {
+	diskOperationsMetric := getMetric(t, "process.disk.operations", resourceMetrics)
+	if startTime != 0 {
+		internal.AssertSumMetricStartTimeEquals(t, diskOperationsMetric, startTime)
+	}
+	internal.AssertSumMetricHasAttributeValue(t, diskOperationsMetric, 0, "direction",
+		pcommon.NewValueStr(metadata.AttributeDirectionRead.String()))
+	internal.AssertSumMetricHasAttributeValue(t, diskOperationsMetric, 1, "direction",
 		pcommon.NewValueStr(metadata.AttributeDirectionWrite.String()))
 }
 
@@ -945,6 +961,7 @@ func TestScrapeMetrics_DontCheckDisabledMetrics(t *testing.T) {
 
 	metricSettings.ProcessCPUTime.Enabled = false
 	metricSettings.ProcessDiskIo.Enabled = false
+	metricSettings.ProcessDiskOperations.Enabled = false
 	metricSettings.ProcessMemoryPhysicalUsage.Enabled = false
 	metricSettings.ProcessMemoryVirtualUsage.Enabled = false
 


### PR DESCRIPTION
**Description:**

This pull request adds a new metric named `process.disk.operations` to the metrics scraped by the `process` scraper of the `hostmetrics` receiver.

Adding this metric to the semantic conventions has been proposed here: https://github.com/open-telemetry/opentelemetry-specification/issues/2812.

**Link to tracking Issue:** 

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14084