### PR TITLE
[extension/sigv4authextension] Make `sts_region` default to `region` if value not provided

### DIFF
--- a/.chloggen/sigv4_default_stsregion.yaml
+++ b/.chloggen/sigv4_default_stsregion.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sigv4authextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Have "sts_region" default to "region" if not provided
+
+# One or more tracking issues related to the change
+issues: [14573]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/extension/sigv4authextension/README.md
+++ b/extension/sigv4authextension/README.md
@@ -15,6 +15,7 @@ The configuration fields are as follows:
   * `arn`: The Amazon Resource Name (ARN) of a role to assume
   * `session_name`: **Optional**. The name of a role session
   * `sts_region`: The AWS region where STS is used to assumed the configured role
+    * Note that if a role is intended to be assumed, and `sts_region` is not provided, then `sts_region` will default to the value for `region` if `region` is provided
 * `region`: **Optional**. The AWS region for the service you are exporting to for AWS Sigv4. This is differentiated from `sts_region` to handle cross region authentication
     * Note that an attempt will be made to obtain a valid region from the endpoint of the service you are exporting to
     * [List of AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -47,7 +47,7 @@ func (cfg *Config) Validate() error {
 	if cfg.AssumeRole.STSRegion == "" && cfg.Region != "" {
 		cfg.AssumeRole.STSRegion = cfg.Region
 	}
-	
+
 	credsProvider, err := getCredsProviderFromConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credential provider: %w", err)

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -44,6 +44,10 @@ var _ config.Extension = (*Config)(nil)
 // We aim to catch most errors here to ensure that we
 // fail early and to avoid revalidating static data.
 func (cfg *Config) Validate() error {
+	if cfg.AssumeRole.STSRegion == "" && cfg.Region != "" {
+		cfg.AssumeRole.STSRegion = cfg.Region
+	}
+	
 	credsProvider, err := getCredsProviderFromConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credential provider: %w", err)

--- a/extension/sigv4authextension/config_test.go
+++ b/extension/sigv4authextension/config_test.go
@@ -47,7 +47,7 @@ func TestLoadConfig(t *testing.T) {
 		Service:           "service",
 		AssumeRole: AssumeRole{
 			SessionName: "role_session_name",
-			STSRegion: "region",
+			STSRegion:   "region",
 		},
 		// Ensure creds are the same for load config test; tested in extension_test.go
 		credsProvider: cfg.(*Config).credsProvider,

--- a/extension/sigv4authextension/config_test.go
+++ b/extension/sigv4authextension/config_test.go
@@ -47,6 +47,7 @@ func TestLoadConfig(t *testing.T) {
 		Service:           "service",
 		AssumeRole: AssumeRole{
 			SessionName: "role_session_name",
+			STSRegion: "region",
 		},
 		// Ensure creds are the same for load config test; tested in extension_test.go
 		credsProvider: cfg.(*Config).credsProvider,


### PR DESCRIPTION
**Description:** 
This PR makes the value `sts_region` default to the value of `region` if the `sts_region` value is not provided and the `region` value is provided.

**Link to tracking Issue:**
#14573 

**Testing:** <Describe what testing was performed and which tests were added.>
`config_test.go` was updated

**Documentation:** <Describe the documentation added.>
`README.md` was updated