### PR TITLE
[chore] Remove redundant pcommon.Map.Clear() calls

### DIFF
--- a/exporter/datadogexporter/internal/testutils/test_utils.go
+++ b/exporter/datadogexporter/internal/testutils/test_utils.go
@@ -140,7 +140,6 @@ func newMetadataEndpoint(c chan []byte) func(http.ResponseWriter, *http.Request)
 }
 
 func fillAttributeMap(attrs pcommon.Map, mp map[string]string) {
-	attrs.Clear()
 	attrs.EnsureCapacity(len(mp))
 	for k, v := range mp {
 		attrs.PutString(k, v)

--- a/exporter/sumologicexporter/prometheus_formatter_test.go
+++ b/exporter/sumologicexporter/prometheus_formatter_test.go
@@ -58,9 +58,6 @@ func TestTags2String(t *testing.T) {
 
 func TestTags2StringNoAttributes(t *testing.T) {
 	f := newPrometheusFormatter()
-
-	mp := exampleIntMetric()
-	mp.attributes.Clear()
 	assert.Equal(t, prometheusTags(""), f.tags2String(pcommon.NewMap(), pcommon.NewMap()))
 }
 

--- a/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
+++ b/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
@@ -128,7 +128,6 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			orig:   refNumberDataPoint.Attributes(),
 			newVal: newAttrs,
 			modified: func(datapoint pmetric.NumberDataPoint) {
-				datapoint.Attributes().Clear()
 				newAttrs.CopyTo(datapoint.Attributes())
 			},
 		},
@@ -454,7 +453,6 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			orig:   refHistogramDataPoint.Attributes(),
 			newVal: newAttrs,
 			modified: func(datapoint pmetric.HistogramDataPoint) {
-				datapoint.Attributes().Clear()
 				newAttrs.CopyTo(datapoint.Attributes())
 			},
 		},
@@ -876,7 +874,6 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			orig:   refExpoHistogramDataPoint.Attributes(),
 			newVal: newAttrs,
 			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
-				datapoint.Attributes().Clear()
 				newAttrs.CopyTo(datapoint.Attributes())
 			},
 		},
@@ -1183,7 +1180,6 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			orig:   refExpoHistogramDataPoint.Attributes(),
 			newVal: newAttrs,
 			modified: func(datapoint pmetric.SummaryDataPoint) {
-				datapoint.Attributes().Clear()
 				newAttrs.CopyTo(datapoint.Attributes())
 			},
 		},

--- a/pkg/ottl/contexts/ottllogs/logs_test.go
+++ b/pkg/ottl/contexts/ottllogs/logs_test.go
@@ -193,7 +193,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			orig:   refLog.Attributes(),
 			newVal: newAttrs,
 			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource) {
-				log.Attributes().Clear()
 				newAttrs.CopyTo(log.Attributes())
 			},
 		},

--- a/pkg/ottl/contexts/ottltraces/traces_test.go
+++ b/pkg/ottl/contexts/ottltraces/traces_test.go
@@ -216,7 +216,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			orig:   refSpan.Attributes(),
 			newVal: newAttrs,
 			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
-				span.Attributes().Clear()
 				newAttrs.CopyTo(span.Attributes())
 			},
 		},

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -47,7 +47,6 @@ func Test_deleteKey(t *testing.T) {
 			target: target,
 			key:    "test",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutBool("test3", true)
 				expectedMap.PutInt("test2", 3)
 			},
@@ -57,7 +56,6 @@ func Test_deleteKey(t *testing.T) {
 			target: target,
 			key:    "test2",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutBool("test3", true)
 			},
@@ -67,7 +65,6 @@ func Test_deleteKey(t *testing.T) {
 			target: target,
 			key:    "not a valid key",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutInt("test2", 3)
 				expectedMap.PutBool("test3", true)

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -47,7 +47,6 @@ func Test_deleteMatchingKeys(t *testing.T) {
 			target:  target,
 			pattern: "test.*",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.EnsureCapacity(3)
 			},
 		},
@@ -56,7 +55,6 @@ func Test_deleteMatchingKeys(t *testing.T) {
 			target:  target,
 			pattern: "\\d$",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 			},
 		},
