### PR TITLE
exporter/awsxrayexporter: fix stacktrace parsing for dotnet

### DIFF
--- a/.chloggen/fix_dotnet_stacktrace.yaml
+++ b/.chloggen/fix_dotnet_stacktrace.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix an issue where the awsxrayexporter would not parse .Net stacktrace correctly.
+
+# One or more tracking issues related to the change
+issues: [14780]

--- a/exporter/awsxrayexporter/internal/translator/cause.go
+++ b/exporter/awsxrayexporter/internal/translator/cause.go
@@ -456,12 +456,13 @@ func fillDotnetStacktrace(stacktrace string, exceptions []awsxray.Exception) []a
 
 	exception.Stack = nil
 	for {
-		if strings.HasPrefix(line, "\tat ") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "at ") {
 			index := strings.Index(line, " in ")
 			if index >= 0 {
 				parts := strings.Split(line, " in ")
 
-				label := parts[0][len("\tat "):]
+				label := parts[0][len("at "):]
 				path := parts[1]
 				lineNumber := 0
 
@@ -486,7 +487,7 @@ func fillDotnetStacktrace(stacktrace string, exceptions []awsxray.Exception) []a
 			} else {
 				idx := strings.LastIndexByte(line, ')')
 				if idx >= 0 {
-					label := line[len("\tat ") : idx+1]
+					label := line[len("at ") : idx+1]
 					path := ""
 					lineNumber := 0
 


### PR DESCRIPTION
**Description:** 
This change fixes the .Net stacktrace parsing logic in awsxrayexporter where the code looks for stacktrace lines to begin with `\at` but they actually begin with `   at`.  More info on the tracking issue.

Instead of relying on whitespace characters or tab, now the code first trims each line and proceeds with the parsing.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14780
https://github.com/aws-observability/aws-otel-collector/issues/1467

**Testing:** Simulated an exception with another inner exception and updated the unit test with this stack trace to verify the parsing logic works.

**Documentation:** N/A