### PR TITLE
[receiver/elasticsearch]: add query cache metrics on index level

### DIFF
--- a/.chloggen/elasticsearch-query-cache.yaml
+++ b/.chloggen/elasticsearch-query-cache.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add query cache metrics on index level
+
+# One or more tracking issues related to the change
+issues: [14635]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -22,7 +22,9 @@ These are the metrics available for this scraper.
 | **elasticsearch.cluster.state_queue** | Number of cluster states in queue. | 1 | Sum(Int) | <ul> <li>cluster_state_queue_state</li> </ul> |
 | **elasticsearch.cluster.state_update.count** | The number of cluster state update attempts that changed the cluster state since the node started. | 1 | Sum(Int) | <ul> <li>cluster_state_update_state</li> </ul> |
 | **elasticsearch.cluster.state_update.time** | The cumulative amount of time updating the cluster state since the node started. | ms | Sum(Int) | <ul> <li>cluster_state_update_state</li> <li>cluster_state_update_type</li> </ul> |
+| elasticsearch.index.cache.evictions | The number of evictions from the cache for an index. | {evictions} | Sum(Int) | <ul> <li>cache_name</li> <li>index_aggregation_type</li> </ul> |
 | elasticsearch.index.cache.memory.usage | The size in bytes of the cache for an index. | By | Sum(Int) | <ul> <li>cache_name</li> <li>index_aggregation_type</li> </ul> |
+| elasticsearch.index.cache.size | The number of elements of the cache for an index. | 1 | Sum(Int) | <ul> <li>cache_name</li> <li>index_aggregation_type</li> </ul> |
 | **elasticsearch.index.operations.completed** | The number of operations completed for an index. | {operations} | Sum(Int) | <ul> <li>operation</li> <li>index_aggregation_type</li> </ul> |
 | elasticsearch.index.operations.merge.docs_count | The total number of documents in merge operations for an index. | {documents} | Sum(Int) | <ul> <li>index_aggregation_type</li> </ul> |
 | elasticsearch.index.operations.merge.size | The total size of merged segments for an index. | By | Sum(Int) | <ul> <li>index_aggregation_type</li> </ul> |
@@ -38,8 +40,8 @@ These are the metrics available for this scraper.
 | **elasticsearch.indexing_pressure.memory.total.replica_rejections** | Number of indexing requests rejected in the replica stage. | 1 | Sum(Int) | <ul> </ul> |
 | **elasticsearch.memory.indexing_pressure** | Memory consumed, in bytes, by indexing requests in the specified stage. | By | Sum(Int) | <ul> <li>indexing_pressure_stage</li> </ul> |
 | **elasticsearch.node.cache.count** | Total count of query cache misses across all shards assigned to selected nodes. | {count} | Sum(Int) | <ul> <li>query_cache_count_type</li> </ul> |
-| **elasticsearch.node.cache.evictions** | The number of evictions from the cache. | {evictions} | Sum(Int) | <ul> <li>cache_name</li> </ul> |
-| **elasticsearch.node.cache.memory.usage** | The size in bytes of the cache. | By | Sum(Int) | <ul> <li>cache_name</li> </ul> |
+| **elasticsearch.node.cache.evictions** | The number of evictions from the cache on a node. | {evictions} | Sum(Int) | <ul> <li>cache_name</li> </ul> |
+| **elasticsearch.node.cache.memory.usage** | The size in bytes of the cache on a node. | By | Sum(Int) | <ul> <li>cache_name</li> </ul> |
 | **elasticsearch.node.cluster.connections** | The number of open tcp connections for internal cluster communication. | {connections} | Sum(Int) | <ul> </ul> |
 | **elasticsearch.node.cluster.io** | The number of bytes sent and received on the network for internal cluster communication. | By | Sum(Int) | <ul> <li>direction</li> </ul> |
 | **elasticsearch.node.disk.io.read** | The total number of kilobytes read across all file stores for this node. | KiBy | Sum(Int) | <ul> </ul> |

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -24,7 +24,7 @@ These are the metrics available for this scraper.
 | **elasticsearch.cluster.state_update.time** | The cumulative amount of time updating the cluster state since the node started. | ms | Sum(Int) | <ul> <li>cluster_state_update_state</li> <li>cluster_state_update_type</li> </ul> |
 | elasticsearch.index.cache.evictions | The number of evictions from the cache for an index. | {evictions} | Sum(Int) | <ul> <li>cache_name</li> <li>index_aggregation_type</li> </ul> |
 | elasticsearch.index.cache.memory.usage | The size in bytes of the cache for an index. | By | Sum(Int) | <ul> <li>cache_name</li> <li>index_aggregation_type</li> </ul> |
