### PR TITLE
[receiver/kubeletstats] remove direction feature gate

### DIFF
--- a/.chloggen/rm-direction-kubeletstats.yaml
+++ b/.chloggen/rm-direction-kubeletstats.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kubeletstatsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "remove direction feature gate"
+
+# One or more tracking issues related to the change
+issues: [14961]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -191,17 +191,5 @@ with detailed sample configurations [here](./testdata/config.yaml).
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml) with further documentation in [documentation.md](./documentation.md)
 
-### Feature gate configurations
-
-#### Transition from metrics with "direction" attribute
-
-The proposal to change metrics from being reported with a `direction` attribute has been reverted in the specification. As a result, the
-following feature gates will be removed in v0.62.0:
-
-- **receiver.kubeletstatsreceiver.emitMetricsWithoutDirectionAttribute**
-- **receiver.kubeletstatsreceiver.emitMetricsWithDirectionAttribute**
-
-For additional information, see https://github.com/open-telemetry/opentelemetry-specification/issues/2726.
-
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/kubeletstatsreceiver/documentation.md
+++ b/receiver/kubeletstatsreceiver/documentation.md
@@ -31,11 +31,7 @@ These are the metrics available for this scraper.
 | **k8s.node.memory.usage** | Node memory usage | By | Gauge(Int) | <ul> </ul> |
 | **k8s.node.memory.working_set** | Node memory working_set | By | Gauge(Int) | <ul> </ul> |
 | **k8s.node.network.errors** | Node network errors | 1 | Sum(Int) | <ul> <li>interface</li> <li>direction</li> </ul> |
-| **k8s.node.network.errors.receive** | Node network receive errors | 1 | Sum(Int) | <ul> <li>interface</li> </ul> |
-| **k8s.node.network.errors.transmit** | Node network transmission errors | 1 | Sum(Int) | <ul> <li>interface</li> </ul> |
 | **k8s.node.network.io** | Node network IO | By | Sum(Int) | <ul> <li>interface</li> <li>direction</li> </ul> |
-| **k8s.node.network.io.receive** | Node network IO received | By | Sum(Int) | <ul> <li>interface</li> </ul> |
-| **k8s.node.network.io.transmit** | Node network IO transmitted | By | Sum(Int) | <ul> <li>interface</li> </ul> |
 | **k8s.pod.cpu.time** | Pod CPU time | s | Sum(Double) | <ul> </ul> |
 | **k8s.pod.cpu.utilization** | Pod CPU utilization | 1 | Gauge(Double) | <ul> </ul> |
 | **k8s.pod.filesystem.available** | Pod filesystem available | By | Gauge(Int) | <ul> </ul> |
@@ -48,11 +44,7 @@ These are the metrics available for this scraper.
 | **k8s.pod.memory.usage** | Pod memory usage | By | Gauge(Int) | <ul> </ul> |
 | **k8s.pod.memory.working_set** | Pod memory working_set | By | Gauge(Int) | <ul> </ul> |
 | **k8s.pod.network.errors** | Pod network errors | 1 | Sum(Int) | <ul> <li>interface</li> <li>direction</li> </ul> |
-| **k8s.pod.network.errors.receive** | Pod network receive errors | 1 | Sum(Int) | <ul> <li>interface</li> </ul> |
-| **k8s.pod.network.errors.transmit** | Pod network transmission errors | 1 | Sum(Int) | <ul> <li>interface</li> </ul> |
 | **k8s.pod.network.io** | Pod network IO | By | Sum(Int) | <ul> <li>interface</li> <li>direction</li> </ul> |
-| **k8s.pod.network.io.receive** | Pod network IO received | By | Sum(Int) | <ul> <li>interface</li> </ul> |
-| **k8s.pod.network.io.transmit** | Pod network IO transmitted | By | Sum(Int) | <ul> <li>interface</li> </ul> |
 | **k8s.volume.available** | The number of available bytes in the volume. | By | Gauge(Int) | <ul> </ul> |
 | **k8s.volume.capacity** | The total capacity in bytes of the volume. | By | Gauge(Int) | <ul> </ul> |
 | **k8s.volume.inodes** | The total inodes in the filesystem. | 1 | Gauge(Int) | <ul> </ul> |

