### PR TITLE
[receiver/hostmetrics] Add `process.signals_pending` metric

### DIFF
--- a/.chloggen/add-process-signals-pending-metric.yaml
+++ b/.chloggen/add-process-signals-pending-metric.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a new optional metric `process.signals_pending` to the metrics scraped by the `process` scraper of the `hostmetrics` receiver.
+
+# One or more tracking issues related to the change
+issues: [14084]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
@@ -17,6 +17,7 @@ These are the metrics available for this scraper.
 | **process.memory.virtual_usage** | Deprecated: Use `process.memory.virtual` metric instead. Virtual memory size. | By | Sum(Int) | <ul> </ul> |
 | process.open_file_descriptors | Number of file descriptors in use by the process. | {count} | Sum(Int) | <ul> </ul> |
 | process.paging.faults | Number of page faults the process has made. This metric is only available on Linux. | {faults} | Sum(Int) | <ul> <li>paging_fault_type</li> </ul> |
+| process.signals_pending | Number of pending signals for the process. This metric is only available on Linux. | {signals} | Sum(Int) | <ul> </ul> |
 | process.threads | Process threads count. | {threads} | Sum(Int) | <ul> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -124,6 +124,15 @@ metrics:
       monotonic: true
     attributes: [paging_fault_type]
 
