### PR TITLE
[receiver/iis] Fix flaky test by ignoring volatile attribute value

### DIFF
--- a/receiver/iisreceiver/integration_test.go
+++ b/receiver/iisreceiver/integration_test.go
@@ -54,5 +54,7 @@ func TestIisIntegration(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics, scrapertest.IgnoreMetricValues()))
+	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics,
+		scrapertest.IgnoreResourceAttributeValue("iis.application_pool"),
+		scrapertest.IgnoreMetricValues()))
 }


### PR DESCRIPTION
Resolves #14756 