### PR TITLE
[exporter/dynatraceexporter] skip non-string attribute values

### DIFF
--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -340,6 +340,14 @@ can produce inconsistent data unless it can be guaranteed that metrics from the
 same source are processed by the same collector instance. This can be circumvented 
 by configuring the OpenTelemetry SDK to export DELTA values.
 
+# Typed attributes support
+
+The OpenTelemetry Collector supports the concept of [Attributes]( https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes).
+These attributes consist of key-value pairs, where the keys are strings and the values are either primitive types or arrays of uniform primitive types.
+
+At the moment, this exporter **only supports attributes with string key and value type**.
+This means that if attributes of any other type are used, they will be **ignored** and **only** the string-valued attributes are going to be sent to Dynatrace.
+
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [AWS]:https://aws-otel.github.io/docs/partners/dynatrace

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -342,7 +342,7 @@ by configuring the OpenTelemetry SDK to export DELTA values.
 
 # Typed attributes support
 
-The OpenTelemetry Collector supports the concept of [Attributes]( https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes).
+The OpenTelemetry Collector supports the concept of [Attributes](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/common#attribute).
 These attributes consist of key-value pairs, where the keys are strings and the values are either primitive types or arrays of uniform primitive types.
 
 At the moment, this exporter **only supports attributes with string key and value type**.

--- a/exporter/dynatraceexporter/internal/serialization/serialization.go
+++ b/exporter/dynatraceexporter/internal/serialization/serialization.go
@@ -53,7 +53,9 @@ func makeCombinedDimensions(defaultDimensions dimensions.NormalizedDimensionList
 	dimsFromAttributes := make([]dimensions.Dimension, 0, dataPointAttributes.Len())
 
 	dataPointAttributes.Range(func(k string, v pcommon.Value) bool {
-		dimsFromAttributes = append(dimsFromAttributes, dimensions.NewDimension(k, v.AsString()))
+		if v.Type() == pcommon.ValueTypeStr {
+			dimsFromAttributes = append(dimsFromAttributes, dimensions.NewDimension(k, v.AsString()))
+		}
 		return true
 	})
 	return dimensions.MergeLists(

--- a/exporter/dynatraceexporter/internal/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/internal/serialization/serialization_test.go
@@ -103,6 +103,12 @@ func Test_makeCombinedDimensions(t *testing.T) {
 	attributes := pcommon.NewMap()
 	attributes.PutString("a", "attribute")
 	attributes.PutString("b", "attribute")
+
+	// these should all be droped
+	attributes.PutBool("dropped_bool", true)
+	attributes.PutDouble("drouped_double", 1.5)
+	attributes.PutInt("dropped_int", 1)
+
 	staticDims := dimensions.NewNormalizedDimensionList(
 		dimensions.NewDimension("a", "static"),
 	)

--- a/exporter/dynatraceexporter/internal/serialization/sum.go
+++ b/exporter/dynatraceexporter/internal/serialization/sum.go
@@ -152,7 +152,9 @@ func convertTotalCounterToDelta(name, prefix string, dims dimensions.NormalizedD
 	id := name
 
 	dp.Attributes().Sort().Range(func(k string, v pcommon.Value) bool {
-		id += fmt.Sprintf(",%s=%s", k, v.AsString())
+		if v.Type() == pcommon.ValueTypeStr {
+			id += fmt.Sprintf(",%s=%s", k, v.AsString())
+		}
 		return true
 	})
 


### PR DESCRIPTION
**Description:** Previously all attributes were exported as strings. For non-string attribute values, this caused them to be exported as empty strings. Empty strings are dropped on the server side, so this does not change behavior.

**Link to tracking Issue:** n/a

**Testing:** n/a

**Documentation:** n/a