@@ -65,7 +63,6 @@ func Test_deleteMatchingKeys(t *testing.T) {
 			target:  target,
 			pattern: "not a matching pattern",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutInt("test2", 3)
 				expectedMap.PutBool("test3", true)

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -35,7 +35,6 @@ func Test_keepKeys(t *testing.T) {
 			return ctx
 		},
 		Setter: func(ctx pcommon.Map, val interface{}) {
-			ctx.Clear()
 			val.(pcommon.Map).CopyTo(ctx)
 		},
 	}
@@ -51,7 +50,6 @@ func Test_keepKeys(t *testing.T) {
 			target: target,
 			keys:   []string{"test"},
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 			},
 		},
@@ -60,7 +58,6 @@ func Test_keepKeys(t *testing.T) {
 			target: target,
 			keys:   []string{"test", "test2"},
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutInt("test2", 3)
 			},
@@ -69,25 +66,19 @@ func Test_keepKeys(t *testing.T) {
 			name:   "keep none",
 			target: target,
 			keys:   []string{},
-			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
-			},
+			want:   func(expectedMap pcommon.Map) {},
 		},
 		{
 			name:   "no match",
 			target: target,
 			keys:   []string{"no match"},
-			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
-			},
+			want:   func(expectedMap pcommon.Map) {},
 		},
 		{
 			name:   "input is not a pcommon.Map",
 			target: target,
 			keys:   []string{"no match"},
-			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
-			},
+			want:   func(expectedMap pcommon.Map) {},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/ottl/ottlfuncs/func_limit_test.go
+++ b/pkg/ottl/ottlfuncs/func_limit_test.go
@@ -35,7 +35,6 @@ func Test_limit(t *testing.T) {
 			return ctx
 		},
 		Setter: func(ctx pcommon.Map, val interface{}) {
-			ctx.Clear()
 			val.(pcommon.Map).CopyTo(ctx)
 		},
 	}
@@ -52,7 +51,6 @@ func Test_limit(t *testing.T) {
 			target: target,
 			limit:  int64(1),
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 			},
 		},
@@ -69,7 +67,6 @@ func Test_limit(t *testing.T) {
 			target: target,
 			limit:  int64(100),
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutInt("test2", 3)
 				expectedMap.PutBool("test3", true)
@@ -80,7 +77,6 @@ func Test_limit(t *testing.T) {
 			target: target,
 			limit:  int64(3),
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutInt("test2", 3)
 				expectedMap.PutBool("test3", true)
@@ -92,7 +88,6 @@ func Test_limit(t *testing.T) {
 			limit:  int64(2),
 			keep:   []string{"test3"},
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutBool("test3", true)
 			},
@@ -103,7 +98,6 @@ func Test_limit(t *testing.T) {
 			limit:  int64(2),
 			keep:   []string{"test", "test3"},
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutBool("test3", true)
 			},
@@ -114,7 +108,6 @@ func Test_limit(t *testing.T) {
 			limit:  int64(1),
 			keep:   []string{"te"},
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 			},
 		},
@@ -124,7 +117,6 @@ func Test_limit(t *testing.T) {
 			limit:  int64(2),
 			keep:   []string{"te", "test3"},
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutBool("test3", true)
 			},

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
@@ -35,7 +35,6 @@ func Test_replaceAllMatches(t *testing.T) {
 			return ctx
 		},
 		Setter: func(ctx pcommon.Map, val interface{}) {
-			ctx.Clear()
 			val.(pcommon.Map).CopyTo(ctx)
 		},
 	}
