### PR TITLE
Add metric prefix config to googlemanagedprometheus exporter

### DIFF
--- a/.chloggen/googlemanagedprometheus-metric-prefix.yaml
+++ b/.chloggen/googlemanagedprometheus-metric-prefix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/googlemanagedprometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an option to change the default metric name prefix for advanced use cases.
+
+# One or more tracking issues related to the change
+issues: [10543]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/googlemanagedprometheus-metric-prefix.yaml
+++ b/.chloggen/googlemanagedprometheus-metric-prefix.yaml
@@ -1,11 +1,11 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: exporter/googlemanagedprometheusexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add an option to change the default metric name prefix for advanced use cases.
+note: Moved ClientConfig under MetricConfig, and added an option to change the default metric name prefix for advanced use cases.
 
 # One or more tracking issues related to the change
 issues: [10543]

--- a/exporter/googlemanagedprometheusexporter/README.md
+++ b/exporter/googlemanagedprometheusexporter/README.md
@@ -16,7 +16,8 @@ The following configuration options are supported:
 
 - `project` (optional): GCP project identifier.
 - `user_agent` (optional): Override the user agent string sent on requests to Cloud Monitoring (currently only applies to metrics). Specify `{{version}}` to include the application version number. Defaults to `opentelemetry-collector-contrib {{version}}`.
-- `endpoint` (optional): Endpoint where metric data is going to be sent to. Replaces `endpoint`.
+- `metric`(optional): Configuration for sending metrics to Cloud Monitoring.
+  - `endpoint` (optional): Endpoint where metric data is going to be sent to. Replaces `endpoint`.
 - `use_insecure` (optional): If true, use gRPC as their communication transport. Only has effect if Endpoint is not "".
 - `retry_on_failure` (optional): Configuration for how to handle retries when sending data to Google Cloud fails.
   - `enabled` (default = true)

