### PR TITLE
[Receiver/redisreceiver] Support redis.cpu.time with more label values for Redis versions >= 6.0

### DIFF
--- a/.chloggen/redisreceiver.yaml
+++ b/.chloggen/redisreceiver.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: redisreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support more metric label values for redis.cpu.time
+
+# One or more tracking issues related to the change
+issues: [14943]

--- a/receiver/redisreceiver/documentation.md
+++ b/receiver/redisreceiver/documentation.md
@@ -64,4 +64,4 @@ metrics:
 | cmd | Redis command name |  |
 | db | Redis database identifier |  |
 | role | Redis node's role | replica, primary |
-| state | Redis CPU usage state |  |
+| state | Redis CPU usage state | sys, sys_children, sys_main_thread, user, user_children, user_main_thread |

--- a/receiver/redisreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics.go
@@ -182,6 +182,48 @@ var MapAttributeRole = map[string]AttributeRole{
 	"primary": AttributeRolePrimary,
 }
 
+// AttributeState specifies the a value state attribute.
+type AttributeState int
+
+const (
+	_ AttributeState = iota
+	AttributeStateSys
+	AttributeStateSysChildren
+	AttributeStateSysMainThread
+	AttributeStateUser
+	AttributeStateUserChildren
+	AttributeStateUserMainThread
+)
+
+// String returns the string representation of the AttributeState.
+func (av AttributeState) String() string {
+	switch av {
+	case AttributeStateSys:
+		return "sys"
+	case AttributeStateSysChildren:
+		return "sys_children"
+	case AttributeStateSysMainThread:
+		return "sys_main_thread"
+	case AttributeStateUser:
+		return "user"
+	case AttributeStateUserChildren:
+		return "user_children"
+	case AttributeStateUserMainThread:
+		return "user_main_thread"
+	}
+	return ""
+}
+
+// MapAttributeState is a helper map of string to AttributeState attribute value.
+var MapAttributeState = map[string]AttributeState{
+	"sys":              AttributeStateSys,
+	"sys_children":     AttributeStateSysChildren,
+	"sys_main_thread":  AttributeStateSysMainThread,
+	"user":             AttributeStateUser,
+	"user_children":    AttributeStateUserChildren,
+	"user_main_thread": AttributeStateUserMainThread,
+}
+
 type metricRedisClientsBlocked struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -2102,8 +2144,8 @@ func (mb *MetricsBuilder) RecordRedisConnectionsRejectedDataPoint(ts pcommon.Tim
 }
 
 // RecordRedisCPUTimeDataPoint adds a data point to redis.cpu.time metric.
-func (mb *MetricsBuilder) RecordRedisCPUTimeDataPoint(ts pcommon.Timestamp, val float64, stateAttributeValue string) {
-	mb.metricRedisCPUTime.recordDataPoint(mb.startTime, ts, val, stateAttributeValue)
+func (mb *MetricsBuilder) RecordRedisCPUTimeDataPoint(ts pcommon.Timestamp, val float64, stateAttributeValue AttributeState) {
+	mb.metricRedisCPUTime.recordDataPoint(mb.startTime, ts, val, stateAttributeValue.String())
 }
 
 // RecordRedisDbAvgTTLDataPoint adds a data point to redis.db.avg_ttl metric.

--- a/receiver/redisreceiver/metadata.yaml
+++ b/receiver/redisreceiver/metadata.yaml
@@ -8,6 +8,21 @@ resource_attributes:
 attributes:
   state:
     description: Redis CPU usage state
+    # Redis versions < 6.0 have:
+    #   used_cpu_sys: System CPU consumed by the Redis server, which is the sum of system CPU consumed by all threads of the server process (main thread and background threads)
+    #   used_cpu_user: User CPU consumed by the Redis server, which is the sum of user CPU consumed by all threads of the server process (main thread and background threads)
+    #   used_cpu_sys_children: System CPU consumed by the background processes
+    #   used_cpu_user_children: User CPU consumed by the background processes
+    # Redis versions >= 6.0 have two more:
+    #   used_cpu_sys_main_thread: System CPU consumed by the Redis server main thread
+    #   used_cpu_user_main_thread: User CPU consumed by the Redis server main thread
+    enum:
+      - sys
+      - sys_children
+      - sys_main_thread
+      - user
+      - user_children
+      - user_main_thread 
   db:
     description: Redis database identifier
   role:

--- a/receiver/redisreceiver/metric_functions.go
+++ b/receiver/redisreceiver/metric_functions.go
@@ -14,7 +14,11 @@
 
 package redisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver"
 
-import "go.opentelemetry.io/collector/pdata/pcommon"
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver/internal/metadata"
+)
 
 // dataPointRecorders is called once at startup. Returns recorders for all metrics (except keyspace)
 // we want to extract from Redis INFO.
