### PR TITLE
[pkg/stanza] readerFactory and  Reader  use  bufio.SplitFunc directly

### DIFF
--- a/.chloggen/stanza-reader-splitFunc.yaml
+++ b/.chloggen/stanza-reader-splitFunc.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`readerFactory` and  `Reader` use  `bufio.SplitFunc` directly, no longer depends on `helper.Splitter`"
+
+# One or more tracking issues related to the change
+issues: [14766]

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -15,6 +15,7 @@
 package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -34,8 +35,8 @@ type readerConfig struct {
 type Reader struct {
 	*zap.SugaredLogger `json:"-"` // json tag excludes embedded fields from storage
 	*readerConfig
-	splitter *helper.Splitter
-	encoding helper.Encoding
+	splitFunc bufio.SplitFunc
+	encoding  helper.Encoding
 
 	Fingerprint    *Fingerprint
 	Offset         int64
@@ -61,7 +62,7 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 		return
 	}
 
-	scanner := NewPositionalScanner(r, r.maxLogSize, r.Offset, r.splitter.SplitFunc)
+	scanner := NewPositionalScanner(r, r.maxLogSize, r.Offset, r.splitFunc)
 
 	// Iterate over the tokenized file, emitting entries as we go
 	for {

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -15,6 +15,7 @@
 package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 
 import (
+	"bufio"
 	"os"
 
 	"go.uber.org/zap"
@@ -43,7 +44,7 @@ func (f *readerFactory) copy(old *Reader, newFile *os.File) (*Reader, error) {
 		withFile(newFile).
 		withFingerprint(old.Fingerprint.Copy()).
 		withOffset(old.Offset).
-		withSplitter(old.splitter).
+		withSplitterFunc(old.splitFunc).
 		build()
 }
 
@@ -57,18 +58,18 @@ func (f *readerFactory) newFingerprint(file *os.File) (*Fingerprint, error) {
 
 type readerBuilder struct {
 	*readerFactory
-	file     *os.File
-	fp       *Fingerprint
-	offset   int64
-	splitter *helper.Splitter
+	file      *os.File
+	fp        *Fingerprint
+	offset    int64
+	splitFunc bufio.SplitFunc
 }
 
 func (f *readerFactory) newReaderBuilder() *readerBuilder {
 	return &readerBuilder{readerFactory: f}
 }
 
-func (b *readerBuilder) withSplitter(s *helper.Splitter) *readerBuilder {
-	b.splitter = s
+func (b *readerBuilder) withSplitterFunc(s bufio.SplitFunc) *readerBuilder {
+	b.splitFunc = s
 	return b
 }
 
@@ -93,12 +94,13 @@ func (b *readerBuilder) build() (r *Reader, err error) {
 		Offset:       b.offset,
 	}
 
-	if b.splitter != nil {
-		r.splitter = b.splitter
+	if b.splitFunc != nil {
+		r.splitFunc = b.splitFunc
 	} else {
-		r.splitter, err = b.splitterConfig.Build(false, b.readerConfig.maxLogSize)
+		splitter, err := b.splitterConfig.Build(false, b.readerConfig.maxLogSize)
+		r.splitFunc = splitter.SplitFunc
 		if err != nil {
-			return
+			return nil, err
 		}
 	}
 

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -94,13 +94,14 @@ func (b *readerBuilder) build() (r *Reader, err error) {
 		Offset:       b.offset,
 	}
 
+	var splitter *helper.Splitter
 	if b.splitFunc != nil {
 		r.splitFunc = b.splitFunc
 	} else {
-		splitter, err := b.splitterConfig.Build(false, b.readerConfig.maxLogSize)
+		splitter, err = b.splitterConfig.Build(false, b.readerConfig.maxLogSize)
 		r.splitFunc = splitter.SplitFunc
 		if err != nil {
-			return nil, err
+			return
 		}
 	}
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`readerFactory` and  `Reader` use  `bufio.SplitFunc` directly, no longer depends on `helper.Splitter`

**Link to tracking Issue:** <Issue number if applicable>
#14766
**Testing:** <Describe what testing was performed and which tests were added.>
test unit