### PR TITLE
[receiver/mysql]: add mysql queries (all, client and slow) count metrics

### DIFF
--- a/.chloggen/drosiek-mysql-questions.yaml
+++ b/.chloggen/drosiek-mysql-questions.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add mysql queries (all, client and slow) count metrics
+
+# One or more tracking issues related to the change
+issues: [14138]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -23,6 +23,9 @@ These are the metrics available for this scraper.
 | **mysql.log_operations** | The number of InnoDB log operations. | 1 | Sum(Int) | <ul> <li>log_operations</li> </ul> |
 | **mysql.operations** | The number of InnoDB operations. | 1 | Sum(Int) | <ul> <li>operations</li> </ul> |
 | **mysql.page_operations** | The number of InnoDB page operations. | 1 | Sum(Int) | <ul> <li>page_operations</li> </ul> |
+| **mysql.queries.client.count** | The number of statements executed by the server. This includes only statements sent to the server by clients. | 1 | Sum(Int) | <ul> </ul> |
+| **mysql.queries.count** | The number of statements executed by the server. | 1 | Sum(Int) | <ul> </ul> |
+| **mysql.queries.slow.count** | The number of slow queries. | 1 | Sum(Int) | <ul> </ul> |
 | **mysql.row_locks** | The number of InnoDB row locks. | 1 | Sum(Int) | <ul> <li>row_locks</li> </ul> |
 | **mysql.row_operations** | The number of InnoDB row operations. | 1 | Sum(Int) | <ul> <li>row_operations</li> </ul> |
 | **mysql.sorts** | The number of MySQL sorts. | 1 | Sum(Int) | <ul> <li>sorts</li> </ul> |

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -279,3 +279,30 @@ metrics:
       monotonic: false
       aggregation: cumulative
     attributes: [threads]
+  mysql.queries.client.count:
+    enabled: true
+    description: The number of statements executed by the server. This includes only statements sent to the server by clients.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation: cumulative
+  mysql.queries.count:
+    enabled: true
+    description: The number of statements executed by the server.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation: cumulative
+  mysql.queries.slow.count:
+    enabled: true
+    description: The number of slow queries.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation: cumulative

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -266,6 +266,14 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 		case "Table_locks_waited":
 			addPartialIfError(errs, m.mb.RecordMysqlLocksDataPoint(now, v, metadata.AttributeLocksWaited))
 
+		// queries
+		case "Queries":
+			addPartialIfError(errs, m.mb.RecordMysqlQueriesCountDataPoint(now, v))
+		case "Questions":
+			addPartialIfError(errs, m.mb.RecordMysqlQueriesClientCountDataPoint(now, v))
+		case "Slow_queries":
+			addPartialIfError(errs, m.mb.RecordMysqlQueriesSlowCountDataPoint(now, v))
+
 		// sorts
 		case "Sort_merge_passes":
 			addPartialIfError(errs, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsMergePasses))

--- a/receiver/mysqlreceiver/testdata/scraper/expected.json
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.json
@@ -1536,6 +1536,54 @@
                         ]
                      },
                      "unit": "ns"
+                  },
+                  {
+                     "description": "The number of statements executed by the server. This includes only statements sent to the server by clients.",
+                     "name": "mysql.queries.client.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "407",
+                              "startTimeUnixNano": "1644862687825728000",
+                              "timeUnixNano": "1644862687825772000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of statements executed by the server.",
+                     "name": "mysql.queries.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "406",
+                              "startTimeUnixNano": "1644862687825728000",
+                              "timeUnixNano": "1644862687825772000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of slow queries.",
+                     "name": "mysql.queries.slow.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "415",
+                              "startTimeUnixNano": "1644862687825728000",
+                              "timeUnixNano": "1644862687825772000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
                   }
                ]
             }


### PR DESCRIPTION
**Description:**

add mysql queries (all, client and slow) count metrics

**Link to tracking Issue:**

#14138

**Testing:**

unit tests

**Documentation:**

`metadata.yaml`