### PR TITLE
 [receiver/vcenter] removing direction feature gate

### DIFF
--- a/.chloggen/rm-direction-vcenterreceiver.yaml
+++ b/.chloggen/rm-direction-vcenterreceiver.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "removing direction feature gate"
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/rm-direction-vcenterreceiver.yaml
+++ b/.chloggen/rm-direction-vcenterreceiver.yaml
@@ -8,7 +8,7 @@ component: vcenterreceiver
 note: "removing direction feature gate"
 
 # One or more tracking issues related to the change
-issues: []
+issues: [14963]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/vcenterreceiver/README.md
+++ b/receiver/vcenterreceiver/README.md
@@ -47,17 +47,5 @@ The full list of settings exposed for this receiver are documented [here](./conf
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml) with further documentation in [documentation.md](./documentation.md)
 
-### Feature gate configurations
-
-#### Transition from metrics with "direction" attribute
-
-The proposal to change metrics from being reported with a `direction` attribute has been reverted in the specification. As a result, the
-following feature gates will be removed in v0.62.0:
-
-- **receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute**
-- **receiver.vcenterreceiver.emitMetricsWithDirectionAttribute**
-
-For additional information, see https://github.com/open-telemetry/opentelemetry-specification/issues/2726.
-
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -20,31 +20,19 @@ These are the metrics available for this scraper.
 | **vcenter.host.cpu.usage** | The amount of CPU in Hz used by the host. | MHz | Sum(Int) | <ul> </ul> |
 | **vcenter.host.cpu.utilization** | The CPU utilization of the host system. | % | Gauge(Double) | <ul> </ul> |
 | **vcenter.host.disk.latency.avg** | The latency of operations to the host system's disk. This latency is the sum of the device and kernel read and write latencies. Requires Performance Counter level 2 for metric to populate. | ms | Gauge(Int) | <ul> <li>disk_direction</li> </ul> |
-| **vcenter.host.disk.latency.avg.read** | The latency of reads to the host system's disk. This latency is the sum of the device and kernel read latencies. Requires Performance Counter level 2 for metric to populate. | ms | Gauge(Int) | <ul> </ul> |
-| **vcenter.host.disk.latency.avg.write** | The latency of writes to the host system's disk. This latency is the sum of the device and kernel write latencies. Requires Performance Counter level 2 for metric to populate. | ms | Gauge(Int) | <ul> </ul> |
 | **vcenter.host.disk.latency.max** | Highest latency value across all disks used by the host. As measured over the most recent 20s interval. Requires Performance Level 3. | ms | Gauge(Int) | <ul> </ul> |
 | **vcenter.host.disk.throughput** | Average number of kilobytes read from or written to the disk each second. As measured over the most recent 20s interval. Aggregated disk I/O rate. Requires Performance Level 4. | {KiBy/s} | Sum(Int) | <ul> <li>disk_direction</li> </ul> |
-| **vcenter.host.disk.throughput.read** | Average number of kilobytes read from the disk each second. As measured over the most recent 20s interval. Aggregated disk read rate. Requires Performance Level 4. | {KiBy/s} | Sum(Int) | <ul> </ul> |
-| **vcenter.host.disk.throughput.write** | Average number of kilobytes written to the disk each second. As measured over the most recent 20s interval. Aggregated disk write rate. Requires Performance Level 4. | {KiBy/s} | Sum(Int) | <ul> </ul> |
 | **vcenter.host.memory.usage** | The amount of memory the host system is using. | MiBy | Sum(Int) | <ul> </ul> |
 | **vcenter.host.memory.utilization** | The percentage of the host system's memory capacity that is being utilized. | % | Gauge(Double) | <ul> </ul> |
 | **vcenter.host.network.packet.count** | The number of packets transmitted and received, as measured over the most recent 20s interval. | {packets/sec} | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
-| **vcenter.host.network.packet.count.receive** | The number of packets received, as measured over the most recent 20s interval. | {packets/sec} | Sum(Int) | <ul> </ul> |
-| **vcenter.host.network.packet.count.transmit** | The number of packets transmitted, as measured over the most recent 20s interval. | {packets/sec} | Sum(Int) | <ul> </ul> |
 | **vcenter.host.network.packet.errors** | The summation of packet errors on the host network. As measured over the most recent 20s interval. | {errors} | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
-| **vcenter.host.network.packet.errors.receive** | The summation of receive packet errors on the host network. As measured over the most recent 20s interval. | {errors} | Sum(Int) | <ul> </ul> |
-| **vcenter.host.network.packet.errors.transmit** | The summation of transmit packet errors on the host network. As measured over the most recent 20s interval. | {errors} | Sum(Int) | <ul> </ul> |
 | **vcenter.host.network.throughput** | The amount of data that was transmitted or received over the network by the host. As measured over the most recent 20s interval. | {KiBy/s} | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
-| **vcenter.host.network.throughput.receive** | The amount of data that was received over the network by the host. As measured over the most recent 20s interval. | {KiBy/s} | Sum(Int) | <ul> </ul> |
-| **vcenter.host.network.throughput.transmit** | The amount of data that was transmitted over the network by the host. As measured over the most recent 20s interval. | {KiBy/s} | Sum(Int) | <ul> </ul> |
 | **vcenter.host.network.usage** | The sum of the data transmitted and received for all the NIC instances of the host. | {KiBy/s} | Sum(Int) | <ul> </ul> |
 | **vcenter.resource_pool.cpu.shares** | The amount of shares of CPU in the resource pool. | {shares} | Sum(Int) | <ul> </ul> |
 | **vcenter.resource_pool.cpu.usage** | The usage of the CPU used by the resource pool. | {MHz} | Sum(Int) | <ul> </ul> |
 | **vcenter.resource_pool.memory.shares** | The amount of shares of memory in the resource pool. | {shares} | Sum(Int) | <ul> </ul> |
 | **vcenter.resource_pool.memory.usage** | The usage of the memory by the resource pool. | MiBy | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.disk.latency.avg** | The latency of operations to the virtual machine's disk. Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval. | ms | Gauge(Int) | <ul> <li>disk_direction</li> <li>disk_type</li> </ul> |
-| **vcenter.vm.disk.latency.avg.read** | The latency of reads to the virtual machine's disk. Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval. | ms | Gauge(Int) | <ul> <li>disk_type</li> </ul> |
-| **vcenter.vm.disk.latency.avg.write** | The latency of writes to the virtual machine's disk. Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval. | ms | Gauge(Int) | <ul> <li>disk_type</li> </ul> |
 | **vcenter.vm.disk.latency.max** | The highest reported total latency (device and kernel times) over an interval of 20 seconds. | ms | Gauge(Int) | <ul> </ul> |
 | **vcenter.vm.disk.throughput** | The throughput of the virtual machine's disk. | By/sec | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.disk.usage** | The amount of storage space used by the virtual machine. | By | Sum(Int) | <ul> <li>disk_state</li> </ul> |
@@ -52,11 +40,7 @@ These are the metrics available for this scraper.
 | **vcenter.vm.memory.ballooned** | The amount of memory that is ballooned due to virtualization. | By | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.memory.usage** | The amount of memory that is used by the virtual machine. | MiBy | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.network.packet.count** | The amount of packets that was received or transmitted over the instance's network. | {packets/sec} | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
-| **vcenter.vm.network.packet.count.receive** | The amount of packets that was received over the instance's network. | {packets/sec} | Sum(Int) | <ul> </ul> |
-| **vcenter.vm.network.packet.count.transmit** | The amount of packets that was transmitted over the instance's network. | {packets/sec} | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.network.throughput** | The amount of data that was transmitted or received over the network of the virtual machine. As measured over the most recent 20s interval. | By/sec | Sum(Int) | <ul> <li>throughput_direction</li> </ul> |
-| **vcenter.vm.network.throughput.receive** | The amount of data that was received over the network of the virtual machine. As measured over the most recent 20s interval. | By/sec | Sum(Int) | <ul> </ul> |
-| **vcenter.vm.network.throughput.transmit** | The amount of data that was transmitted over the network of the virtual machine. As measured over the most recent 20s interval. | By/sec | Sum(Int) | <ul> </ul> |
 | **vcenter.vm.network.usage** | The network utilization combined transmit and receive rates during an interval. As measured over the most recent 20s interval. | {KiBy/s} | Sum(Int) | <ul> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.

--- a/receiver/vcenterreceiver/factory.go
+++ b/receiver/vcenterreceiver/factory.go
@@ -23,9 +23,7 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver/internal/metadata"
 )
