### PR TITLE
Use `BuildInfo.Command` for identifying the collector in some AWS exporter user agents

### DIFF
--- a/.chloggen/fix_UASource.yaml
+++ b/.chloggen/fix_UASource.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporters
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Use `BuildInfo.Command` for identifying the collector in some AWS exporter user agents."
+
+# One or more tracking issues related to the change
+issues: [14719]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "Some exporters were using a build-time constant definition to change the identity of the collector binary in user agent strings.  These will now use the collector service's `BuildInfo.Command` value."

--- a/exporter/awsxrayexporter/xray_client.go
+++ b/exporter/awsxrayexporter/xray_client.go
@@ -28,8 +28,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var collectorDistribution = "opentelemetry-collector-contrib"
-
 // xrayClient represents X-Ray client.
 type xrayClient struct {
 	xRay *xray.XRay
@@ -73,6 +71,6 @@ func newXRay(logger *zap.Logger, awsConfig *aws.Config, buildInfo component.Buil
 func newCollectorUserAgentHandler(buildInfo component.BuildInfo) request.NamedHandler {
 	return request.NamedHandler{
 		Name: "otel.collector.UserAgentHandler",
-		Fn:   request.MakeAddToUserAgentHandler(collectorDistribution, buildInfo.Version),
+		Fn:   request.MakeAddToUserAgentHandler(buildInfo.Command, buildInfo.Version),
 	}
 }

--- a/exporter/awsxrayexporter/xray_client_test.go
+++ b/exporter/awsxrayexporter/xray_client_test.go
@@ -30,6 +30,7 @@ func TestUserAgent(t *testing.T) {
 	logger := zap.NewNop()
 
 	buildInfo := component.BuildInfo{
+		Command: "test-collector-contrib",
 		Version: "1.0",
 	}
 
@@ -43,5 +44,5 @@ func TestUserAgent(t *testing.T) {
 	}, nil, nil)
 
 	x.Handlers.Build.Run(req)
-	assert.Contains(t, req.HTTPRequest.UserAgent(), "opentelemetry-collector-contrib/1.0")
+	assert.Contains(t, req.HTTPRequest.UserAgent(), "test-collector-contrib/1.0")
 }

--- a/internal/aws/cwlogs/cwlog_client.go
+++ b/internal/aws/cwlogs/cwlog_client.go
@@ -31,8 +31,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs/handler"
 )
 
-var collectorDistribution = "opentelemetry-collector-contrib"
-
 const (
 	// this is the retry count, the total attempts will be at most retry count + 1.
 	defaultRetryCount          = 1
@@ -180,9 +178,9 @@ func (client *Client) CreateStream(logGroup, streamName *string) (token string, 
 }
 
 func newCollectorUserAgentHandler(buildInfo component.BuildInfo, logGroupName string) request.NamedHandler {
-	fn := request.MakeAddToUserAgentHandler(collectorDistribution, buildInfo.Version)
+	fn := request.MakeAddToUserAgentHandler(buildInfo.Command, buildInfo.Version)
 	if matchContainerInsightsPattern(logGroupName) {
-		fn = request.MakeAddToUserAgentHandler(collectorDistribution, buildInfo.Version, "ContainerInsights")
+		fn = request.MakeAddToUserAgentHandler(buildInfo.Command, buildInfo.Version, "ContainerInsights")
 	}
 	return request.NamedHandler{
 		Name: "otel.collector.UserAgentHandler",

--- a/internal/aws/cwlogs/cwlog_client_test.go
+++ b/internal/aws/cwlogs/cwlog_client_test.go
@@ -448,31 +448,37 @@ func TestUserAgent(t *testing.T) {
 	}{
 		{
 			"emptyLogGroup",
-			component.BuildInfo{Version: "1.0"},
+			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"",
 			"opentelemetry-collector-contrib/1.0",
 		},
 		{
+			"buildInfoCommandUsed",
+			component.BuildInfo{Command: "test-collector-contrib", Version: "1.0"},
+			"",
+			"test-collector-contrib/1.0",
+		},
+		{
 			"non container insights",
-			component.BuildInfo{Version: "1.1"},
+			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.1"},
 			"test-group",
 			"opentelemetry-collector-contrib/1.1",
 		},
 		{
 			"container insights EKS",
-			component.BuildInfo{Version: "1.0"},
+			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"/aws/containerinsights/eks-cluster-name/performance",
 			"opentelemetry-collector-contrib/1.0 (ContainerInsights)",
 		},
 		{
 			"container insights ECS",
-			component.BuildInfo{Version: "1.0"},
+			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"/aws/ecs/containerinsights/ecs-cluster-name/performance",
 			"opentelemetry-collector-contrib/1.0 (ContainerInsights)",
 		},
 		{
 			"container insights prometheus",
-			component.BuildInfo{Version: "1.0"},
+			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"/aws/containerinsights/cluster-name/prometheus",
 			"opentelemetry-collector-contrib/1.0 (ContainerInsights)",
 		},


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>