--- a/receiver/kubeletstatsreceiver/internal/kubelet/accumulator.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/accumulator.go
@@ -44,14 +44,12 @@ var ValidMetricGroups = map[MetricGroup]bool{
 }
 
 type metricDataAccumulator struct {
-	m                                    []pmetric.Metrics
-	metadata                             Metadata
-	logger                               *zap.Logger
-	metricGroupsToCollect                map[MetricGroup]bool
-	time                                 time.Time
-	mbs                                  *metadata.MetricsBuilders
-	emitMetricsWithDirectionAttribute    bool
-	emitMetricsWithoutDirectionAttribute bool
+	m                     []pmetric.Metrics
+	metadata              Metadata
+	logger                *zap.Logger
+	metricGroupsToCollect map[MetricGroup]bool
+	time                  time.Time
+	mbs                   *metadata.MetricsBuilders
 }
 
 func (a *metricDataAccumulator) nodeStats(s stats.NodeStats) {
@@ -63,12 +61,7 @@ func (a *metricDataAccumulator) nodeStats(s stats.NodeStats) {
 	addCPUMetrics(a.mbs.NodeMetricsBuilder, metadata.NodeCPUMetrics, s.CPU, currentTime)
 	addMemoryMetrics(a.mbs.NodeMetricsBuilder, metadata.NodeMemoryMetrics, s.Memory, currentTime)
 	addFilesystemMetrics(a.mbs.NodeMetricsBuilder, metadata.NodeFilesystemMetrics, s.Fs, currentTime)
-	if a.emitMetricsWithDirectionAttribute {
-		addNetworkMetricsWithDirection(a.mbs.NodeMetricsBuilder, metadata.NodeNetworkMetricsWithDirection, s.Network, currentTime)
-	}
-	if a.emitMetricsWithoutDirectionAttribute {
-		addNetworkMetrics(a.mbs.NodeMetricsBuilder, metadata.NodeNetworkMetrics, s.Network, currentTime)
-	}
+	addNetworkMetricsWithDirection(a.mbs.NodeMetricsBuilder, metadata.NodeNetworkMetricsWithDirection, s.Network, currentTime)
 	// todo s.Runtime.ImageFs
 
 	a.m = append(a.m, a.mbs.NodeMetricsBuilder.Emit(
@@ -86,12 +79,7 @@ func (a *metricDataAccumulator) podStats(s stats.PodStats) {
 	addCPUMetrics(a.mbs.PodMetricsBuilder, metadata.PodCPUMetrics, s.CPU, currentTime)
 	addMemoryMetrics(a.mbs.PodMetricsBuilder, metadata.PodMemoryMetrics, s.Memory, currentTime)
 	addFilesystemMetrics(a.mbs.PodMetricsBuilder, metadata.PodFilesystemMetrics, s.EphemeralStorage, currentTime)
-	if a.emitMetricsWithDirectionAttribute {
-		addNetworkMetricsWithDirection(a.mbs.PodMetricsBuilder, metadata.PodNetworkMetricsWithDirection, s.Network, currentTime)
-	}
-	if a.emitMetricsWithoutDirectionAttribute {
-		addNetworkMetrics(a.mbs.PodMetricsBuilder, metadata.PodNetworkMetrics, s.Network, currentTime)
-	}
+	addNetworkMetricsWithDirection(a.mbs.PodMetricsBuilder, metadata.PodNetworkMetricsWithDirection, s.Network, currentTime)
 
 	a.m = append(a.m, a.mbs.PodMetricsBuilder.Emit(
 		metadata.WithStartTimeOverride(pcommon.NewTimestampFromTime(s.StartTime.Time)),

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metrics.go
@@ -28,17 +28,13 @@ func MetricsData(
 	logger *zap.Logger, summary *stats.Summary,
 	metadata Metadata,
 	metricGroupsToCollect map[MetricGroup]bool,
-	mbs *metadata.MetricsBuilders,
-	emitMetricsWithDirectionAttribute,
-	emitMetricsWithoutDirectionAttribute bool) []pmetric.Metrics {
+	mbs *metadata.MetricsBuilders) []pmetric.Metrics {
 	acc := &metricDataAccumulator{
-		metadata:                             metadata,
-		logger:                               logger,
-		metricGroupsToCollect:                metricGroupsToCollect,
-		time:                                 time.Now(),
-		mbs:                                  mbs,
-		emitMetricsWithDirectionAttribute:    emitMetricsWithDirectionAttribute,
-		emitMetricsWithoutDirectionAttribute: emitMetricsWithoutDirectionAttribute,
+		metadata:              metadata,
+		logger:                logger,
+		metricGroupsToCollect: metricGroupsToCollect,
+		time:                  time.Now(),
+		mbs:                   mbs,
 	}
 	acc.nodeStats(summary.Node)
 	for _, podStats := range summary.Pods {

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
@@ -51,12 +51,12 @@ func TestMetricAccumulator(t *testing.T) {
 		ContainerMetricsBuilder: metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings(), componenttest.NewNopReceiverCreateSettings().BuildInfo),
 		OtherMetricsBuilder:     metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings(), componenttest.NewNopReceiverCreateSettings().BuildInfo),
 	}
-	requireMetricsOk(t, MetricsData(zap.NewNop(), summary, k8sMetadata, ValidMetricGroups, mbs, true, false))
+	requireMetricsOk(t, MetricsData(zap.NewNop(), summary, k8sMetadata, ValidMetricGroups, mbs))
 	// Disable all groups
 	mbs.NodeMetricsBuilder.Reset()
 	mbs.PodMetricsBuilder.Reset()
 	mbs.OtherMetricsBuilder.Reset()
-	require.Equal(t, 0, len(MetricsData(zap.NewNop(), summary, k8sMetadata, map[MetricGroup]bool{}, mbs, true, false)))
+	require.Equal(t, 0, len(MetricsData(zap.NewNop(), summary, k8sMetadata, map[MetricGroup]bool{}, mbs)))
 }
 
 func requireMetricsOk(t *testing.T, mds []pmetric.Metrics) {
@@ -112,7 +112,7 @@ func requireResourceOk(t *testing.T, resource pcommon.Resource) {
 }
 
 func TestWorkingSetMem(t *testing.T) {
-	metrics := indexedFakeMetrics(true, false)
+	metrics := indexedFakeMetrics()
 	requireContains(t, metrics, "k8s.pod.memory.working_set")
 	requireContains(t, metrics, "container.memory.working_set")
 
@@ -122,7 +122,7 @@ func TestWorkingSetMem(t *testing.T) {
 }
 
 func TestPageFaults(t *testing.T) {
-	metrics := indexedFakeMetrics(true, false)
+	metrics := indexedFakeMetrics()
 	requireContains(t, metrics, "k8s.pod.memory.page_faults")
 	requireContains(t, metrics, "container.memory.page_faults")
 
@@ -132,7 +132,7 @@ func TestPageFaults(t *testing.T) {
 }
 
 func TestMajorPageFaults(t *testing.T) {
-	metrics := indexedFakeMetrics(true, false)
+	metrics := indexedFakeMetrics()
 	requireContains(t, metrics, "k8s.pod.memory.major_page_faults")
 	requireContains(t, metrics, "container.memory.major_page_faults")
 
@@ -142,7 +142,7 @@ func TestMajorPageFaults(t *testing.T) {
 }
 
 func TestEmitMetricsWithDirectionAttribute(t *testing.T) {
-	metrics := indexedFakeMetrics(true, false)
+	metrics := indexedFakeMetrics()
 	metricNamesWithDirectionAttr := []string{
 		"k8s.node.network.io",
 		"k8s.node.network.errors",
@@ -160,36 +160,13 @@ func TestEmitMetricsWithDirectionAttribute(t *testing.T) {
 	}
 }
 
-func TestEmitMetricsWithoutDirectionAttribute(t *testing.T) {
-	metrics := indexedFakeMetrics(false, true)
-	metricNamesWithoutDirectionAttr := []string{
-		"k8s.node.network.io.receive",
-		"k8s.node.network.io.transmit",
-		"k8s.node.network.errors.receive",
-		"k8s.node.network.errors.transmit",
-		"k8s.pod.network.io.receive",
-		"k8s.pod.network.io.transmit",
-		"k8s.pod.network.errors.receive",
-		"k8s.pod.network.errors.transmit",
-	}
-	for _, name := range metricNamesWithoutDirectionAttr {
-		requireContains(t, metrics, name)
-		metric := metrics[name][0]
-		for i := 0; i < metric.Sum().DataPoints().Len(); i++ {
-			dp := metric.Sum().DataPoints().At(i)
-			_, found := dp.Attributes().Get("direction")
-			require.False(t, found, "unexpected direction attribute")
-		}
-	}
-}
-
 func requireContains(t *testing.T, metrics map[string][]pmetric.Metric, metricName string) {
 	_, found := metrics[metricName]
 	require.True(t, found)
 }
 
-func indexedFakeMetrics(emitMetricsWithDirectionAttribute, emitMetricsWithoutDirectionAttribute bool) map[string][]pmetric.Metric {
-	mds := fakeMetrics(emitMetricsWithDirectionAttribute, emitMetricsWithoutDirectionAttribute)
+func indexedFakeMetrics() map[string][]pmetric.Metric {
+	mds := fakeMetrics()
 	metrics := make(map[string][]pmetric.Metric)
 	for _, md := range mds {
 		for i := 0; i < md.ResourceMetrics().Len(); i++ {
@@ -209,7 +186,7 @@ func indexedFakeMetrics(emitMetricsWithDirectionAttribute, emitMetricsWithoutDir
 	return metrics
 }
 
-func fakeMetrics(emitMetricsWithDirectionAttribute, emitMetricsWithoutDirectionAttribute bool) []pmetric.Metrics {
+func fakeMetrics() []pmetric.Metrics {
 	rc := &fakeRestClient{}
 	statsProvider := NewStatsProvider(rc)
 	summary, _ := statsProvider.StatsSummary()
@@ -224,5 +201,5 @@ func fakeMetrics(emitMetricsWithDirectionAttribute, emitMetricsWithoutDirectionA
 		ContainerMetricsBuilder: metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings(), componenttest.NewNopReceiverCreateSettings().BuildInfo),
 		OtherMetricsBuilder:     metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings(), componenttest.NewNopReceiverCreateSettings().BuildInfo),
 	}
-	return MetricsData(zap.NewNop(), summary, Metadata{}, mgs, mbs, emitMetricsWithDirectionAttribute, emitMetricsWithoutDirectionAttribute)
+	return MetricsData(zap.NewNop(), summary, Metadata{}, mgs, mbs)
 }

--- a/receiver/kubeletstatsreceiver/internal/kubelet/network.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/network.go
@@ -23,27 +23,6 @@ import (
 
 type getNetworkDataFunc func(s *stats.NetworkStats) (rx *uint64, tx *uint64)
 
-func addNetworkMetrics(mb *metadata.MetricsBuilder, networkMetrics metadata.NetworkMetrics, s *stats.NetworkStats, currentTime pcommon.Timestamp) {
-	if s == nil {
-		return
-	}
-
-	recordNetworkDataPoint(mb, networkMetrics.IO, s, getNetworkIO, currentTime)
-	recordNetworkDataPoint(mb, networkMetrics.Errors, s, getNetworkErrors, currentTime)
-}
-
-func recordNetworkDataPoint(mb *metadata.MetricsBuilder, r metadata.NetworkMetricsRecorder, s *stats.NetworkStats, getData getNetworkDataFunc, currentTime pcommon.Timestamp) {
-	rx, tx := getData(s)
-
-	if rx != nil {
-		r.RecordReceiveDataPoint(mb, currentTime, int64(*rx), s.Name)
-	}
-
-	if tx != nil {
-		r.RecordTransmitDataPoint(mb, currentTime, int64(*tx), s.Name)
-	}
-}
-
 func addNetworkMetricsWithDirection(mb *metadata.MetricsBuilder, networkMetrics metadata.NetworkMetricsWithDirection, s *stats.NetworkStats, currentTime pcommon.Timestamp) {
 	if s == nil {
 		return

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
@@ -40,11 +40,7 @@ type MetricsSettings struct {
 	K8sNodeMemoryUsage             MetricSettings `mapstructure:"k8s.node.memory.usage"`
 	K8sNodeMemoryWorkingSet        MetricSettings `mapstructure:"k8s.node.memory.working_set"`
 	K8sNodeNetworkErrors           MetricSettings `mapstructure:"k8s.node.network.errors"`
-	K8sNodeNetworkErrorsReceive    MetricSettings `mapstructure:"k8s.node.network.errors.receive"`
-	K8sNodeNetworkErrorsTransmit   MetricSettings `mapstructure:"k8s.node.network.errors.transmit"`
 	K8sNodeNetworkIo               MetricSettings `mapstructure:"k8s.node.network.io"`
-	K8sNodeNetworkIoReceive        MetricSettings `mapstructure:"k8s.node.network.io.receive"`
-	K8sNodeNetworkIoTransmit       MetricSettings `mapstructure:"k8s.node.network.io.transmit"`
 	K8sPodCPUTime                  MetricSettings `mapstructure:"k8s.pod.cpu.time"`
 	K8sPodCPUUtilization           MetricSettings `mapstructure:"k8s.pod.cpu.utilization"`
 	K8sPodFilesystemAvailable      MetricSettings `mapstructure:"k8s.pod.filesystem.available"`
@@ -57,11 +53,7 @@ type MetricsSettings struct {
 	K8sPodMemoryUsage              MetricSettings `mapstructure:"k8s.pod.memory.usage"`
 	K8sPodMemoryWorkingSet         MetricSettings `mapstructure:"k8s.pod.memory.working_set"`
 	K8sPodNetworkErrors            MetricSettings `mapstructure:"k8s.pod.network.errors"`
-	K8sPodNetworkErrorsReceive     MetricSettings `mapstructure:"k8s.pod.network.errors.receive"`
-	K8sPodNetworkErrorsTransmit    MetricSettings `mapstructure:"k8s.pod.network.errors.transmit"`
 	K8sPodNetworkIo                MetricSettings `mapstructure:"k8s.pod.network.io"`
-	K8sPodNetworkIoReceive         MetricSettings `mapstructure:"k8s.pod.network.io.receive"`
-	K8sPodNetworkIoTransmit        MetricSettings `mapstructure:"k8s.pod.network.io.transmit"`
 	K8sVolumeAvailable             MetricSettings `mapstructure:"k8s.volume.available"`
 	K8sVolumeCapacity              MetricSettings `mapstructure:"k8s.volume.capacity"`
 	K8sVolumeInodes                MetricSettings `mapstructure:"k8s.volume.inodes"`
@@ -140,19 +132,7 @@ func DefaultMetricsSettings() MetricsSettings {
 		K8sNodeNetworkErrors: MetricSettings{
 			Enabled: true,
 		},
-		K8sNodeNetworkErrorsReceive: MetricSettings{
-			Enabled: true,
-		},
-		K8sNodeNetworkErrorsTransmit: MetricSettings{
-			Enabled: true,
-		},
 		K8sNodeNetworkIo: MetricSettings{
-			Enabled: true,
-		},
-		K8sNodeNetworkIoReceive: MetricSettings{
-			Enabled: true,
-		},
-		K8sNodeNetworkIoTransmit: MetricSettings{
 			Enabled: true,
 		},
 		K8sPodCPUTime: MetricSettings{
@@ -191,19 +171,7 @@ func DefaultMetricsSettings() MetricsSettings {
 		K8sPodNetworkErrors: MetricSettings{
 			Enabled: true,
 		},
-		K8sPodNetworkErrorsReceive: MetricSettings{
-			Enabled: true,
-		},
-		K8sPodNetworkErrorsTransmit: MetricSettings{
-			Enabled: true,
-		},
 		K8sPodNetworkIo: MetricSettings{
-			Enabled: true,
-		},
-		K8sPodNetworkIoReceive: MetricSettings{
-			Enabled: true,
-		},
-		K8sPodNetworkIoTransmit: MetricSettings{
 			Enabled: true,
 		},
 		K8sVolumeAvailable: MetricSettings{
@@ -1386,112 +1354,6 @@ func newMetricK8sNodeNetworkErrors(settings MetricSettings) metricK8sNodeNetwork
 	return m
 }
 
-type metricK8sNodeNetworkErrorsReceive struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills k8s.node.network.errors.receive metric with initial data.
-func (m *metricK8sNodeNetworkErrorsReceive) init() {
-	m.data.SetName("k8s.node.network.errors.receive")
-	m.data.SetDescription("Node network receive errors")
-	m.data.SetUnit("1")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricK8sNodeNetworkErrorsReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricK8sNodeNetworkErrorsReceive) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricK8sNodeNetworkErrorsReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricK8sNodeNetworkErrorsReceive(settings MetricSettings) metricK8sNodeNetworkErrorsReceive {
-	m := metricK8sNodeNetworkErrorsReceive{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricK8sNodeNetworkErrorsTransmit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills k8s.node.network.errors.transmit metric with initial data.
-func (m *metricK8sNodeNetworkErrorsTransmit) init() {
-	m.data.SetName("k8s.node.network.errors.transmit")
-	m.data.SetDescription("Node network transmission errors")
-	m.data.SetUnit("1")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricK8sNodeNetworkErrorsTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricK8sNodeNetworkErrorsTransmit) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricK8sNodeNetworkErrorsTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricK8sNodeNetworkErrorsTransmit(settings MetricSettings) metricK8sNodeNetworkErrorsTransmit {
-	m := metricK8sNodeNetworkErrorsTransmit{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricK8sNodeNetworkIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1539,112 +1401,6 @@ func (m *metricK8sNodeNetworkIo) emit(metrics pmetric.MetricSlice) {
 
 func newMetricK8sNodeNetworkIo(settings MetricSettings) metricK8sNodeNetworkIo {
 	m := metricK8sNodeNetworkIo{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricK8sNodeNetworkIoReceive struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills k8s.node.network.io.receive metric with initial data.
-func (m *metricK8sNodeNetworkIoReceive) init() {
-	m.data.SetName("k8s.node.network.io.receive")
-	m.data.SetDescription("Node network IO received")
-	m.data.SetUnit("By")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricK8sNodeNetworkIoReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricK8sNodeNetworkIoReceive) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricK8sNodeNetworkIoReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricK8sNodeNetworkIoReceive(settings MetricSettings) metricK8sNodeNetworkIoReceive {
-	m := metricK8sNodeNetworkIoReceive{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricK8sNodeNetworkIoTransmit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills k8s.node.network.io.transmit metric with initial data.
-func (m *metricK8sNodeNetworkIoTransmit) init() {
-	m.data.SetName("k8s.node.network.io.transmit")
-	m.data.SetDescription("Node network IO transmitted")
-	m.data.SetUnit("By")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricK8sNodeNetworkIoTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricK8sNodeNetworkIoTransmit) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricK8sNodeNetworkIoTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricK8sNodeNetworkIoTransmit(settings MetricSettings) metricK8sNodeNetworkIoTransmit {
-	m := metricK8sNodeNetworkIoTransmit{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -2247,112 +2003,6 @@ func newMetricK8sPodNetworkErrors(settings MetricSettings) metricK8sPodNetworkEr
 	return m
 }
 
-type metricK8sPodNetworkErrorsReceive struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills k8s.pod.network.errors.receive metric with initial data.
-func (m *metricK8sPodNetworkErrorsReceive) init() {
-	m.data.SetName("k8s.pod.network.errors.receive")
-	m.data.SetDescription("Pod network receive errors")
-	m.data.SetUnit("1")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricK8sPodNetworkErrorsReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricK8sPodNetworkErrorsReceive) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricK8sPodNetworkErrorsReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricK8sPodNetworkErrorsReceive(settings MetricSettings) metricK8sPodNetworkErrorsReceive {
-	m := metricK8sPodNetworkErrorsReceive{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricK8sPodNetworkErrorsTransmit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills k8s.pod.network.errors.transmit metric with initial data.
-func (m *metricK8sPodNetworkErrorsTransmit) init() {
-	m.data.SetName("k8s.pod.network.errors.transmit")
-	m.data.SetDescription("Pod network transmission errors")
-	m.data.SetUnit("1")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricK8sPodNetworkErrorsTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricK8sPodNetworkErrorsTransmit) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricK8sPodNetworkErrorsTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricK8sPodNetworkErrorsTransmit(settings MetricSettings) metricK8sPodNetworkErrorsTransmit {
-	m := metricK8sPodNetworkErrorsTransmit{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricK8sPodNetworkIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -2400,112 +2050,6 @@ func (m *metricK8sPodNetworkIo) emit(metrics pmetric.MetricSlice) {
 
 func newMetricK8sPodNetworkIo(settings MetricSettings) metricK8sPodNetworkIo {
 	m := metricK8sPodNetworkIo{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricK8sPodNetworkIoReceive struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills k8s.pod.network.io.receive metric with initial data.
-func (m *metricK8sPodNetworkIoReceive) init() {
-	m.data.SetName("k8s.pod.network.io.receive")
-	m.data.SetDescription("Pod network IO received")
-	m.data.SetUnit("By")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricK8sPodNetworkIoReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricK8sPodNetworkIoReceive) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricK8sPodNetworkIoReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricK8sPodNetworkIoReceive(settings MetricSettings) metricK8sPodNetworkIoReceive {
-	m := metricK8sPodNetworkIoReceive{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricK8sPodNetworkIoTransmit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills k8s.pod.network.io.transmit metric with initial data.
-func (m *metricK8sPodNetworkIoTransmit) init() {
-	m.data.SetName("k8s.pod.network.io.transmit")
-	m.data.SetDescription("Pod network IO transmitted")
-	m.data.SetUnit("By")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricK8sPodNetworkIoTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricK8sPodNetworkIoTransmit) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricK8sPodNetworkIoTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricK8sPodNetworkIoTransmit(settings MetricSettings) metricK8sPodNetworkIoTransmit {
-	m := metricK8sPodNetworkIoTransmit{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -2789,11 +2333,7 @@ type MetricsBuilder struct {
 	metricK8sNodeMemoryUsage             metricK8sNodeMemoryUsage
 	metricK8sNodeMemoryWorkingSet        metricK8sNodeMemoryWorkingSet
 	metricK8sNodeNetworkErrors           metricK8sNodeNetworkErrors
-	metricK8sNodeNetworkErrorsReceive    metricK8sNodeNetworkErrorsReceive
-	metricK8sNodeNetworkErrorsTransmit   metricK8sNodeNetworkErrorsTransmit
 	metricK8sNodeNetworkIo               metricK8sNodeNetworkIo
-	metricK8sNodeNetworkIoReceive        metricK8sNodeNetworkIoReceive
-	metricK8sNodeNetworkIoTransmit       metricK8sNodeNetworkIoTransmit
 	metricK8sPodCPUTime                  metricK8sPodCPUTime
 	metricK8sPodCPUUtilization           metricK8sPodCPUUtilization
 	metricK8sPodFilesystemAvailable      metricK8sPodFilesystemAvailable
@@ -2806,11 +2346,7 @@ type MetricsBuilder struct {
 	metricK8sPodMemoryUsage              metricK8sPodMemoryUsage
 	metricK8sPodMemoryWorkingSet         metricK8sPodMemoryWorkingSet
 	metricK8sPodNetworkErrors            metricK8sPodNetworkErrors
-	metricK8sPodNetworkErrorsReceive     metricK8sPodNetworkErrorsReceive
-	metricK8sPodNetworkErrorsTransmit    metricK8sPodNetworkErrorsTransmit
 	metricK8sPodNetworkIo                metricK8sPodNetworkIo
-	metricK8sPodNetworkIoReceive         metricK8sPodNetworkIoReceive
-	metricK8sPodNetworkIoTransmit        metricK8sPodNetworkIoTransmit
 	metricK8sVolumeAvailable             metricK8sVolumeAvailable
 	metricK8sVolumeCapacity              metricK8sVolumeCapacity
 	metricK8sVolumeInodes                metricK8sVolumeInodes
@@ -2856,11 +2392,7 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		metricK8sNodeMemoryUsage:             newMetricK8sNodeMemoryUsage(settings.K8sNodeMemoryUsage),
 		metricK8sNodeMemoryWorkingSet:        newMetricK8sNodeMemoryWorkingSet(settings.K8sNodeMemoryWorkingSet),
 		metricK8sNodeNetworkErrors:           newMetricK8sNodeNetworkErrors(settings.K8sNodeNetworkErrors),
-		metricK8sNodeNetworkErrorsReceive:    newMetricK8sNodeNetworkErrorsReceive(settings.K8sNodeNetworkErrorsReceive),
-		metricK8sNodeNetworkErrorsTransmit:   newMetricK8sNodeNetworkErrorsTransmit(settings.K8sNodeNetworkErrorsTransmit),
 		metricK8sNodeNetworkIo:               newMetricK8sNodeNetworkIo(settings.K8sNodeNetworkIo),
-		metricK8sNodeNetworkIoReceive:        newMetricK8sNodeNetworkIoReceive(settings.K8sNodeNetworkIoReceive),
-		metricK8sNodeNetworkIoTransmit:       newMetricK8sNodeNetworkIoTransmit(settings.K8sNodeNetworkIoTransmit),
 		metricK8sPodCPUTime:                  newMetricK8sPodCPUTime(settings.K8sPodCPUTime),
 		metricK8sPodCPUUtilization:           newMetricK8sPodCPUUtilization(settings.K8sPodCPUUtilization),
 		metricK8sPodFilesystemAvailable:      newMetricK8sPodFilesystemAvailable(settings.K8sPodFilesystemAvailable),
@@ -2873,11 +2405,7 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		metricK8sPodMemoryUsage:              newMetricK8sPodMemoryUsage(settings.K8sPodMemoryUsage),
 		metricK8sPodMemoryWorkingSet:         newMetricK8sPodMemoryWorkingSet(settings.K8sPodMemoryWorkingSet),
 		metricK8sPodNetworkErrors:            newMetricK8sPodNetworkErrors(settings.K8sPodNetworkErrors),
-		metricK8sPodNetworkErrorsReceive:     newMetricK8sPodNetworkErrorsReceive(settings.K8sPodNetworkErrorsReceive),
-		metricK8sPodNetworkErrorsTransmit:    newMetricK8sPodNetworkErrorsTransmit(settings.K8sPodNetworkErrorsTransmit),
 		metricK8sPodNetworkIo:                newMetricK8sPodNetworkIo(settings.K8sPodNetworkIo),
-		metricK8sPodNetworkIoReceive:         newMetricK8sPodNetworkIoReceive(settings.K8sPodNetworkIoReceive),
-		metricK8sPodNetworkIoTransmit:        newMetricK8sPodNetworkIoTransmit(settings.K8sPodNetworkIoTransmit),
 		metricK8sVolumeAvailable:             newMetricK8sVolumeAvailable(settings.K8sVolumeAvailable),
 		metricK8sVolumeCapacity:              newMetricK8sVolumeCapacity(settings.K8sVolumeCapacity),
 		metricK8sVolumeInodes:                newMetricK8sVolumeInodes(settings.K8sVolumeInodes),
@@ -3063,11 +2591,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricK8sNodeMemoryUsage.emit(ils.Metrics())
 	mb.metricK8sNodeMemoryWorkingSet.emit(ils.Metrics())
 	mb.metricK8sNodeNetworkErrors.emit(ils.Metrics())
-	mb.metricK8sNodeNetworkErrorsReceive.emit(ils.Metrics())
-	mb.metricK8sNodeNetworkErrorsTransmit.emit(ils.Metrics())
 	mb.metricK8sNodeNetworkIo.emit(ils.Metrics())
-	mb.metricK8sNodeNetworkIoReceive.emit(ils.Metrics())
-	mb.metricK8sNodeNetworkIoTransmit.emit(ils.Metrics())
 	mb.metricK8sPodCPUTime.emit(ils.Metrics())
 	mb.metricK8sPodCPUUtilization.emit(ils.Metrics())
 	mb.metricK8sPodFilesystemAvailable.emit(ils.Metrics())
@@ -3080,11 +2604,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricK8sPodMemoryUsage.emit(ils.Metrics())
 	mb.metricK8sPodMemoryWorkingSet.emit(ils.Metrics())
 	mb.metricK8sPodNetworkErrors.emit(ils.Metrics())
-	mb.metricK8sPodNetworkErrorsReceive.emit(ils.Metrics())
-	mb.metricK8sPodNetworkErrorsTransmit.emit(ils.Metrics())
 	mb.metricK8sPodNetworkIo.emit(ils.Metrics())
-	mb.metricK8sPodNetworkIoReceive.emit(ils.Metrics())
-	mb.metricK8sPodNetworkIoTransmit.emit(ils.Metrics())
 	mb.metricK8sVolumeAvailable.emit(ils.Metrics())
 	mb.metricK8sVolumeCapacity.emit(ils.Metrics())
 	mb.metricK8sVolumeInodes.emit(ils.Metrics())
@@ -3224,29 +2744,9 @@ func (mb *MetricsBuilder) RecordK8sNodeNetworkErrorsDataPoint(ts pcommon.Timesta
 	mb.metricK8sNodeNetworkErrors.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue, directionAttributeValue.String())
 }
 
-// RecordK8sNodeNetworkErrorsReceiveDataPoint adds a data point to k8s.node.network.errors.receive metric.
-func (mb *MetricsBuilder) RecordK8sNodeNetworkErrorsReceiveDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	mb.metricK8sNodeNetworkErrorsReceive.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue)
-}
-
-// RecordK8sNodeNetworkErrorsTransmitDataPoint adds a data point to k8s.node.network.errors.transmit metric.
-func (mb *MetricsBuilder) RecordK8sNodeNetworkErrorsTransmitDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	mb.metricK8sNodeNetworkErrorsTransmit.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue)
-}
-
 // RecordK8sNodeNetworkIoDataPoint adds a data point to k8s.node.network.io metric.
 func (mb *MetricsBuilder) RecordK8sNodeNetworkIoDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue AttributeDirection) {
 	mb.metricK8sNodeNetworkIo.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue, directionAttributeValue.String())
-}
-
-// RecordK8sNodeNetworkIoReceiveDataPoint adds a data point to k8s.node.network.io.receive metric.
-func (mb *MetricsBuilder) RecordK8sNodeNetworkIoReceiveDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	mb.metricK8sNodeNetworkIoReceive.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue)
-}
-
-// RecordK8sNodeNetworkIoTransmitDataPoint adds a data point to k8s.node.network.io.transmit metric.
-func (mb *MetricsBuilder) RecordK8sNodeNetworkIoTransmitDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	mb.metricK8sNodeNetworkIoTransmit.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue)
 }
 
 // RecordK8sPodCPUTimeDataPoint adds a data point to k8s.pod.cpu.time metric.
@@ -3309,29 +2809,9 @@ func (mb *MetricsBuilder) RecordK8sPodNetworkErrorsDataPoint(ts pcommon.Timestam
 	mb.metricK8sPodNetworkErrors.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue, directionAttributeValue.String())
 }
 
-// RecordK8sPodNetworkErrorsReceiveDataPoint adds a data point to k8s.pod.network.errors.receive metric.
-func (mb *MetricsBuilder) RecordK8sPodNetworkErrorsReceiveDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	mb.metricK8sPodNetworkErrorsReceive.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue)
-}
-
-// RecordK8sPodNetworkErrorsTransmitDataPoint adds a data point to k8s.pod.network.errors.transmit metric.
-func (mb *MetricsBuilder) RecordK8sPodNetworkErrorsTransmitDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	mb.metricK8sPodNetworkErrorsTransmit.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue)
-}
-
 // RecordK8sPodNetworkIoDataPoint adds a data point to k8s.pod.network.io metric.
 func (mb *MetricsBuilder) RecordK8sPodNetworkIoDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue AttributeDirection) {
 	mb.metricK8sPodNetworkIo.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue, directionAttributeValue.String())
-}
-
-// RecordK8sPodNetworkIoReceiveDataPoint adds a data point to k8s.pod.network.io.receive metric.
-func (mb *MetricsBuilder) RecordK8sPodNetworkIoReceiveDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	mb.metricK8sPodNetworkIoReceive.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue)
-}
-
-// RecordK8sPodNetworkIoTransmitDataPoint adds a data point to k8s.pod.network.io.transmit metric.
-func (mb *MetricsBuilder) RecordK8sPodNetworkIoTransmitDataPoint(ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	mb.metricK8sPodNetworkIoTransmit.recordDataPoint(mb.startTime, ts, val, interfaceAttributeValue)
 }
 
 // RecordK8sVolumeAvailableDataPoint adds a data point to k8s.volume.available metric.

--- a/receiver/kubeletstatsreceiver/internal/metadata/metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/metrics.go
@@ -121,28 +121,6 @@ type NetworkMetricsRecorder struct {
 	RecordTransmitDataPoint RecordIntDataPointWithStringAttributeFunc
 }
 
-var NodeNetworkMetrics = NetworkMetrics{
-	IO: NetworkMetricsRecorder{
-		RecordReceiveDataPoint:  (*MetricsBuilder).RecordK8sNodeNetworkIoReceiveDataPoint,
-		RecordTransmitDataPoint: (*MetricsBuilder).RecordK8sNodeNetworkIoTransmitDataPoint,
-	},
-	Errors: NetworkMetricsRecorder{
-		RecordReceiveDataPoint:  (*MetricsBuilder).RecordK8sNodeNetworkErrorsReceiveDataPoint,
-		RecordTransmitDataPoint: (*MetricsBuilder).RecordK8sNodeNetworkErrorsTransmitDataPoint,
-	},
-}
-
-var PodNetworkMetrics = NetworkMetrics{
-	IO: NetworkMetricsRecorder{
-		RecordReceiveDataPoint:  (*MetricsBuilder).RecordK8sPodNetworkIoReceiveDataPoint,
-		RecordTransmitDataPoint: (*MetricsBuilder).RecordK8sPodNetworkIoTransmitDataPoint,
-	},
-	Errors: NetworkMetricsRecorder{
-		RecordReceiveDataPoint:  (*MetricsBuilder).RecordK8sPodNetworkErrorsReceiveDataPoint,
-		RecordTransmitDataPoint: (*MetricsBuilder).RecordK8sPodNetworkErrorsTransmitDataPoint,
-	},
-}
-
 type NetworkMetricsWithDirection struct {
 	IO     RecordIntDataPointWithDirectionFunc
 	Errors RecordIntDataPointWithDirectionFunc

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -135,7 +135,6 @@ metrics:
     gauge:
       value_type: int
     attributes: []
-  # produced when receiver.kubeletstats.emitMetricsWithDirectionAttribute feature gate is enabled
   k8s.node.network.io:
     enabled: true
     description: "Node network IO"
@@ -145,27 +144,6 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: ["interface", "direction"]
-  # produced when receiver.kubeletstats.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  k8s.node.network.io.transmit:
-    enabled: true
-    description: "Node network IO transmitted"
-    unit: By
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: ["interface"]
-  # produced when receiver.kubeletstats.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  k8s.node.network.io.receive:
-    enabled: true
-    description: "Node network IO received"
-    unit: By
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: ["interface"]
-  # produced when receiver.kubeletstats.emitMetricsWithDirectionAttribute feature gate is enabled
   k8s.node.network.errors:
     enabled: true
     description: "Node network errors"
@@ -175,26 +153,6 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: ["interface", "direction"]
-  # produced when receiver.kubeletstats.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  k8s.node.network.errors.transmit:
-    enabled: true
-    description: "Node network transmission errors"
-    unit: 1
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: ["interface"]
-  # produced when receiver.kubeletstats.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  k8s.node.network.errors.receive:
-    enabled: true
-    description: "Node network receive errors"
-    unit: 1
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: ["interface"]
   k8s.pod.cpu.utilization:
     enabled: true
     description: "Pod CPU utilization"
@@ -274,7 +232,6 @@ metrics:
     gauge:
       value_type: int
     attributes: []
-  # produced when receiver.kubeletstats.emitMetricsWithDirectionAttribute feature gate is enabled
   k8s.pod.network.io:
     enabled: true
     description: "Pod network IO"
@@ -284,27 +241,6 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: ["interface", "direction"]
-  # produced when receiver.kubeletstats.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  k8s.pod.network.io.transmit:
-    enabled: true
-    description: "Pod network IO transmitted"
-    unit: By
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: ["interface"]
-  # produced when receiver.kubeletstats.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  k8s.pod.network.io.receive:
-    enabled: true
-    description: "Pod network IO received"
-    unit: By
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: ["interface"]
-  # produced when receiver.kubeletstats.emitMetricsWithDirectionAttribute feature gate is enabled
   k8s.pod.network.errors:
     enabled: true
     description: "Pod network errors"
@@ -314,26 +250,6 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: ["interface", "direction"]
-  # produced when receiver.kubeletstats.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  k8s.pod.network.errors.transmit:
-    enabled: true
-    description: "Pod network transmission errors"
-    unit: 1
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: ["interface"]
-  # produced when receiver.kubeletstats.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  k8s.pod.network.errors.receive:
-    enabled: true
-    description: "Pod network receive errors"
-    unit: 1
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: ["interface"]
   container.cpu.utilization:
     enabled: true
     description: "Container CPU utilization"

--- a/receiver/kubeletstatsreceiver/scraper.go
+++ b/receiver/kubeletstatsreceiver/scraper.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/zap"
@@ -33,38 +32,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/internal/metadata"
 )
 
-const (
-	emitMetricsWithDirectionAttributeFeatureGateID    = "receiver.kubeletstatsreceiver.emitMetricsWithDirectionAttribute"
-	emitMetricsWithoutDirectionAttributeFeatureGateID = "receiver.kubeletstatsreceiver.emitMetricsWithoutDirectionAttribute"
-)
-
-var (
-	emitMetricsWithDirectionAttributeFeatureGate = featuregate.Gate{
-		ID:      emitMetricsWithDirectionAttributeFeatureGateID,
-		Enabled: true,
-		Description: "Some kubeletstats metrics reported are transitioning from being reported with a direction " +
-			"attribute to being reported with the direction included in the metric name to adhere to the " +
-			"OpenTelemetry specification. This feature gate controls emitting the old metrics with the direction " +
-			"attribute. For more details, see: " +
-			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/README.md#feature-gate-configurations",
-	}
-
-	emitMetricsWithoutDirectionAttributeFeatureGate = featuregate.Gate{
-		ID:      emitMetricsWithoutDirectionAttributeFeatureGateID,
-		Enabled: false,
-		Description: "Some kubeletstats metrics reported are transitioning from being reported with a direction " +
-			"attribute to being reported with the direction included in the metric name to adhere to the " +
-			"OpenTelemetry specification. This feature gate controls emitting the new metrics without the direction " +
-			"attribute. For more details, see: " +
-			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/README.md#feature-gate-configurations",
-	}
-)
-
-func init() {
-	featuregate.GetRegistry().MustRegister(emitMetricsWithDirectionAttributeFeatureGate)
-	featuregate.GetRegistry().MustRegister(emitMetricsWithoutDirectionAttributeFeatureGate)
-}
-
 type scraperOptions struct {
 	id                    config.ComponentID
 	collectionInterval    time.Duration
@@ -74,22 +41,14 @@ type scraperOptions struct {
 }
 
 type kubletScraper struct {
-	statsProvider                        *kubelet.StatsProvider
-	metadataProvider                     *kubelet.MetadataProvider
-	logger                               *zap.Logger
-	extraMetadataLabels                  []kubelet.MetadataLabel
-	metricGroupsToCollect                map[kubelet.MetricGroup]bool
-	k8sAPIClient                         kubernetes.Interface
-	cachedVolumeLabels                   map[string][]metadata.ResourceMetricsOption
-	mbs                                  *metadata.MetricsBuilders
-	emitMetricsWithDirectionAttribute    bool
-	emitMetricsWithoutDirectionAttribute bool
-}
-
-func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
-	log.Warn("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
-		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
-		"for additional details.")
+	statsProvider         *kubelet.StatsProvider
+	metadataProvider      *kubelet.MetadataProvider
+	logger                *zap.Logger
+	extraMetadataLabels   []kubelet.MetadataLabel
+	metricGroupsToCollect map[kubelet.MetricGroup]bool
+	k8sAPIClient          kubernetes.Interface
+	cachedVolumeLabels    map[string][]metadata.ResourceMetricsOption
+	mbs                   *metadata.MetricsBuilders
 }
 
 func newKubletScraper(
@@ -112,15 +71,6 @@ func newKubletScraper(
 			ContainerMetricsBuilder: metadata.NewMetricsBuilder(metricsConfig, set.BuildInfo),
 			OtherMetricsBuilder:     metadata.NewMetricsBuilder(metricsConfig, set.BuildInfo),
 		},
-		emitMetricsWithDirectionAttribute:    featuregate.GetRegistry().IsEnabled(emitMetricsWithDirectionAttributeFeatureGateID),
-		emitMetricsWithoutDirectionAttribute: featuregate.GetRegistry().IsEnabled(emitMetricsWithoutDirectionAttributeFeatureGateID),
-	}
-	if !ks.emitMetricsWithDirectionAttribute {
-		logDeprecatedFeatureGateForDirection(ks.logger, emitMetricsWithDirectionAttributeFeatureGate)
-	}
-
-	if ks.emitMetricsWithoutDirectionAttribute {
-		logDeprecatedFeatureGateForDirection(ks.logger, emitMetricsWithoutDirectionAttributeFeatureGate)
 	}
 	return scraperhelper.NewScraper(typeStr, ks.scrape)
 }
@@ -143,7 +93,7 @@ func (r *kubletScraper) scrape(context.Context) (pmetric.Metrics, error) {
 	}
 
 	metadata := kubelet.NewMetadata(r.extraMetadataLabels, podsMetadata, r.detailedPVCLabelsSetter())
-	mds := kubelet.MetricsData(r.logger, summary, metadata, r.metricGroupsToCollect, r.mbs, r.emitMetricsWithDirectionAttribute, r.emitMetricsWithoutDirectionAttribute)
+	mds := kubelet.MetricsData(r.logger, summary, metadata, r.metricGroupsToCollect, r.mbs)
 	md := pmetric.NewMetrics()
 	for i := range mds {
 		mds[i].ResourceMetrics().MoveAndAppendTo(md.ResourceMetrics())


### PR DESCRIPTION
The following feature gates have been removed after being deprecated for a few versions:

- `receiver.kubeletstatsreceiver.emitMetricsWithoutDirectionAttribute`
- `receiver.kubeletstatsreceiver.emitMetricsWithDirectionAttribute`