@@ -57,12 +55,6 @@ func createDefaultConfig() config.Receiver {
 
 var errConfigNotVcenter = errors.New("config was not an vcenter receiver config")
 
-func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
-	log.Warn("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
-		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
-		"for additional details.")
-}
-
 func createMetricsReceiver(
 	_ context.Context,
 	params component.ReceiverCreateSettings,
@@ -75,13 +67,6 @@ func createMetricsReceiver(
 	}
 	vr := newVmwareVcenterScraper(params.Logger, cfg, params)
 
-	if !vr.emitMetricsWithDirectionAttribute {
-		logDeprecatedFeatureGateForDirection(vr.logger, emitMetricsWithDirectionAttributeFeatureGate)
-	}
-
-	if vr.emitMetricsWithoutDirectionAttribute {
-		logDeprecatedFeatureGateForDirection(vr.logger, emitMetricsWithoutDirectionAttributeFeatureGate)
-	}
 	scraper, err := scraperhelper.NewScraper(
 		typeStr,
 		vr.scrape,

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -17,56 +17,40 @@ type MetricSettings struct {
 
 // MetricsSettings provides settings for vcenterreceiver metrics.
 type MetricsSettings struct {
-	VcenterClusterCPUEffective             MetricSettings `mapstructure:"vcenter.cluster.cpu.effective"`
-	VcenterClusterCPULimit                 MetricSettings `mapstructure:"vcenter.cluster.cpu.limit"`
-	VcenterClusterHostCount                MetricSettings `mapstructure:"vcenter.cluster.host.count"`
-	VcenterClusterMemoryEffective          MetricSettings `mapstructure:"vcenter.cluster.memory.effective"`
-	VcenterClusterMemoryLimit              MetricSettings `mapstructure:"vcenter.cluster.memory.limit"`
-	VcenterClusterMemoryUsed               MetricSettings `mapstructure:"vcenter.cluster.memory.used"`
-	VcenterClusterVMCount                  MetricSettings `mapstructure:"vcenter.cluster.vm.count"`
-	VcenterDatastoreDiskUsage              MetricSettings `mapstructure:"vcenter.datastore.disk.usage"`
-	VcenterDatastoreDiskUtilization        MetricSettings `mapstructure:"vcenter.datastore.disk.utilization"`
-	VcenterHostCPUUsage                    MetricSettings `mapstructure:"vcenter.host.cpu.usage"`
-	VcenterHostCPUUtilization              MetricSettings `mapstructure:"vcenter.host.cpu.utilization"`
-	VcenterHostDiskLatencyAvg              MetricSettings `mapstructure:"vcenter.host.disk.latency.avg"`
-	VcenterHostDiskLatencyAvgRead          MetricSettings `mapstructure:"vcenter.host.disk.latency.avg.read"`
-	VcenterHostDiskLatencyAvgWrite         MetricSettings `mapstructure:"vcenter.host.disk.latency.avg.write"`
-	VcenterHostDiskLatencyMax              MetricSettings `mapstructure:"vcenter.host.disk.latency.max"`
-	VcenterHostDiskThroughput              MetricSettings `mapstructure:"vcenter.host.disk.throughput"`
-	VcenterHostDiskThroughputRead          MetricSettings `mapstructure:"vcenter.host.disk.throughput.read"`
-	VcenterHostDiskThroughputWrite         MetricSettings `mapstructure:"vcenter.host.disk.throughput.write"`
-	VcenterHostMemoryUsage                 MetricSettings `mapstructure:"vcenter.host.memory.usage"`
-	VcenterHostMemoryUtilization           MetricSettings `mapstructure:"vcenter.host.memory.utilization"`
-	VcenterHostNetworkPacketCount          MetricSettings `mapstructure:"vcenter.host.network.packet.count"`
-	VcenterHostNetworkPacketCountReceive   MetricSettings `mapstructure:"vcenter.host.network.packet.count.receive"`
-	VcenterHostNetworkPacketCountTransmit  MetricSettings `mapstructure:"vcenter.host.network.packet.count.transmit"`
-	VcenterHostNetworkPacketErrors         MetricSettings `mapstructure:"vcenter.host.network.packet.errors"`
-	VcenterHostNetworkPacketErrorsReceive  MetricSettings `mapstructure:"vcenter.host.network.packet.errors.receive"`
-	VcenterHostNetworkPacketErrorsTransmit MetricSettings `mapstructure:"vcenter.host.network.packet.errors.transmit"`
-	VcenterHostNetworkThroughput           MetricSettings `mapstructure:"vcenter.host.network.throughput"`
-	VcenterHostNetworkThroughputReceive    MetricSettings `mapstructure:"vcenter.host.network.throughput.receive"`
-	VcenterHostNetworkThroughputTransmit   MetricSettings `mapstructure:"vcenter.host.network.throughput.transmit"`
-	VcenterHostNetworkUsage                MetricSettings `mapstructure:"vcenter.host.network.usage"`
-	VcenterResourcePoolCPUShares           MetricSettings `mapstructure:"vcenter.resource_pool.cpu.shares"`
-	VcenterResourcePoolCPUUsage            MetricSettings `mapstructure:"vcenter.resource_pool.cpu.usage"`
-	VcenterResourcePoolMemoryShares        MetricSettings `mapstructure:"vcenter.resource_pool.memory.shares"`
-	VcenterResourcePoolMemoryUsage         MetricSettings `mapstructure:"vcenter.resource_pool.memory.usage"`
-	VcenterVMDiskLatencyAvg                MetricSettings `mapstructure:"vcenter.vm.disk.latency.avg"`
-	VcenterVMDiskLatencyAvgRead            MetricSettings `mapstructure:"vcenter.vm.disk.latency.avg.read"`
-	VcenterVMDiskLatencyAvgWrite           MetricSettings `mapstructure:"vcenter.vm.disk.latency.avg.write"`
-	VcenterVMDiskLatencyMax                MetricSettings `mapstructure:"vcenter.vm.disk.latency.max"`
-	VcenterVMDiskThroughput                MetricSettings `mapstructure:"vcenter.vm.disk.throughput"`
-	VcenterVMDiskUsage                     MetricSettings `mapstructure:"vcenter.vm.disk.usage"`
-	VcenterVMDiskUtilization               MetricSettings `mapstructure:"vcenter.vm.disk.utilization"`
-	VcenterVMMemoryBallooned               MetricSettings `mapstructure:"vcenter.vm.memory.ballooned"`
-	VcenterVMMemoryUsage                   MetricSettings `mapstructure:"vcenter.vm.memory.usage"`
-	VcenterVMNetworkPacketCount            MetricSettings `mapstructure:"vcenter.vm.network.packet.count"`
-	VcenterVMNetworkPacketCountReceive     MetricSettings `mapstructure:"vcenter.vm.network.packet.count.receive"`
-	VcenterVMNetworkPacketCountTransmit    MetricSettings `mapstructure:"vcenter.vm.network.packet.count.transmit"`
-	VcenterVMNetworkThroughput             MetricSettings `mapstructure:"vcenter.vm.network.throughput"`
-	VcenterVMNetworkThroughputReceive      MetricSettings `mapstructure:"vcenter.vm.network.throughput.receive"`
-	VcenterVMNetworkThroughputTransmit     MetricSettings `mapstructure:"vcenter.vm.network.throughput.transmit"`
-	VcenterVMNetworkUsage                  MetricSettings `mapstructure:"vcenter.vm.network.usage"`
+	VcenterClusterCPUEffective      MetricSettings `mapstructure:"vcenter.cluster.cpu.effective"`
+	VcenterClusterCPULimit          MetricSettings `mapstructure:"vcenter.cluster.cpu.limit"`
+	VcenterClusterHostCount         MetricSettings `mapstructure:"vcenter.cluster.host.count"`
+	VcenterClusterMemoryEffective   MetricSettings `mapstructure:"vcenter.cluster.memory.effective"`
+	VcenterClusterMemoryLimit       MetricSettings `mapstructure:"vcenter.cluster.memory.limit"`
+	VcenterClusterMemoryUsed        MetricSettings `mapstructure:"vcenter.cluster.memory.used"`
+	VcenterClusterVMCount           MetricSettings `mapstructure:"vcenter.cluster.vm.count"`
+	VcenterDatastoreDiskUsage       MetricSettings `mapstructure:"vcenter.datastore.disk.usage"`
+	VcenterDatastoreDiskUtilization MetricSettings `mapstructure:"vcenter.datastore.disk.utilization"`
+	VcenterHostCPUUsage             MetricSettings `mapstructure:"vcenter.host.cpu.usage"`
+	VcenterHostCPUUtilization       MetricSettings `mapstructure:"vcenter.host.cpu.utilization"`
+	VcenterHostDiskLatencyAvg       MetricSettings `mapstructure:"vcenter.host.disk.latency.avg"`
+	VcenterHostDiskLatencyMax       MetricSettings `mapstructure:"vcenter.host.disk.latency.max"`
+	VcenterHostDiskThroughput       MetricSettings `mapstructure:"vcenter.host.disk.throughput"`
+	VcenterHostMemoryUsage          MetricSettings `mapstructure:"vcenter.host.memory.usage"`
+	VcenterHostMemoryUtilization    MetricSettings `mapstructure:"vcenter.host.memory.utilization"`
+	VcenterHostNetworkPacketCount   MetricSettings `mapstructure:"vcenter.host.network.packet.count"`
+	VcenterHostNetworkPacketErrors  MetricSettings `mapstructure:"vcenter.host.network.packet.errors"`
+	VcenterHostNetworkThroughput    MetricSettings `mapstructure:"vcenter.host.network.throughput"`
+	VcenterHostNetworkUsage         MetricSettings `mapstructure:"vcenter.host.network.usage"`
+	VcenterResourcePoolCPUShares    MetricSettings `mapstructure:"vcenter.resource_pool.cpu.shares"`
+	VcenterResourcePoolCPUUsage     MetricSettings `mapstructure:"vcenter.resource_pool.cpu.usage"`
+	VcenterResourcePoolMemoryShares MetricSettings `mapstructure:"vcenter.resource_pool.memory.shares"`
+	VcenterResourcePoolMemoryUsage  MetricSettings `mapstructure:"vcenter.resource_pool.memory.usage"`
+	VcenterVMDiskLatencyAvg         MetricSettings `mapstructure:"vcenter.vm.disk.latency.avg"`
+	VcenterVMDiskLatencyMax         MetricSettings `mapstructure:"vcenter.vm.disk.latency.max"`
+	VcenterVMDiskThroughput         MetricSettings `mapstructure:"vcenter.vm.disk.throughput"`
+	VcenterVMDiskUsage              MetricSettings `mapstructure:"vcenter.vm.disk.usage"`
+	VcenterVMDiskUtilization        MetricSettings `mapstructure:"vcenter.vm.disk.utilization"`
+	VcenterVMMemoryBallooned        MetricSettings `mapstructure:"vcenter.vm.memory.ballooned"`
+	VcenterVMMemoryUsage            MetricSettings `mapstructure:"vcenter.vm.memory.usage"`
+	VcenterVMNetworkPacketCount     MetricSettings `mapstructure:"vcenter.vm.network.packet.count"`
+	VcenterVMNetworkThroughput      MetricSettings `mapstructure:"vcenter.vm.network.throughput"`
+	VcenterVMNetworkUsage           MetricSettings `mapstructure:"vcenter.vm.network.usage"`
 }
 
 func DefaultMetricsSettings() MetricsSettings {
@@ -107,22 +91,10 @@ func DefaultMetricsSettings() MetricsSettings {
 		VcenterHostDiskLatencyAvg: MetricSettings{
 			Enabled: true,
 		},
-		VcenterHostDiskLatencyAvgRead: MetricSettings{
-			Enabled: true,
-		},
-		VcenterHostDiskLatencyAvgWrite: MetricSettings{
-			Enabled: true,
-		},
 		VcenterHostDiskLatencyMax: MetricSettings{
 			Enabled: true,
 		},
 		VcenterHostDiskThroughput: MetricSettings{
-			Enabled: true,
-		},
-		VcenterHostDiskThroughputRead: MetricSettings{
-			Enabled: true,
-		},
-		VcenterHostDiskThroughputWrite: MetricSettings{
 			Enabled: true,
 		},
 		VcenterHostMemoryUsage: MetricSettings{
@@ -134,28 +106,10 @@ func DefaultMetricsSettings() MetricsSettings {
 		VcenterHostNetworkPacketCount: MetricSettings{
 			Enabled: true,
 		},
-		VcenterHostNetworkPacketCountReceive: MetricSettings{
-			Enabled: true,
-		},
-		VcenterHostNetworkPacketCountTransmit: MetricSettings{
-			Enabled: true,
-		},
 		VcenterHostNetworkPacketErrors: MetricSettings{
 			Enabled: true,
 		},
-		VcenterHostNetworkPacketErrorsReceive: MetricSettings{
-			Enabled: true,
-		},
-		VcenterHostNetworkPacketErrorsTransmit: MetricSettings{
-			Enabled: true,
-		},
 		VcenterHostNetworkThroughput: MetricSettings{
-			Enabled: true,
-		},
-		VcenterHostNetworkThroughputReceive: MetricSettings{
-			Enabled: true,
-		},
-		VcenterHostNetworkThroughputTransmit: MetricSettings{
 			Enabled: true,
 		},
 		VcenterHostNetworkUsage: MetricSettings{
@@ -174,12 +128,6 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		VcenterVMDiskLatencyAvg: MetricSettings{
-			Enabled: true,
-		},
-		VcenterVMDiskLatencyAvgRead: MetricSettings{
-			Enabled: true,
-		},
-		VcenterVMDiskLatencyAvgWrite: MetricSettings{
 			Enabled: true,
 		},
 		VcenterVMDiskLatencyMax: MetricSettings{
@@ -203,19 +151,7 @@ func DefaultMetricsSettings() MetricsSettings {
 		VcenterVMNetworkPacketCount: MetricSettings{
 			Enabled: true,
 		},
-		VcenterVMNetworkPacketCountReceive: MetricSettings{
-			Enabled: true,
-		},
-		VcenterVMNetworkPacketCountTransmit: MetricSettings{
-			Enabled: true,
-		},
 		VcenterVMNetworkThroughput: MetricSettings{
-			Enabled: true,
-		},
-		VcenterVMNetworkThroughputReceive: MetricSettings{
-			Enabled: true,
-		},
-		VcenterVMNetworkThroughputTransmit: MetricSettings{
 			Enabled: true,
 		},
 		VcenterVMNetworkUsage: MetricSettings{
@@ -994,104 +930,6 @@ func newMetricVcenterHostDiskLatencyAvg(settings MetricSettings) metricVcenterHo
 	return m
 }
 
-type metricVcenterHostDiskLatencyAvgRead struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.disk.latency.avg.read metric with initial data.
-func (m *metricVcenterHostDiskLatencyAvgRead) init() {
-	m.data.SetName("vcenter.host.disk.latency.avg.read")
-	m.data.SetDescription("The latency of reads to the host system's disk.")
-	m.data.SetUnit("ms")
-	m.data.SetEmptyGauge()
-}
-
-func (m *metricVcenterHostDiskLatencyAvgRead) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostDiskLatencyAvgRead) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostDiskLatencyAvgRead) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostDiskLatencyAvgRead(settings MetricSettings) metricVcenterHostDiskLatencyAvgRead {
-	m := metricVcenterHostDiskLatencyAvgRead{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterHostDiskLatencyAvgWrite struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.disk.latency.avg.write metric with initial data.
-func (m *metricVcenterHostDiskLatencyAvgWrite) init() {
-	m.data.SetName("vcenter.host.disk.latency.avg.write")
-	m.data.SetDescription("The latency of writes to the host system's disk.")
-	m.data.SetUnit("ms")
-	m.data.SetEmptyGauge()
-}
-
-func (m *metricVcenterHostDiskLatencyAvgWrite) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostDiskLatencyAvgWrite) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostDiskLatencyAvgWrite) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostDiskLatencyAvgWrite(settings MetricSettings) metricVcenterHostDiskLatencyAvgWrite {
-	m := metricVcenterHostDiskLatencyAvgWrite{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricVcenterHostDiskLatencyMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1187,108 +1025,6 @@ func (m *metricVcenterHostDiskThroughput) emit(metrics pmetric.MetricSlice) {
 
 func newMetricVcenterHostDiskThroughput(settings MetricSettings) metricVcenterHostDiskThroughput {
 	m := metricVcenterHostDiskThroughput{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterHostDiskThroughputRead struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.disk.throughput.read metric with initial data.
-func (m *metricVcenterHostDiskThroughputRead) init() {
-	m.data.SetName("vcenter.host.disk.throughput.read")
-	m.data.SetDescription("Average number of kilobytes read from the disk each second.")
-	m.data.SetUnit("{KiBy/s}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterHostDiskThroughputRead) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostDiskThroughputRead) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostDiskThroughputRead) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostDiskThroughputRead(settings MetricSettings) metricVcenterHostDiskThroughputRead {
-	m := metricVcenterHostDiskThroughputRead{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterHostDiskThroughputWrite struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.disk.throughput.write metric with initial data.
-func (m *metricVcenterHostDiskThroughputWrite) init() {
-	m.data.SetName("vcenter.host.disk.throughput.write")
-	m.data.SetDescription("Average number of kilobytes written to the disk each second.")
-	m.data.SetUnit("{KiBy/s}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterHostDiskThroughputWrite) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostDiskThroughputWrite) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostDiskThroughputWrite) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostDiskThroughputWrite(settings MetricSettings) metricVcenterHostDiskThroughputWrite {
-	m := metricVcenterHostDiskThroughputWrite{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -1449,108 +1185,6 @@ func newMetricVcenterHostNetworkPacketCount(settings MetricSettings) metricVcent
 	return m
 }
 
-type metricVcenterHostNetworkPacketCountReceive struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.network.packet.count.receive metric with initial data.
-func (m *metricVcenterHostNetworkPacketCountReceive) init() {
-	m.data.SetName("vcenter.host.network.packet.count.receive")
-	m.data.SetDescription("The number of packets received, as measured over the most recent 20s interval.")
-	m.data.SetUnit("{packets/sec}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterHostNetworkPacketCountReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostNetworkPacketCountReceive) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostNetworkPacketCountReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostNetworkPacketCountReceive(settings MetricSettings) metricVcenterHostNetworkPacketCountReceive {
-	m := metricVcenterHostNetworkPacketCountReceive{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterHostNetworkPacketCountTransmit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.network.packet.count.transmit metric with initial data.
-func (m *metricVcenterHostNetworkPacketCountTransmit) init() {
-	m.data.SetName("vcenter.host.network.packet.count.transmit")
-	m.data.SetDescription("The number of packets transmitted, as measured over the most recent 20s interval.")
-	m.data.SetUnit("{packets/sec}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterHostNetworkPacketCountTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostNetworkPacketCountTransmit) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostNetworkPacketCountTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostNetworkPacketCountTransmit(settings MetricSettings) metricVcenterHostNetworkPacketCountTransmit {
-	m := metricVcenterHostNetworkPacketCountTransmit{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricVcenterHostNetworkPacketErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1604,108 +1238,6 @@ func newMetricVcenterHostNetworkPacketErrors(settings MetricSettings) metricVcen
 	return m
 }
 
-type metricVcenterHostNetworkPacketErrorsReceive struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.network.packet.errors.receive metric with initial data.
-func (m *metricVcenterHostNetworkPacketErrorsReceive) init() {
-	m.data.SetName("vcenter.host.network.packet.errors.receive")
-	m.data.SetDescription("The summation of receive packet errors on the host network.")
-	m.data.SetUnit("{errors}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterHostNetworkPacketErrorsReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostNetworkPacketErrorsReceive) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostNetworkPacketErrorsReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostNetworkPacketErrorsReceive(settings MetricSettings) metricVcenterHostNetworkPacketErrorsReceive {
-	m := metricVcenterHostNetworkPacketErrorsReceive{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterHostNetworkPacketErrorsTransmit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.network.packet.errors.transmit metric with initial data.
-func (m *metricVcenterHostNetworkPacketErrorsTransmit) init() {
-	m.data.SetName("vcenter.host.network.packet.errors.transmit")
-	m.data.SetDescription("The summation of transmit packet errors on the host network.")
-	m.data.SetUnit("{errors}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterHostNetworkPacketErrorsTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostNetworkPacketErrorsTransmit) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostNetworkPacketErrorsTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostNetworkPacketErrorsTransmit(settings MetricSettings) metricVcenterHostNetworkPacketErrorsTransmit {
-	m := metricVcenterHostNetworkPacketErrorsTransmit{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricVcenterHostNetworkThroughput struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1752,108 +1284,6 @@ func (m *metricVcenterHostNetworkThroughput) emit(metrics pmetric.MetricSlice) {
 
 func newMetricVcenterHostNetworkThroughput(settings MetricSettings) metricVcenterHostNetworkThroughput {
 	m := metricVcenterHostNetworkThroughput{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterHostNetworkThroughputReceive struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.network.throughput.receive metric with initial data.
-func (m *metricVcenterHostNetworkThroughputReceive) init() {
-	m.data.SetName("vcenter.host.network.throughput.receive")
-	m.data.SetDescription("The amount of data that was received over the network by the host.")
-	m.data.SetUnit("{KiBy/s}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterHostNetworkThroughputReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostNetworkThroughputReceive) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostNetworkThroughputReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostNetworkThroughputReceive(settings MetricSettings) metricVcenterHostNetworkThroughputReceive {
-	m := metricVcenterHostNetworkThroughputReceive{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterHostNetworkThroughputTransmit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.host.network.throughput.transmit metric with initial data.
-func (m *metricVcenterHostNetworkThroughputTransmit) init() {
-	m.data.SetName("vcenter.host.network.throughput.transmit")
-	m.data.SetDescription("The amount of data that was transmitted over the network by the host.")
-	m.data.SetUnit("{KiBy/s}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterHostNetworkThroughputTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterHostNetworkThroughputTransmit) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterHostNetworkThroughputTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterHostNetworkThroughputTransmit(settings MetricSettings) metricVcenterHostNetworkThroughputTransmit {
-	m := metricVcenterHostNetworkThroughputTransmit{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -2161,108 +1591,6 @@ func (m *metricVcenterVMDiskLatencyAvg) emit(metrics pmetric.MetricSlice) {
 
 func newMetricVcenterVMDiskLatencyAvg(settings MetricSettings) metricVcenterVMDiskLatencyAvg {
 	m := metricVcenterVMDiskLatencyAvg{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterVMDiskLatencyAvgRead struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.vm.disk.latency.avg.read metric with initial data.
-func (m *metricVcenterVMDiskLatencyAvgRead) init() {
-	m.data.SetName("vcenter.vm.disk.latency.avg.read")
-	m.data.SetDescription("The latency of reads to the virtual machine's disk.")
-	m.data.SetUnit("ms")
-	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricVcenterVMDiskLatencyAvgRead) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskTypeAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("disk_type", diskTypeAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterVMDiskLatencyAvgRead) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterVMDiskLatencyAvgRead) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterVMDiskLatencyAvgRead(settings MetricSettings) metricVcenterVMDiskLatencyAvgRead {
-	m := metricVcenterVMDiskLatencyAvgRead{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterVMDiskLatencyAvgWrite struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.vm.disk.latency.avg.write metric with initial data.
-func (m *metricVcenterVMDiskLatencyAvgWrite) init() {
-	m.data.SetName("vcenter.vm.disk.latency.avg.write")
-	m.data.SetDescription("The latency of writes to the virtual machine's disk.")
-	m.data.SetUnit("ms")
-	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricVcenterVMDiskLatencyAvgWrite) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskTypeAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-	dp.Attributes().PutStr("disk_type", diskTypeAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterVMDiskLatencyAvgWrite) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterVMDiskLatencyAvgWrite) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterVMDiskLatencyAvgWrite(settings MetricSettings) metricVcenterVMDiskLatencyAvgWrite {
-	m := metricVcenterVMDiskLatencyAvgWrite{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -2627,108 +1955,6 @@ func newMetricVcenterVMNetworkPacketCount(settings MetricSettings) metricVcenter
 	return m
 }
 
-type metricVcenterVMNetworkPacketCountReceive struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.vm.network.packet.count.receive metric with initial data.
-func (m *metricVcenterVMNetworkPacketCountReceive) init() {
-	m.data.SetName("vcenter.vm.network.packet.count.receive")
-	m.data.SetDescription("The amount of packets that was received over the instance's network.")
-	m.data.SetUnit("{packets/sec}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterVMNetworkPacketCountReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterVMNetworkPacketCountReceive) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterVMNetworkPacketCountReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterVMNetworkPacketCountReceive(settings MetricSettings) metricVcenterVMNetworkPacketCountReceive {
-	m := metricVcenterVMNetworkPacketCountReceive{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterVMNetworkPacketCountTransmit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.vm.network.packet.count.transmit metric with initial data.
-func (m *metricVcenterVMNetworkPacketCountTransmit) init() {
-	m.data.SetName("vcenter.vm.network.packet.count.transmit")
-	m.data.SetDescription("The amount of packets that was transmitted over the instance's network.")
-	m.data.SetUnit("{packets/sec}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterVMNetworkPacketCountTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterVMNetworkPacketCountTransmit) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterVMNetworkPacketCountTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterVMNetworkPacketCountTransmit(settings MetricSettings) metricVcenterVMNetworkPacketCountTransmit {
-	m := metricVcenterVMNetworkPacketCountTransmit{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricVcenterVMNetworkThroughput struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -2775,108 +2001,6 @@ func (m *metricVcenterVMNetworkThroughput) emit(metrics pmetric.MetricSlice) {
 
 func newMetricVcenterVMNetworkThroughput(settings MetricSettings) metricVcenterVMNetworkThroughput {
 	m := metricVcenterVMNetworkThroughput{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterVMNetworkThroughputReceive struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.vm.network.throughput.receive metric with initial data.
-func (m *metricVcenterVMNetworkThroughputReceive) init() {
-	m.data.SetName("vcenter.vm.network.throughput.receive")
-	m.data.SetDescription("The amount of data that was received over the network of the virtual machine.")
-	m.data.SetUnit("By/sec")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterVMNetworkThroughputReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterVMNetworkThroughputReceive) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterVMNetworkThroughputReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterVMNetworkThroughputReceive(settings MetricSettings) metricVcenterVMNetworkThroughputReceive {
-	m := metricVcenterVMNetworkThroughputReceive{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricVcenterVMNetworkThroughputTransmit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills vcenter.vm.network.throughput.transmit metric with initial data.
-func (m *metricVcenterVMNetworkThroughputTransmit) init() {
-	m.data.SetName("vcenter.vm.network.throughput.transmit")
-	m.data.SetDescription("The amount of data that was transmitted over the network of the virtual machine.")
-	m.data.SetUnit("By/sec")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricVcenterVMNetworkThroughputTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVcenterVMNetworkThroughputTransmit) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVcenterVMNetworkThroughputTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricVcenterVMNetworkThroughputTransmit(settings MetricSettings) metricVcenterVMNetworkThroughputTransmit {
-	m := metricVcenterVMNetworkThroughputTransmit{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -2938,61 +2062,45 @@ func newMetricVcenterVMNetworkUsage(settings MetricSettings) metricVcenterVMNetw
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                                    pcommon.Timestamp   // start time that will be applied to all recorded data points.
-	metricsCapacity                              int                 // maximum observed number of metrics per resource.
-	resourceCapacity                             int                 // maximum observed number of resource attributes.
-	metricsBuffer                                pmetric.Metrics     // accumulates metrics data before emitting.
-	buildInfo                                    component.BuildInfo // contains version information
-	metricVcenterClusterCPUEffective             metricVcenterClusterCPUEffective
-	metricVcenterClusterCPULimit                 metricVcenterClusterCPULimit
-	metricVcenterClusterHostCount                metricVcenterClusterHostCount
-	metricVcenterClusterMemoryEffective          metricVcenterClusterMemoryEffective
-	metricVcenterClusterMemoryLimit              metricVcenterClusterMemoryLimit
-	metricVcenterClusterMemoryUsed               metricVcenterClusterMemoryUsed
-	metricVcenterClusterVMCount                  metricVcenterClusterVMCount
-	metricVcenterDatastoreDiskUsage              metricVcenterDatastoreDiskUsage
-	metricVcenterDatastoreDiskUtilization        metricVcenterDatastoreDiskUtilization
-	metricVcenterHostCPUUsage                    metricVcenterHostCPUUsage
-	metricVcenterHostCPUUtilization              metricVcenterHostCPUUtilization
-	metricVcenterHostDiskLatencyAvg              metricVcenterHostDiskLatencyAvg
-	metricVcenterHostDiskLatencyAvgRead          metricVcenterHostDiskLatencyAvgRead
-	metricVcenterHostDiskLatencyAvgWrite         metricVcenterHostDiskLatencyAvgWrite
-	metricVcenterHostDiskLatencyMax              metricVcenterHostDiskLatencyMax
-	metricVcenterHostDiskThroughput              metricVcenterHostDiskThroughput
-	metricVcenterHostDiskThroughputRead          metricVcenterHostDiskThroughputRead
-	metricVcenterHostDiskThroughputWrite         metricVcenterHostDiskThroughputWrite
-	metricVcenterHostMemoryUsage                 metricVcenterHostMemoryUsage
-	metricVcenterHostMemoryUtilization           metricVcenterHostMemoryUtilization
-	metricVcenterHostNetworkPacketCount          metricVcenterHostNetworkPacketCount
-	metricVcenterHostNetworkPacketCountReceive   metricVcenterHostNetworkPacketCountReceive
-	metricVcenterHostNetworkPacketCountTransmit  metricVcenterHostNetworkPacketCountTransmit
-	metricVcenterHostNetworkPacketErrors         metricVcenterHostNetworkPacketErrors
-	metricVcenterHostNetworkPacketErrorsReceive  metricVcenterHostNetworkPacketErrorsReceive
-	metricVcenterHostNetworkPacketErrorsTransmit metricVcenterHostNetworkPacketErrorsTransmit
-	metricVcenterHostNetworkThroughput           metricVcenterHostNetworkThroughput
-	metricVcenterHostNetworkThroughputReceive    metricVcenterHostNetworkThroughputReceive
-	metricVcenterHostNetworkThroughputTransmit   metricVcenterHostNetworkThroughputTransmit
-	metricVcenterHostNetworkUsage                metricVcenterHostNetworkUsage
-	metricVcenterResourcePoolCPUShares           metricVcenterResourcePoolCPUShares
-	metricVcenterResourcePoolCPUUsage            metricVcenterResourcePoolCPUUsage
-	metricVcenterResourcePoolMemoryShares        metricVcenterResourcePoolMemoryShares
-	metricVcenterResourcePoolMemoryUsage         metricVcenterResourcePoolMemoryUsage
-	metricVcenterVMDiskLatencyAvg                metricVcenterVMDiskLatencyAvg
-	metricVcenterVMDiskLatencyAvgRead            metricVcenterVMDiskLatencyAvgRead
-	metricVcenterVMDiskLatencyAvgWrite           metricVcenterVMDiskLatencyAvgWrite
-	metricVcenterVMDiskLatencyMax                metricVcenterVMDiskLatencyMax
-	metricVcenterVMDiskThroughput                metricVcenterVMDiskThroughput
-	metricVcenterVMDiskUsage                     metricVcenterVMDiskUsage
-	metricVcenterVMDiskUtilization               metricVcenterVMDiskUtilization
-	metricVcenterVMMemoryBallooned               metricVcenterVMMemoryBallooned
-	metricVcenterVMMemoryUsage                   metricVcenterVMMemoryUsage
-	metricVcenterVMNetworkPacketCount            metricVcenterVMNetworkPacketCount
-	metricVcenterVMNetworkPacketCountReceive     metricVcenterVMNetworkPacketCountReceive
-	metricVcenterVMNetworkPacketCountTransmit    metricVcenterVMNetworkPacketCountTransmit
-	metricVcenterVMNetworkThroughput             metricVcenterVMNetworkThroughput
-	metricVcenterVMNetworkThroughputReceive      metricVcenterVMNetworkThroughputReceive
-	metricVcenterVMNetworkThroughputTransmit     metricVcenterVMNetworkThroughputTransmit
-	metricVcenterVMNetworkUsage                  metricVcenterVMNetworkUsage
+	startTime                             pcommon.Timestamp   // start time that will be applied to all recorded data points.
+	metricsCapacity                       int                 // maximum observed number of metrics per resource.
+	resourceCapacity                      int                 // maximum observed number of resource attributes.
+	metricsBuffer                         pmetric.Metrics     // accumulates metrics data before emitting.
+	buildInfo                             component.BuildInfo // contains version information
+	metricVcenterClusterCPUEffective      metricVcenterClusterCPUEffective
+	metricVcenterClusterCPULimit          metricVcenterClusterCPULimit
+	metricVcenterClusterHostCount         metricVcenterClusterHostCount
+	metricVcenterClusterMemoryEffective   metricVcenterClusterMemoryEffective
+	metricVcenterClusterMemoryLimit       metricVcenterClusterMemoryLimit
+	metricVcenterClusterMemoryUsed        metricVcenterClusterMemoryUsed
+	metricVcenterClusterVMCount           metricVcenterClusterVMCount
+	metricVcenterDatastoreDiskUsage       metricVcenterDatastoreDiskUsage
+	metricVcenterDatastoreDiskUtilization metricVcenterDatastoreDiskUtilization
+	metricVcenterHostCPUUsage             metricVcenterHostCPUUsage
+	metricVcenterHostCPUUtilization       metricVcenterHostCPUUtilization
+	metricVcenterHostDiskLatencyAvg       metricVcenterHostDiskLatencyAvg
+	metricVcenterHostDiskLatencyMax       metricVcenterHostDiskLatencyMax
+	metricVcenterHostDiskThroughput       metricVcenterHostDiskThroughput
+	metricVcenterHostMemoryUsage          metricVcenterHostMemoryUsage
+	metricVcenterHostMemoryUtilization    metricVcenterHostMemoryUtilization
+	metricVcenterHostNetworkPacketCount   metricVcenterHostNetworkPacketCount
+	metricVcenterHostNetworkPacketErrors  metricVcenterHostNetworkPacketErrors
+	metricVcenterHostNetworkThroughput    metricVcenterHostNetworkThroughput
+	metricVcenterHostNetworkUsage         metricVcenterHostNetworkUsage
+	metricVcenterResourcePoolCPUShares    metricVcenterResourcePoolCPUShares
+	metricVcenterResourcePoolCPUUsage     metricVcenterResourcePoolCPUUsage
+	metricVcenterResourcePoolMemoryShares metricVcenterResourcePoolMemoryShares
+	metricVcenterResourcePoolMemoryUsage  metricVcenterResourcePoolMemoryUsage
+	metricVcenterVMDiskLatencyAvg         metricVcenterVMDiskLatencyAvg
+	metricVcenterVMDiskLatencyMax         metricVcenterVMDiskLatencyMax
+	metricVcenterVMDiskThroughput         metricVcenterVMDiskThroughput
+	metricVcenterVMDiskUsage              metricVcenterVMDiskUsage
+	metricVcenterVMDiskUtilization        metricVcenterVMDiskUtilization
+	metricVcenterVMMemoryBallooned        metricVcenterVMMemoryBallooned
+	metricVcenterVMMemoryUsage            metricVcenterVMMemoryUsage
+	metricVcenterVMNetworkPacketCount     metricVcenterVMNetworkPacketCount
+	metricVcenterVMNetworkThroughput      metricVcenterVMNetworkThroughput
+	metricVcenterVMNetworkUsage           metricVcenterVMNetworkUsage
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -3007,59 +2115,43 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		startTime:                                    pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                                pmetric.NewMetrics(),
-		buildInfo:                                    buildInfo,
-		metricVcenterClusterCPUEffective:             newMetricVcenterClusterCPUEffective(settings.VcenterClusterCPUEffective),
-		metricVcenterClusterCPULimit:                 newMetricVcenterClusterCPULimit(settings.VcenterClusterCPULimit),
-		metricVcenterClusterHostCount:                newMetricVcenterClusterHostCount(settings.VcenterClusterHostCount),
-		metricVcenterClusterMemoryEffective:          newMetricVcenterClusterMemoryEffective(settings.VcenterClusterMemoryEffective),
-		metricVcenterClusterMemoryLimit:              newMetricVcenterClusterMemoryLimit(settings.VcenterClusterMemoryLimit),
-		metricVcenterClusterMemoryUsed:               newMetricVcenterClusterMemoryUsed(settings.VcenterClusterMemoryUsed),
-		metricVcenterClusterVMCount:                  newMetricVcenterClusterVMCount(settings.VcenterClusterVMCount),
-		metricVcenterDatastoreDiskUsage:              newMetricVcenterDatastoreDiskUsage(settings.VcenterDatastoreDiskUsage),
-		metricVcenterDatastoreDiskUtilization:        newMetricVcenterDatastoreDiskUtilization(settings.VcenterDatastoreDiskUtilization),
-		metricVcenterHostCPUUsage:                    newMetricVcenterHostCPUUsage(settings.VcenterHostCPUUsage),
-		metricVcenterHostCPUUtilization:              newMetricVcenterHostCPUUtilization(settings.VcenterHostCPUUtilization),
-		metricVcenterHostDiskLatencyAvg:              newMetricVcenterHostDiskLatencyAvg(settings.VcenterHostDiskLatencyAvg),
-		metricVcenterHostDiskLatencyAvgRead:          newMetricVcenterHostDiskLatencyAvgRead(settings.VcenterHostDiskLatencyAvgRead),
-		metricVcenterHostDiskLatencyAvgWrite:         newMetricVcenterHostDiskLatencyAvgWrite(settings.VcenterHostDiskLatencyAvgWrite),
-		metricVcenterHostDiskLatencyMax:              newMetricVcenterHostDiskLatencyMax(settings.VcenterHostDiskLatencyMax),
-		metricVcenterHostDiskThroughput:              newMetricVcenterHostDiskThroughput(settings.VcenterHostDiskThroughput),
-		metricVcenterHostDiskThroughputRead:          newMetricVcenterHostDiskThroughputRead(settings.VcenterHostDiskThroughputRead),
-		metricVcenterHostDiskThroughputWrite:         newMetricVcenterHostDiskThroughputWrite(settings.VcenterHostDiskThroughputWrite),
-		metricVcenterHostMemoryUsage:                 newMetricVcenterHostMemoryUsage(settings.VcenterHostMemoryUsage),
-		metricVcenterHostMemoryUtilization:           newMetricVcenterHostMemoryUtilization(settings.VcenterHostMemoryUtilization),
-		metricVcenterHostNetworkPacketCount:          newMetricVcenterHostNetworkPacketCount(settings.VcenterHostNetworkPacketCount),
-		metricVcenterHostNetworkPacketCountReceive:   newMetricVcenterHostNetworkPacketCountReceive(settings.VcenterHostNetworkPacketCountReceive),
-		metricVcenterHostNetworkPacketCountTransmit:  newMetricVcenterHostNetworkPacketCountTransmit(settings.VcenterHostNetworkPacketCountTransmit),
-		metricVcenterHostNetworkPacketErrors:         newMetricVcenterHostNetworkPacketErrors(settings.VcenterHostNetworkPacketErrors),
-		metricVcenterHostNetworkPacketErrorsReceive:  newMetricVcenterHostNetworkPacketErrorsReceive(settings.VcenterHostNetworkPacketErrorsReceive),
-		metricVcenterHostNetworkPacketErrorsTransmit: newMetricVcenterHostNetworkPacketErrorsTransmit(settings.VcenterHostNetworkPacketErrorsTransmit),
-		metricVcenterHostNetworkThroughput:           newMetricVcenterHostNetworkThroughput(settings.VcenterHostNetworkThroughput),
-		metricVcenterHostNetworkThroughputReceive:    newMetricVcenterHostNetworkThroughputReceive(settings.VcenterHostNetworkThroughputReceive),
-		metricVcenterHostNetworkThroughputTransmit:   newMetricVcenterHostNetworkThroughputTransmit(settings.VcenterHostNetworkThroughputTransmit),
-		metricVcenterHostNetworkUsage:                newMetricVcenterHostNetworkUsage(settings.VcenterHostNetworkUsage),
-		metricVcenterResourcePoolCPUShares:           newMetricVcenterResourcePoolCPUShares(settings.VcenterResourcePoolCPUShares),
-		metricVcenterResourcePoolCPUUsage:            newMetricVcenterResourcePoolCPUUsage(settings.VcenterResourcePoolCPUUsage),
-		metricVcenterResourcePoolMemoryShares:        newMetricVcenterResourcePoolMemoryShares(settings.VcenterResourcePoolMemoryShares),
-		metricVcenterResourcePoolMemoryUsage:         newMetricVcenterResourcePoolMemoryUsage(settings.VcenterResourcePoolMemoryUsage),
-		metricVcenterVMDiskLatencyAvg:                newMetricVcenterVMDiskLatencyAvg(settings.VcenterVMDiskLatencyAvg),
-		metricVcenterVMDiskLatencyAvgRead:            newMetricVcenterVMDiskLatencyAvgRead(settings.VcenterVMDiskLatencyAvgRead),
-		metricVcenterVMDiskLatencyAvgWrite:           newMetricVcenterVMDiskLatencyAvgWrite(settings.VcenterVMDiskLatencyAvgWrite),
-		metricVcenterVMDiskLatencyMax:                newMetricVcenterVMDiskLatencyMax(settings.VcenterVMDiskLatencyMax),
-		metricVcenterVMDiskThroughput:                newMetricVcenterVMDiskThroughput(settings.VcenterVMDiskThroughput),
-		metricVcenterVMDiskUsage:                     newMetricVcenterVMDiskUsage(settings.VcenterVMDiskUsage),
-		metricVcenterVMDiskUtilization:               newMetricVcenterVMDiskUtilization(settings.VcenterVMDiskUtilization),
-		metricVcenterVMMemoryBallooned:               newMetricVcenterVMMemoryBallooned(settings.VcenterVMMemoryBallooned),
-		metricVcenterVMMemoryUsage:                   newMetricVcenterVMMemoryUsage(settings.VcenterVMMemoryUsage),
-		metricVcenterVMNetworkPacketCount:            newMetricVcenterVMNetworkPacketCount(settings.VcenterVMNetworkPacketCount),
-		metricVcenterVMNetworkPacketCountReceive:     newMetricVcenterVMNetworkPacketCountReceive(settings.VcenterVMNetworkPacketCountReceive),
-		metricVcenterVMNetworkPacketCountTransmit:    newMetricVcenterVMNetworkPacketCountTransmit(settings.VcenterVMNetworkPacketCountTransmit),
-		metricVcenterVMNetworkThroughput:             newMetricVcenterVMNetworkThroughput(settings.VcenterVMNetworkThroughput),
-		metricVcenterVMNetworkThroughputReceive:      newMetricVcenterVMNetworkThroughputReceive(settings.VcenterVMNetworkThroughputReceive),
-		metricVcenterVMNetworkThroughputTransmit:     newMetricVcenterVMNetworkThroughputTransmit(settings.VcenterVMNetworkThroughputTransmit),
-		metricVcenterVMNetworkUsage:                  newMetricVcenterVMNetworkUsage(settings.VcenterVMNetworkUsage),
+		startTime:                             pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                         pmetric.NewMetrics(),
+		buildInfo:                             buildInfo,
+		metricVcenterClusterCPUEffective:      newMetricVcenterClusterCPUEffective(settings.VcenterClusterCPUEffective),
+		metricVcenterClusterCPULimit:          newMetricVcenterClusterCPULimit(settings.VcenterClusterCPULimit),
+		metricVcenterClusterHostCount:         newMetricVcenterClusterHostCount(settings.VcenterClusterHostCount),
+		metricVcenterClusterMemoryEffective:   newMetricVcenterClusterMemoryEffective(settings.VcenterClusterMemoryEffective),
+		metricVcenterClusterMemoryLimit:       newMetricVcenterClusterMemoryLimit(settings.VcenterClusterMemoryLimit),
+		metricVcenterClusterMemoryUsed:        newMetricVcenterClusterMemoryUsed(settings.VcenterClusterMemoryUsed),
+		metricVcenterClusterVMCount:           newMetricVcenterClusterVMCount(settings.VcenterClusterVMCount),
+		metricVcenterDatastoreDiskUsage:       newMetricVcenterDatastoreDiskUsage(settings.VcenterDatastoreDiskUsage),
+		metricVcenterDatastoreDiskUtilization: newMetricVcenterDatastoreDiskUtilization(settings.VcenterDatastoreDiskUtilization),
+		metricVcenterHostCPUUsage:             newMetricVcenterHostCPUUsage(settings.VcenterHostCPUUsage),
+		metricVcenterHostCPUUtilization:       newMetricVcenterHostCPUUtilization(settings.VcenterHostCPUUtilization),
+		metricVcenterHostDiskLatencyAvg:       newMetricVcenterHostDiskLatencyAvg(settings.VcenterHostDiskLatencyAvg),
+		metricVcenterHostDiskLatencyMax:       newMetricVcenterHostDiskLatencyMax(settings.VcenterHostDiskLatencyMax),
+		metricVcenterHostDiskThroughput:       newMetricVcenterHostDiskThroughput(settings.VcenterHostDiskThroughput),
+		metricVcenterHostMemoryUsage:          newMetricVcenterHostMemoryUsage(settings.VcenterHostMemoryUsage),
+		metricVcenterHostMemoryUtilization:    newMetricVcenterHostMemoryUtilization(settings.VcenterHostMemoryUtilization),
+		metricVcenterHostNetworkPacketCount:   newMetricVcenterHostNetworkPacketCount(settings.VcenterHostNetworkPacketCount),
+		metricVcenterHostNetworkPacketErrors:  newMetricVcenterHostNetworkPacketErrors(settings.VcenterHostNetworkPacketErrors),
+		metricVcenterHostNetworkThroughput:    newMetricVcenterHostNetworkThroughput(settings.VcenterHostNetworkThroughput),
+		metricVcenterHostNetworkUsage:         newMetricVcenterHostNetworkUsage(settings.VcenterHostNetworkUsage),
+		metricVcenterResourcePoolCPUShares:    newMetricVcenterResourcePoolCPUShares(settings.VcenterResourcePoolCPUShares),
+		metricVcenterResourcePoolCPUUsage:     newMetricVcenterResourcePoolCPUUsage(settings.VcenterResourcePoolCPUUsage),
+		metricVcenterResourcePoolMemoryShares: newMetricVcenterResourcePoolMemoryShares(settings.VcenterResourcePoolMemoryShares),
+		metricVcenterResourcePoolMemoryUsage:  newMetricVcenterResourcePoolMemoryUsage(settings.VcenterResourcePoolMemoryUsage),
+		metricVcenterVMDiskLatencyAvg:         newMetricVcenterVMDiskLatencyAvg(settings.VcenterVMDiskLatencyAvg),
+		metricVcenterVMDiskLatencyMax:         newMetricVcenterVMDiskLatencyMax(settings.VcenterVMDiskLatencyMax),
+		metricVcenterVMDiskThroughput:         newMetricVcenterVMDiskThroughput(settings.VcenterVMDiskThroughput),
+		metricVcenterVMDiskUsage:              newMetricVcenterVMDiskUsage(settings.VcenterVMDiskUsage),
+		metricVcenterVMDiskUtilization:        newMetricVcenterVMDiskUtilization(settings.VcenterVMDiskUtilization),
+		metricVcenterVMMemoryBallooned:        newMetricVcenterVMMemoryBallooned(settings.VcenterVMMemoryBallooned),
+		metricVcenterVMMemoryUsage:            newMetricVcenterVMMemoryUsage(settings.VcenterVMMemoryUsage),
+		metricVcenterVMNetworkPacketCount:     newMetricVcenterVMNetworkPacketCount(settings.VcenterVMNetworkPacketCount),
+		metricVcenterVMNetworkThroughput:      newMetricVcenterVMNetworkThroughput(settings.VcenterVMNetworkThroughput),
+		metricVcenterVMNetworkUsage:           newMetricVcenterVMNetworkUsage(settings.VcenterVMNetworkUsage),
 	}
 	for _, op := range options {
 		op(mb)
@@ -3166,31 +2258,19 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricVcenterHostCPUUsage.emit(ils.Metrics())
 	mb.metricVcenterHostCPUUtilization.emit(ils.Metrics())
 	mb.metricVcenterHostDiskLatencyAvg.emit(ils.Metrics())
-	mb.metricVcenterHostDiskLatencyAvgRead.emit(ils.Metrics())
-	mb.metricVcenterHostDiskLatencyAvgWrite.emit(ils.Metrics())
 	mb.metricVcenterHostDiskLatencyMax.emit(ils.Metrics())
 	mb.metricVcenterHostDiskThroughput.emit(ils.Metrics())
-	mb.metricVcenterHostDiskThroughputRead.emit(ils.Metrics())
-	mb.metricVcenterHostDiskThroughputWrite.emit(ils.Metrics())
 	mb.metricVcenterHostMemoryUsage.emit(ils.Metrics())
 	mb.metricVcenterHostMemoryUtilization.emit(ils.Metrics())
 	mb.metricVcenterHostNetworkPacketCount.emit(ils.Metrics())
-	mb.metricVcenterHostNetworkPacketCountReceive.emit(ils.Metrics())
-	mb.metricVcenterHostNetworkPacketCountTransmit.emit(ils.Metrics())
 	mb.metricVcenterHostNetworkPacketErrors.emit(ils.Metrics())
-	mb.metricVcenterHostNetworkPacketErrorsReceive.emit(ils.Metrics())
-	mb.metricVcenterHostNetworkPacketErrorsTransmit.emit(ils.Metrics())
 	mb.metricVcenterHostNetworkThroughput.emit(ils.Metrics())
-	mb.metricVcenterHostNetworkThroughputReceive.emit(ils.Metrics())
-	mb.metricVcenterHostNetworkThroughputTransmit.emit(ils.Metrics())
 	mb.metricVcenterHostNetworkUsage.emit(ils.Metrics())
 	mb.metricVcenterResourcePoolCPUShares.emit(ils.Metrics())
 	mb.metricVcenterResourcePoolCPUUsage.emit(ils.Metrics())
 	mb.metricVcenterResourcePoolMemoryShares.emit(ils.Metrics())
 	mb.metricVcenterResourcePoolMemoryUsage.emit(ils.Metrics())
 	mb.metricVcenterVMDiskLatencyAvg.emit(ils.Metrics())
-	mb.metricVcenterVMDiskLatencyAvgRead.emit(ils.Metrics())
-	mb.metricVcenterVMDiskLatencyAvgWrite.emit(ils.Metrics())
 	mb.metricVcenterVMDiskLatencyMax.emit(ils.Metrics())
 	mb.metricVcenterVMDiskThroughput.emit(ils.Metrics())
 	mb.metricVcenterVMDiskUsage.emit(ils.Metrics())
@@ -3198,11 +2278,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricVcenterVMMemoryBallooned.emit(ils.Metrics())
 	mb.metricVcenterVMMemoryUsage.emit(ils.Metrics())
 	mb.metricVcenterVMNetworkPacketCount.emit(ils.Metrics())
-	mb.metricVcenterVMNetworkPacketCountReceive.emit(ils.Metrics())
-	mb.metricVcenterVMNetworkPacketCountTransmit.emit(ils.Metrics())
 	mb.metricVcenterVMNetworkThroughput.emit(ils.Metrics())
-	mb.metricVcenterVMNetworkThroughputReceive.emit(ils.Metrics())
-	mb.metricVcenterVMNetworkThroughputTransmit.emit(ils.Metrics())
 	mb.metricVcenterVMNetworkUsage.emit(ils.Metrics())
 	for _, op := range rmo {
 		op(rm)
@@ -3283,16 +2359,6 @@ func (mb *MetricsBuilder) RecordVcenterHostDiskLatencyAvgDataPoint(ts pcommon.Ti
 	mb.metricVcenterHostDiskLatencyAvg.recordDataPoint(mb.startTime, ts, val, diskDirectionAttributeValue.String())
 }
 
-// RecordVcenterHostDiskLatencyAvgReadDataPoint adds a data point to vcenter.host.disk.latency.avg.read metric.
-func (mb *MetricsBuilder) RecordVcenterHostDiskLatencyAvgReadDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostDiskLatencyAvgRead.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordVcenterHostDiskLatencyAvgWriteDataPoint adds a data point to vcenter.host.disk.latency.avg.write metric.
-func (mb *MetricsBuilder) RecordVcenterHostDiskLatencyAvgWriteDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostDiskLatencyAvgWrite.recordDataPoint(mb.startTime, ts, val)
-}
-
 // RecordVcenterHostDiskLatencyMaxDataPoint adds a data point to vcenter.host.disk.latency.max metric.
 func (mb *MetricsBuilder) RecordVcenterHostDiskLatencyMaxDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricVcenterHostDiskLatencyMax.recordDataPoint(mb.startTime, ts, val)
@@ -3301,16 +2367,6 @@ func (mb *MetricsBuilder) RecordVcenterHostDiskLatencyMaxDataPoint(ts pcommon.Ti
 // RecordVcenterHostDiskThroughputDataPoint adds a data point to vcenter.host.disk.throughput metric.
 func (mb *MetricsBuilder) RecordVcenterHostDiskThroughputDataPoint(ts pcommon.Timestamp, val int64, diskDirectionAttributeValue AttributeDiskDirection) {
 	mb.metricVcenterHostDiskThroughput.recordDataPoint(mb.startTime, ts, val, diskDirectionAttributeValue.String())
-}
-
-// RecordVcenterHostDiskThroughputReadDataPoint adds a data point to vcenter.host.disk.throughput.read metric.
-func (mb *MetricsBuilder) RecordVcenterHostDiskThroughputReadDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostDiskThroughputRead.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordVcenterHostDiskThroughputWriteDataPoint adds a data point to vcenter.host.disk.throughput.write metric.
-func (mb *MetricsBuilder) RecordVcenterHostDiskThroughputWriteDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostDiskThroughputWrite.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordVcenterHostMemoryUsageDataPoint adds a data point to vcenter.host.memory.usage metric.
@@ -3328,44 +2384,14 @@ func (mb *MetricsBuilder) RecordVcenterHostNetworkPacketCountDataPoint(ts pcommo
 	mb.metricVcenterHostNetworkPacketCount.recordDataPoint(mb.startTime, ts, val, throughputDirectionAttributeValue.String())
 }
 
-// RecordVcenterHostNetworkPacketCountReceiveDataPoint adds a data point to vcenter.host.network.packet.count.receive metric.
-func (mb *MetricsBuilder) RecordVcenterHostNetworkPacketCountReceiveDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostNetworkPacketCountReceive.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordVcenterHostNetworkPacketCountTransmitDataPoint adds a data point to vcenter.host.network.packet.count.transmit metric.
-func (mb *MetricsBuilder) RecordVcenterHostNetworkPacketCountTransmitDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostNetworkPacketCountTransmit.recordDataPoint(mb.startTime, ts, val)
-}
-
 // RecordVcenterHostNetworkPacketErrorsDataPoint adds a data point to vcenter.host.network.packet.errors metric.
 func (mb *MetricsBuilder) RecordVcenterHostNetworkPacketErrorsDataPoint(ts pcommon.Timestamp, val int64, throughputDirectionAttributeValue AttributeThroughputDirection) {
 	mb.metricVcenterHostNetworkPacketErrors.recordDataPoint(mb.startTime, ts, val, throughputDirectionAttributeValue.String())
 }
 
-// RecordVcenterHostNetworkPacketErrorsReceiveDataPoint adds a data point to vcenter.host.network.packet.errors.receive metric.
-func (mb *MetricsBuilder) RecordVcenterHostNetworkPacketErrorsReceiveDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostNetworkPacketErrorsReceive.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordVcenterHostNetworkPacketErrorsTransmitDataPoint adds a data point to vcenter.host.network.packet.errors.transmit metric.
-func (mb *MetricsBuilder) RecordVcenterHostNetworkPacketErrorsTransmitDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostNetworkPacketErrorsTransmit.recordDataPoint(mb.startTime, ts, val)
-}
-
 // RecordVcenterHostNetworkThroughputDataPoint adds a data point to vcenter.host.network.throughput metric.
 func (mb *MetricsBuilder) RecordVcenterHostNetworkThroughputDataPoint(ts pcommon.Timestamp, val int64, throughputDirectionAttributeValue AttributeThroughputDirection) {
 	mb.metricVcenterHostNetworkThroughput.recordDataPoint(mb.startTime, ts, val, throughputDirectionAttributeValue.String())
-}
-
-// RecordVcenterHostNetworkThroughputReceiveDataPoint adds a data point to vcenter.host.network.throughput.receive metric.
-func (mb *MetricsBuilder) RecordVcenterHostNetworkThroughputReceiveDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostNetworkThroughputReceive.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordVcenterHostNetworkThroughputTransmitDataPoint adds a data point to vcenter.host.network.throughput.transmit metric.
-func (mb *MetricsBuilder) RecordVcenterHostNetworkThroughputTransmitDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterHostNetworkThroughputTransmit.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordVcenterHostNetworkUsageDataPoint adds a data point to vcenter.host.network.usage metric.
@@ -3396,16 +2422,6 @@ func (mb *MetricsBuilder) RecordVcenterResourcePoolMemoryUsageDataPoint(ts pcomm
 // RecordVcenterVMDiskLatencyAvgDataPoint adds a data point to vcenter.vm.disk.latency.avg metric.
 func (mb *MetricsBuilder) RecordVcenterVMDiskLatencyAvgDataPoint(ts pcommon.Timestamp, val int64, diskDirectionAttributeValue AttributeDiskDirection, diskTypeAttributeValue AttributeDiskType) {
 	mb.metricVcenterVMDiskLatencyAvg.recordDataPoint(mb.startTime, ts, val, diskDirectionAttributeValue.String(), diskTypeAttributeValue.String())
-}
-
-// RecordVcenterVMDiskLatencyAvgReadDataPoint adds a data point to vcenter.vm.disk.latency.avg.read metric.
-func (mb *MetricsBuilder) RecordVcenterVMDiskLatencyAvgReadDataPoint(ts pcommon.Timestamp, val int64, diskTypeAttributeValue AttributeDiskType) {
-	mb.metricVcenterVMDiskLatencyAvgRead.recordDataPoint(mb.startTime, ts, val, diskTypeAttributeValue.String())
-}
-
-// RecordVcenterVMDiskLatencyAvgWriteDataPoint adds a data point to vcenter.vm.disk.latency.avg.write metric.
-func (mb *MetricsBuilder) RecordVcenterVMDiskLatencyAvgWriteDataPoint(ts pcommon.Timestamp, val int64, diskTypeAttributeValue AttributeDiskType) {
-	mb.metricVcenterVMDiskLatencyAvgWrite.recordDataPoint(mb.startTime, ts, val, diskTypeAttributeValue.String())
 }
 
 // RecordVcenterVMDiskLatencyMaxDataPoint adds a data point to vcenter.vm.disk.latency.max metric.
@@ -3443,29 +2459,9 @@ func (mb *MetricsBuilder) RecordVcenterVMNetworkPacketCountDataPoint(ts pcommon.
 	mb.metricVcenterVMNetworkPacketCount.recordDataPoint(mb.startTime, ts, val, throughputDirectionAttributeValue.String())
 }
 
-// RecordVcenterVMNetworkPacketCountReceiveDataPoint adds a data point to vcenter.vm.network.packet.count.receive metric.
-func (mb *MetricsBuilder) RecordVcenterVMNetworkPacketCountReceiveDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterVMNetworkPacketCountReceive.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordVcenterVMNetworkPacketCountTransmitDataPoint adds a data point to vcenter.vm.network.packet.count.transmit metric.
-func (mb *MetricsBuilder) RecordVcenterVMNetworkPacketCountTransmitDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterVMNetworkPacketCountTransmit.recordDataPoint(mb.startTime, ts, val)
-}
-
 // RecordVcenterVMNetworkThroughputDataPoint adds a data point to vcenter.vm.network.throughput metric.
 func (mb *MetricsBuilder) RecordVcenterVMNetworkThroughputDataPoint(ts pcommon.Timestamp, val int64, throughputDirectionAttributeValue AttributeThroughputDirection) {
 	mb.metricVcenterVMNetworkThroughput.recordDataPoint(mb.startTime, ts, val, throughputDirectionAttributeValue.String())
-}
-
-// RecordVcenterVMNetworkThroughputReceiveDataPoint adds a data point to vcenter.vm.network.throughput.receive metric.
-func (mb *MetricsBuilder) RecordVcenterVMNetworkThroughputReceiveDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterVMNetworkThroughputReceive.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordVcenterVMNetworkThroughputTransmitDataPoint adds a data point to vcenter.vm.network.throughput.transmit metric.
-func (mb *MetricsBuilder) RecordVcenterVMNetworkThroughputTransmitDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricVcenterVMNetworkThroughputTransmit.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordVcenterVMNetworkUsageDataPoint adds a data point to vcenter.vm.network.usage metric.

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -160,7 +160,6 @@ metrics:
       value_type: int
       aggregation: cumulative
     attributes: []
-  # produced when receiver.vcenterreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   vcenter.host.disk.throughput:
     enabled: true
     description: Average number of kilobytes read from or written to the disk each second.
@@ -171,27 +170,6 @@ metrics:
       aggregation: cumulative
     attributes: [disk_direction]
     extended_documentation: As measured over the most recent 20s interval. Aggregated disk I/O rate. Requires Performance Level 4.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.disk.throughput.read:
-    enabled: true
-    description: Average number of kilobytes read from the disk each second.
-    unit: "{KiBy/s}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-    extended_documentation: As measured over the most recent 20s interval. Aggregated disk read rate. Requires Performance Level 4.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.disk.throughput.write:
-    enabled: true
-    description: Average number of kilobytes written to the disk each second.
-    unit: "{KiBy/s}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-    extended_documentation: As measured over the most recent 20s interval. Aggregated disk write rate. Requires Performance Level 4.
-  # produced when receiver.vcenterreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   vcenter.host.disk.latency.avg:
     enabled: true
     description: The latency of operations to the host system's disk.
@@ -200,22 +178,6 @@ metrics:
       value_type: int
     attributes: [disk_direction]
     extended_documentation: This latency is the sum of the device and kernel read and write latencies. Requires Performance Counter level 2 for metric to populate.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.disk.latency.avg.read:
-    enabled: true
-    description: The latency of reads to the host system's disk.
-    unit: ms
-    gauge:
-      value_type: int
-    extended_documentation: This latency is the sum of the device and kernel read latencies. Requires Performance Counter level 2 for metric to populate.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.disk.latency.avg.write:
-    enabled: true
-    description: The latency of writes to the host system's disk.
-    unit: ms
-    gauge:
-      value_type: int
-    extended_documentation: This latency is the sum of the device and kernel write latencies. Requires Performance Counter level 2 for metric to populate.
   vcenter.host.disk.latency.max:
     enabled: true
     description: Highest latency value across all disks used by the host.
@@ -240,7 +202,6 @@ metrics:
       value_type: int
       aggregation: cumulative
     attributes: []
-  # produced when receiver.vcenterreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   vcenter.host.network.throughput:
     enabled: true
     description: The amount of data that was transmitted or received over the network by the host.
@@ -251,26 +212,6 @@ metrics:
       aggregation: cumulative
     attributes: [throughput_direction]
     extended_documentation: As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.network.throughput.receive:
-    enabled: true
-    description: The amount of data that was received over the network by the host.
-    unit: "{KiBy/s}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-    extended_documentation: As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.network.throughput.transmit:
-    enabled: true
-    description: The amount of data that was transmitted over the network by the host.
-    unit: "{KiBy/s}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-    extended_documentation: As measured over the most recent 20s interval.
   vcenter.host.network.usage:
     enabled: true
     description: The sum of the data transmitted and received for all the NIC instances of the host.
@@ -280,7 +221,6 @@ metrics:
       value_type: int
       aggregation: cumulative
     attributes: []
-  # produced when receiver.vcenterreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   vcenter.host.network.packet.errors:
     enabled: true
     description: The summation of packet errors on the host network.
@@ -291,27 +231,6 @@ metrics:
       aggregation: cumulative
     attributes: [throughput_direction]
     extended_documentation: As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.network.packet.errors.receive:
-    enabled: true
-    description: The summation of receive packet errors on the host network.
-    unit: "{errors}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-    extended_documentation: As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.network.packet.errors.transmit:
-    enabled: true
-    description: The summation of transmit packet errors on the host network.
-    unit: "{errors}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-    extended_documentation: As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   vcenter.host.network.packet.count:
     enabled: true
     description: The number of packets transmitted and received, as measured over the most recent 20s interval.
@@ -321,24 +240,6 @@ metrics:
       value_type: int
       aggregation: cumulative
     attributes: [throughput_direction]
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.network.packet.count.receive:
-    enabled: true
-    description: The number of packets received, as measured over the most recent 20s interval.
-    unit: "{packets/sec}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.host.network.packet.count.transmit:
-    enabled: true
-    description: The number of packets transmitted, as measured over the most recent 20s interval.
-    unit: "{packets/sec}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
   vcenter.resource_pool.memory.usage:
     enabled: true
     description: The usage of the memory by the resource pool.
@@ -409,7 +310,6 @@ metrics:
     gauge:
       value_type: double
     attributes: []
-  # produced when receiver.vcenterreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   vcenter.vm.disk.latency.avg:
     enabled: true
     description: The latency of operations to the virtual machine's disk.
@@ -417,24 +317,6 @@ metrics:
     gauge:
       value_type: int
     attributes: [disk_direction, disk_type]
-    extended_documentation: Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.vm.disk.latency.avg.read:
-    enabled: true
-    description: The latency of reads to the virtual machine's disk.
-    unit: ms
-    gauge:
-      value_type: int
-    attributes: [disk_type]
-    extended_documentation: Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.vm.disk.latency.avg.write:
-    enabled: true
-    description: The latency of writes to the virtual machine's disk.
-    unit: ms
-    gauge:
-      value_type: int
-    attributes: [disk_type]
     extended_documentation: Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval.
   vcenter.vm.disk.latency.max:
     enabled: true
@@ -452,7 +334,6 @@ metrics:
       value_type: int
       aggregation: cumulative
     attributes: []
-  # produced when receiver.vcenterreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   vcenter.vm.network.throughput:
     enabled: true
     description: The amount of data that was transmitted or received over the network of the virtual machine.
@@ -463,27 +344,6 @@ metrics:
       aggregation: cumulative
     attributes: [throughput_direction]
     extended_documentation: As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.vm.network.throughput.receive:
-    enabled: true
-    description: The amount of data that was received over the network of the virtual machine.
-    unit: By/sec
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-    extended_documentation: As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.vm.network.throughput.transmit:
-    enabled: true
-    description: The amount of data that was transmitted over the network of the virtual machine.
-    unit: By/sec
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-    extended_documentation: As measured over the most recent 20s interval.
-  # produced when receiver.vcenterreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   vcenter.vm.network.packet.count:
     enabled: true
     description: The amount of packets that was received or transmitted over the instance's network.
@@ -493,24 +353,6 @@ metrics:
       value_type: int
       aggregation: cumulative
     attributes: [throughput_direction]
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.vm.network.packet.count.receive:
-    enabled: true
-    description: The amount of packets that was received over the instance's network.
-    unit: "{packets/sec}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
-  # produced when receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  vcenter.vm.network.packet.count.transmit:
-    enabled: true
-    description: The amount of packets that was transmitted over the instance's network.
-    unit: "{packets/sec}"
-    sum:
-      monotonic: false
-      value_type: int
-      aggregation: cumulative
   vcenter.vm.network.usage:
     enabled: true
     description: The network utilization combined transmit and receive rates during an interval.

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -188,65 +188,25 @@ func (v *vcenterMetricScraper) processVMPerformanceMetrics(info *perfSampleResul
 				switch val.Name {
 				// Performance monitoring level 1 metrics
 				case "net.bytesTx.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterVMNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterVMNetworkThroughputTransmitDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterVMNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
 				case "net.bytesRx.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterVMNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterVMNetworkThroughputReceiveDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterVMNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
 				case "net.usage.average":
 					v.mb.RecordVcenterVMNetworkUsageDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
 				case "net.packetsTx.summation":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterVMNetworkPacketCountDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterVMNetworkPacketCountTransmitDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterVMNetworkPacketCountDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
 				case "net.packetsRx.summation":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterVMNetworkPacketCountDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterVMNetworkPacketCountReceiveDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterVMNetworkPacketCountDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
 
 				// Performance monitoring level 2 metrics required
 				case "disk.totalReadLatency.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterVMDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionRead, metadata.AttributeDiskTypePhysical)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterVMDiskLatencyAvgReadDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskTypePhysical)
-					}
+					v.mb.RecordVcenterVMDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionRead, metadata.AttributeDiskTypePhysical)
 				case "virtualDisk.totalReadLatency.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterVMDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionRead, metadata.AttributeDiskTypeVirtual)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterVMDiskLatencyAvgReadDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskTypeVirtual)
-					}
+					v.mb.RecordVcenterVMDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionRead, metadata.AttributeDiskTypeVirtual)
 				case "disk.totalWriteLatency.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterVMDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite, metadata.AttributeDiskTypePhysical)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterVMDiskLatencyAvgWriteDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskTypePhysical)
-					}
+					v.mb.RecordVcenterVMDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite, metadata.AttributeDiskTypePhysical)
 				case "virtualDisk.totalWriteLatency.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterVMDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite, metadata.AttributeDiskTypeVirtual)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterVMDiskLatencyAvgWriteDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskTypeVirtual)
-					}
+					v.mb.RecordVcenterVMDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite, metadata.AttributeDiskTypeVirtual)
 				case "disk.maxTotalLatency.latest":
 					v.mb.RecordVcenterVMDiskLatencyMaxDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
 				}
@@ -265,82 +225,31 @@ func (v *vcenterMetricScraper) processHostPerformance(metrics []performance.Enti
 				case "net.usage.average":
 					v.mb.RecordVcenterHostNetworkUsageDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
 				case "net.bytesTx.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
-					}
-
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkThroughputTransmitDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
 				case "net.bytesRx.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkThroughputReceiveDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
 				case "net.packetsTx.summation":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkPacketCountDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkPacketCountTransmitDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostNetworkPacketCountDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
 				case "net.packetsRx.summation":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkPacketCountDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkPacketCountReceiveDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostNetworkPacketCountDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
 
 				// Following requires performance level 2
 				case "net.errorsRx.summation":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkPacketErrorsDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkPacketErrorsReceiveDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostNetworkPacketErrorsDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived)
 				case "net.errorsTx.summation":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkPacketErrorsDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostNetworkPacketErrorsTransmitDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostNetworkPacketErrorsDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionTransmitted)
 				case "disk.totalWriteLatency.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostDiskLatencyAvgWriteDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite)
 				case "disk.totalReadLatency.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionRead)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostDiskLatencyAvgReadDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionRead)
 				case "disk.maxTotalLatency.latest":
 					v.mb.RecordVcenterHostDiskLatencyMaxDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
 
 				// Following requires performance level 4
 				case "disk.read.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostDiskThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionRead)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostDiskThroughputReadDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostDiskThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionRead)
 				case "disk.write.average":
-					if v.emitMetricsWithDirectionAttribute {
-						v.mb.RecordVcenterHostDiskThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite)
-					}
-					if v.emitMetricsWithoutDirectionAttribute {
-						v.mb.RecordVcenterHostDiskThroughputWriteDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue)
-					}
+					v.mb.RecordVcenterHostDiskThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite)
 				}
 			}
 		}

--- a/receiver/vcenterreceiver/scraper.go
+++ b/receiver/vcenterreceiver/scraper.go
@@ -22,7 +22,6 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
@@ -31,47 +30,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver/internal/metadata"
 )
 
-const (
-	emitMetricsWithDirectionAttributeFeatureGateID    = "receiver.vcenterreceiver.emitMetricsWithDirectionAttribute"
-	emitMetricsWithoutDirectionAttributeFeatureGateID = "receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute"
-)
-
-var (
-	emitMetricsWithDirectionAttributeFeatureGate = featuregate.Gate{
-		ID:      emitMetricsWithDirectionAttributeFeatureGateID,
-		Enabled: true,
-		Description: "Some vcenter metrics reported are transitioning from being reported with a direction " +
-			"attribute to being reported with the direction included in the metric name to adhere to the " +
-			"OpenTelemetry specification. This feature gate controls emitting the old metrics with the direction " +
-			"attribute. For more details, see: " +
-			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/vcenterreceiver/README.md#feature-gate-configurations",
-	}
-
-	emitMetricsWithoutDirectionAttributeFeatureGate = featuregate.Gate{
-		ID:      emitMetricsWithoutDirectionAttributeFeatureGateID,
-		Enabled: false,
-		Description: "Some vcenter metrics reported are transitioning from being reported with a direction " +
-			"attribute to being reported with the direction included in the metric name to adhere to the " +
-			"OpenTelemetry specification. This feature gate controls emitting the new metrics without the direction " +
-			"attribute. For more details, see: " +
-			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/vcenterreceiver/README.md#feature-gate-configurations",
-	}
-)
-
-func init() {
-	featuregate.GetRegistry().MustRegister(emitMetricsWithDirectionAttributeFeatureGate)
-	featuregate.GetRegistry().MustRegister(emitMetricsWithoutDirectionAttributeFeatureGate)
-}
-
 var _ component.Receiver = (*vcenterMetricScraper)(nil)
 
 type vcenterMetricScraper struct {
-	client                               *vcenterClient
-	config                               *Config
-	mb                                   *metadata.MetricsBuilder
-	logger                               *zap.Logger
-	emitMetricsWithDirectionAttribute    bool
-	emitMetricsWithoutDirectionAttribute bool
+	client *vcenterClient
+	config *Config
+	mb     *metadata.MetricsBuilder
+	logger *zap.Logger
 }
 
 func newVmwareVcenterScraper(
@@ -81,12 +46,10 @@ func newVmwareVcenterScraper(
 ) *vcenterMetricScraper {
 	client := newVcenterClient(config)
 	return &vcenterMetricScraper{
-		client:                               client,
-		config:                               config,
-		logger:                               logger,
-		mb:                                   metadata.NewMetricsBuilder(config.Metrics, settings.BuildInfo),
-		emitMetricsWithDirectionAttribute:    featuregate.GetRegistry().IsEnabled(emitMetricsWithDirectionAttributeFeatureGateID),
-		emitMetricsWithoutDirectionAttribute: featuregate.GetRegistry().IsEnabled(emitMetricsWithoutDirectionAttributeFeatureGateID),
+		client: client,
+		config: config,
+		logger: logger,
+		mb:     metadata.NewMetricsBuilder(config.Metrics, settings.BuildInfo),
 	}
 }
 

--- a/receiver/vcenterreceiver/scraper_test.go
+++ b/receiver/vcenterreceiver/scraper_test.go
@@ -55,33 +55,6 @@ func TestScrape(t *testing.T) {
 	require.NoError(t, scraper.Shutdown(ctx))
 }
 
-func TestScrapeWithoutDirectionAttribute(t *testing.T) {
-	ctx := context.Background()
-	mockServer := mock.MockServer(t)
-
-	cfg := &Config{
-		Metrics:  metadata.DefaultMetricsSettings(),
-		Endpoint: mockServer.URL,
-		Username: mock.MockUsername,
-		Password: mock.MockPassword,
-	}
-	scraper := newVmwareVcenterScraper(zap.NewNop(), cfg, componenttest.NewNopReceiverCreateSettings())
-	scraper.emitMetricsWithDirectionAttribute = false
-	scraper.emitMetricsWithoutDirectionAttribute = true
-
-	metrics, err := scraper.scrape(ctx)
-	require.NoError(t, err)
-	require.NotEqual(t, metrics.MetricCount(), 0)
-
-	goldenPath := filepath.Join("testdata", "metrics", "expected_without_direction.json")
-	expectedMetrics, err := golden.ReadMetrics(goldenPath)
-	require.NoError(t, err)
-
-	err = scrapertest.CompareMetrics(expectedMetrics, metrics)
-	require.NoError(t, err)
-	require.NoError(t, scraper.Shutdown(ctx))
-}
-
 func TestScrape_NoClient(t *testing.T) {
 	ctx := context.Background()
 	scraper := &vcenterMetricScraper{


### PR DESCRIPTION
The following feature gates have been removed after being deprecated for a few versions:

- `receiver.vcenterreceiver.emitMetricsWithoutDirectionAttribute`
- `receiver.vcenterreceiver.emitMetricsWithDirectionAttribute`
