### PR TITLE
[confmap.provider/s3provider] Support additional config sources for `s3provider` other than environment

### DIFF
--- a/.chloggen/improve-s3provider.yaml
+++ b/.chloggen/improve-s3provider.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: confmap/provider/s3provider
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support additional config sources for `s3provider` using functional options provided by aws-go-sdk.
+
+# One or more tracking issues related to the change
+issues: [14967]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/confmap/provider/README.md
+++ b/confmap/provider/README.md
@@ -1,0 +1,6 @@
+### Opentelemetry-contrib `confmap` Provider
+
+Place for all the `confmap` providers in the contrib repository. Refer the High Level Design [document](https://github.com/open-telemetry/opentelemetry-collector/blob/main/confmap/README.md) from the core repository.
+
+Current contrib confmap providers-
+  - `s3provider`- Retrieves configuration from **Amazon S3**.

--- a/confmap/provider/s3provider/README.md
+++ b/confmap/provider/s3provider/README.md
@@ -10,15 +10,26 @@ s3://[BUCKET].s3.[REGION].amazonaws.com/[KEY]
 ```
 
 ### Prerequisites
-- Need to setup access keys from IAM console (`aws_access_key_id` and `aws_secret_access_key`) with permissions to access Amazon S3.
-- For more details, refer [Amazon SDK](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/).
+`s3provider` internally uses `aws-sdk-go-v2` which requires credentials (an access key and secret access key) to sign requests to AWS. You can specify your credentials in several locations, depending on your particular use case. For information about obtaining credentials, see [Amazon SDK](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials).
 
 ### Usage
 ```go
 // scheme for s3provider is s3
 uris := []string{"s3://[BUCKET].s3.[REGION].amazonaws.com/[KEY]"}
 providers := make(map[string]confmap.Provider)
-providers[s3provider.Scheme()] = s3provider.New() 
+
+// opts to define on how the aws-sdk will load the access keys. 
+//For more info, refer: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/config#LoadOptionsFunc
+opts := []func(*config.LoadOptions) error{
+    config.WithSharedCredentialsFiles(
+        []string{"test/credentials", "data/credentials"},
+    ),
+    config.WithSharedConfigFiles(
+        []string{"test/config", "data/config"},
+    ),
+}
+
+providers[s3provider.Scheme()] = s3provider.New(opts...) 
 // add other providers if you want
 // providers["file"] = fileprovider.New()
 

--- a/confmap/provider/s3provider/README.md
+++ b/confmap/provider/s3provider/README.md
@@ -1,12 +1,32 @@
 ## Summary
-This package provides a `ConfigMapProvider` implementation for Amazon S3 (`s3provider`) that allows the  Collector the ability to load configuration by fetching and reading config objects stored in Amazon S3.
+`s3provider` is a `confmap.Provider` implementation for **Amazon S3**, that provides the ability to load collector configuration by fetching and reading config objects stored in Amazon S3.
 ## How it works
-- It will be called by `ConfigMapResolver` to load configuration for the Collector.
-- By giving a config URI starting with prefix `s3://`, this `s3provider` will be used to download config objects from the given S3 URIs, and then use the downloaded configuration during Collector initialization.
+- It will be called by `confmap.Resolver` to load the configuration for the collector.
+- By giving a config URI starting with ***prefix-scheme*** `s3://`, this `s3provider` will be used to download config objects from the given S3 URIs, and then use the downloaded configuration during Collector initialization.
 
 Expected URI format:
-- s3://[BUCKET].s3.[REGION].amazonaws.com/[KEY]
+``` url
+s3://[BUCKET].s3.[REGION].amazonaws.com/[KEY]
+```
 
-Prerequistes:
-- Need to setup access keys from IAM console (aws_access_key_id and aws_secret_access_key) with permission to access Amazon S3
-- For details, can take a look at https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/
+### Prerequisites
+- Need to setup access keys from IAM console (`aws_access_key_id` and `aws_secret_access_key`) with permissions to access Amazon S3.
+- For more details, refer [Amazon SDK](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/).
+
+### Usage
+```go
+// scheme for s3provider is s3
+uris := []string{"s3://[BUCKET].s3.[REGION].amazonaws.com/[KEY]"}
+providers := make(map[string]confmap.Provider)
+providers[s3provider.Scheme()] = s3provider.New() 
+// add other providers if you want
+// providers["file"] = fileprovider.New()
+
+cp := service.NewConfigProvider(service.ConfigProviderSettings{
+    ResolverSettings: confmap.ResolverSettings{
+        URIs:       uris,
+        Providers:  providers,
+        Converters: []confmap.Converter{expandconverter.New()},
+    },
+)
+```


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Support additional config sources for `s3provider`. Also fixed few code comments, readme and added couple of unit tests

**Link to tracking Issue:**  #14967

**Testing:** NA

**Documentation:** Added readme

Part of PR split #14617 