### PR TITLE
[exporter/mezmo] Fix HTTP client settings usage

### DIFF
--- a/.chloggen/mezmo_tls-config.yaml
+++ b/.chloggen/mezmo_tls-config.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mezmoexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix usage of HTTP client to honor settings
+
+# One or more tracking issues related to the change
+issues: [15246]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change fixes mezmoexporter's usage of the user supplied HTTP client
+  settings. Previously, the settings were ignored for every request.

--- a/exporter/mezmoexporter/exporter.go
+++ b/exporter/mezmoexporter/exporter.go
@@ -15,7 +15,6 @@
 package mezmoexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter"
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -180,14 +179,14 @@ func (m *mezmoExporter) logDataToMezmo(ld plog.Logs) error {
 }
 
 func (m *mezmoExporter) sendLinesToMezmo(post string) (errs error) {
-	req, _ := http.NewRequest("POST", m.config.IngestURL, bytes.NewBuffer([]byte(post)))
+	req, _ := http.NewRequest("POST", m.config.IngestURL, strings.NewReader(post))
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("User-Agent", m.userAgentString)
 	req.Header.Add("apikey", m.config.IngestKey)
 
 	var res *http.Response
-	if res, errs = http.DefaultClient.Do(req); errs != nil {
+	if res, errs = m.client.Do(req); errs != nil {
 		return fmt.Errorf("failed to POST log to Mezmo: %w", errs)
 	}
 	if res.StatusCode >= 400 {


### PR DESCRIPTION
**Description:** 

Previously, the `mezmoexporter` was ignoring any settings provided by way of https://github.com/open-telemetry/opentelemetry-collector/tree/4d445807f9eca3af660bec2a3fb4ca3518cd255d/config/confighttp. This PR fixes that mistake.

**Link to tracking Issue:** N/A

**Testing:**

**Documentation:** 