### PR TITLE
[receiver/elasticsearch]: add metrics related to GET operations

### DIFF
--- a/.chloggen/elasticsearch-receiver-get-ops.yaml
+++ b/.chloggen/elasticsearch-receiver-get-ops.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: elasticsearchreceiver
+note: Add metrics related to GET operations
+issues: [14635]
+

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -53,6 +53,8 @@ These are the metrics available for this scraper.
 | **elasticsearch.node.ingest.operations.failed** | Total number of failed ingest operations during the lifetime of this node. | {operation} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.open_files** | The number of open file descriptors held by the node. | {files} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.operations.completed** | The number of operations completed by a node. | {operations} | Sum(Int) | <ul> <li>operation</li> </ul> |
+| elasticsearch.node.operations.get.completed | The number of hits and misses resulting from GET operations. | {operations} | Sum(Int) | <ul> <li>get_result</li> </ul> |
+| elasticsearch.node.operations.get.time | The time spent on hits and misses resulting from GET operations. | ms | Sum(Int) | <ul> <li>get_result</li> </ul> |
 | **elasticsearch.node.operations.time** | Time spent on operations by a node. | ms | Sum(Int) | <ul> <li>operation</li> </ul> |
 | **elasticsearch.node.pipeline.ingest.documents.current** | Total number of documents currently being ingested by a pipeline. | {documents} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
 | **elasticsearch.node.pipeline.ingest.documents.preprocessed** | Number of documents preprocessed by the ingest pipeline. | {documents} | Sum(Int) | <ul> <li>ingest_pipeline_name</li> </ul> |
@@ -117,6 +119,7 @@ metrics:
 | direction | The direction of network data. | received, sent |
 | document_state (state) | The state of the document. | active, deleted |
 | fs_direction (direction) | The direction of filesystem IO. | read, write |
+| get_result (result) | Result of get operation | hit, miss |
 | health_status (status) | The health status of the cluster. | green, yellow, red |
 | index_aggregation_type (aggregation) | Type of shard aggregation for index statistics | primary_shards, total |
 | indexing_memory_state (state) | State of the indexing memory | current, total |

--- a/receiver/elasticsearchreceiver/internal/model/nodestats.go
+++ b/receiver/elasticsearchreceiver/internal/model/nodestats.go
@@ -219,8 +219,12 @@ type IndexingOperations struct {
 }
 
 type GetOperation struct {
-	Total         int64 `json:"total"`
-	TotalTimeInMs int64 `json:"time_in_millis"`
+	Total           int64 `json:"total"`
+	TotalTimeInMs   int64 `json:"time_in_millis"`
+	Exists          int64 `json:"exists_total"`
+	ExistsTimeInMs  int64 `json:"exists_time_in_millis"`
+	Missing         int64 `json:"missing_total"`
+	MissingTimeInMs int64 `json:"missing_time_in_millis"`
 }
 
 type SearchOperations struct {

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -154,6 +154,12 @@ attributes:
       - doc_value
       - index_writer
       - fixed_bit_set
+  get_result:
+    value: result
+    description: Result of get operation
+    enum:
+      - hit
+      - miss
 
 metrics:
   # these metrics are from /_nodes/stats, and are node level metrics
@@ -309,6 +315,24 @@ metrics:
       value_type: int
     attributes: [operation]
     enabled: true
+  elasticsearch.node.operations.get.completed:
+    description: The number of hits and misses resulting from GET operations.
+    unit: "{operations}"
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [get_result]
+    enabled: false
+  elasticsearch.node.operations.get.time:
+    description: The time spent on hits and misses resulting from GET operations.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [get_result]
+    enabled: false
   elasticsearch.node.shards.size:
     description: The size of the shards assigned to this node.
     unit: By

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -160,6 +160,12 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.FlushOperations.TotalTimeInMs, metadata.AttributeOperationFlush)
 		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.WarmerOperations.TotalTimeInMs, metadata.AttributeOperationWarmer)
 
