### PR TITLE
[receiver/influxdb] Change status to beta

### DIFF
--- a/.chloggen/maintain-influxdbreceiver.yaml
+++ b/.chloggen/maintain-influxdbreceiver.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/influxdb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: change status to beta
+
+# One or more tracking issues related to the change
+issues: [14099]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -32,5 +32,4 @@ pkg/experimentalmetricmetadata
 processor/deltatorateprocessor
 processor/metricsgenerationprocessor
 receiver/dotnetdiagnosticsreceiver
-receiver/influxdbreceiver
 testbed

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -157,6 +157,7 @@ receiver/fluentforwardreceiver/                      @open-telemetry/collector-c
 receiver/googlecloudpubsubreceiver/                  @open-telemetry/collector-contrib-approvers @alexvanboxel
 receiver/googlecloudspannerreceiver/                 @open-telemetry/collector-contrib-approvers @ydrozhdzhal @asukhyy @khospodarysko @architjugran
 receiver/hostmetricsreceiver/                        @open-telemetry/collector-contrib-approvers @dmitryax
+receiver/influxdbreceiver/                           @open-telemetry/collector-contrib-approvers @jacobmarble
 receiver/iisreceiver/                                @open-telemetry/collector-contrib-approvers @mrod1598 @djaglowski
 receiver/jaegerreceiver/                             @open-telemetry/collector-contrib-approvers @jpkrohling
 receiver/jmxreceiver/                                @open-telemetry/collector-contrib-approvers @rmfitzpatrick

--- a/receiver/influxdbreceiver/README.md
+++ b/receiver/influxdbreceiver/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |           |
 | ------------------------ |-----------|
-| Stability                | [unmaintained]    |
+| Stability                | [beta]    |
 | Supported pipeline types | metrics   |
 | Distributions            | [contrib] |
 
@@ -74,5 +74,5 @@ prometheus,quantile=0.99 rpc_duration_seconds=76656
 prometheus               rpc_duration_seconds_count=1.7560473e+07,rpc_duration_seconds_sum=2693
 ```
 
-[unmaintained]: https://github.com/open-telemetry/opentelemetry-collector#unmaintained
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/influxdbreceiver/factory.go
+++ b/receiver/influxdbreceiver/factory.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	typeStr   = "influxdb"
-	stability = component.StabilityLevelUnmaintained
+	stability = component.StabilityLevelBeta
 )
 
 func NewFactory() component.ReceiverFactory {


### PR DESCRIPTION
**Description:** I would like to properly maintain exporter/influxdb.

The status of this receiver was changed from beta to unmaintained in #14101 because the maintainer (me) didn't respond to at-mentions in GitHub. I'll rectify this in future interactions.

See also #14970

cc @djaglowski 

**Link to tracking Issue:** #14099

**Testing:** n/a

**Documentation:** Updated component status in README.md