### PR TITLE
[chore] Replace unnecessary usages of pcommon.Value.AsValue

### DIFF
--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -1243,10 +1243,10 @@ func TestSubLogs(t *testing.T) {
 
 	// The name of the leftmost log record should be 0_0_0.
 	val, _ := got.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "0_0_0", val.AsString())
+	assert.Equal(t, "0_0_0", val.Str())
 	// The name of the rightmost log record should be 1_1_2.
 	val, _ = got.ResourceLogs().At(1).ScopeLogs().At(1).LogRecords().At(2).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "1_1_2", val.AsString())
+	assert.Equal(t, "1_1_2", val.Str())
 
 	// Logs subset from some mid index (resource 0, library 1, log 2).
 	_0_1_2 := &index{resource: 0, library: 1, record: 2} //revive:disable-line:var-naming
@@ -1256,10 +1256,10 @@ func TestSubLogs(t *testing.T) {
 
 	// The name of the leftmost log record should be 0_1_2.
 	val, _ = got.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "0_1_2", val.AsString())
+	assert.Equal(t, "0_1_2", val.Str())
 	// The name of the rightmost log record should be 1_1_2.
 	val, _ = got.ResourceLogs().At(1).ScopeLogs().At(1).LogRecords().At(2).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "1_1_2", val.AsString())
+	assert.Equal(t, "1_1_2", val.Str())
 
 	// Logs subset from rightmost index (resource 1, library 1, log 2).
 	_1_1_2 := &index{resource: 1, library: 1, record: 2} //revive:disable-line:var-naming
@@ -1270,7 +1270,7 @@ func TestSubLogs(t *testing.T) {
 
 	// The name of the sole log record should be 1_1_2.
 	val, _ = got.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "1_1_2", val.AsString())
+	assert.Equal(t, "1_1_2", val.Str())
 
 	// Now see how profiling and log data are merged
 	logs = createLogDataWithCustomLibraries(2, []string{"otel.logs", "otel.profiling"}, []int{10, 10})
@@ -1282,20 +1282,20 @@ func TestSubLogs(t *testing.T) {
 	assert.Equal(t, 5+2+10, got.LogRecordCount())
 	assert.Equal(t, "otel.logs", got.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name())
 	val, _ = got.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "1_0_5", val.AsString())
+	assert.Equal(t, "1_0_5", val.Str())
 	val, _ = got.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(4).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "1_0_9", val.AsString())
+	assert.Equal(t, "1_0_9", val.Str())
 
 	assert.Equal(t, "otel.profiling", got.ResourceLogs().At(1).ScopeLogs().At(0).Scope().Name())
 	val, _ = got.ResourceLogs().At(1).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "0_1_8", val.AsString())
+	assert.Equal(t, "0_1_8", val.Str())
 	val, _ = got.ResourceLogs().At(1).ScopeLogs().At(0).LogRecords().At(1).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "0_1_9", val.AsString())
+	assert.Equal(t, "0_1_9", val.Str())
 	assert.Equal(t, "otel.profiling", got.ResourceLogs().At(2).ScopeLogs().At(0).Scope().Name())
 	val, _ = got.ResourceLogs().At(2).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "1_1_0", val.AsString())
+	assert.Equal(t, "1_1_0", val.Str())
 	val, _ = got.ResourceLogs().At(2).ScopeLogs().At(0).LogRecords().At(9).Attributes().Get(splunk.DefaultNameLabel)
-	assert.Equal(t, "1_1_9", val.AsString())
+	assert.Equal(t, "1_1_9", val.Str())
 }
 
 // validateCompressedEqual validates that GZipped `got` contains `expected` strings

