### PR TITLE
Add shufo/auto-assign-reviewer-by-files

### DIFF
--- a/.github/assign-by-files.yml
+++ b/.github/assign-by-files.yml
@@ -1,0 +1,4 @@
+"processor/transformprocessor/**/*":
+  - TylerHelmuth
+  - kentquirk
+  - bogdandrutu

--- a/.github/workflows/auto-assign-codeowners.yml
+++ b/.github/workflows/auto-assign-codeowners.yml
@@ -1,0 +1,12 @@
+name: 'Auto Assign Code Owners'
+on:
+  - pull_request
+
+jobs:
+  assign_codeowner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shufo/auto-assign-reviewer-by-files@v1.1.3
+        with:
+          config: ".github/assign-by-files.yml"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-assign-codeowners.yml
+++ b/.github/workflows/auto-assign-codeowners.yml
@@ -1,6 +1,6 @@
 name: 'Auto Assign Code Owners'
 on:
-  - pull_request
+  pull_request_target:
 
 jobs:
   assign_codeowner:


### PR DESCRIPTION
**Description:**
Adds an action to assign code reviewers based on a file.  I wish it was actually Asignees, but I still haven't found an action that can do that.

Runs on every code push, so if new files are changed that affects more Code Owners, they will be asked to review.

Will fail if a user cannot be assigned.  I see this as a good thing since it means we'll identify components owned by people that aren't members, which is against our current guidance.

Downside is that we have to essentially duplicate the CODEOWNERS file in the assign-by-files.yml.

If we like this approach, I'll update the assign-by-files.yml to be comprehensive. 

**Testing:** 
Tested in my fork. Won't run in this repo until it's on main since it used pull_request_target. https://github.com/TylerHelmuth/opentelemetry-collector-contrib/pull/13