### PR TITLE
Reorganize Transform Processor example statements

### DIFF
--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -30,31 +30,32 @@ Example configuration:
 transform:
   traces:
     statements:
-      - set(status.code, 1) where attributes["http.path"] == "/health"
       - keep_keys(resource.attributes, "service.name", "service.namespace", "cloud.region", "process.command_line")
-      - set(name, attributes["http.route"])
-      - replace_match(attributes["http.target"], "/user/*/list/*", "/user/{userId}/list/{listId}")
-      - replace_pattern(resource.attributes["process.command_line"], "password\\=[^\\s]*(\\s?)", "password=***")
       - limit(attributes, 100)
       - limit(resource.attributes, 100)
+      - replace_match(attributes["http.target"], "/user/*/list/*", "/user/{userId}/list/{listId}")
+      - replace_pattern(resource.attributes["process.command_line"], "password\\=[^\\s]*(\\s?)", "password=***")
+      - set(name, attributes["http.route"])
+      - set(status.code, 1) where attributes["http.path"] == "/health"
       - truncate_all(attributes, 4096)
       - truncate_all(resource.attributes, 4096)
   metrics:
     statements:
-      - set(metric.description, "Sum") where metric.type == "Sum"
-      - keep_keys(resource.attributes, "host.name")
-      - limit(attributes, 100, "host.name")
-      - truncate_all(attributes, 4096)
-      - truncate_all(resource.attributes, 4096)
       - convert_sum_to_gauge() where metric.name == "system.processes.count"
       - convert_gauge_to_sum("cumulative", false) where metric.name == "prometheus_metric"
+      - keep_keys(resource.attributes, "host.name")
+      - limit(attributes, 100, "host.name")
+      - set(metric.description, "Sum") where metric.type == "Sum"
+      - truncate_all(attributes, 4096)
+      - truncate_all(resource.attributes, 4096)
   logs:
     statements:
-      - set(severity_text, "FAIL") where body == "request failed"
+      - keep_keys(resource.attributes, "service.name", "service.namespace", "cloud.region")
       - replace_all_matches(attributes, "/user/*/list/*", "/user/{userId}/list/{listId}")
       - replace_all_patterns(attributes, "/account/\\d{4}", "/account/{accountId}")
+      - set(attributes["app.started"], 1) where IsMatch(body, "started") == true
       - set(body, attributes["http.route"])
-      - keep_keys(resource.attributes, "service.name", "service.namespace", "cloud.region")
+      - set(severity_text, "FAIL") where body == "request failed"
 ```
 ## Grammar
 


### PR DESCRIPTION
**Description:**

This orders all example statements to be in alphabetical order (and consequently groups them by function call), which should help users scan the examples if they're looking for a particular function call example.

**Link to tracking Issue:**
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14885

**Documentation:**

The Transform Processor README.md file.