--- a/pkg/translator/zipkin/zipkinv1/json_test.go
+++ b/pkg/translator/zipkin/zipkinv1/json_test.go
@@ -145,8 +145,7 @@ func TestZipkinJSONFallbackToLocalComponent(t *testing.T) {
 	gotSecond, found := reqs.ResourceSpans().At(1).Resource().Attributes().Get(conventions.AttributeServiceName)
 	require.True(t, found)
 
-	if gotFirst.AsString() == "myLocalComponent" {
-		require.Equal(t, "myLocalComponent", gotFirst.Str())
+	if gotFirst.Str() == "myLocalComponent" {
 		require.Equal(t, "myServiceName", gotSecond.Str())
 	} else {
 		require.Equal(t, "myServiceName", gotFirst.Str())

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -779,7 +779,7 @@ func TestMetricAdvancedGrouping(t *testing.T) {
 	assert.Equal(t, 1, hostAGauge1.Gauge().DataPoints().At(0).Attributes().Len())
 	metricIDAttribute, foundMetricIDAttribute := hostAGauge1.Gauge().DataPoints().At(0).Attributes().Get("id")
 	assert.True(t, foundMetricIDAttribute)
-	assert.Equal(t, "eth0", metricIDAttribute.AsString())
+	assert.Equal(t, "eth0", metricIDAttribute.Str())
 	hostAMixedGauge, foundHostAMixedGauge := retrieveMetric(hostA.ScopeMetrics().At(0).Metrics(), "mixed-type", pmetric.MetricTypeGauge)
 	assert.True(t, foundHostAMixedGauge)
 	assert.Equal(t, 2, hostAMixedGauge.Gauge().DataPoints().Len())
@@ -806,7 +806,7 @@ func retrieveHostResource(resources pmetric.ResourceMetricsSlice, hostname strin
 	for i := 0; i < resources.Len(); i++ {
 		resource := resources.At(i)
 		hostnameValue, foundKey := resource.Resource().Attributes().Get("host.name")
-		if foundKey && hostnameValue.AsString() == hostname {
+		if foundKey && hostnameValue.Str() == hostname {
 			return resource, true
 		}
 	}

--- a/processor/routingprocessor/logs_test.go
+++ b/processor/routingprocessor/logs_test.go
@@ -394,7 +394,7 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 		rspan := defaultExp.AllLogs()[0].ResourceLogs().At(0)
 		attr, ok := rspan.Resource().Attributes().Get("X-Tenant")
 		assert.True(t, ok, "routing attribute must exists")
-		assert.Equal(t, attr.AsString(), "something-else")
+		assert.Equal(t, "something-else", attr.Str())
 	})
 }
 

--- a/processor/servicegraphprocessor/processor_test.go
+++ b/processor/servicegraphprocessor/processor_test.go
@@ -196,7 +196,7 @@ func verifyDuration(t *testing.T, m pmetric.Metric) {
 func verifyAttr(t *testing.T, attrs pcommon.Map, k, expected string) {
 	v, ok := attrs.Get(k)
 	assert.True(t, ok)
-	assert.Equal(t, expected, v.AsString())
+	assert.Equal(t, expected, v.Str())
 }
 
 func sampleTraces() ptrace.Traces {

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -855,7 +855,7 @@ func TestSetLatencyExemplars(t *testing.T) {
 
 	assert.NotEmpty(t, exemplarSlice)
 	assert.True(t, exist)
-	assert.Equal(t, traceIDValue.AsString(), traceID.HexString())
+	assert.Equal(t, traceIDValue.Str(), traceID.HexString())
 	assert.Equal(t, exemplarSlice.At(0).Timestamp(), timestamp)
 	assert.Equal(t, exemplarSlice.At(0).DoubleValue(), value)
 }

--- a/receiver/k8seventsreceiver/k8s_event_to_logdata_test.go
+++ b/receiver/k8seventsreceiver/k8s_event_to_logdata_test.go
@@ -47,11 +47,11 @@ func TestK8sEventToLogDataWithApiAndResourceVersion(t *testing.T) {
 	attrs := ld.ResourceLogs().At(0).Resource().Attributes()
 	attr, ok := attrs.Get("k8s.object.api_version")
 	assert.Equal(t, true, ok)
-	assert.Equal(t, "v1", attr.AsString())
+	assert.Equal(t, "v1", attr.Str())
 
 	attr, ok = attrs.Get("k8s.object.resource_version")
 	assert.Equal(t, true, ok)
-	assert.Equal(t, "", attr.AsString())
+	assert.Equal(t, "", attr.Str())
 
 	// add ResourceVersion
 	k8sEvent.InvolvedObject.ResourceVersion = "7387066320"
@@ -59,7 +59,7 @@ func TestK8sEventToLogDataWithApiAndResourceVersion(t *testing.T) {
 	attrs = ld.ResourceLogs().At(0).Resource().Attributes()
 	attr, ok = attrs.Get("k8s.object.resource_version")
 	assert.Equal(t, true, ok)
-	assert.Equal(t, "7387066320", attr.AsString())
+	assert.Equal(t, "7387066320", attr.Str())
 }
 
 func TestUnknownSeverity(t *testing.T) {

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -257,7 +257,7 @@ func testMovieMetrics(t *testing.T, rm pmetric.ResourceMetrics, genreAttrKey str
 	for _, metric := range metricsByName["genre.count"] {
 		pt := metric.Gauge().DataPoints().At(0)
 		genre, _ := pt.Attributes().Get(genreAttrKey)
-		genreStr := genre.AsString()
+		genreStr := genre.Str()
 		switch genreStr {
 		case "SciFi":
 			assert.EqualValues(t, 3, pt.IntValue())
@@ -271,7 +271,7 @@ func testMovieMetrics(t *testing.T, rm pmetric.ResourceMetrics, genreAttrKey str
 	for _, metric := range metricsByName["genre.imdb"] {
 		pt := metric.Gauge().DataPoints().At(0)
 		genre, _ := pt.Attributes().Get(genreAttrKey)
-		genreStr := genre.AsString()
+		genreStr := genre.Str()
 		switch genreStr {
 		case "SciFi":
 			assert.InDelta(t, 8.2, pt.DoubleValue(), 0.1)

--- a/receiver/sqlqueryreceiver/scraper_test.go
+++ b/receiver/sqlqueryreceiver/scraper_test.go
@@ -173,9 +173,9 @@ func TestScraper_SingleRow_MultiMetrics(t *testing.T) {
 		attrs := dp.Attributes()
 		assert.Equal(t, 2, attrs.Len())
 		fooVal, _ := attrs.Get("foo_name")
-		assert.Equal(t, "baz", fooVal.AsString())
+		assert.Equal(t, "baz", fooVal.Str())
 		barVal, _ := attrs.Get("bar_name")
-		assert.Equal(t, "quux", barVal.AsString())
+		assert.Equal(t, "quux", barVal.Str())
 	}
 	{
 		sumMetric := ms.At(1)
@@ -188,9 +188,9 @@ func TestScraper_SingleRow_MultiMetrics(t *testing.T) {
 		attrs := dp.Attributes()
 		assert.Equal(t, 2, attrs.Len())
 		fooVal, _ := attrs.Get("foo_name")
-		assert.Equal(t, "baz", fooVal.AsString())
+		assert.Equal(t, "baz", fooVal.Str())
 		barVal, _ := attrs.Get("bar_name")
-		assert.Equal(t, "quux", barVal.AsString())
+		assert.Equal(t, "quux", barVal.Str())
 	}
 }
 


### PR DESCRIPTION
Do not use `AsString` where the underlying value is always a string