### PR TITLE
[receiver/memcached] removing direction feature gate

### DIFF
--- a/.chloggen/rm-direction-memcached.yaml
+++ b/.chloggen/rm-direction-memcached.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/rm-direction-memcached.yaml
+++ b/.chloggen/rm-direction-memcached.yaml
@@ -1,14 +1,14 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component:
+component: memcachedreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
+note: "removing direction feature gate"
 
 # One or more tracking issues related to the change
-issues: []
+issues: [14964]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/memcachedreceiver/README.md
+++ b/receiver/memcachedreceiver/README.md
@@ -46,17 +46,5 @@ with detailed sample configurations [here](./testdata/config.yaml).
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml) with further documentation in [documentation.md](./documentation.md)
 
-### Feature gate configurations
-
-#### Transition from metrics with "direction" attribute
-
-The proposal to change metrics from being reported with a `direction` attribute has been reverted in the specification. As a result, the
-following feature gates will be removed in v0.62.0:
-
-- **receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute**
-- **receiver.memcachedreceiver.emitMetricsWithDirectionAttribute**
-
-For additional information, see https://github.com/open-telemetry/opentelemetry-specification/issues/2726.
-
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/memcachedreceiver/documentation.md
+++ b/receiver/memcachedreceiver/documentation.md
@@ -16,8 +16,6 @@ These are the metrics available for this scraper.
 | **memcached.current_items** | Number of items currently stored in the cache. | {items} | Sum(Int) | <ul> </ul> |
 | **memcached.evictions** | Cache item evictions. | {evictions} | Sum(Int) | <ul> </ul> |
 | **memcached.network** | Bytes transferred over the network. | by | Sum(Int) | <ul> <li>direction</li> </ul> |
-| **memcached.network.received** | Bytes received over the network. | by | Sum(Int) | <ul> </ul> |
-| **memcached.network.sent** | Bytes sent over the network. | by | Sum(Int) | <ul> </ul> |
 | **memcached.operation_hit_ratio** | Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0. | % | Gauge(Double) | <ul> <li>operation</li> </ul> |
 | **memcached.operations** | Operation counts. | {operations} | Sum(Int) | <ul> <li>type</li> <li>operation</li> </ul> |
 | **memcached.threads** | Number of threads used by the memcached instance. | {threads} | Sum(Int) | <ul> </ul> |

--- a/receiver/memcachedreceiver/factory.go
+++ b/receiver/memcachedreceiver/factory.go
@@ -22,9 +22,7 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver/internal/metadata"
 )
@@ -59,12 +57,6 @@ func createDefaultConfig() config.Receiver {
 	}
 }
 
