### PR TITLE
[receiver/mysql] Add mysql.tmp_resources metric

### DIFF
--- a/.chloggen/drosiek-mysql-created-tmp-metric.yaml
+++ b/.chloggen/drosiek-mysql-created-tmp-metric.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add mysql.tmp_resources metric
+
+# One or more tracking issues related to the change
+issues: [14138]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -29,6 +29,7 @@ These are the metrics available for this scraper.
 | **mysql.table.io.wait.count** | The total count of I/O wait events for a table. | 1 | Sum(Int) | <ul> <li>io_waits_operations</li> <li>table_name</li> <li>schema</li> </ul> |
 | **mysql.table.io.wait.time** | The total time of I/O wait events for a table. | ns | Sum(Int) | <ul> <li>io_waits_operations</li> <li>table_name</li> <li>schema</li> </ul> |
 | **mysql.threads** | The state of MySQL threads. | 1 | Sum(Int) | <ul> <li>threads</li> </ul> |
+| **mysql.tmp_resources** | The number of created temporary resources. | 1 | Sum(Int) | <ul> <li>tmp_resource</li> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
 Any metric can be enabled or disabled with the following scraper configuration:
@@ -67,3 +68,4 @@ metrics:
 | sorts (kind) | The sort count type. | merge_passes, range, rows, scan |
 | table_name (table) | Table name for event or process. |  |
 | threads (kind) | The thread count type. | cached, connected, created, running |
+| tmp_resource (resource) | The kind of temporary resources. | disk_tables, files, tables |

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -75,6 +75,10 @@ attributes:
   index_name:
     value: index
     description: The name of the index.
+  tmp_resource:
+    value: resource
+    description: The kind of temporary resources.
+    enum: [disk_tables, files, tables]
 
 metrics:
   mysql.buffer_pool.pages:
@@ -279,3 +283,13 @@ metrics:
       monotonic: false
       aggregation: cumulative
     attributes: [threads]
+  mysql.tmp_resources:
+    enabled: true
+    description: The number of created temporary resources.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation: cumulative
+    attributes: [tmp_resource]

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -172,6 +172,14 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 		case "Com_stmt_send_long_data":
 			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandSendLongData))
 
+		// created tmps
+		case "Created_tmp_disk_tables":
+			addPartialIfError(errs, m.mb.RecordMysqlTmpResourcesDataPoint(now, v, metadata.AttributeTmpResourceDiskTables))
+		case "Created_tmp_files":
+			addPartialIfError(errs, m.mb.RecordMysqlTmpResourcesDataPoint(now, v, metadata.AttributeTmpResourceFiles))
+		case "Created_tmp_tables":
+			addPartialIfError(errs, m.mb.RecordMysqlTmpResourcesDataPoint(now, v, metadata.AttributeTmpResourceTables))
+
 		// handlers
 		case "Handler_commit":
 			addPartialIfError(errs, m.mb.RecordMysqlHandlersDataPoint(now, v, metadata.AttributeHandlerCommit))

--- a/receiver/mysqlreceiver/testdata/scraper/expected.json
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.json
@@ -1536,6 +1536,56 @@
                         ]
                      },
                      "unit": "ns"
+                  },
+                  {
+                     "description": "The number of created temporary resources.",
+                     "name": "mysql.tmp_resources",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "isMonotonic": true,
+                        "dataPoints": [
+                           {
+                              "asInt": "189",
+                              "attributes": [
+                                 {
+                                    "key": "resource",
+                                    "value": {
+                                       "stringValue": "disk_tables"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1644862687825728000",
+                              "timeUnixNano": "1644862687825772000"
+                           },
+                           {
+                              "asInt": "190",
+                              "attributes": [
+                                 {
+                                    "key": "resource",
+                                    "value": {
+                                       "stringValue": "files"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1644862687825728000",
+                              "timeUnixNano": "1644862687825772000"
+                           },
+                           {
+                              "asInt": "191",
+                              "attributes": [
+                                 {
+                                    "key": "resource",
+                                    "value": {
+                                       "stringValue": "tables"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1644862687825728000",
+                              "timeUnixNano": "1644862687825772000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
                   }
                ]
             }


### PR DESCRIPTION
**Description:**

add mysql.created_tmp metric

ref: https://dev.mysql.com/doc/refman/8.0/en/server-status-variables.html#statvar_Created_tmp_disk_tables

**Link to tracking Issue:**
#14138

**Testing:**
unit tests

**Documentation:**
metadata.yaml