+		r.mb.RecordElasticsearchNodeOperationsGetCompletedDataPoint(now, info.Indices.GetOperation.Exists, metadata.AttributeGetResultHit)
+		r.mb.RecordElasticsearchNodeOperationsGetCompletedDataPoint(now, info.Indices.GetOperation.Missing, metadata.AttributeGetResultMiss)
+
+		r.mb.RecordElasticsearchNodeOperationsGetTimeDataPoint(now, info.Indices.GetOperation.ExistsTimeInMs, metadata.AttributeGetResultHit)
+		r.mb.RecordElasticsearchNodeOperationsGetTimeDataPoint(now, info.Indices.GetOperation.MissingTimeInMs, metadata.AttributeGetResultMiss)
+
 		r.mb.RecordElasticsearchNodeShardsSizeDataPoint(now, info.Indices.StoreInfo.SizeInBy)
 
 		// Elasticsearch version 7.13+ is required to collect `elasticsearch.node.shards.data_set.size`.

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -42,6 +42,10 @@ func TestScraper(t *testing.T) {
 	t.Parallel()
 
 	config := createDefaultConfig().(*Config)
+
+	config.Metrics.ElasticsearchNodeOperationsGetCompleted.Enabled = true
+	config.Metrics.ElasticsearchNodeOperationsGetTime.Enabled = true
+
 	config.Metrics.ElasticsearchIndexOperationsMergeSize.Enabled = true
 	config.Metrics.ElasticsearchIndexOperationsMergeDocsCount.Enabled = true
 	config.Metrics.ElasticsearchIndexSegmentsCount.Enabled = true

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -1451,6 +1451,80 @@
                      "unit": "ms"
                   },
                   {
+                     "description": "The number of hits and misses resulting from GET operations.",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "512",
+                              "attributes": [
+                                 {
+                                    "key": "result",
+                                    "value": {
+                                       "stringValue": "hit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "512",
+                              "attributes": [
+                                 {
+                                    "key": "result",
+                                    "value": {
+                                       "stringValue": "miss"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "name": "elasticsearch.node.operations.get.completed",
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "The time spent on hits and misses resulting from GET operations.",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "209",
+                              "attributes": [
+                                 {
+                                    "key": "result",
+                                    "value": {
+                                       "stringValue": "hit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           },
+                           {
+                              "asInt": "124",
+                              "attributes": [
+                                 {
+                                    "key": "result",
+                                    "value": {
+                                       "stringValue": "miss"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811026803971000",
+                              "timeUnixNano": "1661811026805343000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "name": "elasticsearch.node.operations.get.time",
+                     "unit": "ms"
+                  },
+                  {
                      "description": "Total number of documents currently being ingested by a pipeline.",
                      "name": "elasticsearch.node.pipeline.ingest.documents.current",
                      "sum": {


### PR DESCRIPTION
**Description:** 
New metrics have been added. However, I think that they're a bit troublesome to add. They are metrics that reflect how many GET operations ended up with success (`exists`), how many ended up with failure(`missing`) and time spent on these operations. 
Currently (on main) only total sum of these two values is being sent as `elasticsearch.node.operations.*` metrics with `get` attribute. This is the main reason why I think that adding them is not easy. I thought up of two solutions that wouldn't be breaking changes:

- add another values to the existing attribute, eg. `get_exists` and `get_missing` - it would not be a breaking change, but I feel that it doesn't look good
- add another metrics, eg. `elasticsearch.node.operations.get.*` - it is not consistent with how other metrics are organised, but neither breaks anything. Might seem unintuitive, because then total count would be `elasticsearch.node.operations.completed`, but total success count would be `elasticsearch.node.operations.get.completed`.

I implemented the second one, but I'm open for discussion. If we don't mind breaking changes, then we could for example implement the first one and remove the total count, because `exists + missing = total`.

**Link to tracking Issue:** open-telemetry/opentelemetry-collector-contrib#14635

**Testing:** 
Unit tests and integration tests.

**Documentation:** 
Generated by `mdatagen`.