### PR TITLE
[receiver/k8seventsreceiver] add support for Event semantic attributes

### DIFF
--- a/.chloggen/k8s_event_semantic.yaml
+++ b/.chloggen/k8s_event_semantic.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8seventsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add Event semantic conventions as log attributes
+
+# One or more tracking issues related to the change
+issues: [14474]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/k8seventsreceiver/k8s_event_to_logdata.go
+++ b/receiver/k8seventsreceiver/k8s_event_to_logdata.go
@@ -77,6 +77,8 @@ func k8sEventToLogData(logger *zap.Logger, ev *corev1.Event) plog.Logs {
 	attrs := lr.Attributes()
 	attrs.EnsureCapacity(totalLogAttributes)
 
+	attrs.PutString("event.name", ev.Name)
+	attrs.PutString("event.domain", "k8s")
 	attrs.PutString("k8s.event.reason", ev.Reason)
 	attrs.PutString("k8s.event.action", ev.Action)
 	attrs.PutString("k8s.event.start_time", ev.ObjectMeta.CreationTimestamp.String())

--- a/receiver/k8seventsreceiver/k8s_event_to_logdata_test.go
+++ b/receiver/k8seventsreceiver/k8s_event_to_logdata_test.go
@@ -32,12 +32,12 @@ func TestK8sEventToLogData(t *testing.T) {
 	attrs := lr.LogRecords().At(0).Attributes()
 	assert.Equal(t, ld.ResourceLogs().Len(), 1)
 	assert.Equal(t, resourceAttrs.Len(), 7)
-	assert.Equal(t, attrs.Len(), 7)
+	assert.Equal(t, attrs.Len(), 9)
 
 	// Count attribute will not be present in the LogData
 	k8sEvent.Count = 0
 	ld = k8sEventToLogData(zap.NewNop(), k8sEvent)
-	assert.Equal(t, ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Len(), 6)
+	assert.Equal(t, ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Len(), 8)
 }
 
 func TestK8sEventToLogDataWithApiAndResourceVersion(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Add support for Event semantic attributes defined in https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/logs/events.yaml


**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14474

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>