### PR TITLE
[exporter/fileexporter] set rotation disabled by default

### DIFF
--- a/.chloggen/fileexporter-rotation-disabled.yaml
+++ b/.chloggen/fileexporter-rotation-disabled.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: fileexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: set rotation disabled by default
+
+# One or more tracking issues related to the change
+issues: [14690]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -38,7 +38,7 @@ The following settings are optional:
 
 ## File Rotation
 Telemetry data is exported to a single file by default.
-`fileexporter` only enables file rotation when the user specifies `rotation:` in the config.However, if specified, related default settings would apply.
+`fileexporter` only enables file rotation when the user specifies `rotation:` in the config. However, if specified, related default settings would apply.
 
 Telemetry is first written to a file that exactly matches the `path` setting. 
 When the file size exceeds `max_megabytes` or age exceeds `max_days`, the file will be rotated.
@@ -78,13 +78,12 @@ file/rotation_with_default_settings:
 file/rotation_with_custom_settings:
   path: ./foo
   rotation:
-    max_megabytes: 1234
-      max_megabytes: 10
-      max_days: 3
-      max_backups: 3
-      localtime: true
-    format: proto
-    compression: zstd
+    max_megabytes: 10
+    max_days: 3
+    max_backups: 3
+    localtime: true
+  format: proto
+  compression: zstd
 ```
 
 

--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -71,19 +71,19 @@ exporters:
   file/no_rotation:
     path: ./foo
 
-file/rotation_with_default_settings:
-  path: ./foo
-  rotation:
+  file/rotation_with_default_settings:
+    path: ./foo
+    rotation:
 
-file/rotation_with_custom_settings:
-  path: ./foo
-  rotation:
-    max_megabytes: 10
-    max_days: 3
-    max_backups: 3
-    localtime: true
-  format: proto
-  compression: zstd
+  file/rotation_with_custom_settings:
+    path: ./foo
+    rotation:
+      max_megabytes: 10
+      max_days: 3
+      max_backups: 3
+      localtime: true
+    format: proto
+    compression: zstd
 ```
 
 

--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -22,7 +22,7 @@ This intended for primarily for debugging Collector without setting up backends.
 
 The following settings are required:
 
-- `path` (no default): where to write information.
+- `path` [no default]: where to write information.
 
 The following settings are optional:
 
@@ -37,8 +37,11 @@ The following settings are optional:
 - `compression`[no default]: the compression algorithm used when exporting telemetry data to file. Supported compression algorithms:`zstd`
 
 ## File Rotation
+Telemetry data is exported to a single file by default.
+`fileexporter` only enables file rotation when the user specifies `rotation:` in the config.However, if specified, related default settings would apply.
 
-Telemetry is first written to a file that exactly matches the `path` setting. When the file size exceeds `max_megabytes` or age exceeds `max_days`, the file will be rotated.
+Telemetry is first written to a file that exactly matches the `path` setting. 
+When the file size exceeds `max_megabytes` or age exceeds `max_days`, the file will be rotated.
 
 When a file is rotated, **it is renamed by putting the current time in a timestamp**
 in the name immediately before the file's extension (or the end of the filename if there's no extension).
