### PR TITLE
[exporter/splunkhec] fix error message when metric event fails to marshal

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -399,7 +399,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 			// JSON encoding event and writing to buffer.
 			b, err := jsoniter.Marshal(event)
 			if err != nil {
-				permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf("dropped metric events: %v, error: %w", events, err)))
+				permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf("dropped metric event: %v, error: %w", event, err)))
 				continue
 			}
 			state.buf.Write(b)


### PR DESCRIPTION
When a metric event fails to marshal, it adds a list of events (pointers) in the error message instead of only failed event