### PR TITLE
GoogleCloudSpannerReceiver: Mask lock stats PII

### DIFF
--- a/.chloggen/googlecloudspannerreceiver-hide-lock-stats-pii.yaml
+++ b/.chloggen/googlecloudspannerreceiver-hide-lock-stats-pii.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: googlecloudspannerreceiver
+note: Configurably mask the PII in lock stats metrics.
+issues: [14607]
+subtext:

--- a/receiver/googlecloudspannerreceiver/README.md
+++ b/receiver/googlecloudspannerreceiver/README.md
@@ -64,7 +64,7 @@ Brief description of configuration properties:
 - **top_metrics_query_max_rows** - max number of rows to fetch from Top N built-in table(100 by default)
 - **backfill_enabled** - turn on/off 1-hour data backfill(by default it is turned off)
 - **cardinality_total_limit** - limit of active series per 24 hours period. If specified, turns on cardinality filtering and handling. If zero or not specified, cardinality is not handled. You can read [this document](cardinality.md) for more information about cardinality handling and filtering.
-- **hide_topn_lockstats_rowrangestartkey** - if true, hashes PII (keys) in row_range_start_key label for the "top minute lock stats" metric
+- **hide_topn_lockstats_rowrangestartkey** - if true, masks PII (key values) in row_range_start_key label for the "top minute lock stats" metric
 - **projects** - list of GCP projects
     - **project_id** - identifier of GCP project
     - **service_account_key** - path to service account JSON key It is highly recommended to set this property to the correct value. In case it is empty, the [Application Default Credentials](https://google.aip.dev/auth/4110) will be used for the database connection.

--- a/receiver/googlecloudspannerreceiver/README.md
+++ b/receiver/googlecloudspannerreceiver/README.md
@@ -32,6 +32,7 @@ receivers:
     top_metrics_query_max_rows: 100
     backfill_enabled: true
     cardinality_total_limit: 200000
+    hide_topn_lockstats_rowrangestartkey: false
     projects:
       - project_id: "spanner project 1"
         service_account_key: "path to spanner project 1 service account json key"
@@ -63,6 +64,7 @@ Brief description of configuration properties:
 - **top_metrics_query_max_rows** - max number of rows to fetch from Top N built-in table(100 by default)
 - **backfill_enabled** - turn on/off 1-hour data backfill(by default it is turned off)
 - **cardinality_total_limit** - limit of active series per 24 hours period. If specified, turns on cardinality filtering and handling. If zero or not specified, cardinality is not handled. You can read [this document](cardinality.md) for more information about cardinality handling and filtering.
+- **hide_topn_lockstats_rowrangestartkey** - if true, hashes PII (keys) in row_range_start_key label for the "top minute lock stats" metric
 - **projects** - list of GCP projects
     - **project_id** - identifier of GCP project
     - **service_account_key** - path to service account JSON key It is highly recommended to set this property to the correct value. In case it is empty, the [Application Default Credentials](https://google.aip.dev/auth/4110) will be used for the database connection.

--- a/receiver/googlecloudspannerreceiver/config.go
+++ b/receiver/googlecloudspannerreceiver/config.go
@@ -29,10 +29,11 @@ const (
 type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 
-	TopMetricsQueryMaxRows int       `mapstructure:"top_metrics_query_max_rows"`
-	BackfillEnabled        bool      `mapstructure:"backfill_enabled"`
-	CardinalityTotalLimit  int       `mapstructure:"cardinality_total_limit"`
-	Projects               []Project `mapstructure:"projects"`
+	TopMetricsQueryMaxRows            int       `mapstructure:"top_metrics_query_max_rows"`
+	BackfillEnabled                   bool      `mapstructure:"backfill_enabled"`
+	CardinalityTotalLimit             int       `mapstructure:"cardinality_total_limit"`
+	Projects                          []Project `mapstructure:"projects"`
+	HideTopnLockstatsRowrangestartkey bool      `mapstructure:"hide_topn_lockstats_rowrangestartkey"`
 }
 
 type Project struct {

--- a/receiver/googlecloudspannerreceiver/config_test.go
+++ b/receiver/googlecloudspannerreceiver/config_test.go
@@ -49,6 +49,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, 120*time.Second, receiver.CollectionInterval)
 	assert.Equal(t, 10, receiver.TopMetricsQueryMaxRows)
 	assert.True(t, receiver.BackfillEnabled)
+	assert.True(t, receiver.HideTopnLockstatsRowrangestartkey)
 
 	assert.Equal(t, 2, len(receiver.Projects))
 

--- a/receiver/googlecloudspannerreceiver/factory.go
+++ b/receiver/googlecloudspannerreceiver/factory.go
@@ -28,9 +28,10 @@ const (
 	typeStr   = "googlecloudspanner"
 	stability = component.StabilityLevelBeta
 
-	defaultCollectionInterval     = 60 * time.Second
-	defaultTopMetricsQueryMaxRows = 100
-	defaultBackfillEnabled        = false
+	defaultCollectionInterval                = 60 * time.Second
+	defaultTopMetricsQueryMaxRows            = 100
+	defaultBackfillEnabled                   = false
+	defaultHideTopnLockstatsRowrangestartkey = false
 )
 
 func NewFactory() component.ReceiverFactory {
@@ -46,8 +47,9 @@ func createDefaultConfig() config.Receiver {
 			ReceiverSettings:   config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			CollectionInterval: defaultCollectionInterval,
 		},
-		TopMetricsQueryMaxRows: defaultTopMetricsQueryMaxRows,
-		BackfillEnabled:        defaultBackfillEnabled,
+		TopMetricsQueryMaxRows:            defaultTopMetricsQueryMaxRows,
+		BackfillEnabled:                   defaultBackfillEnabled,
+		HideTopnLockstatsRowrangestartkey: defaultHideTopnLockstatsRowrangestartkey,
 	}
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
@@ -188,6 +188,10 @@ func (v byteSliceLabelValue) SetValueTo(attributes pcommon.Map) {
 	attributes.PutString(v.metadata.Name(), v.value)
 }
 
+func (v *byteSliceLabelValue) ModifyValue(s string) {
+	v.value = s
+}
+
 func newByteSliceLabelValue(metadata LabelValueMetadata, valueHolder interface{}) LabelValue {
 	return byteSliceLabelValue{
 		metadata: metadata,

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
@@ -199,6 +199,9 @@ func TestByteSliceLabelValue(t *testing.T) {
 
 	assert.True(t, exists)
 	assert.Equal(t, stringValue, attributeValue.Str())
+
+	labelValue.ModifyValue(labelName)
+	assert.Equal(t, labelName, labelValue.Value())
 }
 
 func TestLockRequestSliceLabelValue(t *testing.T) {

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
@@ -15,6 +15,8 @@
 package metadata
 
 import (
+	"fmt"
+	"hash/fnv"
 	"testing"
 	"time"
 
@@ -109,6 +111,35 @@ func TestMetricsDataPoint_CopyTo(t *testing.T) {
 		assertDefaultLabels(t, attributesMap, databaseID)
 		assertNonDefaultLabels(t, attributesMap, labelValues)
 	}
+}
+
+func TestMetricsDataPoint_HideLockStatsRowrangestartkeyPII(t *testing.T) {
+	btSliceLabelValueMetadata, _ := NewLabelValueMetadata("row_range_start_key", "byteSliceLabelColumnName", StringValueType)
+	labelValue1 := byteSliceLabelValue{metadata: btSliceLabelValueMetadata, value: "table1.s(23,hello,23+)"}
+	labelValue2 := byteSliceLabelValue{metadata: btSliceLabelValueMetadata, value: "table2(23,hello)"}
+	metricValues := allPossibleMetricValues(metricDataType)
+	labelValues := []LabelValue{labelValue1, labelValue2}
+	timestamp := time.Now().UTC()
+	metricsDataPoint := &MetricsDataPoint{
+		metricName:  metricName,
+		timestamp:   timestamp,
+		databaseID:  databaseID(),
+		labelValues: labelValues,
+		metricValue: metricValues[0],
+	}
+	hashFunction := fnv.New32a()
+	hashFunction.Reset()
+	hashFunction.Write([]byte("23"))
+	hashOf23 := fmt.Sprint(hashFunction.Sum32())
+	hashFunction.Reset()
+	hashFunction.Write([]byte("hello"))
+	hashOfHello := fmt.Sprint(hashFunction.Sum32())
+
+	metricsDataPoint.HideLockStatsRowrangestartkeyPII()
+
+	assert.Equal(t, len(metricsDataPoint.labelValues), 2)
+	assert.Equal(t, metricsDataPoint.labelValues[0].Value(), "table1.s("+hashOf23+","+hashOfHello+","+hashOf23+"+)")
+	assert.Equal(t, metricsDataPoint.labelValues[1].Value(), "table2("+hashOf23+","+hashOfHello+")")
 }
 
 func allPossibleLabelValues() []LabelValue {

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader_test.go
@@ -57,8 +57,9 @@ func TestNewIntervalStatsReader(t *testing.T) {
 	}
 	logger := zaptest.NewLogger(t)
 	config := ReaderConfig{
-		TopMetricsQueryMaxRows: topMetricsQueryMaxRows,
-		BackfillEnabled:        true,
+		TopMetricsQueryMaxRows:            topMetricsQueryMaxRows,
+		BackfillEnabled:                   true,
+		HideTopnLockstatsRowrangestartkey: true,
 	}
 
 	reader := newIntervalStatsReader(logger, database, metricsMetadata, config)
@@ -69,6 +70,7 @@ func TestNewIntervalStatsReader(t *testing.T) {
 	assert.Equal(t, topMetricsQueryMaxRows, reader.topMetricsQueryMaxRows)
 	assert.NotNil(t, reader.timestampsGenerator)
 	assert.True(t, reader.timestampsGenerator.backfillEnabled)
+	assert.True(t, reader.hideTopnLockstatsRowrangestartkey)
 }
 
 func TestIntervalStatsReader_NewPullStatement(t *testing.T) {
@@ -76,8 +78,9 @@ func TestIntervalStatsReader_NewPullStatement(t *testing.T) {
 	timestamp := time.Now().UTC()
 	logger := zaptest.NewLogger(t)
 	config := ReaderConfig{
-		TopMetricsQueryMaxRows: topMetricsQueryMaxRows,
-		BackfillEnabled:        false,
+		TopMetricsQueryMaxRows:            topMetricsQueryMaxRows,
+		BackfillEnabled:                   false,
+		HideTopnLockstatsRowrangestartkey: true,
 	}
 	ctx := context.Background()
 	client, _ := spanner.NewClient(ctx, "")

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
@@ -21,8 +21,9 @@ import (
 )
 
 type ReaderConfig struct {
-	TopMetricsQueryMaxRows int
-	BackfillEnabled        bool
+	TopMetricsQueryMaxRows            int
+	BackfillEnabled                   bool
+	HideTopnLockstatsRowrangestartkey bool
 }
 
 type Reader interface {

--- a/receiver/googlecloudspannerreceiver/receiver.go
+++ b/receiver/googlecloudspannerreceiver/receiver.go
@@ -108,8 +108,9 @@ func (r *googleCloudSpannerReceiver) initializeProjectReaders(ctx context.Contex
 	parsedMetadata []*metadata.MetricsMetadata) error {
 
 	readerConfig := statsreader.ReaderConfig{
-		BackfillEnabled:        r.config.BackfillEnabled,
-		TopMetricsQueryMaxRows: r.config.TopMetricsQueryMaxRows,
+		BackfillEnabled:                   r.config.BackfillEnabled,
+		TopMetricsQueryMaxRows:            r.config.TopMetricsQueryMaxRows,
+		HideTopnLockstatsRowrangestartkey: r.config.HideTopnLockstatsRowrangestartkey,
 	}
 
 	for _, project := range r.config.Projects {

--- a/receiver/googlecloudspannerreceiver/testdata/config.yaml
+++ b/receiver/googlecloudspannerreceiver/testdata/config.yaml
@@ -4,6 +4,7 @@ receivers:
     top_metrics_query_max_rows: 10
     backfill_enabled: true
     cardinality_total_limit: 200000
+    hide_topn_lockstats_rowrangestartkey: true
     projects:
       - project_id: "spanner project 1"
         service_account_key: "path to spanner project 1 service account json key"


### PR DESCRIPTION
**Description:** Cloud Spanner receiver should have the capability to mask sensitive information. This PR adds a configurable option to mask the PII in lock stats metrics for customers. 

For the metric "top minute lock stats", the label "row_range_start_key" (https://cloud.google.com/spanner/docs/introspection/lock-statistics#explain-row-range) has PII information of table key values. We have now given the ability to hash the keys individually such that 
table_name(key1,key2) becomes table_name(hash1,hash2).
Note that even though key values are hashed, a user can identify if sets of keys share common prefix like table1(key1,key2) and table1(key1,key3)



**Link to tracking Issue:** Google-Internal customer-request. 

**Testing:** Unit tests added. Manual end-to-end testing done by running the service locally and verifying the hashed row_range_start_key values.

**Documentation:** Added the configuration option and the corresponding info in the README