### PR TITLE
Update link to JMX Metric Gatherer jar

### DIFF
--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -15,7 +15,7 @@ to report metrics from a target MBean server using a built-in `otel` helper-util
 
 This receiver will launch a child JRE process running the JMX Metric Gatherer configured with your specified JMX
 connection information and target Groovy script.  It then reports metrics to an implicitly created OTLP receiver.
-In order to use you will need to download the most [recent release](https://repo1.maven.org/maven2/io/opentelemetry/contrib/opentelemetry-java-contrib-jmx-metrics/)
+In order to use you will need to download the most [recent release](https://repo1.maven.org/maven2/io/opentelemetry/contrib/opentelemetry-jmx-metrics)
 of the JMX Metric Gatherer JAR and configure the receiver with its path.  It is assumed that the JRE is
 available on your system.
 


### PR DESCRIPTION
**Description:** 
Updated jmxreceiver readme to point to `opentelemetry-jmx-metrics` artifact instead of `opentelemetry-java-contrib-jmx-metrics` since the only version of this artifact doesn't pass the hash check introduced in [this PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9985)