--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -38,6 +38,8 @@ type Config struct {
 type GMPConfig struct {
 	ProjectID    string                 `mapstructure:"project"`
 	UserAgent    string                 `mapstructure:"user_agent"`
+        // MetricPrefix configures the prefix of metrics sent to GoogleManagedPrometheus.  Defaults to prometheus.googleapis.com.
+        // Changing this prefix is not recommended, as it may cause metrics to not be queryable with promql in the Cloud Monitoring UI.
 	MetricPrefix string                 `mapstructure:"metric_prefix"`
 	ClientConfig collector.ClientConfig `mapstructure:",squash"`
 }

--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -36,19 +36,23 @@ type Config struct {
 
 // GMPConfig is a subset of the collector config applicable to the GMP exporter.
 type GMPConfig struct {
-	ProjectID    string                 `mapstructure:"project"`
-	UserAgent    string                 `mapstructure:"user_agent"`
-        // MetricPrefix configures the prefix of metrics sent to GoogleManagedPrometheus.  Defaults to prometheus.googleapis.com.
-        // Changing this prefix is not recommended, as it may cause metrics to not be queryable with promql in the Cloud Monitoring UI.
-	MetricPrefix string                 `mapstructure:"metric_prefix"`
+	ProjectID    string       `mapstructure:"project"`
+	UserAgent    string       `mapstructure:"user_agent"`
+	MetricConfig MetricConfig `mapstructure:"metric"`
+}
+
+type MetricConfig struct {
+	// Prefix configures the prefix of metrics sent to GoogleManagedPrometheus.  Defaults to prometheus.googleapis.com.
+	// Changing this prefix is not recommended, as it may cause metrics to not be queryable with promql in the Cloud Monitoring UI.
+	Prefix       string                 `mapstructure:"prefix"`
 	ClientConfig collector.ClientConfig `mapstructure:",squash"`
 }
 
 func (c *GMPConfig) toCollectorConfig() collector.Config {
 	// start with whatever the default collector config is.
 	cfg := collector.DefaultConfig()
-	cfg.MetricConfig.Prefix = c.MetricPrefix
-	if c.MetricPrefix == "" {
+	cfg.MetricConfig.Prefix = c.MetricConfig.Prefix
+	if c.MetricConfig.Prefix == "" {
 		cfg.MetricConfig.Prefix = "prometheus.googleapis.com"
 	}
 	cfg.MetricConfig.SkipCreateMetricDescriptor = true
@@ -62,7 +66,7 @@ func (c *GMPConfig) toCollectorConfig() collector.Config {
 	// map the GMP config's fields to the collector config
 	cfg.ProjectID = c.ProjectID
 	cfg.UserAgent = c.UserAgent
-	cfg.MetricConfig.ClientConfig = c.ClientConfig
+	cfg.MetricConfig.ClientConfig = c.MetricConfig.ClientConfig
 	return cfg
 }
 

--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -38,14 +38,17 @@ type Config struct {
 type GMPConfig struct {
 	ProjectID    string                 `mapstructure:"project"`
 	UserAgent    string                 `mapstructure:"user_agent"`
+	MetricPrefix string                 `mapstructure:"metric_prefix"`
 	ClientConfig collector.ClientConfig `mapstructure:",squash"`
 }
 
 func (c *GMPConfig) toCollectorConfig() collector.Config {
 	// start with whatever the default collector config is.
 	cfg := collector.DefaultConfig()
-	// hard-code some config options to make it work with GMP
-	cfg.MetricConfig.Prefix = "prometheus.googleapis.com"
+	cfg.MetricConfig.Prefix = c.MetricPrefix
+	if c.MetricPrefix == "" {
+		cfg.MetricConfig.Prefix = "prometheus.googleapis.com"
+	}
 	cfg.MetricConfig.SkipCreateMetricDescriptor = true
 	cfg.MetricConfig.InstrumentationLibraryLabels = false
 	cfg.MetricConfig.ServiceResourceLabels = false

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -38,7 +38,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Exporters), 2)
+	assert.Equal(t, len(cfg.Exporters), 3)
 
 	r0 := cfg.Exporters[config.NewComponentID(typeStr)].(*Config)
 	assert.Equal(t, r0, factory.CreateDefaultConfig().(*Config))
@@ -66,4 +66,10 @@ func TestLoadConfig(t *testing.T) {
 				QueueSize:    10,
 			},
 		})
+
+	r2 := cfg.Exporters[config.NewComponentIDWithName(typeStr, "customprefix")].(*Config)
+	r2Expected := factory.CreateDefaultConfig().(*Config)
+	r2Expected.ExporterSettings = config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "customprefix"))
+	r2Expected.GMPConfig.MetricPrefix = "my-metric-domain.com"
+	assert.Equal(t, r2, r2Expected)
 }

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -70,6 +70,6 @@ func TestLoadConfig(t *testing.T) {
 	r2 := cfg.Exporters[config.NewComponentIDWithName(typeStr, "customprefix")].(*Config)
 	r2Expected := factory.CreateDefaultConfig().(*Config)
 	r2Expected.ExporterSettings = config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "customprefix"))
-	r2Expected.GMPConfig.MetricPrefix = "my-metric-domain.com"
+	r2Expected.GMPConfig.MetricConfig.Prefix = "my-metric-domain.com"
 	assert.Equal(t, r2, r2Expected)
 }

--- a/exporter/googlemanagedprometheusexporter/testdata/config.yaml
+++ b/exporter/googlemanagedprometheusexporter/testdata/config.yaml
@@ -19,6 +19,8 @@ exporters:
       initial_interval: 10s
       max_interval: 60s
       max_elapsed_time: 10m
+  googlemanagedprometheus/customprefix:
+    metric_prefix: my-metric-domain.com
 
 
 service:

--- a/exporter/googlemanagedprometheusexporter/testdata/config.yaml
+++ b/exporter/googlemanagedprometheusexporter/testdata/config.yaml
@@ -20,7 +20,8 @@ exporters:
       max_interval: 60s
       max_elapsed_time: 10m
   googlemanagedprometheus/customprefix:
-    metric_prefix: my-metric-domain.com
+    metric:
+      prefix: my-metric-domain.com
 
 
 service:


### PR DESCRIPTION
**Description: add metric_prefix config to googlemanagedprometheus exporter 

Add an option to change the default metric name prefix for advanced use cases.