### PR TITLE
[pkg/ottl] Add condition parser

### DIFF
--- a/.chloggen/ottl-condition-parser.yaml
+++ b/.chloggen/ottl-condition-parser.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a ParseConditions function that allows parsing ottl statements that contain only conditions.
+
+# One or more tracking issues related to the change
+issues: [14783]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/boolean_value.go
+++ b/pkg/ottl/boolean_value.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 )
 
-// boolExpressionEvaluator is a function that returns the result.
-type boolExpressionEvaluator[K any] func(ctx K) bool
+// BoolExpressionEvaluator is a function that returns the result.
+type BoolExpressionEvaluator[K any] func(ctx K) bool
 
 func alwaysTrue[K any](K) bool {
 	return true
@@ -30,8 +30,8 @@ func alwaysFalse[K any](K) bool {
 }
 
 // builds a function that returns a short-circuited result of ANDing
-// boolExpressionEvaluator funcs
-func andFuncs[K any](funcs []boolExpressionEvaluator[K]) boolExpressionEvaluator[K] {
+// BoolExpressionEvaluator funcs
+func andFuncs[K any](funcs []BoolExpressionEvaluator[K]) BoolExpressionEvaluator[K] {
 	return func(ctx K) bool {
 		for _, f := range funcs {
 			if !f(ctx) {
@@ -43,8 +43,8 @@ func andFuncs[K any](funcs []boolExpressionEvaluator[K]) boolExpressionEvaluator
 }
 
 // builds a function that returns a short-circuited result of ORing
-// boolExpressionEvaluator funcs
-func orFuncs[K any](funcs []boolExpressionEvaluator[K]) boolExpressionEvaluator[K] {
+// BoolExpressionEvaluator funcs
+func orFuncs[K any](funcs []BoolExpressionEvaluator[K]) BoolExpressionEvaluator[K] {
 	return func(ctx K) bool {
 		for _, f := range funcs {
 			if f(ctx) {
@@ -55,7 +55,7 @@ func orFuncs[K any](funcs []boolExpressionEvaluator[K]) boolExpressionEvaluator[
 	}
 }
 
-func (p *Parser[K]) newComparisonEvaluator(comparison *comparison) (boolExpressionEvaluator[K], error) {
+func (p *Parser[K]) newComparisonEvaluator(comparison *comparison) (BoolExpressionEvaluator[K], error) {
 	if comparison == nil {
 		return alwaysTrue[K], nil
 	}
@@ -77,7 +77,7 @@ func (p *Parser[K]) newComparisonEvaluator(comparison *comparison) (boolExpressi
 
 }
 
-func (p *Parser[K]) newBooleanExpressionEvaluator(expr *booleanExpression) (boolExpressionEvaluator[K], error) {
+func (p *Parser[K]) newBooleanExpressionEvaluator(expr *booleanExpression) (BoolExpressionEvaluator[K], error) {
 	if expr == nil {
 		return alwaysTrue[K], nil
 	}
@@ -85,7 +85,7 @@ func (p *Parser[K]) newBooleanExpressionEvaluator(expr *booleanExpression) (bool
 	if err != nil {
 		return nil, err
 	}
-	funcs := []boolExpressionEvaluator[K]{f}
+	funcs := []BoolExpressionEvaluator[K]{f}
 	for _, rhs := range expr.Right {
 		f, err := p.newBooleanTermEvaluator(rhs.Term)
 		if err != nil {
@@ -97,7 +97,7 @@ func (p *Parser[K]) newBooleanExpressionEvaluator(expr *booleanExpression) (bool
 	return orFuncs(funcs), nil
 }
 
-func (p *Parser[K]) newBooleanTermEvaluator(term *term) (boolExpressionEvaluator[K], error) {
+func (p *Parser[K]) newBooleanTermEvaluator(term *term) (BoolExpressionEvaluator[K], error) {
 	if term == nil {
 		return alwaysTrue[K], nil
 	}
@@ -105,7 +105,7 @@ func (p *Parser[K]) newBooleanTermEvaluator(term *term) (boolExpressionEvaluator
 	if err != nil {
 		return nil, err
 	}
-	funcs := []boolExpressionEvaluator[K]{f}
+	funcs := []BoolExpressionEvaluator[K]{f}
 	for _, rhs := range term.Right {
 		f, err := p.newBooleanValueEvaluator(rhs.Value)
 		if err != nil {
@@ -117,7 +117,7 @@ func (p *Parser[K]) newBooleanTermEvaluator(term *term) (boolExpressionEvaluator
 	return andFuncs(funcs), nil
 }
 
-func (p *Parser[K]) newBooleanValueEvaluator(value *booleanValue) (boolExpressionEvaluator[K], error) {
+func (p *Parser[K]) newBooleanValueEvaluator(value *booleanValue) (BoolExpressionEvaluator[K], error) {
 	if value == nil {
 		return alwaysTrue[K], nil
 	}

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -20,10 +20,15 @@ import (
 	"github.com/alecthomas/participle/v2/lexer"
 )
 
-// parsedStatement represents a parsed statement. It is the entry point into the statement DSL.
-type parsedStatement struct {
+// transformationStatement represents a transformation statement. It is the entry point into the statement DSL.
+type transformationStatement struct {
 	Invocation  invocation         `parser:"@@"`
 	WhereClause *booleanExpression `parser:"( 'where' @@ )?"`
+}
+
+// conditionStatement represents a condition statement.
+type conditionStatement struct {
+	BooleanExpression *booleanExpression `parser:"@@"`
 }
 
 // booleanValue represents something that evaluates to a boolean --
@@ -149,13 +154,6 @@ type Path struct {
 type Field struct {
 	Name   string  `parser:"@Lowercase"`
 	MapKey *string `parser:"( '[' @String ']' )?"`
-}
-
-// Statement holds a top level Statement for processing telemetry data. A Statement is a combination of a function
-// invocation and the expression to match telemetry for invoking the function.
-type Statement[K any] struct {
-	Function  ExprFunc[K]
-	Condition boolExpressionEvaluator[K]
 }
 
 // byteSlice type for capturing byte slices

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -20,28 +20,63 @@ import (
 	"go.uber.org/multierr"
 )
 
+// Statement holds a top level statement for processing telemetry data. A Statement is a combination of a function
+// invocation and the expression to match telemetry for invoking the function.
+type Statement[K any] struct {
+	Function  ExprFunc[K]
+	Condition BoolExpressionEvaluator[K]
+}
+
 type Parser[K any] struct {
-	functions         map[string]interface{}
-	pathParser        PathExpressionParser[K]
-	enumParser        EnumParser
-	telemetrySettings component.TelemetrySettings
+	functions            map[string]interface{}
+	pathParser           PathExpressionParser[K]
+	enumParser           EnumParser
+	telemetrySettings    component.TelemetrySettings
+	transformationParser *participle.Parser[transformationStatement]
+	conditionParser      *participle.Parser[conditionStatement]
 }
 
 func NewParser[K any](functions map[string]interface{}, pathParser PathExpressionParser[K], enumParser EnumParser, telemetrySettings component.TelemetrySettings) Parser[K] {
 	return Parser[K]{
-		functions:         functions,
-		pathParser:        pathParser,
-		enumParser:        enumParser,
-		telemetrySettings: telemetrySettings,
+		functions:            functions,
+		pathParser:           pathParser,
+		enumParser:           enumParser,
+		telemetrySettings:    telemetrySettings,
+		transformationParser: newParser[transformationStatement](),
+		conditionParser:      newParser[conditionStatement](),
 	}
 }
 
-func (p *Parser[K]) ParseStatements(statements []string) ([]Statement[K], error) {
-	var parsedStatements []Statement[K]
+func (p *Parser[K]) ParseConditions(rawStatements []string) ([]BoolExpressionEvaluator[K], error) {
+	var statements []BoolExpressionEvaluator[K]
 	var errors error
 
-	for _, statement := range statements {
-		parsed, err := parseStatement(statement)
+	for _, statement := range rawStatements {
+		parsed, err := parseStatement(p.conditionParser, statement)
+		if err != nil {
+			errors = multierr.Append(errors, err)
+			continue
+		}
+		expression, err := p.newBooleanExpressionEvaluator(parsed.BooleanExpression)
+		if err != nil {
+			errors = multierr.Append(errors, err)
+			continue
+		}
+		statements = append(statements, expression)
+	}
+
+	if errors != nil {
+		return nil, errors
+	}
+	return statements, nil
+}
+
+func (p *Parser[K]) ParseStatements(rawStatements []string) ([]Statement[K], error) {
+	var statements []Statement[K]
+	var errors error
+
+	for _, statement := range rawStatements {
+		parsed, err := parseStatement(p.transformationParser, statement)
 		if err != nil {
 			errors = multierr.Append(errors, err)
 			continue
@@ -56,7 +91,7 @@ func (p *Parser[K]) ParseStatements(statements []string) ([]Statement[K], error)
 			errors = multierr.Append(errors, err)
 			continue
 		}
-		parsedStatements = append(parsedStatements, Statement[K]{
+		statements = append(statements, Statement[K]{
 			Function:  function,
 			Condition: expression,
 		})
@@ -65,12 +100,10 @@ func (p *Parser[K]) ParseStatements(statements []string) ([]Statement[K], error)
 	if errors != nil {
 		return nil, errors
 	}
-	return parsedStatements, nil
+	return statements, nil
 }
 
-var parser = newParser()
-
-func parseStatement(raw string) (*parsedStatement, error) {
+func parseStatement[G transformationStatement | conditionStatement](parser *participle.Parser[G], raw string) (*G, error) {
 	parsed, err := parser.ParseString("", raw)
 	if err != nil {
 		return nil, err
@@ -78,11 +111,11 @@ func parseStatement(raw string) (*parsedStatement, error) {
 	return parsed, nil
 }
 
-// newParser returns a parser that can be used to read a string into a parsedStatement. An error will be returned if the string
+// newParser returns a parser that can be used to read a string into a transformationStatement. An error will be returned if the string
 // is not formatted for the DSL.
-func newParser() *participle.Parser[parsedStatement] {
+func newParser[K any]() *participle.Parser[K] {
 	lex := buildLexer()
-	parser, err := participle.Build[parsedStatement](
+	parser, err := participle.Build[K](
 		participle.Lexer(lex),
 		participle.Unquote("String"),
 		participle.Elide("whitespace"),

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -482,31 +482,6 @@ func testParsePath(val *Path) (GetSetter[interface{}], error) {
 	return nil, fmt.Errorf("bad path %v", val)
 }
 
-// Helper for test cases where the WHERE clause is all that matters.
-// Parse string should start with `set(name, "test") where`...
-func setNameTest(b *booleanExpression) *transformationStatement {
-	return &transformationStatement{
-		Invocation: invocation{
-			Function: "set",
-			Arguments: []value{
-				{
-					Path: &Path{
-						Fields: []Field{
-							{
-								Name: "name",
-							},
-						},
-					},
-				},
-				{
-					String: ottltest.Strp("test"),
-				},
-			},
-		},
-		WhereClause: b,
-	}
-}
-
 func Test_parseWhere(t *testing.T) {
 	tests := []struct {
 		statement string


### PR DESCRIPTION
**Description:** 
Adds a new function to Parser that allows parsing `conditionStatements`, which is a new type of statement that represents only a booleanExpression.  These types of statements do not include an Invocation or `where` token.

This new functionality can be used by any component to create complex boolean expressions and then invoke the expression during the hot path to make decisions.  The routingprocessor is an example of a component that could use this functionality instead of the existing functionality, where it is forced to add a noop function to the statements.

**Link to tracking Issue:**
Closes #13545

**Testing:** 
Updated unit tests

**Documentation:** 
If we like this approach I will update documentation.