### PR TITLE
Rename OTTL `expression` config parameter to `statement`.

### DIFF
--- a/.chloggen/routing-processor-rename-config-parameter.yaml
+++ b/.chloggen/routing-processor-rename-config-parameter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/routingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename OTTL `expression` configuration parameter of the routing table to `statement` to align with the OTTL naming.
+
+# One or more tracking issues related to the change
+issues: [14950]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/routingprocessor/README.md
+++ b/processor/routingprocessor/README.md
@@ -53,7 +53,7 @@ exporters:
 
 ### Tech Preview: OpenTelemetry Transformation Language statements as routing conditions
 
-Alternatively, it is possible to use subset of the [OpenTelemetry Transformation Language (OTTL)](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language) statements as routing conditions.
+Alternatively, it is possible to use subset of the [OpenTelemetry Transformation Language (OTTL)](../../pkg/ottl/README.md) statements as routing conditions.
 
 To configure the routing processor with [OTTL] routing conditions use the following options:
 

--- a/processor/routingprocessor/README.md
+++ b/processor/routingprocessor/README.md
@@ -51,14 +51,14 @@ exporters:
     endpoint: localhost:24250
 ```
 
-### Tech Preview: OpenTelemetry Transformation Language expressions as routing conditions
+### Tech Preview: OpenTelemetry Transformation Language statements as routing conditions
 
-Alternatively, it is possible to use subset of the [OpenTelemetry Transformation Language (OTTL)](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language) expressions as routing conditions.
+Alternatively, it is possible to use subset of the [OpenTelemetry Transformation Language (OTTL)](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/processing.md#telemetry-query-language) statements as routing conditions.
 
 To configure the routing processor with [OTTL] routing conditions use the following options:
 
 - `table (required)`: the routing table for this processor.
-- `table.expression (required)`: the routing condition provided as the [OTTL] expression.
+- `table.statement (required)`: the routing condition provided as the [OTTL] statement.
 - `table.exporters (required)`: the list of exporters to use when the routing condition is met.
 - `default_exporters (optional)`: contains the list of exporters to use when a record
 does not meet any of specified conditions.
@@ -70,9 +70,9 @@ processors:
     default_exporters:
     - jaeger
     table:
-      - expression: route() where resource.attributes["X-Tenant"] == "acme"
+      - statement: route() where resource.attributes["X-Tenant"] == "acme"
         exporters: [jaeger/acme]
-      - expression: delete_key(resource.attributes, "X-Tenant") where IsMatch(resource.attributes["X-Tenant"], ".*corp") == true
+      - statement: delete_key(resource.attributes, "X-Tenant") where IsMatch(resource.attributes["X-Tenant"], ".*corp") == true
         exporters: [jaeger/ecorp]
 
 exporters:
@@ -91,8 +91,8 @@ It is also possible to use both the conventional routing items configuration and
 
 #### Limitations:
 
-- [OTTL] expressions can be applied only to resource attributes.
-- Currently, it is not possible to specify the boolean expression without function invocation as the routing condition. It is required to provide the NOOP `route()` or any other supported function as part of the routing expression, see [#13545](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545) for more information.
+- [OTTL] statements can be applied only to resource attributes.
+- Currently, it is not possible to specify the boolean statements without function invocation as the routing condition. It is required to provide the NOOP `route()` or any other supported function as part of the routing statement, see [#13545](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545) for more information.
 - Supported [OTTL] functions:
   - [IsMatch](../../pkg/ottl/ottlfuncs/README.md#IsMatch)
   - [delete_key](../../pkg/ottl/ottlfuncs/README.md#delete_key)

--- a/processor/routingprocessor/config_test.go
+++ b/processor/routingprocessor/config_test.go
@@ -113,22 +113,22 @@ func TestValidateConfig(t *testing.T) {
 		error  string
 	}{
 		{
-			name: "both expression and value specified",
+			name: "both statement and value specified",
 			config: &Config{
 				FromAttribute:   "attr",
 				AttributeSource: resourceAttributeSource,
 				Table: []RoutingTableItem{
 					{
-						Exporters:  []string{"otlp"},
-						Value:      "acme",
-						Expression: `route() where resource.attributes["attr"] == "acme"`,
+						Exporters: []string{"otlp"},
+						Value:     "acme",
+						Statement: `route() where resource.attributes["attr"] == "acme"`,
 					},
 				},
 			},
-			error: "invalid route: both expression (route() where resource.attributes[\"attr\"] == \"acme\") and value (acme) provided",
+			error: "invalid route: both statement (route() where resource.attributes[\"attr\"] == \"acme\") and value (acme) provided",
 		},
 		{
-			name: "neither expression or value provided",
+			name: "neither statement or value provided",
 			config: &Config{
 				FromAttribute:   "attr",
 				AttributeSource: resourceAttributeSource,
@@ -185,8 +185,8 @@ func TestRewriteLegacyConfigToOTTL(t *testing.T) {
 			want: Config{
 				Table: []RoutingTableItem{
 					{
-						Exporters:  []string{"otlp"},
-						Expression: `route() where resource.attributes["attr"] == "acme"`,
+						Exporters: []string{"otlp"},
+						Statement: `route() where resource.attributes["attr"] == "acme"`,
 					},
 				},
 			},
@@ -210,12 +210,12 @@ func TestRewriteLegacyConfigToOTTL(t *testing.T) {
 			want: Config{
 				Table: []RoutingTableItem{
 					{
-						Exporters:  []string{"otlp"},
-						Expression: `route() where resource.attributes["attr"] == "acme"`,
+						Exporters: []string{"otlp"},
+						Statement: `route() where resource.attributes["attr"] == "acme"`,
 					},
 					{
-						Exporters:  []string{"otlp/2"},
-						Expression: `route() where resource.attributes["attr"] == "ecorp"`,
+						Exporters: []string{"otlp/2"},
+						Statement: `route() where resource.attributes["attr"] == "ecorp"`,
 					},
 				},
 			},
@@ -236,8 +236,8 @@ func TestRewriteLegacyConfigToOTTL(t *testing.T) {
 			want: Config{
 				Table: []RoutingTableItem{
 					{
-						Exporters:  []string{"otlp"},
-						Expression: `delete_key(resource.attributes, "attr") where resource.attributes["attr"] == "acme"`,
+						Exporters: []string{"otlp"},
+						Statement: `delete_key(resource.attributes, "attr") where resource.attributes["attr"] == "acme"`,
 					},
 				},
 			},
@@ -276,20 +276,20 @@ func TestRewriteLegacyConfigToOTTL(t *testing.T) {
 						Value:     "acme",
 					},
 					{
-						Exporters:  []string{"otlp/2"},
-						Expression: `route() where resource.attributes["attr"] == "ecorp"`,
+						Exporters: []string{"otlp/2"},
+						Statement: `route() where resource.attributes["attr"] == "ecorp"`,
 					},
 				},
 			},
 			want: Config{
 				Table: []RoutingTableItem{
 					{
-						Exporters:  []string{"otlp"},
-						Expression: `route() where resource.attributes["attr"] == "acme"`,
+						Exporters: []string{"otlp"},
+						Statement: `route() where resource.attributes["attr"] == "acme"`,
 					},
 					{
-						Exporters:  []string{"otlp/2"},
-						Expression: `route() where resource.attributes["attr"] == "ecorp"`,
+						Exporters: []string{"otlp/2"},
+						Statement: `route() where resource.attributes["attr"] == "ecorp"`,
 					},
 				},
 			},

--- a/processor/routingprocessor/logs.go
+++ b/processor/routingprocessor/logs.go
@@ -101,7 +101,7 @@ func (p *logProcessor) route(ctx context.Context, l plog.Logs) error {
 
 		matchCount := len(p.router.routes)
 		for key, route := range p.router.routes {
-			if _, isMatch := route.expression.Execute(ltx); !isMatch {
+			if _, isMatch := route.statement.Execute(ltx); !isMatch {
 				matchCount--
 				continue
 			}

--- a/processor/routingprocessor/logs_test.go
+++ b/processor/routingprocessor/logs_test.go
@@ -295,12 +295,12 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 		DefaultExporters: []string{"otlp"},
 		Table: []RoutingTableItem{
 			{
-				Expression: `route() where IsMatch(resource.attributes["X-Tenant"], ".*acme") == true`,
-				Exporters:  []string{"otlp/1"},
+				Statement: `route() where IsMatch(resource.attributes["X-Tenant"], ".*acme") == true`,
+				Exporters: []string{"otlp/1"},
 			},
 			{
-				Expression: `route() where IsMatch(resource.attributes["X-Tenant"], "_acme") == true`,
-				Exporters:  []string{"otlp/2"},
+				Statement: `route() where IsMatch(resource.attributes["X-Tenant"], "_acme") == true`,
+				Exporters: []string{"otlp/2"},
 			},
 		},
 	})

--- a/processor/routingprocessor/metrics.go
+++ b/processor/routingprocessor/metrics.go
@@ -103,7 +103,7 @@ func (p *metricsProcessor) route(ctx context.Context, tm pmetric.Metrics) error 
 
 		matchCount := len(p.router.routes)
 		for key, route := range p.router.routes {
-			if _, isMatch := route.expression.Execute(mtx); !isMatch {
+			if _, isMatch := route.statement.Execute(mtx); !isMatch {
 				matchCount--
 				continue
 			}

--- a/processor/routingprocessor/metrics_test.go
+++ b/processor/routingprocessor/metrics_test.go
@@ -354,12 +354,12 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithOTTL(t *testing.
 		DefaultExporters: []string{"otlp"},
 		Table: []RoutingTableItem{
 			{
-				Expression: `route() where resource.attributes["value"] > 2.5`,
-				Exporters:  []string{"otlp/1"},
+				Statement: `route() where resource.attributes["value"] > 2.5`,
+				Exporters: []string{"otlp/1"},
 			},
 			{
-				Expression: `route() where resource.attributes["value"] > 3.0`,
-				Exporters:  []string{"otlp/2"},
+				Statement: `route() where resource.attributes["value"] > 3.0`,
+				Exporters: []string{"otlp/2"},
 			},
 		},
 	})

--- a/processor/routingprocessor/router.go
+++ b/processor/routingprocessor/router.go
@@ -61,8 +61,8 @@ func newRouter[E component.Exporter, K any](
 }
 
 type routingItem[E component.Exporter, K any] struct {
-	exporters  []E
-	expression *ottl.Statement[K]
+	exporters []E
+	statement *ottl.Statement[K]
 }
 
 func (r *router[E, K]) registerExporters(available map[config.ComponentID]component.Exporter) error {
@@ -102,14 +102,14 @@ func (r *router[E, K]) registerDefaultExporters(available map[config.ComponentID
 // available exporters map to check if they were available.
 func (r *router[E, K]) registerRouteExporters(available map[config.ComponentID]component.Exporter) error {
 	for _, item := range r.table {
-		e, err := r.routingExpression(item)
+		statement, err := r.getStatementFrom(item)
 		if err != nil {
 			return err
 		}
 
 		route, ok := r.routes[key(item)]
 		if !ok {
-			route.expression = e
+			route.statement = statement
 		}
 
 		for _, name := range item.Exporters {
@@ -127,29 +127,29 @@ func (r *router[E, K]) registerRouteExporters(available map[config.ComponentID]c
 	return nil
 }
 
-// routingExpression builds a routing OTTL expressions from provided
+// getStatementFrom builds a routing OTTL statements from provided
 // routing table entry configuration. If routing table entry configuration
-// does not contain a OTTL expressions then nil is returned.
-func (r *router[E, K]) routingExpression(item RoutingTableItem) (*ottl.Statement[K], error) {
-	var e *ottl.Statement[K]
-	if item.Expression != "" {
-		queries, err := r.parser.ParseStatements([]string{item.Expression})
+// does not contain a OTTL statement then nil is returned.
+func (r *router[E, K]) getStatementFrom(item RoutingTableItem) (*ottl.Statement[K], error) {
+	var statement *ottl.Statement[K]
+	if item.Statement != "" {
+		statements, err := r.parser.ParseStatements([]string{item.Statement})
 		if err != nil {
-			return e, err
+			return statement, err
 		}
-		if len(queries) != 1 {
-			return e, errors.New("more than one expression specified")
+		if len(statements) != 1 {
+			return statement, errors.New("more than one statement specified")
 		}
-		e = queries[0]
+		statement = statements[0]
 	}
-	return e, nil
+	return statement, nil
 }
 
 func key(entry RoutingTableItem) string {
 	if entry.Value != "" {
 		return entry.Value
 	}
-	return entry.Expression
+	return entry.Statement
 }
 
 // extractExporter returns an exporter for the given name (type/name) and type

--- a/processor/routingprocessor/traces.go
+++ b/processor/routingprocessor/traces.go
@@ -101,7 +101,7 @@ func (p *tracesProcessor) route(ctx context.Context, t ptrace.Traces) error {
 
 		matchCount := len(p.router.routes)
 		for key, route := range p.router.routes {
-			if _, isMatch := route.expression.Execute(stx); !isMatch {
+			if _, isMatch := route.statement.Execute(stx); !isMatch {
 				matchCount--
 				continue
 			}

--- a/processor/routingprocessor/traces_test.go
+++ b/processor/routingprocessor/traces_test.go
@@ -356,12 +356,12 @@ func TestTracesAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 		DefaultExporters: []string{"otlp"},
 		Table: []RoutingTableItem{
 			{
-				Expression: `route() where resource.attributes["value"] > 0 and resource.attributes["value"] < 4`,
-				Exporters:  []string{"otlp/1"},
+				Statement: `route() where resource.attributes["value"] > 0 and resource.attributes["value"] < 4`,
+				Exporters: []string{"otlp/1"},
 			},
 			{
-				Expression: `route() where resource.attributes["value"] > 1 and resource.attributes["value"] < 4`,
-				Exporters:  []string{"otlp/2"},
+				Statement: `route() where resource.attributes["value"] > 1 and resource.attributes["value"] < 4`,
+				Exporters: []string{"otlp/2"},
 			},
 		},
 	})


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Rename OTTL `expression` configuration parameter of the routing table to `statement` to align with OTTL naming.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14950
