### PR TITLE
[exporter/influxdb] Change status to beta

### DIFF
--- a/.chloggen/maintain-influxdbexporter.yaml
+++ b/.chloggen/maintain-influxdbexporter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/influxdb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: change status to beta
+
+# One or more tracking issues related to the change
+issues: [14098]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -16,7 +16,6 @@
 cmd/configschema
 examples/demo/client
 examples/demo/server
-exporter/influxdbexporter
 exporter/parquetexporter
 extension/fluentbitextension
 extension/httpforwarder

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ exporter/googlecloudexporter/                        @open-telemetry/collector-c
 exporter/googlemanagedprometheusexporter/            @open-telemetry/collector-contrib-approvers @aabmass @dashpole @jsuereth @punya @tbarker25 @damemi
 exporter/googlecloudpubsubexporter/                  @open-telemetry/collector-contrib-approvers @alexvanboxel
 exporter/humioexporter/                              @open-telemetry/collector-contrib-approvers @xitric
+exporter/influxdbexporter/                           @open-telemetry/collector-contrib-approvers @jacobmarble
 exporter/instanaexporter/                            @open-telemetry/collector-contrib-approvers @jpkrohling @hickeyma
 exporter/jaegerexporter/                             @open-telemetry/collector-contrib-approvers @jpkrohling
 exporter/jaegerthrifthttpexporter/                   @open-telemetry/collector-contrib-approvers @jpkrohling @pavolloffay

--- a/exporter/influxdbexporter/README.md
+++ b/exporter/influxdbexporter/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |                       |
 | ------------------------ |-----------------------|
-| Stability                | [unmaintained]        |
+| Stability                | [beta]                |
 | Supported pipeline types | traces, logs, metrics |
 | Distributions            | [contrib]             |
 
@@ -19,7 +19,7 @@ The following configuration options are supported:
   - header `User-Agent` is `OpenTelemetry -> Influx` by default
   - if `token` (below) is set, then header `Authorization` will overridden with the given token
 * `org` (required) Name of InfluxDB organization that owns the destination bucket
-* `bucket` (required) InfluxDB bucket name to where signals will
+* `bucket` (required) name of InfluxDB bucket to which signals will be written
 * `token` (optional) The authentication token for InfluxDB
 * `metrics_schema` (default = telegraf-prometheus-v1) The chosen metrics schema to write; must be one of:
   * `telegraf-prometheus-v1`
@@ -121,5 +121,5 @@ logs fluent.tag="fluent.debug",instance=1720i,queue_size=0i,stage_size=0i 161376
 logs fluent.tag="fluent.info",worker=0i 1613769568896515100
 ```
 
-[unmaintained]:https://github.com/open-telemetry/opentelemetry-collector#unmaintained
+[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/influxdbexporter/config.go
+++ b/exporter/influxdbexporter/config.go
@@ -27,7 +27,7 @@ const (
 	// The value of "type" key in configuration.
 	typeStr = "influxdb"
 	// The stability level of the exporter.
-	stability = component.StabilityLevelUnmaintained
+	stability = component.StabilityLevelBeta
 )
 
 // Config defines configuration for the InfluxDB exporter.


### PR DESCRIPTION
**Description:** I would like to properly maintain exporter/influxdb.

The status of this exporter was changed from beta to unmaintained in #14100 because the maintainer (me) didn't respond to at-mentions in GitHub. I'll rectify this in future interactions.

See also #14971

cc @djaglowski 

**Link to tracking Issue:** #14098

**Testing:** n/a

**Documentation:** Updated component status in README.md