-| elasticsearch.index.cache.size | The number of elements of the cache for an index. | 1 | Sum(Int) | <ul> <li>cache_name</li> <li>index_aggregation_type</li> </ul> |
+| elasticsearch.index.cache.size | The number of elements of the query cache for an index. | 1 | Sum(Int) | <ul> <li>index_aggregation_type</li> </ul> |
 | **elasticsearch.index.operations.completed** | The number of operations completed for an index. | {operations} | Sum(Int) | <ul> <li>operation</li> <li>index_aggregation_type</li> </ul> |
 | elasticsearch.index.operations.merge.docs_count | The total number of documents in merge operations for an index. | {documents} | Sum(Int) | <ul> <li>index_aggregation_type</li> </ul> |
 | elasticsearch.index.operations.merge.size | The total size of merged segments for an index. | By | Sum(Int) | <ul> <li>index_aggregation_type</li> </ul> |

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -1794,7 +1794,7 @@ type metricElasticsearchIndexCacheSize struct {
 // init fills elasticsearch.index.cache.size metric with initial data.
 func (m *metricElasticsearchIndexCacheSize) init() {
 	m.data.SetName("elasticsearch.index.cache.size")
-	m.data.SetDescription("The number of elements of the cache for an index.")
+	m.data.SetDescription("The number of elements of the query cache for an index.")
 	m.data.SetUnit("1")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
@@ -1802,7 +1802,7 @@ func (m *metricElasticsearchIndexCacheSize) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricElasticsearchIndexCacheSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cacheNameAttributeValue string, indexAggregationTypeAttributeValue string) {
+func (m *metricElasticsearchIndexCacheSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -1810,7 +1810,6 @@ func (m *metricElasticsearchIndexCacheSize) recordDataPoint(start pcommon.Timest
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("cache_name", cacheNameAttributeValue)
 	dp.Attributes().PutStr("aggregation", indexAggregationTypeAttributeValue)
 }
 
@@ -5687,8 +5686,8 @@ func (mb *MetricsBuilder) RecordElasticsearchIndexCacheMemoryUsageDataPoint(ts p
 }
 
 // RecordElasticsearchIndexCacheSizeDataPoint adds a data point to elasticsearch.index.cache.size metric.
-func (mb *MetricsBuilder) RecordElasticsearchIndexCacheSizeDataPoint(ts pcommon.Timestamp, val int64, cacheNameAttributeValue AttributeCacheName, indexAggregationTypeAttributeValue AttributeIndexAggregationType) {
-	mb.metricElasticsearchIndexCacheSize.recordDataPoint(mb.startTime, ts, val, cacheNameAttributeValue.String(), indexAggregationTypeAttributeValue.String())
+func (mb *MetricsBuilder) RecordElasticsearchIndexCacheSizeDataPoint(ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue AttributeIndexAggregationType) {
+	mb.metricElasticsearchIndexCacheSize.recordDataPoint(mb.startTime, ts, val, indexAggregationTypeAttributeValue.String())
 }
 
 // RecordElasticsearchIndexOperationsCompletedDataPoint adds a data point to elasticsearch.index.operations.completed metric.

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -878,6 +878,15 @@ metrics:
       value_type: int
     attributes: [cache_name, index_aggregation_type]
     enabled: false
+  elasticsearch.index.cache.size:
+    description: The number of elements of the cache for an index.
+    unit: 1
+    sum:
+      monotonic: false
+      aggregation: cumulative
+      value_type: int
+    attributes: [cache_name, index_aggregation_type]
+    enabled: false
   elasticsearch.index.cache.evictions:
     description: The number of evictions from the cache for an index.
     unit: "{evictions}"

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -879,13 +879,13 @@ metrics:
     attributes: [cache_name, index_aggregation_type]
     enabled: false
   elasticsearch.index.cache.size:
-    description: The number of elements of the cache for an index.
+    description: The number of elements of the query cache for an index.
     unit: 1
     sum:
       monotonic: false
       aggregation: cumulative
       value_type: int
-    attributes: [cache_name, index_aggregation_type]
+    attributes: [index_aggregation_type]
     enabled: false
   elasticsearch.index.cache.evictions:
     description: The number of evictions from the cache for an index.

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -189,7 +189,7 @@ metrics:
     attributes: [circuit_breaker_name]
     enabled: true
   elasticsearch.node.cache.memory.usage:
-    description: The size in bytes of the cache.
+    description: The size in bytes of the cache on a node.
     unit: By
     sum:
       monotonic: false
@@ -198,7 +198,7 @@ metrics:
     attributes: [cache_name]
     enabled: true
   elasticsearch.node.cache.evictions:
-    description: The number of evictions from the cache.
+    description: The number of evictions from the cache on a node.
     unit: "{evictions}"
     sum:
       monotonic: true
@@ -874,6 +874,15 @@ metrics:
     unit: By
     sum:
       monotonic: false
+      aggregation: cumulative
+      value_type: int
+    attributes: [cache_name, index_aggregation_type]
+    enabled: false
+  elasticsearch.index.cache.evictions:
+    description: The number of evictions from the cache for an index.
+    unit: "{evictions}"
+    sum:
+      monotonic: true
       aggregation: cumulative
       value_type: int
     attributes: [cache_name, index_aggregation_type]

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -341,7 +341,7 @@ func (r *elasticsearchScraper) scrapeIndicesMetrics(ctx context.Context, now pco
 	indexStats, err := r.client.IndexStats(ctx, r.cfg.Indices)
 
 	if err != nil {
-		errs.AddPartial(18, err)
+		errs.AddPartial(22, err)
 		return
 	}
 
@@ -457,6 +457,19 @@ func (r *elasticsearchScraper) scrapeOneIndexMetrics(now pcommon.Timestamp, name
 	)
 	r.mb.RecordElasticsearchIndexCacheMemoryUsageDataPoint(
 		now, stats.Total.FieldDataCache.MemorySizeInBy, metadata.AttributeCacheNameFielddata, metadata.AttributeIndexAggregationTypeTotal,
+	)
+	r.mb.RecordElasticsearchIndexCacheMemoryUsageDataPoint(
+		now, stats.Total.QueryCache.MemorySizeInBy, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypeTotal,
+	)
+	r.mb.RecordElasticsearchIndexCacheMemoryUsageDataPoint(
+		now, stats.Primaries.QueryCache.MemorySizeInBy, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypePrimaryShards,
+	)
+
+	r.mb.RecordElasticsearchIndexCacheEvictionsDataPoint(
+		now, stats.Primaries.QueryCache.Evictions, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypePrimaryShards,
+	)
+	r.mb.RecordElasticsearchIndexCacheEvictionsDataPoint(
+		now, stats.Total.QueryCache.Evictions, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypeTotal,
 	)
 
 	r.mb.EmitForResource(metadata.WithElasticsearchIndexName(name), metadata.WithElasticsearchClusterName(r.clusterName))

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -466,10 +466,10 @@ func (r *elasticsearchScraper) scrapeOneIndexMetrics(now pcommon.Timestamp, name
 	)
 
 	r.mb.RecordElasticsearchIndexCacheSizeDataPoint(
-		now, stats.Primaries.QueryCache.CacheSize, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypePrimaryShards,
+		now, stats.Primaries.QueryCache.CacheSize, metadata.AttributeIndexAggregationTypePrimaryShards,
 	)
 	r.mb.RecordElasticsearchIndexCacheSizeDataPoint(
-		now, stats.Total.QueryCache.CacheSize, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypeTotal,
+		now, stats.Total.QueryCache.CacheSize, metadata.AttributeIndexAggregationTypeTotal,
 	)
 
 	r.mb.RecordElasticsearchIndexCacheEvictionsDataPoint(

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -465,6 +465,13 @@ func (r *elasticsearchScraper) scrapeOneIndexMetrics(now pcommon.Timestamp, name
 		now, stats.Primaries.QueryCache.MemorySizeInBy, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypePrimaryShards,
 	)
 
+	r.mb.RecordElasticsearchIndexCacheSizeDataPoint(
+		now, stats.Primaries.QueryCache.CacheSize, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypePrimaryShards,
+	)
+	r.mb.RecordElasticsearchIndexCacheSizeDataPoint(
+		now, stats.Total.QueryCache.CacheSize, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypeTotal,
+	)
+
 	r.mb.RecordElasticsearchIndexCacheEvictionsDataPoint(
 		now, stats.Primaries.QueryCache.Evictions, metadata.AttributeCacheNameQuery, metadata.AttributeIndexAggregationTypePrimaryShards,
 	)

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -56,6 +56,7 @@ func TestScraper(t *testing.T) {
 	config.Metrics.ElasticsearchIndexTranslogOperations.Enabled = true
 	config.Metrics.ElasticsearchIndexTranslogSize.Enabled = true
 	config.Metrics.ElasticsearchIndexCacheMemoryUsage.Enabled = true
+	config.Metrics.ElasticsearchIndexCacheSize.Enabled = true
 	config.Metrics.ElasticsearchIndexCacheEvictions.Enabled = true
 
 	sc := newElasticSearchScraper(componenttest.NewNopReceiverCreateSettings(), config)

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -56,6 +56,7 @@ func TestScraper(t *testing.T) {
 	config.Metrics.ElasticsearchIndexTranslogOperations.Enabled = true
 	config.Metrics.ElasticsearchIndexTranslogSize.Enabled = true
 	config.Metrics.ElasticsearchIndexCacheMemoryUsage.Enabled = true
+	config.Metrics.ElasticsearchIndexCacheEvictions.Enabled = true
 
 	sc := newElasticSearchScraper(componenttest.NewNopReceiverCreateSettings(), config)
 

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.json
@@ -830,7 +830,7 @@
                      "unit": "{count}"
                   },
                   {
-                     "description": "The number of evictions from the cache.",
+                     "description": "The number of evictions from the cache on a node.",
                      "name": "elasticsearch.node.cache.evictions",
                      "sum": {
                         "aggregationTemporality": 2,
@@ -867,7 +867,7 @@
                      "unit": "{evictions}"
                   },
                   {
-                     "description": "The size in bytes of the cache.",
+                     "description": "The size in bytes of the cache on a node.",
                      "name": "elasticsearch.node.cache.memory.usage",
                      "sum": {
                         "aggregationTemporality": 2,

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -3045,6 +3045,104 @@
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "The number of elements of the cache for an index.",
+                     "name": "elasticsearch.index.cache.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "isMonotonic": false,
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "primary_shards"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of evictions from the cache for an index.",
+                     "name": "elasticsearch.index.cache.evictions",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "isMonotonic": true,
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "primary_shards"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ]
+                     },
+                     "unit": "{evictions}"
                   }
                ],
                "scope": {
@@ -3592,10 +3690,146 @@
                               ],
                               "startTimeUnixNano": "1661811689941624000",
                               "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "12",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "primary_shards"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "12",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "The number of elements of the cache for an index.",
+                     "name": "elasticsearch.index.cache.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "isMonotonic": false,
+                        "dataPoints": [
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "primary_shards"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "3",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of evictions from the cache for an index.",
+                     "name": "elasticsearch.index.cache.evictions",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "isMonotonic": true,
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "primary_shards"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ]
+                     },
+                     "unit": "{evictions}"
                   }
                ],
                "scope": {

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -3047,7 +3047,7 @@
                      "unit": "By"
                   },
                   {
-                     "description": "The number of elements of the cache for an index.",
+                     "description": "The number of elements of the query cache for an index.",
                      "name": "elasticsearch.index.cache.size",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -3056,12 +3056,6 @@
                            {
                               "asInt": "3",
                               "attributes": [
-                                 {
-                                    "key": "cache_name",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 },
                                  {
                                     "key": "aggregation",
                                     "value": {
@@ -3075,12 +3069,6 @@
                            {
                               "asInt": "3",
                               "attributes": [
-                                 {
-                                    "key": "cache_name",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 },
                                  {
                                     "key": "aggregation",
                                     "value": {
@@ -3734,7 +3722,7 @@
                      "unit": "By"
                   },
                   {
-                     "description": "The number of elements of the cache for an index.",
+                     "description": "The number of elements of the query cache for an index.",
                      "name": "elasticsearch.index.cache.size",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -3743,12 +3731,6 @@
                            {
                               "asInt": "3",
                               "attributes": [
-                                 {
-                                    "key": "cache_name",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 },
                                  {
                                     "key": "aggregation",
                                     "value": {
@@ -3762,12 +3744,6 @@
                            {
                               "asInt": "3",
                               "attributes": [
-                                 {
-                                    "key": "cache_name",
-                                    "value": {
-                                       "stringValue": "query"
-                                    }
-                                 },
                                  {
                                     "key": "aggregation",
                                     "value": {

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -830,7 +830,7 @@
                      "unit": "{count}"
                   },
                   {
-                     "description": "The number of evictions from the cache.",
+                     "description": "The number of evictions from the cache on a node.",
                      "name": "elasticsearch.node.cache.evictions",
                      "sum": {
                         "aggregationTemporality": 2,
@@ -867,7 +867,7 @@
                      "unit": "{evictions}"
                   },
                   {
-                     "description": "The size in bytes of the cache.",
+                     "description": "The size in bytes of the cache on a node.",
                      "name": "elasticsearch.node.cache.memory.usage",
                      "sum": {
                         "aggregationTemporality": 2,
@@ -2992,6 +2992,44 @@
                                     "key": "cache_name",
                                     "value": {
                                        "stringValue": "fielddata"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "12",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 },
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "primary_shards"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           },
+                           {
+                              "asInt": "12",
+                              "attributes": [
+                                 {
+                                    "key": "cache_name",
+                                    "value": {
+                                       "stringValue": "query"
                                     }
                                  },
                                  {

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.json
@@ -833,7 +833,7 @@
                      "unit": "By"
                   },
                   {
-                     "description": "The number of evictions from the cache.",
+                     "description": "The number of evictions from the cache on a node.",
                      "name": "elasticsearch.node.cache.evictions",
                      "sum": {
                         "aggregationTemporality": 2,
@@ -870,7 +870,7 @@
                      "unit": "{evictions}"
                   },
                   {
-                     "description": "The size in bytes of the cache.",
+                     "description": "The size in bytes of the cache on a node.",
                      "name": "elasticsearch.node.cache.memory.usage",
                      "sum": {
                         "aggregationTemporality": 2,

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.json
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.json
@@ -489,7 +489,7 @@
                      "unit": "{count}"
                   },
                   {
-                     "description": "The number of evictions from the cache.",
+                     "description": "The number of evictions from the cache on a node.",
                      "name": "elasticsearch.node.cache.evictions",
                      "sum": {
                         "aggregationTemporality": 2,
@@ -526,7 +526,7 @@
                      "unit": "{evictions}"
                   },
                   {
-                     "description": "The size in bytes of the cache.",
+                     "description": "The size in bytes of the cache on a node.",
                      "name": "elasticsearch.node.cache.memory.usage",
                      "sum": {
                         "aggregationTemporality": 2,

--- a/receiver/elasticsearchreceiver/testdata/sample_payloads/indices.json
+++ b/receiver/elasticsearchreceiver/testdata/sample_payloads/indices.json
@@ -84,13 +84,13 @@
           "total_time_in_millis" : 0
         },
         "query_cache" : {
-          "memory_size_in_bytes" : 0,
+          "memory_size_in_bytes" : 12,
           "total_count" : 0,
           "hit_count" : 0,
           "miss_count" : 0,
-          "cache_size" : 0,
+          "cache_size" : 3,
           "cache_count" : 0,
-          "evictions" : 0
+          "evictions" : 2
         },
         "fielddata" : {
           "memory_size_in_bytes" : 3,
@@ -212,13 +212,13 @@
           "total_time_in_millis" : 0
         },
         "query_cache" : {
-          "memory_size_in_bytes" : 0,
+          "memory_size_in_bytes" : 12,
           "total_count" : 0,
           "hit_count" : 0,
           "miss_count" : 0,
-          "cache_size" : 0,
+          "cache_size" : 3,
           "cache_count" : 0,
-          "evictions" : 0
+          "evictions" : 2
         },
         "fielddata" : {
           "memory_size_in_bytes" : 3,
@@ -344,13 +344,13 @@
             "total_time_in_millis" : 0
           },
           "query_cache" : {
-            "memory_size_in_bytes" : 0,
+            "memory_size_in_bytes" : 12,
             "total_count" : 0,
             "hit_count" : 0,
             "miss_count" : 0,
-            "cache_size" : 0,
+            "cache_size" : 3,
             "cache_count" : 0,
-            "evictions" : 0
+            "evictions" : 2
           },
           "fielddata" : {
             "memory_size_in_bytes" : 3,
@@ -472,13 +472,13 @@
             "total_time_in_millis" : 0
           },
           "query_cache" : {
-            "memory_size_in_bytes" : 0,
+            "memory_size_in_bytes" : 12,
             "total_count" : 0,
             "hit_count" : 0,
             "miss_count" : 0,
-            "cache_size" : 0,
+            "cache_size" : 3,
             "cache_count" : 0,
-            "evictions" : 0
+            "evictions" : 2
           },
           "fielddata" : {
             "memory_size_in_bytes" : 3,


### PR DESCRIPTION
**Description:** 
New metrics related to query cache have been added:
```
elasticsearch_indices_stats_primaries_query_cache_cache_size
elasticsearch_indices_stats_primaries_query_cache_evictions
elasticsearch_indices_stats_total_query_cache_evictions
```

**Link to tracking Issue:** #14635

**Testing:** 
Tests will be modified once the metrics format gets accepted.

**Documentation:** 
`mdatagen`