### PR TITLE
[CI] Reduce cache download timeout

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -33,6 +33,8 @@ jobs:
           path: |
             ~\go\pkg\mod
           key: go-mod-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -70,12 +72,16 @@ jobs:
           path: |
             ~\go\pkg\mod
           key: go-mod-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Cache Go Build
         uses: actions/cache@v3
         with:
           path: |
             ~\AppData\Local\go-build
           key: go-build-cache-${{ runner.os }}-${{ matrix.group }}-go-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Run Unit tests
         run: make gotest GROUP=${{ matrix.group }}
   windows-unittest:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: build-and-test
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
@@ -35,6 +35,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -87,6 +89,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -98,6 +102,8 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: go-lint-build-${{ matrix.group }}-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Lint
         run: make -j2 golint GROUP=${{ matrix.group }}
   lint:
@@ -134,6 +140,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -188,6 +196,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -199,6 +209,8 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Run Unit Tests
         run: make gotest GROUP=${{ matrix.group }}
   unittest:
@@ -239,6 +251,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Run Integration Tests
         run: make integration-tests-with-cover
 
@@ -260,6 +274,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -286,6 +302,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -347,6 +365,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -427,6 +447,8 @@ jobs:
           path: |
             "C:\Program Files (x86)\WiX Toolset v3.11"
           key: wix-3.11
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install Wix Toolset
         if: steps.wix-cache.outputs.cache-hit != 'true'
         run: .\internal\buildscripts\packaging\msi\make.ps1 Install-Tools
@@ -483,6 +505,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -508,14 +532,14 @@ jobs:
       - name: Build Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-            make docker-otelcontribcol
-            docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
-            docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:latest
+          make docker-otelcontribcol
+          docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
+          docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:latest
       - name: Validate Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-            docker run otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA --version
-            docker run otel/opentelemetry-collector-contrib-dev:latest --version
+          docker run otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA --version
+          docker run otel/opentelemetry-collector-contrib-dev:latest --version
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -524,8 +548,8 @@ jobs:
       - name: Push Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-            docker push otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
-            docker push otel/opentelemetry-collector-contrib-dev:latest
+          docker push otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
+          docker push otel/opentelemetry-collector-contrib-dev:latest
   publish-stable:
     runs-on: ubuntu-latest
     needs: [lint, unittest, integration-tests, build-package]
@@ -548,6 +572,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -42,6 +42,8 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: changelog-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
 
       - name: Ensure no changes to the CHANGELOG
         run: |

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -38,6 +38,8 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
           key: loadtest-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install Dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
@@ -70,6 +72,8 @@ jobs:
         with:
           path: /opt/td-agent-bit
           key: fluentbit-cache-1.5.3
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - run: sudo ln -s /opt/td-agent-bit/bin/td-agent-bit /usr/local/bin/fluent-bit
       - name: Install fluentbit
         if: steps.fluentbit-cache.outputs.cache-hit != 'true'
@@ -89,6 +93,8 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
           key: loadtest-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - name: Install Dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -37,6 +37,8 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
           key: prometheus-${{ runner.os }}-go-${{ hashFiles('**/go.mod', '**/go.sum') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       - run: make otelcontribcol
         working-directory: opentelemetry-collector-contrib
       - name: Checkout compliance repo


### PR DESCRIPTION
To fail earlier in cases when the "actions/cache" job is stuck which happens occasionally. One example: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/3176319280/jobs/5175848268

10 minutes must be more than enough for all the jobs