### PR TITLE
[exporter/dynatrace] Improve logging of metrics ingest responses

### DIFF
--- a/.chloggen/dynatraceexporter-improve-logging.yaml
+++ b/.chloggen/dynatraceexporter-improve-logging.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/dynatrace
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Provide more logs on the results of metrics submissions
+
+# One or more tracking issues related to the change
+issues: [15248]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/dynatraceexporter/metrics_exporter.go
+++ b/exporter/dynatraceexporter/metrics_exporter.go
@@ -219,6 +219,8 @@ func (e *exporter) sendBatch(ctx context.Context, lines []string) error {
 
 	defer resp.Body.Close()
 
+	responseBody, rbUnmarshalErr := e.unmarshalResponseBody(resp)
+
 	if resp.StatusCode == http.StatusRequestEntityTooLarge {
 		// If a payload is too large, resending it will not help
 		return consumererror.NewPermanent(fmt.Errorf("payload too large"))
@@ -226,19 +228,7 @@ func (e *exporter) sendBatch(ctx context.Context, lines []string) error {
 
 	if resp.StatusCode == http.StatusBadRequest {
 		// At least some metrics were not accepted
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			// if the response cannot be read, do not retry the batch as it may have been successful
-			e.settings.Logger.Error("Failed to read response from Dynatrace", zap.Error(err))
-			return nil
-		}
-
-		responseBody := metricsResponse{}
-		if err := json.Unmarshal(bodyBytes, &responseBody); err != nil {
-			// if the response cannot be read, do not retry the batch as it may have been successful
-			bodyStr := string(bodyBytes)
-			bodyStr = truncateString(bodyStr, 1000)
-			e.settings.Logger.Error("Failed to unmarshal response from Dynatrace", zap.Error(err), zap.String("body", bodyStr))
+		if rbUnmarshalErr != nil {
 			return nil
 		}
 
@@ -276,6 +266,24 @@ func (e *exporter) sendBatch(ctx context.Context, lines []string) error {
 		return consumererror.NewPermanent(fmt.Errorf("metrics ingest v2 module not found - ensure module is enabled and endpoint is correct"))
 	}
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return consumererror.NewPermanent(
+			fmt.Errorf("The server responded that too many requests have been sent. Please check your export interval and batch sizes and see https://www.dynatrace.com/support/help/dynatrace-api/basics/access-limit for more information"),
+		)
+	}
+
+	if resp.StatusCode > http.StatusBadRequest { // '400 Bad Request' itself is handled above
+		return consumererror.NewPermanent(fmt.Errorf(`Received error response status: "%v"`, resp.Status))
+	}
+
+	if rbUnmarshalErr == nil {
+		e.settings.Logger.Debug(
+			"Export successful. Response from Dynatrace:",
+			zap.Int("accepted-lines", responseBody.Ok),
+			zap.String("status", resp.Status),
+		)
+	}
+
 	// No known errors
 	return nil
 }
@@ -291,6 +299,26 @@ func (e *exporter) start(_ context.Context, host component.Host) (err error) {
 	e.client = client
 
 	return nil
+}
+
+func (e *exporter) unmarshalResponseBody(resp *http.Response) (metricsResponse, error) {
+	bodyBytes, err := io.ReadAll(resp.Body)
+	responseBody := metricsResponse{}
+	if err != nil {
+		// if the response cannot be read, do not retry the batch as it may have been successful
+		e.settings.Logger.Error("Failed to read response from Dynatrace", zap.Error(err))
+		return responseBody, fmt.Errorf("Failed to read response")
+	}
+
+	if err := json.Unmarshal(bodyBytes, &responseBody); err != nil {
+		// if the response cannot be read, do not retry the batch as it may have been successful
+		bodyStr := string(bodyBytes)
+		bodyStr = truncateString(bodyStr, 1000)
+		e.settings.Logger.Error("Failed to unmarshal response from Dynatrace", zap.Error(err), zap.String("body", bodyStr))
+		return responseBody, fmt.Errorf("Failed to unmarshal response")
+	}
+
+	return responseBody, nil
 }
 
 func truncateString(str string, num int) string {


### PR DESCRIPTION
**Description:**

Add additional logging to the Dynatrace exporter to help debug failure scenarios and provide ingestion confirmation in success scenarios.

**Testing:**

Unit tests were added.