### PR TITLE
[pkg/ottl] Add ability to only pass logger into functions

### DIFF
--- a/.chloggen/ottl-logger-param.yaml
+++ b/.chloggen/ottl-logger-param.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ability to specify `zap.Logger` in function params
+
+# One or more tracking issues related to the change
+issues: [14471]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/ottl-logger-param.yaml
+++ b/.chloggen/ottl-logger-param.yaml
@@ -8,7 +8,7 @@ component: pkg/ottl
 note: Add ability to specify `zap.Logger` in function params
 
 # One or more tracking issues related to the change
-issues: [14471]
+issues: [14703]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -159,7 +159,7 @@ It is possible to update the Value in a telemetry field using a Setter. For read
 
 ## Logging inside a OTTL function
 
-To emit logs inside a OTTL function, add a parameter of type [`component.TelemetrySettings`](https://pkg.go.dev/go.opentelemetry.io/collector/component#TelemetrySettings) or `zap.Logger` to the function signature. For `component.TelemetrySettings`, the OTTL will inject the TelemetrySettings that were passed to `NewParser` into the function, which includes the collector's logger.  For `zap.Logger`, the OTTL will inject the TelemetrySettings' Logger only.  Use `component.TelemetrySettings` if you need all the collector's telemetry settings and use `zap.Logger` if all you need is a logger.  
+To emit logs inside a OTTL function, add a parameter of type [`component.TelemetrySettings`](https://pkg.go.dev/go.opentelemetry.io/collector/component#TelemetrySettings) or `zap.Logger` to the function signature. For `component.TelemetrySettings`, the OTTL will inject the TelemetrySettings that were passed to `NewParser` into the function, which includes the Collector's logger.  For `zap.Logger`, the OTTL will inject the TelemetrySettings' Logger only.  Use `component.TelemetrySettings` if you need all the Collector's telemetry settings and use `zap.Logger` if all you need is a logger.  
 
 ## Examples
 

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -159,7 +159,7 @@ It is possible to update the Value in a telemetry field using a Setter. For read
 
 ## Logging inside a OTTL function
 
-To emit logs inside a OTTL function, add a parameter of type [`component.TelemetrySettings`](https://pkg.go.dev/go.opentelemetry.io/collector/component#TelemetrySettings) to the function signature. The OTTL will then inject the TelemetrySettings that were passed to `NewParser` into the function.  TelemetrySettings can be used to emit logs.
+To emit logs inside a OTTL function, add a parameter of type [`component.TelemetrySettings`](https://pkg.go.dev/go.opentelemetry.io/collector/component#TelemetrySettings) or `zap.Logger` to the function signature. For `component.TelemetrySettings`, the OTTL will inject the TelemetrySettings that were passed to `NewParser` into the function, which includes the collector's logger.  For `zap.Logger`, the OTTL will inject the TelemetrySettings' Logger only.  Use `component.TelemetrySettings` if you need all the collector's telemetry settings and use `zap.Logger` if all you need is a logger.  
 
 ## Examples
 

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -197,9 +197,7 @@ func (p *Parser[K]) buildArg(argDef value, argType reflect.Type, index int, args
 // Handle interfaces that can be declared as parameters to a OTTL function, but will
 // never be called in an invocation. Returns whether the arg is an internal arg.
 func (p *Parser[K]) buildInternalArg(argType reflect.Type, args *[]reflect.Value) bool {
-	temp := argType.Name()
-
-	switch temp {
+	switch argType.Name() {
 	case "TelemetrySettings":
 		*args = append(*args, reflect.ValueOf(p.telemetrySettings))
 	case "Logger":

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -197,9 +197,13 @@ func (p *Parser[K]) buildArg(argDef value, argType reflect.Type, index int, args
 // Handle interfaces that can be declared as parameters to a OTTL function, but will
 // never be called in an invocation. Returns whether the arg is an internal arg.
 func (p *Parser[K]) buildInternalArg(argType reflect.Type, args *[]reflect.Value) bool {
-	switch argType.Name() {
+	temp := argType.Name()
+
+	switch temp {
 	case "TelemetrySettings":
 		*args = append(*args, reflect.ValueOf(p.telemetrySettings))
+	case "Logger":
+		*args = append(*args, reflect.ValueOf(*p.telemetrySettings.Logger))
 	default:
 		return false
 	}

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -16,6 +16,7 @@ package ottl
 
 import (
 	"errors"
+	"go.uber.org/zap"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -214,7 +215,7 @@ func Test_NewFunctionCall(t *testing.T) {
 		defaultFunctionsForTests(),
 		testParsePath,
 		testParseEnum,
-		component.TelemetrySettings{},
+		component.TelemetrySettings{Logger: zap.NewNop()},
 	)
 
 	tests := []struct {
@@ -531,6 +532,23 @@ func Test_NewFunctionCall(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Logger",
+			inv: invocation{
+				Function: "testing_logger",
+				Arguments: []value{
+					{
+						String: ottltest.Strp("test0"),
+					},
+					{
+						String: ottltest.Strp("test1"),
+					},
+					{
+						Int: ottltest.Intp(1),
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -649,6 +667,12 @@ func functionWithTelemetrySettingsLast(_ string, _ string, _ int64, _ component.
 	}, nil
 }
 
+func functionWithLogger(_ zap.Logger, _ string, _ string, _ int64) (ExprFunc[interface{}], error) {
+	return func(interface{}) interface{} {
+		return "anything"
+	}, nil
+}
+
 func defaultFunctionsForTests() map[string]interface{} {
 	functions := make(map[string]interface{})
 	functions["testing_string_slice"] = functionWithStringSlice
@@ -668,5 +692,6 @@ func defaultFunctionsForTests() map[string]interface{} {
 	functions["testing_telemetry_settings_first"] = functionWithTelemetrySettingsFirst
 	functions["testing_telemetry_settings_middle"] = functionWithTelemetrySettingsMiddle
 	functions["testing_telemetry_settings_last"] = functionWithTelemetrySettingsLast
+	functions["testing_logger"] = functionWithLogger
 	return functions
 }

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -16,11 +16,11 @@ package ottl
 
 import (
 	"errors"
-	"go.uber.org/zap"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )


### PR DESCRIPTION
**Description:** 
Adds back the ability to pass Logger to functions.  Now users can choose either `component.TelemetrySettings` or `zap.Logger`, depending on whether or not they need all the settings or just a logger.

**Link to tracking Issue:**
Fixes #14471

**Testing:** 
Added unit test

**Documentation:**
Updated OTTL doc