### PR TITLE
[processor/cumulativetodelta] Reduce Memory Consumption

### DIFF
--- a/.chloggen/c2d-reduce-memory-consumption.yaml
+++ b/.chloggen/c2d-reduce-memory-consumption.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cumulativetodeltaprocessor
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reduce memory consumption in cumulativetodeltaprocessor by removing unnecessary storage of metric identities.
+
+# One or more tracking issues related to the change
+issues: [13751]

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -37,7 +37,6 @@ var identityBufferPool = sync.Pool{
 
 type State struct {
 	sync.Mutex
-	Identity  MetricIdentity
 	PrevPoint ValuePoint
 }
 
@@ -86,7 +85,6 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool) {
 	var ok bool
 	if s, ok = t.states.Load(hashableID); !ok {
 		s, ok = t.states.LoadOrStore(hashableID, &State{
-			Identity:  metricID,
 			PrevPoint: metricPoint,
 		})
 	}

--- a/processor/cumulativetodeltaprocessor/processor.go
+++ b/processor/cumulativetodeltaprocessor/processor.go
@@ -66,12 +66,9 @@ func newCumulativeToDeltaProcessor(config *Config, logger *zap.Logger) *cumulati
 
 // processMetrics implements the ProcessMetricsFunc type.
 func (ctdp *cumulativeToDeltaProcessor) processMetrics(_ context.Context, md pmetric.Metrics) (pmetric.Metrics, error) {
-	resourceMetricsSlice := md.ResourceMetrics()
-	resourceMetricsSlice.RemoveIf(func(rm pmetric.ResourceMetrics) bool {
-		ilms := rm.ScopeMetrics()
-		ilms.RemoveIf(func(ilm pmetric.ScopeMetrics) bool {
-			ms := ilm.Metrics()
-			ms.RemoveIf(func(m pmetric.Metric) bool {
+	md.ResourceMetrics().RemoveIf(func(rm pmetric.ResourceMetrics) bool {
+		rm.ScopeMetrics().RemoveIf(func(ilm pmetric.ScopeMetrics) bool {
+			ilm.Metrics().RemoveIf(func(m pmetric.Metric) bool {
 				if !ctdp.shouldConvertMetric(m.Name()) {
 					return false
 				}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This change removes the unnecessary storage of metric identities.

Metric identities are only required for building the keys to look up items in the store. They do not need to be stored themselves.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13751

**Testing:**
Memory consumption before and after:
![Screenshot 2022-10-05 at 14 41 58](https://user-images.githubusercontent.com/16084033/194075210-82c252fb-9ac5-45b5-8dbf-47c5970b421d.png)

CPU throttling before and after:
![Screenshot 2022-10-05 at 14 42 11](https://user-images.githubusercontent.com/16084033/194075332-04a455b7-bd07-44f1-b505-d2c4b4a265d6.png)
