### PR TITLE
[receiver/awscloudwatch] Fix validation in some scenarios

### DIFF
--- a/.chloggen/fix-validate-of-awscloudwatchreceiver.yaml
+++ b/.chloggen/fix-validate-of-awscloudwatchreceiver.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awscloudwatchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix config validation for some named configurations.
+
+# One or more tracking issues related to the change
+issues: [14953]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/fix-validate-of-awscloudwatchreceiver.yaml
+++ b/.chloggen/fix-validate-of-awscloudwatchreceiver.yaml
@@ -8,7 +8,7 @@ component: awscloudwatchreceiver
 note: Fix config validation for some named configurations.
 
 # One or more tracking issues related to the change
-issues: [14953]
+issues: [14952]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -33,7 +33,7 @@ This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/devel
 
 ### Group Parameters
 
-`autodiscover` and `named` are ways to control and filter which log groups and log streams which are collected from. They are mutually exclusive and are incompatible and should not be configured at the same time.
+`autodiscover` and `named` are ways to control and filter which log groups and log streams which are collected from. They are mutually exclusive and are incompatible to be configured at the same time.
 
 - `autodiscover`
   - `limit`: (optional; default = 50) Limits the number of discovered log groups.

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -10,7 +10,7 @@ Receives Cloudwatch events from [AWS Cloudwatch](https://aws.amazon.com/cloudwat
 
 ## Getting Started
 
-This receiver uses the [AWS SDK Profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) as  mode of authentication.
+This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) as mode of authentication, which includes [Profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) and [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) authentication for EC2 instances.
 
 ## Configuration
 
@@ -33,7 +33,7 @@ This receiver uses the [AWS SDK Profiles](https://docs.aws.amazon.com/cli/latest
 
 ### Group Parameters
 
-`autodiscover` and `named` are ways to control and filter which log groups and log streams which are collected from. They are mutually exclusive and are incompatible to be configured at the same time.
+`autodiscover` and `named` are ways to control and filter which log groups and log streams which are collected from. They are mutually exclusive and are incompatible and should not be configured at the same time.
 
 - `autodiscover`
   - `limit`: (optional; default = 50) Limits the number of discovered log groups.
@@ -76,7 +76,6 @@ awscloudwatch:
           streams:
             names: [kube-apiserver-ea9c831555adca1815ae04b87661klasdj]
 ```
-
 
 ## Sample Configs
 

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -66,12 +66,11 @@ type StreamConfig struct {
 }
 
 var (
-	errNoRegion                       = errors.New("no region was specified")
-	errNoLogsConfigured               = errors.New("no logs configured")
-	errInvalidEventLimit              = errors.New("event limit is improperly configured, value must be greater than 0")
-	errInvalidPollInterval            = errors.New("poll interval is incorrect, it must be a duration greater than one second")
-	errInvalidAutodiscoverLimit       = errors.New("the limit of autodiscovery of log groups is improperly configured, value must be greater than 0")
-	errAutodiscoverAndNamedConfigured = errors.New("both autodiscover and named configs are configured, Only one or the other is permitted")
+	errNoRegion                 = errors.New("no region was specified")
+	errNoLogsConfigured         = errors.New("no logs configured")
+	errInvalidEventLimit        = errors.New("event limit is improperly configured, value must be greater than 0")
+	errInvalidPollInterval      = errors.New("poll interval is incorrect, it must be a duration greater than one second")
+	errInvalidAutodiscoverLimit = errors.New("the limit of autodiscovery of log groups is improperly configured, value must be greater than 0")
 )
 
 // Validate validates all portions of the relevant config

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -109,10 +109,6 @@ func (c *Config) validateLogsConfig() error {
 }
 
 func (c *GroupConfig) validate() error {
-	if c.AutodiscoverConfig != nil && len(c.NamedConfigs) > 0 {
-		return errAutodiscoverAndNamedConfigured
-	}
-
 	if c.AutodiscoverConfig != nil {
 		return validateAutodiscover(*c.AutodiscoverConfig)
 	}

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -263,6 +263,7 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, config.UnmarshalReceiver(loaded, cfg))
 			require.Equal(t, cfg, tc.expectedConfig)
+			require.NoError(t, cfg.Validate())
 		})
 	}
 }

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -115,6 +115,27 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErr: errors.New("unable to parse URI for imds_endpoint"),
 		},
+		{
+			name: "Both Logs Autodiscover and Named Set",
+			config: Config{
+				Region: "us-east-1",
+				Logs: &LogsConfig{
+					MaxEventsPerRequest: defaultEventLimit,
+					PollInterval:        defaultPollInterval,
+					Groups: GroupConfig{
+						AutodiscoverConfig: &AutodiscoverConfig{
+							Limit: defaultEventLimit,
+						},
+						NamedConfigs: map[string]StreamConfig{
+							"some-log-group": {
+								Names: []*string{aws.String("some-lg-name")},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errAutodiscoverAndNamedConfigured,
+		},
 	}
 
 	for _, tc := range cases {
@@ -218,10 +239,6 @@ func TestLoadConfig(t *testing.T) {
 					PollInterval:        5 * time.Minute,
 					MaxEventsPerRequest: defaultEventLimit,
 					Groups: GroupConfig{
-						// this is ignored since named configs are present
-						AutodiscoverConfig: &AutodiscoverConfig{
-							Limit: defaultLogGroupLimit,
-						},
 						NamedConfigs: map[string]StreamConfig{
 							"/aws/eks/dev-0/cluster": {},
 						},
@@ -239,10 +256,6 @@ func TestLoadConfig(t *testing.T) {
 					PollInterval:        5 * time.Minute,
 					MaxEventsPerRequest: defaultEventLimit,
 					Groups: GroupConfig{
-						// this is ignored since named configs are present
-						AutodiscoverConfig: &AutodiscoverConfig{
-							Limit: defaultLogGroupLimit,
-						},
 						NamedConfigs: map[string]StreamConfig{
 							"/aws/eks/dev-0/cluster": {
 								Names: []*string{aws.String("kube-apiserver-ea9c831555adca1815ae04b87661klasdj")},


### PR DESCRIPTION
**Description:** Since the default config obtains an `autodiscover` config, the real config loading runs into issues more often than expected. We should remove the constriction so exclusive named config users can use the receiver. 

**Link to tracking Issue:** Resolves #14952

**Testing:** Existing tests and this is now a valid config:

```yaml

receivers:
  awscloudwatch:
    region: us-east-2
    logs:
      poll_interval: 10s
      groups:
        named:
          /aws/eks/dev-eks-0/cluster:
            names: [kube-apiserver-audit-ea9c831555adca1815ae04b884b30566]

```

**Documentation:** Updated documentation to reflect this change. 