-func logDeprecatedFeatureGateForDirection(log *zap.Logger, gate featuregate.Gate) {
-	log.Warn("WARNING: The " + gate.ID + " feature gate is deprecated and will be removed in the next release. The change to remove " +
-		"the direction attribute has been reverted in the specification. See https://github.com/open-telemetry/opentelemetry-specification/issues/2726 " +
-		"for additional details.")
-}
-
 func createMetricsReceiver(
 	_ context.Context,
 	params component.ReceiverCreateSettings,
@@ -74,14 +66,6 @@ func createMetricsReceiver(
 	cfg := rConf.(*Config)
 
 	ms := newMemcachedScraper(params, cfg)
-
-	if !ms.emitMetricsWithDirectionAttribute {
-		logDeprecatedFeatureGateForDirection(ms.logger, emitMetricsWithDirectionAttributeFeatureGate)
-	}
-
-	if ms.emitMetricsWithoutDirectionAttribute {
-		logDeprecatedFeatureGateForDirection(ms.logger, emitMetricsWithoutDirectionAttributeFeatureGate)
-	}
 
 	scraper, err := scraperhelper.NewScraper(typeStr, ms.scrape)
 	if err != nil {

--- a/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
@@ -25,8 +25,6 @@ type MetricsSettings struct {
 	MemcachedCurrentItems       MetricSettings `mapstructure:"memcached.current_items"`
 	MemcachedEvictions          MetricSettings `mapstructure:"memcached.evictions"`
 	MemcachedNetwork            MetricSettings `mapstructure:"memcached.network"`
-	MemcachedNetworkReceived    MetricSettings `mapstructure:"memcached.network.received"`
-	MemcachedNetworkSent        MetricSettings `mapstructure:"memcached.network.sent"`
 	MemcachedOperationHitRatio  MetricSettings `mapstructure:"memcached.operation_hit_ratio"`
 	MemcachedOperations         MetricSettings `mapstructure:"memcached.operations"`
 	MemcachedThreads            MetricSettings `mapstructure:"memcached.threads"`
@@ -56,12 +54,6 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		MemcachedNetwork: MetricSettings{
-			Enabled: true,
-		},
-		MemcachedNetworkReceived: MetricSettings{
-			Enabled: true,
-		},
-		MemcachedNetworkSent: MetricSettings{
 			Enabled: true,
 		},
 		MemcachedOperationHitRatio: MetricSettings{
@@ -630,108 +622,6 @@ func newMetricMemcachedNetwork(settings MetricSettings) metricMemcachedNetwork {
 	return m
 }
 
-type metricMemcachedNetworkReceived struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills memcached.network.received metric with initial data.
-func (m *metricMemcachedNetworkReceived) init() {
-	m.data.SetName("memcached.network.received")
-	m.data.SetDescription("Bytes received over the network.")
-	m.data.SetUnit("by")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricMemcachedNetworkReceived) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricMemcachedNetworkReceived) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricMemcachedNetworkReceived) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricMemcachedNetworkReceived(settings MetricSettings) metricMemcachedNetworkReceived {
-	m := metricMemcachedNetworkReceived{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricMemcachedNetworkSent struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills memcached.network.sent metric with initial data.
-func (m *metricMemcachedNetworkSent) init() {
-	m.data.SetName("memcached.network.sent")
-	m.data.SetDescription("Bytes sent over the network.")
-	m.data.SetUnit("by")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricMemcachedNetworkSent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricMemcachedNetworkSent) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricMemcachedNetworkSent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricMemcachedNetworkSent(settings MetricSettings) metricMemcachedNetworkSent {
-	m := metricMemcachedNetworkSent{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricMemcachedOperationHitRatio struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -904,8 +794,6 @@ type MetricsBuilder struct {
 	metricMemcachedCurrentItems       metricMemcachedCurrentItems
 	metricMemcachedEvictions          metricMemcachedEvictions
 	metricMemcachedNetwork            metricMemcachedNetwork
-	metricMemcachedNetworkReceived    metricMemcachedNetworkReceived
-	metricMemcachedNetworkSent        metricMemcachedNetworkSent
 	metricMemcachedOperationHitRatio  metricMemcachedOperationHitRatio
 	metricMemcachedOperations         metricMemcachedOperations
 	metricMemcachedThreads            metricMemcachedThreads
@@ -934,8 +822,6 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		metricMemcachedCurrentItems:       newMetricMemcachedCurrentItems(settings.MemcachedCurrentItems),
 		metricMemcachedEvictions:          newMetricMemcachedEvictions(settings.MemcachedEvictions),
 		metricMemcachedNetwork:            newMetricMemcachedNetwork(settings.MemcachedNetwork),
-		metricMemcachedNetworkReceived:    newMetricMemcachedNetworkReceived(settings.MemcachedNetworkReceived),
-		metricMemcachedNetworkSent:        newMetricMemcachedNetworkSent(settings.MemcachedNetworkSent),
 		metricMemcachedOperationHitRatio:  newMetricMemcachedOperationHitRatio(settings.MemcachedOperationHitRatio),
 		metricMemcachedOperations:         newMetricMemcachedOperations(settings.MemcachedOperations),
 		metricMemcachedThreads:            newMetricMemcachedThreads(settings.MemcachedThreads),
@@ -999,8 +885,6 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricMemcachedCurrentItems.emit(ils.Metrics())
 	mb.metricMemcachedEvictions.emit(ils.Metrics())
 	mb.metricMemcachedNetwork.emit(ils.Metrics())
-	mb.metricMemcachedNetworkReceived.emit(ils.Metrics())
-	mb.metricMemcachedNetworkSent.emit(ils.Metrics())
 	mb.metricMemcachedOperationHitRatio.emit(ils.Metrics())
 	mb.metricMemcachedOperations.emit(ils.Metrics())
 	mb.metricMemcachedThreads.emit(ils.Metrics())
@@ -1061,16 +945,6 @@ func (mb *MetricsBuilder) RecordMemcachedEvictionsDataPoint(ts pcommon.Timestamp
 // RecordMemcachedNetworkDataPoint adds a data point to memcached.network metric.
 func (mb *MetricsBuilder) RecordMemcachedNetworkDataPoint(ts pcommon.Timestamp, val int64, directionAttributeValue AttributeDirection) {
 	mb.metricMemcachedNetwork.recordDataPoint(mb.startTime, ts, val, directionAttributeValue.String())
-}
-
-// RecordMemcachedNetworkReceivedDataPoint adds a data point to memcached.network.received metric.
-func (mb *MetricsBuilder) RecordMemcachedNetworkReceivedDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricMemcachedNetworkReceived.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordMemcachedNetworkSentDataPoint adds a data point to memcached.network.sent metric.
-func (mb *MetricsBuilder) RecordMemcachedNetworkSentDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricMemcachedNetworkSent.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordMemcachedOperationHitRatioDataPoint adds a data point to memcached.operation_hit_ratio metric.

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -83,7 +83,6 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: []
-  # produced when receiver.memcachedreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   memcached.network:
     enabled: true
     description: Bytes transferred over the network.
@@ -93,26 +92,6 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [direction]
-  # produced when receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  memcached.network.sent:
-    enabled: true
-    description: Bytes sent over the network.
-    unit: by
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: []
-  # produced when receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
-  memcached.network.received:
-    enabled: true
-    description: Bytes received over the network.
-    unit: by
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-    attributes: []
   memcached.operations:
     enabled: true
     description:  Operation counts.

--- a/receiver/memcachedreceiver/scraper.go
+++ b/receiver/memcachedreceiver/scraper.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
@@ -28,45 +27,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver/internal/metadata"
 )
 
-const (
-	emitMetricsWithDirectionAttributeFeatureGateID    = "receiver.memcached.emitMetricsWithDirectionAttribute"
-	emitMetricsWithoutDirectionAttributeFeatureGateID = "receiver.memcached.emitMetricsWithoutDirectionAttribute"
-)
-
-var (
-	emitMetricsWithDirectionAttributeFeatureGate = featuregate.Gate{
-		ID:      emitMetricsWithDirectionAttributeFeatureGateID,
-		Enabled: true,
-		Description: "Some memcached metrics reported are transitioning from being reported with a direction " +
-			"attribute to being reported with the direction included in the metric name to adhere to the " +
-			"OpenTelemetry specification. This feature gate controls emitting the old metrics with the direction " +
-			"attribute. For more details, see: " +
-			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/memcachedreceiver/README.md#feature-gate-configurations",
-	}
-
-	emitMetricsWithoutDirectionAttributeFeatureGate = featuregate.Gate{
-		ID:      emitMetricsWithoutDirectionAttributeFeatureGateID,
-		Enabled: false,
-		Description: "Some memcached metrics reported are transitioning from being reported with a direction " +
-			"attribute to being reported with the direction included in the metric name to adhere to the " +
-			"OpenTelemetry specification. This feature gate controls emitting the new metrics without the direction " +
-			"attribute. For more details, see: " +
-			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/memcachedreceiver/README.md#feature-gate-configurations",
-	}
-)
-
-func init() {
-	featuregate.GetRegistry().MustRegister(emitMetricsWithDirectionAttributeFeatureGate)
-	featuregate.GetRegistry().MustRegister(emitMetricsWithoutDirectionAttributeFeatureGate)
-}
-
 type memcachedScraper struct {
-	logger                               *zap.Logger
-	config                               *Config
-	mb                                   *metadata.MetricsBuilder
-	newClient                            newMemcachedClientFunc
-	emitMetricsWithDirectionAttribute    bool
-	emitMetricsWithoutDirectionAttribute bool
+	logger    *zap.Logger
+	config    *Config
+	mb        *metadata.MetricsBuilder
+	newClient newMemcachedClientFunc
 }
 
 func newMemcachedScraper(
@@ -74,12 +39,10 @@ func newMemcachedScraper(
 	config *Config,
 ) memcachedScraper {
 	return memcachedScraper{
-		logger:                               settings.Logger,
-		config:                               config,
-		newClient:                            newMemcachedClient,
-		mb:                                   metadata.NewMetricsBuilder(config.Metrics, settings.BuildInfo),
-		emitMetricsWithDirectionAttribute:    featuregate.GetRegistry().IsEnabled(emitMetricsWithDirectionAttributeFeatureGateID),
-		emitMetricsWithoutDirectionAttribute: featuregate.GetRegistry().IsEnabled(emitMetricsWithoutDirectionAttributeFeatureGateID),
+		logger:    settings.Logger,
+		config:    config,
+		newClient: newMemcachedClient,
+		mb:        metadata.NewMetricsBuilder(config.Metrics, settings.BuildInfo),
 	}
 }
 
@@ -147,21 +110,11 @@ func (r *memcachedScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 				}
 			case "bytes_read":
 				if parsedV, ok := r.parseInt(k, v); ok {
-					if r.emitMetricsWithDirectionAttribute {
-						r.mb.RecordMemcachedNetworkDataPoint(now, parsedV, metadata.AttributeDirectionReceived)
-					}
-					if r.emitMetricsWithoutDirectionAttribute {
-						r.mb.RecordMemcachedNetworkReceivedDataPoint(now, parsedV)
-					}
+					r.mb.RecordMemcachedNetworkDataPoint(now, parsedV, metadata.AttributeDirectionReceived)
 				}
 			case "bytes_written":
 				if parsedV, ok := r.parseInt(k, v); ok {
-					if r.emitMetricsWithDirectionAttribute {
-						r.mb.RecordMemcachedNetworkDataPoint(now, parsedV, metadata.AttributeDirectionSent)
-					}
-					if r.emitMetricsWithoutDirectionAttribute {
-						r.mb.RecordMemcachedNetworkSentDataPoint(now, parsedV)
-					}
+					r.mb.RecordMemcachedNetworkDataPoint(now, parsedV, metadata.AttributeDirectionSent)
 				}
 			case "get_hits":
 				if parsedV, ok := r.parseInt(k, v); ok {

--- a/receiver/memcachedreceiver/scraper_test.go
+++ b/receiver/memcachedreceiver/scraper_test.go
@@ -44,23 +44,3 @@ func TestScraper(t *testing.T) {
 
 	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 }
-
-func TestScraperWithoutDirectionAttribute(t *testing.T) {
-	f := NewFactory()
-	cfg := f.CreateDefaultConfig().(*Config)
-	scraper := newMemcachedScraper(componenttest.NewNopReceiverCreateSettings(), cfg)
-	scraper.emitMetricsWithDirectionAttribute = false
-	scraper.emitMetricsWithoutDirectionAttribute = true
-	scraper.newClient = func(endpoint string, timeout time.Duration) (client, error) {
-		return &fakeClient{}, nil
-	}
-
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
-
-	expectedFile := filepath.Join("testdata", "expected_metrics", "test_scraper", "expected_without_direction.json")
-	expectedMetrics, err := golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
-
-	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
-}


### PR DESCRIPTION
The following feature gates have been removed after being deprecated for a few versions:

- receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute
- receiver.memcachedreceiver.emitMetricsWithDirectionAttribute