@@ -53,7 +52,6 @@ func Test_replaceAllMatches(t *testing.T) {
 			pattern:     "hello*",
 			replacement: "hello {universe}",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello {universe}")
 				expectedMap.PutString("test2", "hello {universe}")
 				expectedMap.PutString("test3", "goodbye")
@@ -65,7 +63,6 @@ func Test_replaceAllMatches(t *testing.T) {
 			pattern:     "nothing*",
 			replacement: "nothing {matches}",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutString("test2", "hello")
 				expectedMap.PutString("test3", "goodbye")

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -35,7 +35,6 @@ func Test_replaceAllPatterns(t *testing.T) {
 			return ctx
 		},
 		Setter: func(ctx pcommon.Map, val interface{}) {
-			ctx.Clear()
 			val.(pcommon.Map).CopyTo(ctx)
 		},
 	}
@@ -53,7 +52,6 @@ func Test_replaceAllPatterns(t *testing.T) {
 			pattern:     "hello",
 			replacement: "hello {universe}",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello {universe} world")
 				expectedMap.PutString("test2", "hello {universe}")
 				expectedMap.PutString("test3", "goodbye world1 and world2")
@@ -65,7 +63,6 @@ func Test_replaceAllPatterns(t *testing.T) {
 			pattern:     "nothing",
 			replacement: "nothing {matches}",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutString("test2", "hello")
 				expectedMap.PutString("test3", "goodbye world1 and world2")
@@ -77,7 +74,6 @@ func Test_replaceAllPatterns(t *testing.T) {
 			pattern:     `world[^\s]*(\s?)`,
 			replacement: "**** ",
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello **** ")
 				expectedMap.PutString("test2", "hello")
 				expectedMap.PutString("test3", "goodbye **** and **** ")

--- a/pkg/ottl/ottlfuncs/func_truncate_all_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all_test.go
@@ -35,7 +35,6 @@ func Test_truncateAll(t *testing.T) {
 			return ctx
 		},
 		Setter: func(ctx pcommon.Map, val interface{}) {
-			ctx.Clear()
 			val.(pcommon.Map).CopyTo(ctx)
 		},
 	}
@@ -51,7 +50,6 @@ func Test_truncateAll(t *testing.T) {
 			target: target,
 			limit:  1,
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "h")
 				expectedMap.PutInt("test2", 3)
 				expectedMap.PutBool("test3", true)
@@ -62,7 +60,6 @@ func Test_truncateAll(t *testing.T) {
 			target: target,
 			limit:  0,
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "")
 				expectedMap.PutInt("test2", 3)
 				expectedMap.PutBool("test3", true)
@@ -73,7 +70,6 @@ func Test_truncateAll(t *testing.T) {
 			target: target,
 			limit:  100,
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutInt("test2", 3)
 				expectedMap.PutBool("test3", true)
@@ -84,7 +80,6 @@ func Test_truncateAll(t *testing.T) {
 			target: target,
 			limit:  11,
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.Clear()
 				expectedMap.PutString("test", "hello world")
 				expectedMap.PutInt("test2", 3)
 				expectedMap.PutBool("test3", true)

--- a/pkg/translator/jaeger/jaegerproto_to_traces.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces.go
@@ -150,7 +150,6 @@ func jProcessToInternalResource(process *model.Process, dest pcommon.Resource) {
 	}
 
 	attrs := dest.Attributes()
-	attrs.Clear()
 	if serviceName != "" {
 		attrs.EnsureCapacity(len(tags) + 1)
 		attrs.PutString(conventions.AttributeServiceName, serviceName)
@@ -400,7 +399,6 @@ func jLogsToSpanEvents(logs []model.Log, dest ptrace.SpanEventSlice) {
 		}
 
 		attrs := event.Attributes()
-		attrs.Clear()
 		attrs.EnsureCapacity(len(log.Fields))
 		jTagsToInternalAttributes(log.Fields, attrs)
 		if name, ok := attrs.Get(eventNameAttr); ok {

--- a/pkg/translator/jaeger/jaegerthrift_to_traces.go
+++ b/pkg/translator/jaeger/jaegerthrift_to_traces.go
@@ -64,7 +64,6 @@ func jThriftProcessToInternalResource(process *jaeger.Process, dest pcommon.Reso
 	}
 
 	attrs := dest.Attributes()
-	attrs.Clear()
 	if serviceName != "" {
 		attrs.EnsureCapacity(len(tags) + 1)
 		attrs.PutString(conventions.AttributeServiceName, serviceName)
@@ -158,7 +157,6 @@ func jThriftLogsToSpanEvents(logs []*jaeger.Log, dest ptrace.SpanEventSlice) {
 		}
 
 		attrs := event.Attributes()
-		attrs.Clear()
 		attrs.EnsureCapacity(len(log.Fields))
 		jThriftTagsToInternalAttributes(log.Fields, attrs)
 		if name, ok := attrs.Get(eventNameAttr); ok {

--- a/pkg/translator/opencensus/oc_to_metrics.go
+++ b/pkg/translator/opencensus/oc_to_metrics.go
@@ -212,7 +212,6 @@ func fillAttributesMap(ocLabelsKeys []*ocmetrics.LabelKey, ocLabelValues []*ocme
 		lablesCount = len(ocLabelValues)
 	}
 
-	attributesMap.Clear()
 	attributesMap.EnsureCapacity(lablesCount)
 	for i := 0; i < lablesCount; i++ {
 		if !ocLabelValues[i].GetHasValue() {

--- a/pkg/translator/opencensus/oc_to_traces.go
+++ b/pkg/translator/opencensus/oc_to_traces.go
@@ -219,7 +219,6 @@ func initAttributeMapFromOC(ocAttrs *octrace.Span_Attributes, dest pcommon.Map) 
 		return
 	}
 
-	dest.Clear()
 	dest.EnsureCapacity(len(ocAttrs.AttributeMap))
 	for key, ocAttr := range ocAttrs.AttributeMap {
 		switch attribValue := ocAttr.Value.(type) {

--- a/pkg/translator/signalfx/to_metrics.go
+++ b/pkg/translator/signalfx/to_metrics.go
@@ -113,7 +113,6 @@ func fillNumberDataPoint(sfxDataPoint *model.DataPoint, dps pmetric.NumberDataPo
 }
 
 func fillInAttributes(dimensions []*model.Dimension, attributes pcommon.Map) {
-	attributes.Clear()
 	attributes.EnsureCapacity(len(dimensions))
 
 	for _, dim := range dimensions {

--- a/pkg/translator/zipkin/zipkinv2/to_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/to_translator.go
@@ -144,7 +144,6 @@ func zSpanToInternal(zspan *zipkinmodel.SpanModel, tags map[string]string, dest 
 	}
 
 	attrs := dest.Attributes()
-	attrs.Clear()
 	attrs.EnsureCapacity(len(tags))
 	if err := zTagsToInternalAttrs(zspan, tags, attrs, parseStringTags); err != nil {
 		return err

--- a/processor/probabilisticsamplerprocessor/probabilisticsampler_test.go
+++ b/processor/probabilisticsamplerprocessor/probabilisticsampler_test.go
@@ -225,7 +225,7 @@ func Test_tracesamplerprocessor_SamplingPercentageRange_MultipleResourceSpans(t 
 func Test_tracesamplerprocessor_SpanSamplingPriority(t *testing.T) {
 	singleSpanWithAttrib := func(key string, attribValue pcommon.Value) ptrace.Traces {
 		traces := ptrace.NewTraces()
-		initSpanWithAttributes(key, attribValue, traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty())
+		initSpanWithAttribute(key, attribValue, traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty())
 		return traces
 	}
 	tests := []struct {
@@ -423,13 +423,12 @@ func Test_parseSpanSamplingPriority(t *testing.T) {
 
 func getSpanWithAttributes(key string, value pcommon.Value) ptrace.Span {
 	span := ptrace.NewSpan()
-	initSpanWithAttributes(key, value, span)
+	initSpanWithAttribute(key, value, span)
 	return span
 }
 
-func initSpanWithAttributes(key string, value pcommon.Value, dest ptrace.Span) {
+func initSpanWithAttribute(key string, value pcommon.Value, dest ptrace.Span) {
 	dest.SetName("spanName")
-	dest.Attributes().Clear()
 	value.CopyTo(dest.Attributes().PutEmpty(key))
 }
 

--- a/receiver/awsxrayreceiver/internal/translator/cause.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause.go
@@ -66,7 +66,6 @@ func addCause(seg *awsxray.Segment, span ptrace.Span) {
 			evt := evts.AppendEmpty()
 			evt.SetName(ExceptionEventName)
 			attrs := evt.Attributes()
-			attrs.Clear()
 			attrs.EnsureCapacity(8)
 
 			// ID is a required field

--- a/receiver/signalfxreceiver/signalfxv2_event_to_logdata.go
+++ b/receiver/signalfxreceiver/signalfxv2_event_to_logdata.go
@@ -32,7 +32,6 @@ func signalFxV2EventsToLogRecords(events []*sfxpb.Event, lrs plog.LogRecordSlice
 		lr := lrs.AppendEmpty()
 
 		attrs := lr.Attributes()
-		attrs.Clear()
 		attrs.EnsureCapacity(2 + len(event.Dimensions) + len(event.Properties))
 
 		for _, dim := range event.Dimensions {


### PR DESCRIPTION
Wanted to see how `Map.Clear` is used in contrib. Removed obviously redundant usages but kept where it makes sense.