### PR TITLE
[receiver/awscloudwatch] Fix links for awscloudwatchreceiver status table

### DIFF
--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -109,3 +109,6 @@ This receiver has a number of sample configs for reference.
    - Specifies the names of the log groups to collect
    - Does not attempt autodiscovery
    - Only collects from log streams matching a prefix
+
+[alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
**Description:** 

Super small readme update, wasn't planning on making a changelog entry. 