### PR TITLE
[receiver/mysql]: add mysql.commands metric with support for delete, insert, select, update

### DIFF
--- a/.chloggen/drosiek-commands-metric.yaml
+++ b/.chloggen/drosiek-commands-metric.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add mysql.commands metric with supprot for delete, insert, select, update
+
+# One or more tracking issues related to the change
+issues: [14138]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -52,7 +52,7 @@ metrics:
 | buffer_pool_data (status) | The status of buffer pool data. | dirty, clean |
 | buffer_pool_operations (operation) | The buffer pool operations types. | read_ahead_rnd, read_ahead, read_ahead_evicted, read_requests, reads, wait_free, write_requests |
 | buffer_pool_pages (kind) | The buffer pool pages types. | data, free, misc |
-| command (command) | The command types. | execute, close, fetch, prepare, reset, send_long_data |
+| command (command) | The command types. | delete, insert, select, update |
 | double_writes (kind) | The doublewrite types. | pages_written, writes |
 | handler (kind) | The handler types. | commit, delete, discover, external_lock, mrr_init, prepare, read_first, read_key, read_last, read_next, read_prev, read_rnd, read_rnd_next, rollback, savepoint, savepoint_rollback, update, write |
 | index_name (index) | The name of the index. |  |

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -217,41 +217,33 @@ type AttributeCommand int
 
 const (
 	_ AttributeCommand = iota
-	AttributeCommandExecute
-	AttributeCommandClose
-	AttributeCommandFetch
-	AttributeCommandPrepare
-	AttributeCommandReset
-	AttributeCommandSendLongData
+	AttributeCommandDelete
+	AttributeCommandInsert
+	AttributeCommandSelect
+	AttributeCommandUpdate
 )
 
 // String returns the string representation of the AttributeCommand.
 func (av AttributeCommand) String() string {
 	switch av {
-	case AttributeCommandExecute:
-		return "execute"
-	case AttributeCommandClose:
-		return "close"
-	case AttributeCommandFetch:
-		return "fetch"
-	case AttributeCommandPrepare:
-		return "prepare"
-	case AttributeCommandReset:
-		return "reset"
-	case AttributeCommandSendLongData:
-		return "send_long_data"
+	case AttributeCommandDelete:
+		return "delete"
+	case AttributeCommandInsert:
+		return "insert"
+	case AttributeCommandSelect:
+		return "select"
+	case AttributeCommandUpdate:
+		return "update"
 	}
 	return ""
 }
 
 // MapAttributeCommand is a helper map of string to AttributeCommand attribute value.
 var MapAttributeCommand = map[string]AttributeCommand{
-	"execute":        AttributeCommandExecute,
-	"close":          AttributeCommandClose,
-	"fetch":          AttributeCommandFetch,
-	"prepare":        AttributeCommandPrepare,
-	"reset":          AttributeCommandReset,
-	"send_long_data": AttributeCommandSendLongData,
+	"delete": AttributeCommandDelete,
+	"insert": AttributeCommandInsert,
+	"select": AttributeCommandSelect,
+	"update": AttributeCommandUpdate,
 }
 
 // AttributeDoubleWrites specifies the a value double_writes attribute.

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -21,7 +21,7 @@ attributes:
   command:
     value: command
     description: The command types.
-    enum: [execute, close, fetch, prepare, reset, send_long_data]
+    enum: [delete, insert, select, update]
   handler:
     value: kind
     description: The handler types.

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -159,18 +159,14 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 				metadata.AttributeBufferPoolOperationsWriteRequests))
 
 		// commands
-		case "Com_stmt_execute":
-			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandExecute))
-		case "Com_stmt_close":
-			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandClose))
-		case "Com_stmt_fetch":
-			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandFetch))
-		case "Com_stmt_prepare":
-			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandPrepare))
-		case "Com_stmt_reset":
-			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandReset))
-		case "Com_stmt_send_long_data":
-			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandSendLongData))
+		case "Com_delete":
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandDelete))
+		case "Com_insert":
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandInsert))
+		case "Com_select":
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandSelect))
+		case "Com_update":
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandUpdate))
 
 		// handlers
 		case "Handler_commit":

--- a/receiver/mysqlreceiver/testdata/scraper/expected.json
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.json
@@ -269,12 +269,12 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "165",
+                              "asInt": "50",
                               "attributes": [
                                  {
                                     "key": "command",
                                     "value": {
-                                       "stringValue": "prepare"
+                                       "stringValue": "delete"
                                     }
                                  }
                               ],
@@ -282,12 +282,12 @@
                               "timeUnixNano": "1644862687825772000"
                            },
                            {
-                              "asInt": "163",
+                              "asInt": "78",
                               "attributes": [
                                  {
                                     "key": "command",
                                     "value": {
-                                       "stringValue": "close"
+                                       "stringValue": "insert"
                                     }
                                  }
                               ],
@@ -295,12 +295,12 @@
                               "timeUnixNano": "1644862687825772000"
                            },
                            {
-                              "asInt": "167",
+                              "asInt": "106",
                               "attributes": [
                                  {
                                     "key": "command",
                                     "value": {
-                                       "stringValue": "send_long_data"
+                                       "stringValue": "select"
                                     }
                                  }
                               ],
@@ -308,38 +308,12 @@
                               "timeUnixNano": "1644862687825772000"
                            },
                            {
-                              "asInt": "166",
+                              "asInt": "173",
                               "attributes": [
                                  {
                                     "key": "command",
                                     "value": {
-                                       "stringValue": "reset"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "162",
-                              "attributes": [
-                                 {
-                                    "key": "command",
-                                    "value": {
-                                       "stringValue": "execute"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "164",
-                              "attributes": [
-                                 {
-                                    "key": "command",
-                                    "value": {
-                                       "stringValue": "fetch"
+                                       "stringValue": "update"
                                     }
                                  }
                               ],


### PR DESCRIPTION
**Description:**

add mysql.commands metric with support for delete, insert, select, update

related PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14722

**Link to tracking Issue:**

#14138

**Testing:**

unit tests

**Documentation:**

`metadata.yaml`