### PR TITLE
[receiver/elasticsearch]: add translog metrics on index level

### DIFF
--- a/.chloggen/elasticsearch-translog.yaml
+++ b/.chloggen/elasticsearch-translog.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add translog metrics on index level
+
+# One or more tracking issues related to the change
+issues: [14635]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -30,6 +30,8 @@ These are the metrics available for this scraper.
 | elasticsearch.index.segments.memory | Size of memory for segment object of an index. | By | Sum(Int) | <ul> <li>index_aggregation_type</li> <li>segments_memory_object_type</li> </ul> |
 | elasticsearch.index.segments.size | Size of segments of an index. | By | Sum(Int) | <ul> <li>index_aggregation_type</li> </ul> |
 | **elasticsearch.index.shards.size** | The size of the shards assigned to this index. | By | Sum(Int) | <ul> <li>index_aggregation_type</li> </ul> |
+| elasticsearch.index.translog.operations | Number of transaction log operations for an index. | {operations} | Sum(Int) | <ul> <li>index_aggregation_type</li> </ul> |
+| elasticsearch.index.translog.size | Size of the transaction log for an index. | By | Sum(Int) | <ul> <li>index_aggregation_type</li> </ul> |
 | **elasticsearch.indexing_pressure.memory.limit** | Configured memory limit, in bytes, for the indexing requests. | By | Gauge(Int) | <ul> </ul> |
 | **elasticsearch.indexing_pressure.memory.total.primary_rejections** | Cumulative number of indexing requests rejected in the primary stage. | 1 | Sum(Int) | <ul> </ul> |
 | **elasticsearch.indexing_pressure.memory.total.replica_rejections** | Number of indexing requests rejected in the replica stage. | 1 | Sum(Int) | <ul> </ul> |

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -820,3 +820,21 @@ metrics:
       value_type: int
     attributes: [index_aggregation_type, segments_memory_object_type]
     enabled: false
+  elasticsearch.index.translog.operations:
+    description: Number of transaction log operations for an index.
+    unit: "{operations}"
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: false
+  elasticsearch.index.translog.size:
+    description: Size of the transaction log for an index.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: false

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -333,7 +333,7 @@ func (r *elasticsearchScraper) scrapeIndicesMetrics(ctx context.Context, now pco
 	indexStats, err := r.client.IndexStats(ctx, r.cfg.Indices)
 
 	if err != nil {
-		errs.AddPartial(14, err)
+		errs.AddPartial(16, err)
 		return
 	}
 
@@ -405,6 +405,13 @@ func (r *elasticsearchScraper) scrapeOneIndexMetrics(now pcommon.Timestamp, name
 		stats.Total.SegmentsStats.TermsMemoryInBy,
 		metadata.AttributeIndexAggregationTypeTotal,
 		metadata.AttributeSegmentsMemoryObjectTypeTerm,
+	)
+
+	r.mb.RecordElasticsearchIndexTranslogOperationsDataPoint(
+		now, stats.Total.TranslogStats.Operations, metadata.AttributeIndexAggregationTypeTotal,
+	)
+	r.mb.RecordElasticsearchIndexTranslogSizeDataPoint(
+		now, stats.Total.TranslogStats.SizeInBy, metadata.AttributeIndexAggregationTypeTotal,
 	)
 
 	r.mb.EmitForResource(metadata.WithElasticsearchIndexName(name), metadata.WithElasticsearchClusterName(r.clusterName))

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -47,6 +47,8 @@ func TestScraper(t *testing.T) {
 	config.Metrics.ElasticsearchIndexSegmentsCount.Enabled = true
 	config.Metrics.ElasticsearchIndexSegmentsSize.Enabled = true
 	config.Metrics.ElasticsearchIndexSegmentsMemory.Enabled = true
+	config.Metrics.ElasticsearchIndexTranslogOperations.Enabled = true
+	config.Metrics.ElasticsearchIndexTranslogSize.Enabled = true
 
 	sc := newElasticSearchScraper(componenttest.NewNopReceiverCreateSettings(), config)
 

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -2720,6 +2720,54 @@
                         ]
                      },
                      "unit": "By"
+                  },
+                  {
+                     "description": "Number of transaction log operations for an index.",
+                     "name": "elasticsearch.index.translog.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "isMonotonic": true,
+                        "dataPoints": [
+                           {
+                              "asInt": "5",
+                              "attributes": [
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ]
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "Size of the transaction log for an index.",
+                     "name": "elasticsearch.index.translog.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "isMonotonic": false,
+                        "dataPoints": [
+                           {
+                              "asInt": "55",
+                              "attributes": [
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
                   }
                ],
                "scope": {
@@ -3063,6 +3111,54 @@
                                     "key": "object",
                                     "value": {
                                        "stringValue": "fixed_bit_set"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Number of transaction log operations for an index.",
+                     "name": "elasticsearch.index.translog.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "isMonotonic": true,
+                        "dataPoints": [
+                           {
+                              "asInt": "5",
+                              "attributes": [
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ]
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "Size of the transaction log for an index.",
+                     "name": "elasticsearch.index.translog.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "isMonotonic": false,
+                        "dataPoints": [
+                           {
+                              "asInt": "55",
+                              "attributes": [
+                                 {
+                                    "key": "aggregation",
+                                    "value": {
+                                       "stringValue": "total"
                                     }
                                  }
                               ],

--- a/receiver/elasticsearchreceiver/testdata/sample_payloads/indices.json
+++ b/receiver/elasticsearchreceiver/testdata/sample_payloads/indices.json
@@ -115,7 +115,7 @@
           "file_sizes" : { }
         },
         "translog" : {
-          "operations" : 0,
+          "operations" : 5,
           "size_in_bytes" : 55,
           "uncommitted_operations" : 0,
           "uncommitted_size_in_bytes" : 55,
@@ -243,7 +243,7 @@
           "file_sizes" : { }
         },
         "translog" : {
-          "operations" : 0,
+          "operations" : 5,
           "size_in_bytes" : 55,
           "uncommitted_operations" : 0,
           "uncommitted_size_in_bytes" : 55,
@@ -375,7 +375,7 @@
             "file_sizes" : { }
           },
           "translog" : {
-            "operations" : 0,
+            "operations" : 5,
             "size_in_bytes" : 55,
             "uncommitted_operations" : 0,
             "uncommitted_size_in_bytes" : 55,
@@ -503,7 +503,7 @@
             "file_sizes" : { }
           },
           "translog" : {
-            "operations" : 0,
+            "operations" : 5,
             "size_in_bytes" : 55,
             "uncommitted_operations" : 0,
             "uncommitted_size_in_bytes" : 55,


### PR DESCRIPTION
**Description:**
Translog metrics (size and number of operations) have been added on index level with total shard aggregation.
Similar metrics already exist for node level, so I tried to keep them as similar as possible.

**Link to tracking Issue:** #14635 

**Testing:** 
Unit and integration tests

**Documentation:** 
`mdatagen`