@@ -44,7 +48,10 @@ func (rs *redisScraper) dataPointRecorders() map[string]interface{} {
 		"uptime_in_seconds":               rs.mb.RecordRedisUptimeDataPoint,
 		"used_cpu_sys":                    rs.recordUsedCPUSys,
 		"used_cpu_sys_children":           rs.recordUsedCPUSysChildren,
-		"used_cpu_user":                   rs.recordUsedCPUSysUser,
+		"used_cpu_sys_main_thread":        rs.recordUsedCPUSysMainThread,
+		"used_cpu_user":                   rs.recordUsedCPUUser,
+		"used_cpu_user_children":          rs.recordUsedCPUUserChildren,
+		"used_cpu_user_main_thread":       rs.recordUsedCPUUserMainThread,
 		"used_memory":                     rs.mb.RecordRedisMemoryUsedDataPoint,
 		"used_memory_lua":                 rs.mb.RecordRedisMemoryLuaDataPoint,
 		"used_memory_peak":                rs.mb.RecordRedisMemoryPeakDataPoint,
@@ -53,13 +60,25 @@ func (rs *redisScraper) dataPointRecorders() map[string]interface{} {
 }
 
 func (rs *redisScraper) recordUsedCPUSys(now pcommon.Timestamp, val float64) {
-	rs.mb.RecordRedisCPUTimeDataPoint(now, val, "sys")
+	rs.mb.RecordRedisCPUTimeDataPoint(now, val, metadata.AttributeStateSys)
 }
 
 func (rs *redisScraper) recordUsedCPUSysChildren(now pcommon.Timestamp, val float64) {
-	rs.mb.RecordRedisCPUTimeDataPoint(now, val, "children")
+	rs.mb.RecordRedisCPUTimeDataPoint(now, val, metadata.AttributeStateSysChildren)
 }
 
-func (rs *redisScraper) recordUsedCPUSysUser(now pcommon.Timestamp, val float64) {
-	rs.mb.RecordRedisCPUTimeDataPoint(now, val, "user")
+func (rs *redisScraper) recordUsedCPUSysMainThread(now pcommon.Timestamp, val float64) {
+	rs.mb.RecordRedisCPUTimeDataPoint(now, val, metadata.AttributeStateSysMainThread)
+}
+
+func (rs *redisScraper) recordUsedCPUUser(now pcommon.Timestamp, val float64) {
+	rs.mb.RecordRedisCPUTimeDataPoint(now, val, metadata.AttributeStateUser)
+}
+
+func (rs *redisScraper) recordUsedCPUUserChildren(now pcommon.Timestamp, val float64) {
+	rs.mb.RecordRedisCPUTimeDataPoint(now, val, metadata.AttributeStateUserChildren)
+}
+
+func (rs *redisScraper) recordUsedCPUUserMainThread(now pcommon.Timestamp, val float64) {
+	rs.mb.RecordRedisCPUTimeDataPoint(now, val, metadata.AttributeStateUserMainThread)
 }

--- a/receiver/redisreceiver/redis_svc_test.go
+++ b/receiver/redisreceiver/redis_svc_test.go
@@ -28,6 +28,6 @@ func TestParser(t *testing.T) {
 	s := newFakeAPIParser()
 	info, err := s.info()
 	require.Nil(t, err)
-	require.Equal(t, 128, len(info))
+	require.Equal(t, 130, len(info))
 	require.Equal(t, "1.24", info["allocator_frag_ratio"]) // spot check
 }

--- a/receiver/redisreceiver/testdata/info.txt
+++ b/receiver/redisreceiver/testdata/info.txt
@@ -131,6 +131,8 @@ used_cpu_sys:185.649184
 used_cpu_user:46.396430
 used_cpu_sys_children:0.002354
 used_cpu_user_children:0.001619
+used_cpu_sys_main_thread:180.0
+used_cpu_user_main_thread:42.39
 
 # Cluster
 cluster_enabled:0


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Redis with version >= 6.0 introduced two more cpu usage time items:
- used_cpu_sys_main_thread
- used_cpu_user_main_thread

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Existing test.

**Documentation:** <Describe the documentation added.>