### PR TITLE
[pkg/ottl] Add resource context

### DIFF
--- a/.chloggen/ottl-resource-context.yaml
+++ b/.chloggen/ottl-resource-context.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new Resource context to allow for efficient transformation of resource telemetry.
+
+# One or more tracking issues related to the change
+issues: [14887]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/contexts/ottlresource/README.md
+++ b/pkg/ottl/contexts/ottlresource/README.md
@@ -1,0 +1,10 @@
+# Resource Context
+
+The Resource Context is a Context implementation for [pdata Resources](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/pcommon/generated_resource.go), the collector's internal representation for an OTLP Resource.  This Context should be used when interacting only with OTLP resources.
+
+## Paths
+In general, the Resource Context supports accessing pdata using the field names from the [resource proto](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/resource/v1/resource.proto).  All integers are returned and set via `int64`.  All doubles are returned and set via `float64`.
+
+## Enums
+
+The Resource Context does not define any Enums at this time.

--- a/pkg/ottl/contexts/ottlresource/README.md
+++ b/pkg/ottl/contexts/ottlresource/README.md
@@ -1,6 +1,6 @@
 # Resource Context
 
-The Resource Context is a Context implementation for [pdata Resources](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/pcommon/generated_resource.go), the collector's internal representation for an OTLP Resource.  This Context should be used when interacting only with OTLP resources.
+The Resource Context is a Context implementation for [pdata Resources](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/pcommon/generated_resource.go), the Collector's internal representation for an OTLP Resource.  This Context should be used when interacting only with OTLP resources.
 
 ## Paths
 In general, the Resource Context supports accessing pdata using the field names from the [resource proto](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/resource/v1/resource.proto).  All integers are returned and set via `int64`.  All doubles are returned and set via `float64`.

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -15,10 +15,12 @@
 package ottlresource // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlresource"
 import (
 	"fmt"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
 )
 
 var _ ottlcommon.ResourceContext = TransformContext{}

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ottlresource // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlresource"
+import (
+	"fmt"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+var _ ottlcommon.ResourceContext = TransformContext{}
+
+type TransformContext struct {
+	resource pcommon.Resource
+}
+
+func NewTransformContext(resource pcommon.Resource) TransformContext {
+	return TransformContext{
+		resource: resource,
+	}
+}
+
+func (ctx TransformContext) GetResource() pcommon.Resource {
+	return ctx.resource
+}
+
+func NewParser(functions map[string]interface{}, telemetrySettings component.TelemetrySettings) ottl.Parser[TransformContext] {
+	return ottl.NewParser[TransformContext](functions, parsePath, parseEnum, telemetrySettings)
+}
+
+func parseEnum(_ *ottl.EnumSymbol) (*ottl.Enum, error) {
+	return nil, fmt.Errorf("resource context does not provide Enum support")
+}
+
+func parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
+	if val != nil && len(val.Fields) > 0 {
+		return newPathGetSetter(val.Fields)
+	}
+	return nil, fmt.Errorf("bad path %v", val)
+}
+
+func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
+	return ottlcommon.ResourcePathGetSetter[TransformContext](path)
+}

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -1,0 +1,272 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ottlresource
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"testing"
+)
+
+func Test_newPathGetSetter(t *testing.T) {
+	refResource := createTelemetry()
+
+	newAttrs := pcommon.NewMap()
+	newAttrs.PutStr("hello", "world")
+
+	tests := []struct {
+		name     string
+		path     []ottl.Field
+		orig     interface{}
+		newVal   interface{}
+		modified func(resource pcommon.Resource)
+	}{
+		{
+			name: "attributes",
+			path: []ottl.Field{
+				{
+					Name: "attributes",
+				},
+			},
+			orig:   refResource.Attributes(),
+			newVal: newAttrs,
+			modified: func(resource pcommon.Resource) {
+				newAttrs.CopyTo(resource.Attributes())
+			},
+		},
+		{
+			name: "attributes string",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("str"),
+				},
+			},
+			orig:   "val",
+			newVal: "newVal",
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutStr("str", "newVal")
+			},
+		},
+		{
+			name: "attributes bool",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("bool"),
+				},
+			},
+			orig:   true,
+			newVal: false,
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutBool("bool", false)
+			},
+		},
+		{
+			name: "attributes int",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("int"),
+				},
+			},
+			orig:   int64(10),
+			newVal: int64(20),
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutInt("int", 20)
+			},
+		},
+		{
+			name: "attributes float",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("double"),
+				},
+			},
+			orig:   float64(1.2),
+			newVal: float64(2.4),
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutDouble("double", 2.4)
+			},
+		},
+		{
+			name: "attributes bytes",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("bytes"),
+				},
+			},
+			orig:   []byte{1, 3, 2},
+			newVal: []byte{2, 3, 4},
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+			},
+		},
+		{
+			name: "attributes array string",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("arr_str"),
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refResource.Attributes().Get("arr_str")
+				return val.Slice()
+			}(),
+			newVal: []string{"new"},
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
+			},
+		},
+		{
+			name: "attributes array bool",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("arr_bool"),
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refResource.Attributes().Get("arr_bool")
+				return val.Slice()
+			}(),
+			newVal: []bool{false},
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
+			},
+		},
+		{
+			name: "attributes array int",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("arr_int"),
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refResource.Attributes().Get("arr_int")
+				return val.Slice()
+			}(),
+			newVal: []int64{20},
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
+			},
+		},
+		{
+			name: "attributes array float",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("arr_float"),
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refResource.Attributes().Get("arr_float")
+				return val.Slice()
+			}(),
+			newVal: []float64{2.0},
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
+			},
+		},
+		{
+			name: "attributes array bytes",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("arr_bytes"),
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refResource.Attributes().Get("arr_bytes")
+				return val.Slice()
+			}(),
+			newVal: [][]byte{{9, 6, 4}},
+			modified: func(resource pcommon.Resource) {
+				resource.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
+			},
+		},
+		{
+			name: "dropped_attributes_count",
+			path: []ottl.Field{
+				{
+					Name: "dropped_attributes_count",
+				},
+			},
+			orig:   int64(10),
+			newVal: int64(20),
+			modified: func(resource pcommon.Resource) {
+				resource.SetDroppedAttributesCount(20)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessor, err := newPathGetSetter(tt.path)
+			assert.NoError(t, err)
+
+			resource := createTelemetry()
+
+			got := accessor.Get(NewTransformContext(resource))
+			assert.Equal(t, tt.orig, got)
+
+			accessor.Set(NewTransformContext(resource), tt.newVal)
+
+			exRes := createTelemetry()
+			tt.modified(exRes)
+
+			assert.Equal(t, exRes, resource)
+		})
+	}
+}
+
+func createTelemetry() pcommon.Resource {
+	resource := pcommon.NewResource()
+
+	resource.Attributes().PutStr("str", "val")
+	resource.Attributes().PutBool("bool", true)
+	resource.Attributes().PutInt("int", 10)
+	resource.Attributes().PutDouble("double", 1.2)
+	resource.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+
+	arrStr := resource.Attributes().PutEmptySlice("arr_str")
+	arrStr.AppendEmpty().SetStr("one")
+	arrStr.AppendEmpty().SetStr("two")
+
+	arrBool := resource.Attributes().PutEmptySlice("arr_bool")
+	arrBool.AppendEmpty().SetBool(true)
+	arrBool.AppendEmpty().SetBool(false)
+
+	arrInt := resource.Attributes().PutEmptySlice("arr_int")
+	arrInt.AppendEmpty().SetInt(2)
+	arrInt.AppendEmpty().SetInt(3)
+
+	arrFloat := resource.Attributes().PutEmptySlice("arr_float")
+	arrFloat.AppendEmpty().SetDouble(1.0)
+	arrFloat.AppendEmpty().SetDouble(2.0)
+
+	arrBytes := resource.Attributes().PutEmptySlice("arr_bytes")
+	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2, 3})
+	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{2, 3, 4})
+
+	resource.SetDroppedAttributesCount(10)
+
+	return resource
+}

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -15,11 +15,13 @@
 package ottlresource
 
 import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func Test_newPathGetSetter(t *testing.T) {


### PR DESCRIPTION
**Description:** 
Adds a new context specific to resources to allow for specific and efficient access to resource telemetry.

I specifically did not remove the ability for "lower" telemetry contexts to access the resource with which they are associated.  It is important that when processing a span/logrecord/datapoint that the user have access to the resource in case they need it for a condition or something else.

**Link to tracking Issue:**
#14578

**Testing:**
Added unit tests

**Documentation:**
Added context documentation