### PR TITLE
[receiver/podmanreceiver] update stability level to in development

### DIFF
--- a/receiver/podmanreceiver/README.md
+++ b/receiver/podmanreceiver/README.md
@@ -1,7 +1,8 @@
 # Podman Stats Receiver
+
 | Status                   |                   |
 | ------------------------ |-------------------|
-| Stability                | [unmaintained]    |
+| Stability                | [in development]  |
 | Supported pipeline types | metrics           |
 | Distributions            | [contrib]         |
 
@@ -88,5 +89,5 @@ Recommended build tags to use when including this receiver in your build:
 - `exclude_graphdriver_btrfs`
 - `exclude_graphdriver_devicemapper`
 
-[unmaintained]: https://github.com/open-telemetry/opentelemetry-collector#unmaintained
+[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/podmanreceiver/factory.go
+++ b/receiver/podmanreceiver/factory.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	typeStr           = "podman_stats"
-	stability         = component.StabilityLevelUnmaintained
+	stability         = component.StabilityLevelInDevelopment
 	defaultAPIVersion = "3.3.1"
 )
 


### PR DESCRIPTION
Update stability level to in development. 

Once https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9013 is finished we could consider changing the stability level to alpha (it will have the same features as the docker stats receiver). 

Skip changelog tag?