+  process.signals_pending:
+    enabled: false
+    description: Number of pending signals for the process. This metric is only available on Linux.
+    unit: "{signals}"
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+
   process.threads:
     enabled: false
     description: Process threads count.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -96,6 +96,8 @@ type processHandle interface {
 	PageFaults() (*process.PageFaultsStat, error)
 	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
 	NumFDs() (int32, error)
+	// If gatherUsed is true, the currently used value will be gathered and added to the resulting RlimitStat.
+	RlimitUsage(gatherUsed bool) ([]process.RlimitStat, error)
 }
 
 type gopsProcessHandles struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -52,6 +52,7 @@ func enableLinuxOnlyMetrics(ms *metadata.MetricsSettings) {
 	ms.ProcessPagingFaults.Enabled = true
 	ms.ProcessContextSwitches.Enabled = true
 	ms.ProcessOpenFileDescriptors.Enabled = true
+	ms.ProcessSignalsPending.Enabled = true
 }
 
 func TestScrape(t *testing.T) {
@@ -119,6 +120,9 @@ func TestScrape(t *testing.T) {
 			assertOldDiskIOMetricValid(t, md.ResourceMetrics(), expectedStartTime)
 			if metricsSettings.ProcessPagingFaults.Enabled {
 				assertPagingMetricValid(t, md.ResourceMetrics(), expectedStartTime)
+			}
+			if metricsSettings.ProcessSignalsPending.Enabled {
+				assertSignalsPendingMetricValid(t, md.ResourceMetrics(), expectedStartTime)
 			}
 			if metricsSettings.ProcessThreads.Enabled {
 				assertThreadsCountValid(t, md.ResourceMetrics(), expectedStartTime)
@@ -188,6 +192,13 @@ func assertPagingMetricValid(t *testing.T, resourceMetrics pmetric.ResourceMetri
 
 	if startTime != 0 {
 		internal.AssertSumMetricStartTimeEquals(t, pagingFaultsMetric, startTime)
+	}
+}
+
+func assertSignalsPendingMetricValid(t *testing.T, resourceMetrics pmetric.ResourceMetricsSlice, startTime pcommon.Timestamp) {
+	signalsPendingMetric := getMetric(t, "process.signals_pending", resourceMetrics)
+	if startTime != 0 {
+		internal.AssertSumMetricStartTimeEquals(t, signalsPendingMetric, startTime)
 	}
 }
 
@@ -396,6 +407,11 @@ func (p *processHandleMock) NumFDs() (int32, error) {
 	return args.Get(0).(int32), args.Error(1)
 }
 
+func (p *processHandleMock) RlimitUsage(gatherUsed bool) ([]process.RlimitStat, error) {
+	args := p.MethodCalled("RlimitUsage")
+	return args.Get(0).([]process.RlimitStat), args.Error(1)
+}
+
 func newDefaultHandleMock() *processHandleMock {
 	handleMock := &processHandleMock{}
 	handleMock.On("Username").Return("username", nil)
@@ -409,6 +425,7 @@ func newDefaultHandleMock() *processHandleMock {
 	handleMock.On("PageFaults").Return(&process.PageFaultsStat{}, nil)
 	handleMock.On("NumCtxSwitches").Return(&process.NumCtxSwitchesStat{}, nil)
 	handleMock.On("NumFDs").Return(int32(0), nil)
+	handleMock.On("RlimitUsage").Return([]process.RlimitStat{}, nil)
 	return handleMock
 }
 
@@ -545,6 +562,7 @@ func enableOptionalMetrics(ms *metadata.MetricsSettings) {
 	ms.ProcessPagingFaults.Enabled = true
 	ms.ProcessContextSwitches.Enabled = true
 	ms.ProcessOpenFileDescriptors.Enabled = true
+	ms.ProcessSignalsPending.Enabled = true
 }
 
 func TestScrapeMetrics_ProcessErrors(t *testing.T) {
@@ -566,6 +584,7 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 		numThreadsError     error
 		numCtxSwitchesError error
 		numFDsError         error
+		rlimitError         error
 		expectedError       string
 	}
 
@@ -637,6 +656,11 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 			expectedError: `error reading open file descriptor count for process "test" (pid 1): err10`,
 		},
 		{
+			name:          "Signals Pending Error",
+			rlimitError:   errors.New("err-rlimit"),
+			expectedError: `error reading pending signals for process "test" (pid 1): err-rlimit`,
+		},
+		{
 			name:                "Multiple Errors",
 			cmdlineError:        errors.New("err2"),
 			usernameError:       errors.New("err3"),
@@ -648,6 +672,7 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 			numThreadsError:     errors.New("err8"),
 			numCtxSwitchesError: errors.New("err9"),
 			numFDsError:         errors.New("err10"),
+			rlimitError:         errors.New("err-rlimit"),
 			expectedError: `error reading command for process "test" (pid 1): err2; ` +
 				`error reading username for process "test" (pid 1): err3; ` +
 				`error reading create time for process "test" (pid 1): err4; ` +
@@ -657,7 +682,8 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 				`error reading memory paging info for process "test" (pid 1): err-paging; ` +
 				`error reading thread info for process "test" (pid 1): err8; ` +
 				`error reading context switch counts for process "test" (pid 1): err9; ` +
-				`error reading open file descriptor count for process "test" (pid 1): err10`,
+				`error reading open file descriptor count for process "test" (pid 1): err10; ` +
+				`error reading pending signals for process "test" (pid 1): err-rlimit`,
 		},
 	}
 
@@ -695,6 +721,12 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 			handleMock.On("PageFaults").Return(&process.PageFaultsStat{}, test.pageFaultsError)
 			handleMock.On("NumCtxSwitches").Return(&process.NumCtxSwitchesStat{}, test.numCtxSwitchesError)
 			handleMock.On("NumFDs").Return(int32(0), test.numFDsError)
+			handleMock.On("RlimitUsage").Return([]process.RlimitStat{
+				{
+					Resource: process.RLIMIT_SIGPENDING,
+					Used:     0,
+				},
+			}, test.rlimitError)
 
 			scraper.getProcessHandles = func() (processHandles, error) {
 				return &processHandlesMock{handles: []*processHandleMock{handleMock}}, nil
@@ -702,7 +734,7 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 
 			md, err := scraper.scrape(context.Background())
 
-			expectedResourceMetricsLen, expectedMetricsLen := getExpectedLengthOfReturnedMetrics(test.nameError, test.exeError, test.timesError, test.memoryInfoError, test.ioCountersError, test.pageFaultsError, test.numThreadsError, test.numCtxSwitchesError, test.numFDsError)
+			expectedResourceMetricsLen, expectedMetricsLen := getExpectedLengthOfReturnedMetrics(test.nameError, test.exeError, test.timesError, test.memoryInfoError, test.ioCountersError, test.pageFaultsError, test.numThreadsError, test.numCtxSwitchesError, test.numFDsError, test.rlimitError)
 			assert.Equal(t, expectedResourceMetricsLen, md.ResourceMetrics().Len())
 			assert.Equal(t, expectedMetricsLen, md.MetricCount())
 
@@ -710,7 +742,7 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 			isPartial := scrapererror.IsPartialScrapeError(err)
 			assert.True(t, isPartial)
 			if isPartial {
-				expectedFailures := getExpectedScrapeFailures(test.nameError, test.exeError, test.timesError, test.memoryInfoError, test.ioCountersError, test.pageFaultsError, test.numThreadsError, test.numCtxSwitchesError, test.numFDsError)
+				expectedFailures := getExpectedScrapeFailures(test.nameError, test.exeError, test.timesError, test.memoryInfoError, test.ioCountersError, test.pageFaultsError, test.numThreadsError, test.numCtxSwitchesError, test.numFDsError, test.rlimitError)
 				var scraperErr scrapererror.PartialScrapeError
 				require.ErrorAs(t, err, &scraperErr)
 				assert.Equal(t, expectedFailures, scraperErr.Failed)
@@ -719,7 +751,7 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 	}
 }
 
-func getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError, diskError, pageFaultsError, threadError, contextSwitchError, fileDescriptorError error) (int, int) {
+func getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError, diskError, pageFaultsError, threadError, contextSwitchError, fileDescriptorError error, rlimitError error) (int, int) {
 	if nameError != nil || exeError != nil {
 		return 0, 0
 	}
@@ -737,6 +769,9 @@ func getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError
 	if pageFaultsError == nil {
 		expectedLen += pagingMetricsLen
 	}
+	if rlimitError == nil {
+		expectedLen += signalMetricsLen
+	}
 	if threadError == nil {
 		expectedLen += threadMetricsLen
 	}
@@ -753,11 +788,11 @@ func getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError
 	return 1, expectedLen
 }
 
-func getExpectedScrapeFailures(nameError, exeError, timeError, memError, diskError, pageFaultsError, threadError, contextSwitchError, fileDescriptorError error) int {
+func getExpectedScrapeFailures(nameError, exeError, timeError, memError, diskError, pageFaultsError, threadError, contextSwitchError, fileDescriptorError error, rlimitError error) int {
 	if nameError != nil || exeError != nil {
 		return 1
 	}
-	_, expectedMetricsLen := getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError, diskError, pageFaultsError, threadError, contextSwitchError, fileDescriptorError)
+	_, expectedMetricsLen := getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError, diskError, pageFaultsError, threadError, contextSwitchError, fileDescriptorError, rlimitError)
 	return metricsLen - expectedMetricsLen
 }
 


### PR DESCRIPTION
**Description:**

This pull request adds a new optional metric named `process.signals_pending` to the metrics scraped by the `process` scraper of the `hostmetrics` receiver.

Adding this metric to the semantic conventions has been proposed here:
- https://github.com/open-telemetry/opentelemetry-specification/issues/2826.

**Link to tracking Issue:** 

- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14084