### PR TITLE
[receiver/jmx] Update supported verions of java-contrib jmx metrics jar

### DIFF
--- a/.chloggen/jmx-jars.yaml
+++ b/.chloggen/jmx-jars.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: jmxreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds support for new versions of the jmx metrics receiver
+
+# One or more tracking issues related to the change
+issues: []

--- a/.chloggen/jmx-jars.yaml
+++ b/.chloggen/jmx-jars.yaml
@@ -8,4 +8,4 @@ component: jmxreceiver
 note: Adds support for new versions of the jmx metrics receiver
 
 # One or more tracking issues related to the change
-issues: []
+issues: [14698]

--- a/receiver/jmxreceiver/supported_jars.go
+++ b/receiver/jmxreceiver/supported_jars.go
@@ -42,31 +42,43 @@ func oldFormatProperties(c *Config, j supportedJar) error {
 // If you change this variable name, please open an issue in opentelemetry-java-contrib
 // so that repository's release automation can be updated
 var jmxMetricsGathererVersions = map[string]supportedJar{
+	"fd8a1c7bcd8580e66d90878954afd23eaf2110d840f968a7fc73963e4ecdf902": {
+		version: "1.18.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
+	"2ce5255ee07e139b93011f780d814dbe9440bf1eded35f6bd5c7776dbc3fcd70": {
+		version: "1.17.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
+	"2e6213a5649b58c85a20ddfb72be06d3d4abf87258ee2850b4bf08baa0f4c021": {
+		version: "1.16.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
 	"3c46cff8521cdb0d36bb2891b15cbc1bb2fcbca7c5344253403ab30fe9f693a6": {
-		version: "1.15.0",
+		version: "1.15.0-alpha",
 		jar:     "JMX metrics gatherer",
 	},
 	"0646639df98404bd9b1263b46e2fd4612bc378f9951a561f0a0be9725718db36": {
-		version: "1.14.0",
+		version: "1.14.0-alpha",
 		jar:     "JMX metrics gatherer",
 	},
 	"623572be30e3c546d60b0ac890935790bc3cb8d0b4ff5150a58b43a99f68ed05": {
-		version:         "1.13.0",
+		version:         "1.13.0-alpha",
 		jar:             "JMX metrics gatherer",
 		addedValidation: oldFormatProperties,
 	},
 	"c0b1a19c4965c7961abaaccfbb4d358e5f3b0b5b105578a4782702f126bfa8b7": {
-		version:         "1.12.0",
+		version:         "1.12.0-alpha",
 		jar:             "JMX metrics gatherer",
 		addedValidation: oldFormatProperties,
 	},
 	"ca689ca2da8a412c7f4ea0e816f47e8639b4270a48fb877c9a910b44757bc0a4": {
-		version:         "1.11.0",
+		version:         "1.11.0-alpha",
 		jar:             "JMX metrics gatherer",
 		addedValidation: oldFormatProperties,
 	},
 	"4b14d26fb383ed925fe1faf1b7fe2103559ed98ce6cf761ac9afc0158d2a218c": {
-		version:         "1.10.0",
+		version:         "1.10.0-alpha",
 		jar:             "JMX metrics gatherer",
 		addedValidation: oldFormatProperties,
 	},


### PR DESCRIPTION
**Description:** Update the list of supported jmx jar versions based on conversations in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13438

**Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14698