@@ -65,19 +68,17 @@ Otherwise, when using `proto` format or any kind of encoding, each encoded objec
 
 ```yaml
 exporters:
-  file:
-    path: ./file
-    format: json
-  file/2:
-    path: ./filename.json
-    rotation:
-      max_megabytes: 10
-      max_days: 3
-      max_backups: 3
-      localtime: true
-  file/3:
-    path: ./filename
-    rotation:
+  file/no_rotation:
+    path: ./foo
+
+file/rotation_with_default_settings:
+  path: ./foo
+  rotation:
+
+file/rotation_with_custom_settings:
+  path: ./foo
+  rotation:
+    max_megabytes: 1234
       max_megabytes: 10
       max_days: 3
       max_backups: 3

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -18,6 +18,12 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+const (
+	rotationFieldName = "rotation"
+	backupsFieldName  = "max_backups"
 )
 
 // Config defines configuration for file exporter.
@@ -28,7 +34,7 @@ type Config struct {
 	Path string `mapstructure:"path"`
 
 	// Rotation defines an option about rotation of telemetry files
-	Rotation Rotation `mapstructure:"rotation"`
+	Rotation *Rotation `mapstructure:"rotation"`
 
 	// FormatType define the data format of encoded telemetry data
 	// Options:
@@ -76,6 +82,36 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.Compression != "" && cfg.Compression != compressionZSTD {
 		return errors.New("compression is not supported")
+	}
+	return nil
+}
+
+// Unmarshal a confmap.Conf into the config struct.
+func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
+	if componentParser == nil {
+		return errors.New("empty config for file exporter")
+	}
+	// first load the config normally
+	err := componentParser.UnmarshalExact(cfg)
+	if err != nil {
+		return err
+	}
+
+	// next manually search for protocols in the confmap.Conf,
+	// if rotation is not present it means it is disabled.
+	if !componentParser.IsSet(rotationFieldName) {
+		return nil
+	}
+	rotation := componentParser.Get(rotationFieldName)
+	if rotation == nil {
+		cfg.Rotation = &Rotation{MaxBackups: defaultMaxBackups}
+	}
+	rotationCfg, err := componentParser.Sub(rotationFieldName)
+	if err != nil {
+		return nil
+	}
+	if !rotationCfg.IsSet(backupsFieldName) {
+		cfg.Rotation.MaxBackups = defaultMaxBackups
 	}
 	return nil
 }

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -105,6 +105,7 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 	rotation := componentParser.Get(rotationFieldName)
 	if rotation == nil {
 		cfg.Rotation = &Rotation{MaxBackups: defaultMaxBackups}
+		return nil
 	}
 	rotationCfg, err := componentParser.Sub(rotationFieldName)
 	if err != nil {

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -102,17 +102,19 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 	if !componentParser.IsSet(rotationFieldName) {
 		return nil
 	}
-	rotation := componentParser.Get(rotationFieldName)
-	if rotation == nil {
-		cfg.Rotation = &Rotation{MaxBackups: defaultMaxBackups}
-		return nil
-	}
-	rotationCfg, err := componentParser.Sub(rotationFieldName)
+	rotationConfmap, err := componentParser.Sub(rotationFieldName)
 	if err != nil {
-		return nil
+		return err
 	}
-	if !rotationCfg.IsSet(backupsFieldName) {
-		cfg.Rotation.MaxBackups = defaultMaxBackups
+	rotationCfg := newDefaultRotationConfig()
+	err = rotationConfmap.UnmarshalExact(rotationCfg)
+	if err != nil {
+		return err
 	}
+	cfg.Rotation = rotationCfg
 	return nil
+}
+
+func newDefaultRotationConfig() *Rotation {
+	return &Rotation{MaxBackups: defaultMaxBackups}
 }

--- a/exporter/fileexporter/config_test.go
+++ b/exporter/fileexporter/config_test.go
@@ -43,7 +43,7 @@ func TestLoadConfig(t *testing.T) {
 		&Config{
 			ExporterSettings: config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "2")),
 			Path:             "./filename.json",
-			Rotation: Rotation{
+			Rotation: &Rotation{
 				MaxMegabytes: 10,
 				MaxDays:      3,
 				MaxBackups:   3,
@@ -56,7 +56,7 @@ func TestLoadConfig(t *testing.T) {
 		&Config{
 			ExporterSettings: config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "3")),
 			Path:             "./filename",
-			Rotation: Rotation{
+			Rotation: &Rotation{
 				MaxMegabytes: 10,
 				MaxDays:      3,
 				MaxBackups:   3,
@@ -64,6 +64,36 @@ func TestLoadConfig(t *testing.T) {
 			},
 			FormatType:  formatTypeProto,
 			Compression: compressionZSTD,
+		})
+	e3 := cfg.Exporters[config.NewComponentIDWithName(typeStr, "no_rotation")]
+	assert.Equal(t, e3,
+		&Config{
+			ExporterSettings: config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "no_rotation")),
+			Path:             "./foo",
+			FormatType:       formatTypeJSON,
+		})
+	e4 := cfg.Exporters[config.NewComponentIDWithName(typeStr, "rotation_with_default_settings")]
+	assert.Equal(t, e4,
+		&Config{
+			ExporterSettings: config.NewExporterSettings(
+				config.NewComponentIDWithName(typeStr, "rotation_with_default_settings")),
+			Path:       "./foo",
+			FormatType: formatTypeJSON,
+			Rotation: &Rotation{
+				MaxBackups: defaultMaxBackups,
+			},
+		})
+	e5 := cfg.Exporters[config.NewComponentIDWithName(typeStr, "rotation_with_custom_settings")]
+	assert.Equal(t, e5,
+		&Config{
+			ExporterSettings: config.NewExporterSettings(
+				config.NewComponentIDWithName(typeStr, "rotation_with_custom_settings")),
+			Path: "./foo",
+			Rotation: &Rotation{
+				MaxMegabytes: 1234,
+				MaxBackups:   defaultMaxBackups,
+			},
+			FormatType: formatTypeJSON,
 		})
 }
 

--- a/exporter/fileexporter/factory_test.go
+++ b/exporter/fileexporter/factory_test.go
@@ -16,12 +16,16 @@ package fileexporter
 
 import (
 	"context"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtest"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -30,8 +34,21 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 }
 
-func TestCreateMetricsExporter(t *testing.T) {
+func TestCreateMetricsExporterError(t *testing.T) {
 	cfg := createDefaultConfig()
+	_, err := createMetricsExporter(
+		context.Background(),
+		componenttest.NewNopExporterCreateSettings(),
+		cfg)
+	assert.Error(t, err)
+}
+
+func TestCreateMetricsExporter(t *testing.T) {
+	cfg := &Config{
+		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
+		FormatType:       formatTypeJSON,
+		Path:             tempFileName(t),
+	}
 	exp, err := createMetricsExporter(
 		context.Background(),
 		componenttest.NewNopExporterCreateSettings(),
@@ -41,7 +58,11 @@ func TestCreateMetricsExporter(t *testing.T) {
 }
 
 func TestCreateTracesExporter(t *testing.T) {
-	cfg := createDefaultConfig()
+	cfg := &Config{
+		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
+		FormatType:       formatTypeJSON,
+		Path:             tempFileName(t),
+	}
 	exp, err := createTracesExporter(
 		context.Background(),
 		componenttest.NewNopExporterCreateSettings(),
@@ -50,12 +71,110 @@ func TestCreateTracesExporter(t *testing.T) {
 	require.NotNil(t, exp)
 }
 
+func TestCreateTracesExporterError(t *testing.T) {
+	cfg := &Config{
+		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
+		FormatType:       formatTypeJSON,
+	}
+	_, err := createTracesExporter(
+		context.Background(),
+		componenttest.NewNopExporterCreateSettings(),
+		cfg)
+	assert.Error(t, err)
+}
+
 func TestCreateLogsExporter(t *testing.T) {
-	cfg := createDefaultConfig()
+	cfg := &Config{
+		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
+		FormatType:       formatTypeJSON,
+		Path:             tempFileName(t),
+	}
 	exp, err := createLogsExporter(
 		context.Background(),
 		componenttest.NewNopExporterCreateSettings(),
 		cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, exp)
+}
+
+func TestCreateLogsExporterError(t *testing.T) {
+	cfg := &Config{
+		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
+		FormatType:       formatTypeJSON,
+	}
+	_, err := createLogsExporter(
+		context.Background(),
+		componenttest.NewNopExporterCreateSettings(),
+		cfg)
+	assert.Error(t, err)
+}
+
+func TestBuildFileWriter(t *testing.T) {
+	type args struct {
+		cfg *Config
+	}
+	tests := []struct {
+		name     string
+		args     args
+		want     io.WriteCloser
+		validate func(*testing.T, io.WriteCloser)
+	}{
+		{
+			name: "single file",
+			args: args{
+				cfg: &Config{
+					Path: tempFileName(t),
+				},
+			},
+			validate: func(t *testing.T, closer io.WriteCloser) {
+				_, ok := closer.(*os.File)
+				assert.Equal(t, true, ok)
+			},
+		},
+		{
+			name: "rotation file",
+			args: args{
+				cfg: &Config{
+					Path: tempFileName(t),
+					Rotation: &Rotation{
+						MaxBackups: defaultMaxBackups,
+					},
+				},
+			},
+			validate: func(t *testing.T, closer io.WriteCloser) {
+				writer, ok := closer.(*lumberjack.Logger)
+				assert.Equal(t, true, ok)
+				assert.Equal(t, defaultMaxBackups, writer.MaxBackups)
+			},
+		},
+		{
+			name: "rotation file with user's configuration",
+			args: args{
+				cfg: &Config{
+					Path: tempFileName(t),
+					Rotation: &Rotation{
+						MaxMegabytes: 30,
+						MaxDays:      100,
+						MaxBackups:   3,
+						LocalTime:    true,
+					},
+				},
+			},
+			validate: func(t *testing.T, closer io.WriteCloser) {
+				writer, ok := closer.(*lumberjack.Logger)
+				assert.Equal(t, true, ok)
+				assert.Equal(t, 3, writer.MaxBackups)
+				assert.Equal(t, 30, writer.MaxSize)
+				assert.Equal(t, 100, writer.MaxAge)
+				assert.Equal(t, true, writer.LocalTime)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildFileWriter(tt.args.cfg)
+			assert.NoError(t, err)
+			tt.validate(t, got)
+		})
+	}
 }

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -95,20 +95,33 @@ func TestFileTracesExporter(t *testing.T) {
 				unmarshaler: ptrace.NewProtoUnmarshaler(),
 			},
 		},
+		{
+			name: "Proto: compression configuration--rotation",
+			args: args{
+				conf: &Config{
+					Path:        tempFileName(t),
+					FormatType:  "proto",
+					Compression: compressionZSTD,
+					Rotation: &Rotation{
+						MaxMegabytes: 3,
+						MaxDays:      0,
+						MaxBackups:   defaultMaxBackups,
+						LocalTime:    false,
+					},
+				},
+				unmarshaler: ptrace.NewProtoUnmarshaler(),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := tt.args.conf
+			writer, err := buildFileWriter(conf)
+			assert.NoError(t, err)
 			fe := &fileExporter{
-				path:       conf.Path,
-				formatType: conf.FormatType,
-				file: &lumberjack.Logger{
-					Filename:   conf.Path,
-					MaxSize:    conf.Rotation.MaxMegabytes,
-					MaxAge:     conf.Rotation.MaxDays,
-					MaxBackups: conf.Rotation.MaxBackups,
-					LocalTime:  conf.Rotation.LocalTime,
-				},
+				path:            conf.Path,
+				formatType:      conf.FormatType,
+				file:            writer,
 				tracesMarshaler: tracesMarshalers[conf.FormatType],
 				exporter:        buildExportFunc(conf),
 				compression:     conf.Compression,
@@ -216,20 +229,33 @@ func TestFileMetricsExporter(t *testing.T) {
 				unmarshaler: pmetric.NewProtoUnmarshaler(),
 			},
 		},
+		{
+			name: "Proto: compression configuration--rotation",
+			args: args{
+				conf: &Config{
+					Path:        tempFileName(t),
+					FormatType:  "proto",
+					Compression: compressionZSTD,
+					Rotation: &Rotation{
+						MaxMegabytes: 3,
+						MaxDays:      0,
+						MaxBackups:   defaultMaxBackups,
+						LocalTime:    false,
+					},
+				},
+				unmarshaler: pmetric.NewProtoUnmarshaler(),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := tt.args.conf
+			writer, err := buildFileWriter(conf)
+			assert.NoError(t, err)
 			fe := &fileExporter{
-				path:       conf.Path,
-				formatType: conf.FormatType,
-				file: &lumberjack.Logger{
-					Filename:   conf.Path,
-					MaxSize:    conf.Rotation.MaxMegabytes,
-					MaxAge:     conf.Rotation.MaxDays,
-					MaxBackups: conf.Rotation.MaxBackups,
-					LocalTime:  conf.Rotation.LocalTime,
-				},
+				path:             conf.Path,
+				formatType:       conf.FormatType,
+				file:             writer,
 				metricsMarshaler: metricsMarshalers[conf.FormatType],
 				exporter:         buildExportFunc(conf),
 				compression:      conf.Compression,
@@ -339,20 +365,33 @@ func TestFileLogsExporter(t *testing.T) {
 				unmarshaler: plog.NewProtoUnmarshaler(),
 			},
 		},
+		{
+			name: "Proto: compression configuration--rotation",
+			args: args{
+				conf: &Config{
+					Path:        tempFileName(t),
+					FormatType:  "proto",
+					Compression: compressionZSTD,
+					Rotation: &Rotation{
+						MaxMegabytes: 3,
+						MaxDays:      0,
+						MaxBackups:   defaultMaxBackups,
+						LocalTime:    false,
+					},
+				},
+				unmarshaler: plog.NewProtoUnmarshaler(),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := tt.args.conf
+			writer, err := buildFileWriter(conf)
+			assert.NoError(t, err)
 			fe := &fileExporter{
-				path:       conf.Path,
-				formatType: conf.FormatType,
-				file: &lumberjack.Logger{
-					Filename:   conf.Path,
-					MaxSize:    conf.Rotation.MaxMegabytes,
-					MaxAge:     conf.Rotation.MaxDays,
-					MaxBackups: conf.Rotation.MaxBackups,
-					LocalTime:  conf.Rotation.LocalTime,
-				},
+				path:          conf.Path,
+				formatType:    conf.FormatType,
+				file:          writer,
 				logsMarshaler: logsMarshalers[conf.FormatType],
 				exporter:      buildExportFunc(conf),
 				compression:   conf.Compression,

--- a/exporter/fileexporter/testdata/config.yaml
+++ b/exporter/fileexporter/testdata/config.yaml
@@ -29,6 +29,15 @@ exporters:
     format: proto
     compression: zstd
 
+  file/no_rotation:
+    path: ./foo
+  file/rotation_with_default_settings:
+    path: ./foo
+    rotation:
+  file/rotation_with_custom_settings:
+    path: ./foo
+    rotation:
+      max_megabytes: 1234
 service:
   pipelines:
     traces:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
rotation settings were added in v0.60.0. and  are enabled by default, which was an undeclared breaking change.

**Link to tracking Issue:** <Issue number if applicable>
#14690

**Testing:** <Describe what testing was performed and which tests were added.>
Test unit 
**Documentation:** <Describe the documentation added.>
update readme.md