### PR TITLE
[receiver/oracledbreceiver] additional oracledb metrics

### DIFF
--- a/.chloggen/more_metrics_oracledb.yaml
+++ b/.chloggen/more_metrics_oracledb.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: oracledbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds DML locks and transaction metrics to capture usage and limits
+
+# One or more tracking issues related to the change
+issues: [13939]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -9,6 +9,8 @@ These are the metrics available for this scraper.
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
 | **oracledb.cpu_time** | Cumulative CPU time, in seconds | s | Sum(Double) | <ul> </ul> |
+| **oracledb.dml_locks.limit** | Maximum limit of active DML (Data Manipulation Language) locks. | {locks} | Gauge(Int) | <ul> </ul> |
+| **oracledb.dml_locks.usage** | Current count of active DML (Data Manipulation Language) locks. | {locks} | Gauge(Int) | <ul> </ul> |
 | **oracledb.enqueue_deadlocks** | Total number of deadlocks between table or row locks in different sessions. | {deadlocks} | Sum(Int) | <ul> </ul> |
 | **oracledb.enqueue_locks.limit** | Maximum limit of active enqueue locks. | {locks} | Gauge(Int) | <ul> </ul> |
 | **oracledb.enqueue_locks.usage** | Current count of active enqueue locks. | {locks} | Gauge(Int) | <ul> </ul> |
@@ -27,6 +29,8 @@ These are the metrics available for this scraper.
 | **oracledb.sessions.usage** | Count of active sessions. | {sessions} | Gauge(Int) | <ul> <li>session_type</li> <li>session_status</li> </ul> |
 | **oracledb.tablespace_size.limit** | Maximum size of tablespace in bytes. | By | Gauge(Int) | <ul> <li>tablespace_name</li> </ul> |
 | **oracledb.tablespace_size.usage** | Used tablespace in bytes. | By | Gauge(Int) | <ul> <li>tablespace_name</li> </ul> |
+| **oracledb.transactions.limit** | Maximum limit of active transactions. | {transactions} | Gauge(Int) | <ul> </ul> |
+| **oracledb.transactions.usage** | Current count of active transactions. | {transactions} | Gauge(Int) | <ul> </ul> |
 | **oracledb.user_commits** | Number of user commits. When a user commits a transaction, the redo generated that reflects the changes made to database blocks must be written to disk. Commits often represent the closest thing to a user transaction rate. | {commits} | Sum(Int) | <ul> </ul> |
 | **oracledb.user_rollbacks** | Number of times users manually issue the ROLLBACK statement or an error occurs during a user's transactions | 1 | Sum(Int) | <ul> </ul> |
 

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -146,6 +146,18 @@ metrics:
     gauge:
       value_type: int
     unit: "{locks}"
+  oracledb.dml_locks.usage:
+    description: Current count of active DML (Data Manipulation Language) locks.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: "{locks}"
+  oracledb.dml_locks.limit:
+    description: Maximum limit of active DML (Data Manipulation Language) locks.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: "{locks}"
   oracledb.enqueue_resources.usage:
     description: Current count of active enqueue resources.
     enabled: true
@@ -158,6 +170,18 @@ metrics:
     gauge:
       value_type: int
     unit: "{resources}"
+  oracledb.transactions.usage:
+    description: Current count of active transactions.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: "{transactions}"
+  oracledb.transactions.limit:
+    description: Maximum limit of active transactions.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: "{transactions}"
   oracledb.tablespace_size.limit:
     attributes:
       - tablespace_name
@@ -174,4 +198,3 @@ metrics:
     gauge:
       value_type: int
     unit: By
-


### PR DESCRIPTION
**Description:** 
Adds four additional useful metrics for the OracleDB receiver:
* Transactions usage and limit
* DML (Data Manipulation Language) Locks usage and limit

**Link to tracking Issue:**
#13939

**Testing:**
N/A just adding the metrics

**Documentation:**
metadata.yaml and generated docs