### PR TITLE
[extension/bearertokenauth] Allow for other token auth schemes

### DIFF
--- a/.chloggen/bearertoken-auth-scheme.yaml
+++ b/.chloggen/bearertoken-auth-scheme.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: bearertokenauthextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow bearertokenauthextension to support custom auth schemes apart from "Bearer"
+
+# One or more tracking issues related to the change
+issues: [14771]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/extension/bearertokenauthextension/README.md
+++ b/extension/bearertokenauthextension/README.md
@@ -36,7 +36,7 @@ extensions:
     token: "somerandomtoken"
     filename: "file-containing.token"
   bearertokenauth/withscheme:
-    scheme: "Scheme"
+    scheme: "Bearer"
     token: "randomtoken"
 
 receivers:

--- a/extension/bearertokenauthextension/README.md
+++ b/extension/bearertokenauthextension/README.md
@@ -15,13 +15,15 @@ The authenticator type has to be set to `bearertokenauth`.
 
 One of the following two options is required. If a token **and** a tokenfile are specified, the token is **ignored**:
 
-- `token`: static authorization token that needs to be sent on every gRPC client call as metadata.
-  This token is prepended by "Bearer " before being sent as a value of "authorization" key in
+- `scheme`: Specifies the auth scheme name. Defaults to "Bearer".
+
+- `token`: Static authorization token that needs to be sent on every gRPC client call as metadata.
+  This token is prepended by `${scheme}` before being sent as a value of "authorization" key in
   RPC metadata.
 
-- `filename`: filename of file that contains a authorization token that needs to be sent on every
+- `filename`: Name of file that contains a authorization token that needs to be sent on every
   gRPC client call as metadata.
-  This token is prepended by "Bearer " before being sent as a value of "authorization" key in
+  This token is prepended by `${scheme}` before being sent as a value of "authorization" key in
   RPC metadata.
 
 
@@ -33,6 +35,9 @@ extensions:
   bearertokenauth:
     token: "somerandomtoken"
     filename: "file-containing.token"
+  bearertokenauth/withscheme:
+    scheme: "Scheme"
+    token: "randomtoken"
 
 receivers:
   hostmetrics:
@@ -55,7 +60,7 @@ exporters:
       authenticator: bearertokenauth
 
 service:
-  extensions: [bearertokenauth]
+  extensions: [bearertokenauth, bearertokenauth/withscheme]
   pipelines:
     metrics:
       receivers: [hostmetrics]

--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -48,6 +48,7 @@ func (c *PerRPCAuth) RequireTransportSecurity() bool {
 // BearerTokenAuth is an implementation of configauth.GRPCClientAuthenticator. It embeds a static authorization "bearer" token in every rpc call.
 type BearerTokenAuth struct {
 	muTokenString sync.RWMutex
+	scheme        string
 	tokenString   string
 
 	shutdownCH chan struct{}
@@ -63,6 +64,7 @@ func newBearerTokenAuth(cfg *Config, logger *zap.Logger) *BearerTokenAuth {
 		logger.Warn("a filename is specified. Configured token is ignored!")
 	}
 	return &BearerTokenAuth{
+		scheme:      cfg.Scheme,
 		tokenString: cfg.BearerToken,
 		filename:    cfg.Filename,
 		logger:      logger,
@@ -167,7 +169,7 @@ func (b *BearerTokenAuth) PerRPCCredentials() (credentials.PerRPCCredentials, er
 
 func (b *BearerTokenAuth) bearerToken() string {
 	b.muTokenString.RLock()
-	token := fmt.Sprintf("Bearer %s", b.tokenString)
+	token := fmt.Sprintf("%s %s", b.scheme, b.tokenString)
 	b.muTokenString.RUnlock()
 	return token
 }

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -54,8 +54,10 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func TestBearerAuthenticatorHttp(t *testing.T) {
+	scheme := "TestScheme"
 	cfg := createDefaultConfig().(*Config)
 	cfg.BearerToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+	cfg.Scheme = scheme
 
 	bauth := newBearerTokenAuth(cfg, nil)
 	assert.NotNil(t, bauth)
@@ -69,7 +71,8 @@ func TestBearerAuthenticatorHttp(t *testing.T) {
 	resp, err := c.RoundTrip(request)
 	assert.NoError(t, err)
 	authHeaderValue := resp.Header.Get("Authorization")
-	assert.Equal(t, authHeaderValue, fmt.Sprintf("Bearer %s", cfg.BearerToken))
+	assert.Equal(t, authHeaderValue, fmt.Sprintf("%s %s", scheme, cfg.BearerToken))
+
 }
 
 func TestBearerAuthenticator(t *testing.T) {

--- a/extension/bearertokenauthextension/config.go
+++ b/extension/bearertokenauthextension/config.go
@@ -24,6 +24,9 @@ import (
 type Config struct {
 	config.ExtensionSettings `mapstructure:",squash"`
 
+	// Scheme specifies the auth-scheme for the token. Defaults to "Bearer"
+	Scheme string `mapstructure:"scheme,omitempty"`
+
 	// BearerToken specifies the bearer token to use for every RPC.
 	BearerToken string `mapstructure:"token,omitempty"`
 

--- a/extension/bearertokenauthextension/config_test.go
+++ b/extension/bearertokenauthextension/config_test.go
@@ -40,7 +40,16 @@ func TestLoadConfig(t *testing.T) {
 			id: config.NewComponentIDWithName(typeStr, "sometoken"),
 			expected: &Config{
 				ExtensionSettings: config.NewExtensionSettings(config.NewComponentID(typeStr)),
+				Scheme:            defaultScheme,
 				BearerToken:       "sometoken",
+			},
+		},
+		{
+			id: config.NewComponentIDWithName(typeStr, "withscheme"),
+			expected: &Config{
+				ExtensionSettings: config.NewExtensionSettings(config.NewComponentID(typeStr)),
+				Scheme:            "MyScheme",
+				BearerToken:       "my-token",
 			},
 		},
 	}

--- a/extension/bearertokenauthextension/factory.go
+++ b/extension/bearertokenauthextension/factory.go
@@ -24,6 +24,8 @@ import (
 const (
 	// The value of extension "type" in configuration.
 	typeStr = "bearertokenauth"
+
+	defaultScheme = "Bearer"
 )
 
 // NewFactory creates a factory for the static bearer token Authenticator extension.
@@ -39,6 +41,7 @@ func NewFactory() component.ExtensionFactory {
 func createDefaultConfig() config.Extension {
 	return &Config{
 		ExtensionSettings: config.NewExtensionSettings(config.NewComponentID(typeStr)),
+		Scheme:            defaultScheme,
 	}
 }
 

--- a/extension/bearertokenauthextension/factory_test.go
+++ b/extension/bearertokenauthextension/factory_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
-	assert.Equal(t, &Config{ExtensionSettings: config.NewExtensionSettings(config.NewComponentID(typeStr))}, cfg)
+	assert.Equal(t, &Config{ExtensionSettings: config.NewExtensionSettings(config.NewComponentID(typeStr)), Scheme: defaultScheme}, cfg)
 	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 }
 

--- a/extension/bearertokenauthextension/testdata/config.yaml
+++ b/extension/bearertokenauthextension/testdata/config.yaml
@@ -1,3 +1,6 @@
 bearertokenauth:
 bearertokenauth/sometoken:
   token: "sometoken"
+bearertokenauth/withscheme:
+  scheme: MyScheme
+  token: "my-token"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Custom Auth scheme apart from "Bearer" now supported

**Link to tracking Issue:** #14771

**Testing:** Unit Tests, Manual

**Documentation:** Updated Readme.md