### PR TITLE
[translator/jaeger] Convert ValueTypeBytes attributes in Jaeger translator

### DIFF
--- a/pkg/translator/jaeger/traces_to_jaegerproto.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto.go
@@ -15,6 +15,8 @@
 package jaeger // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 
 import (
+	"encoding/base64"
+
 	"github.com/jaegertracing/jaeger/model"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -147,6 +149,9 @@ func attributeToJaegerProtoTag(key string, attr pcommon.Value) model.KeyValue {
 	case pcommon.ValueTypeDouble:
 		tag.VType = model.ValueType_FLOAT64
 		tag.VFloat64 = attr.Double()
+	case pcommon.ValueTypeBytes:
+		tag.VType = model.ValueType_STRING
+		tag.VStr = base64.StdEncoding.EncodeToString(attr.Bytes().AsRaw())
 	case pcommon.ValueTypeMap, pcommon.ValueTypeSlice:
 		tag.VType = model.ValueType_STRING
 		tag.VStr = attr.AsString()

--- a/pkg/translator/jaeger/traces_to_jaegerproto_test.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto_test.go
@@ -181,6 +181,7 @@ func TestAttributesToJaegerProtoTags(t *testing.T) {
 	attributes.PutInt("int-val", 123)
 	attributes.PutString("string-val", "abc")
 	attributes.PutDouble("double-val", 1.23)
+	attributes.PutEmptyBytes("bytes-val").FromRaw([]byte{1, 2, 3, 4})
 	attributes.PutString(conventions.AttributeServiceName, "service-name")
 
 	expected := []model.KeyValue{
@@ -205,6 +206,11 @@ func TestAttributesToJaegerProtoTags(t *testing.T) {
 			VFloat64: 1.23,
 		},
 		{
+			Key:   "bytes-val",
+			VType: model.ValueType_STRING,
+			VStr:  "AQIDBA==", // base64 encoding of the byte array [1,2,3,4]
+		},
+		{
 			Key:   conventions.AttributeServiceName,
 			VType: model.ValueType_STRING,
 			VStr:  "service-name",
@@ -216,7 +222,7 @@ func TestAttributesToJaegerProtoTags(t *testing.T) {
 
 	// The last item in expected ("service-name") must be skipped in resource tags translation
 	got = appendTagsFromResourceAttributes(make([]model.KeyValue, 0, len(expected)-1), attributes)
-	require.EqualValues(t, expected[:4], got)
+	require.EqualValues(t, expected[:5], got)
 }
 
 func TestInternalTracesToJaegerProto(t *testing.T) {

--- a/unreleased/jaeger-bytearray.yaml
+++ b/unreleased/jaeger-bytearray.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: jaegerexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Adds support for ValueTypeBytes to Jaeger's trace to jaegerproto translator."
+
+# One or more tracking issues related to the change
+issues: [14574]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** Adds support for ValueTypeBytes to Jaeger's trace to jaegerproto translator. 
See https://github.com/open-telemetry/opentelemetry-collector/pull/6153

**Link to tracking Issue:**

**Testing:** Added unit test case for the new type

**Documentation:** None, minor change