### PR TITLE
[receiver/postgresql] Fix data type for postgresql.bgwriter.duration

### DIFF
--- a/.chloggen/postgresql-bgwriter-duration-type.yaml
+++ b/.chloggen/postgresql-bgwriter-duration-type.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change postgresql.bgwriter.duration data type from int to double
+
+# One or more tracking issues related to the change
+issues: [14725, 14972]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -288,15 +288,15 @@ type tableIOStats struct {
 }
 
 func (c *postgreSQLClient) getBlocksReadByTable(ctx context.Context, db string) (map[tableIdentifier]tableIOStats, error) {
-	query := `SELECT schemaname || '.' || relname AS table, 
-	coalesce(heap_blks_read, 0) AS heap_read, 
-	coalesce(heap_blks_hit, 0) AS heap_hit, 
-	coalesce(idx_blks_read, 0) AS idx_read, 
-	coalesce(idx_blks_hit, 0) AS idx_hit, 
-	coalesce(toast_blks_read, 0) AS toast_read, 
-	coalesce(toast_blks_hit, 0) AS toast_hit, 
-	coalesce(tidx_blks_read, 0) AS tidx_read, 
-	coalesce(tidx_blks_hit, 0) AS tidx_hit 
+	query := `SELECT schemaname || '.' || relname AS table,
+	coalesce(heap_blks_read, 0) AS heap_read,
+	coalesce(heap_blks_hit, 0) AS heap_hit,
+	coalesce(idx_blks_read, 0) AS idx_read,
+	coalesce(idx_blks_hit, 0) AS idx_hit,
+	coalesce(toast_blks_read, 0) AS toast_read,
+	coalesce(toast_blks_hit, 0) AS toast_hit,
+	coalesce(tidx_blks_read, 0) AS tidx_read,
+	coalesce(tidx_blks_hit, 0) AS tidx_hit
 	FROM pg_statio_user_tables;`
 
 	tios := map[tableIdentifier]tableIOStats{}
@@ -376,8 +376,8 @@ func (c *postgreSQLClient) getIndexStats(ctx context.Context, database string) (
 type bgStat struct {
 	checkpointsReq       int64
 	checkpointsScheduled int64
-	checkpointWriteTime  int64
-	checkpointSyncTime   int64
+	checkpointWriteTime  float64
+	checkpointSyncTime   float64
 	bgWrites             int64
 	backendWrites        int64
 	bufferBackendWrites  int64
@@ -388,7 +388,7 @@ type bgStat struct {
 }
 
 func (c *postgreSQLClient) getBGWriterStats(ctx context.Context) (*bgStat, error) {
-	query := `SELECT 
+	query := `SELECT
 	checkpoints_req AS checkpoint_req,
 	checkpoints_timed AS checkpoint_scheduled,
 	checkpoint_write_time AS checkpoint_duration_write,
@@ -404,7 +404,7 @@ func (c *postgreSQLClient) getBGWriterStats(ctx context.Context) (*bgStat, error
 	row := c.client.QueryRowContext(ctx, query)
 	var (
 		checkpointsReq, checkpointsScheduled               int64
-		checkpointSyncTime, checkpointWriteTime            int64
+		checkpointSyncTime, checkpointWriteTime            float64
 		bgWrites, bufferCheckpoints, bufferAllocated       int64
 		bufferBackendWrites, bufferFsyncWrites, maxWritten int64
 	)
@@ -455,7 +455,7 @@ type replicationStats struct {
 }
 
 func (c *postgreSQLClient) getReplicationStats(ctx context.Context) ([]replicationStats, error) {
-	query := `SELECT 
+	query := `SELECT
 	client_addr,
 	coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn), 0) AS replication_bytes_pending,
 	write_lag,

--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -12,7 +12,7 @@ These are the metrics available for this scraper.
 | **postgresql.bgwriter.buffers.allocated** | Number of buffers allocated. | {buffers} | Sum(Int) | <ul> </ul> |
 | **postgresql.bgwriter.buffers.writes** | Number of buffers written. | {buffers} | Sum(Int) | <ul> <li>bg_buffer_source</li> </ul> |
 | **postgresql.bgwriter.checkpoint.count** | The number of checkpoints performed. | {checkpoints} | Sum(Int) | <ul> <li>bg_checkpoint_type</li> </ul> |
-| **postgresql.bgwriter.duration** | Total time spent writing and syncing files to disk by checkpoints. | ms | Sum(Int) | <ul> <li>bg_duration_type</li> </ul> |
+| **postgresql.bgwriter.duration** | Total time spent writing and syncing files to disk by checkpoints. | ms | Sum(Double) | <ul> <li>bg_duration_type</li> </ul> |
 | **postgresql.bgwriter.maxwritten** | Number of times the background writer stopped a cleaning scan because it had written too many buffers. |  | Sum(Int) | <ul> </ul> |
 | **postgresql.blocks_read** | The number of blocks read. | 1 | Sum(Int) | <ul> <li>database</li> <li>table</li> <li>source</li> </ul> |
 | **postgresql.commits** | The number of commits. | 1 | Sum(Int) | <ul> <li>database</li> </ul> |

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
@@ -565,14 +565,14 @@ func (m *metricPostgresqlBgwriterDuration) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricPostgresqlBgwriterDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, bgDurationTypeAttributeValue string) {
+func (m *metricPostgresqlBgwriterDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, bgDurationTypeAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
+	dp.SetDoubleValue(val)
 	dp.Attributes().PutStr("type", bgDurationTypeAttributeValue)
 }
 
@@ -1685,7 +1685,7 @@ func (mb *MetricsBuilder) RecordPostgresqlBgwriterCheckpointCountDataPoint(ts pc
 }
 
 // RecordPostgresqlBgwriterDurationDataPoint adds a data point to postgresql.bgwriter.duration metric.
-func (mb *MetricsBuilder) RecordPostgresqlBgwriterDurationDataPoint(ts pcommon.Timestamp, val int64, bgDurationTypeAttributeValue AttributeBgDurationType) {
+func (mb *MetricsBuilder) RecordPostgresqlBgwriterDurationDataPoint(ts pcommon.Timestamp, val float64, bgDurationTypeAttributeValue AttributeBgDurationType) {
 	mb.metricPostgresqlBgwriterDuration.recordDataPoint(mb.startTime, ts, val, bgDurationTypeAttributeValue.String())
 }
 

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -102,7 +102,7 @@ metrics:
     sum:
       aggregation: cumulative
       monotonic: true
-      value_type: int
+      value_type: double
     unit: ms
   postgresql.bgwriter.maxwritten:
     description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
@@ -237,11 +237,11 @@ metrics:
     sum:
       aggregation: cumulative
       monotonic: true
-      value_type: int 
+      value_type: int
   postgresql.wal.age:
     attributes: []
     description: Age of the oldest WAL file.
-    extended_documentation: | 
+    extended_documentation: |
      This metric requires WAL to be enabled with at least one replica.
     enabled: true
     unit: s

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -243,8 +243,8 @@ func (m *mockClient) initMocks(database string, databases []string, index int) {
 		m.On("getBGWriterStats", mock.Anything).Return(&bgStat{
 			checkpointsReq:       1,
 			checkpointsScheduled: 2,
-			checkpointWriteTime:  3,
-			checkpointSyncTime:   4,
+			checkpointWriteTime:  3.12,
+			checkpointSyncTime:   4.23,
 			bgWrites:             5,
 			backendWrites:        6,
 			bufferBackendWrites:  7,

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db.json
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db.json
@@ -1884,7 +1884,7 @@
                                         ],
                                         "startTimeUnixNano": "1662565933924183000",
                                         "timeUnixNano": "1662565943934293000",
-                                        "asInt": "16"
+                                        "asDouble": "16"
                                     },
                                     {
                                         "attributes": [
@@ -1897,7 +1897,7 @@
                                         ],
                                         "startTimeUnixNano": "1662565933924183000",
                                         "timeUnixNano": "1662565943934293000",
-                                        "asInt": "10"
+                                        "asDouble": "10"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db.json
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db.json
@@ -1786,7 +1786,7 @@
                                         ],
                                         "startTimeUnixNano": "1662565922919465000",
                                         "timeUnixNano": "1662565932919535000",
-                                        "asInt": "16"
+                                        "asDouble": "16"
                                     },
                                     {
                                         "attributes": [
@@ -1799,7 +1799,7 @@
                                         ],
                                         "startTimeUnixNano": "1662565922919465000",
                                         "timeUnixNano": "1662565932919535000",
-                                        "asInt": "10"
+                                        "asDouble": "10"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db.json
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db.json
@@ -901,7 +901,7 @@
                                         ],
                                         "startTimeUnixNano": "1662565911916254000",
                                         "timeUnixNano": "1662565921917209000",
-                                        "asInt": "16"
+                                        "asDouble": "16"
                                     },
                                     {
                                         "attributes": [
@@ -914,7 +914,7 @@
                                         ],
                                         "startTimeUnixNano": "1662565911916254000",
                                         "timeUnixNano": "1662565921917209000",
-                                        "asInt": "10"
+                                        "asDouble": "10"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.json
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.json
@@ -2460,7 +2460,7 @@
                                         ],
                                         "startTimeUnixNano": "1660755376404913000",
                                         "timeUnixNano": "1660755376405089000",
-                                        "asInt": "4"
+                                        "asDouble": "4"
                                     },
                                     {
                                         "attributes": [
@@ -2473,7 +2473,7 @@
                                         ],
                                         "startTimeUnixNano": "1660755376404913000",
                                         "timeUnixNano": "1660755376405089000",
-                                        "asInt": "3"
+                                        "asDouble": "3"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.json
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.json
@@ -2460,7 +2460,7 @@
                                         ],
                                         "startTimeUnixNano": "1660755376404913000",
                                         "timeUnixNano": "1660755376405089000",
-                                        "asDouble": "4"
+                                        "asDouble": "4.23"
                                     },
                                     {
                                         "attributes": [
@@ -2473,7 +2473,7 @@
                                         ],
                                         "startTimeUnixNano": "1660755376404913000",
                                         "timeUnixNano": "1660755376405089000",
-                                        "asDouble": "3"
+                                        "asDouble": "3.12"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.json
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.json
@@ -916,7 +916,7 @@
                                         ],
                                         "startTimeUnixNano": "1660755387092164000",
                                         "timeUnixNano": "1660755387092521000",
-                                        "asDouble": "4"
+                                        "asDouble": "4.23"
                                     },
                                     {
                                         "attributes": [
@@ -929,7 +929,7 @@
                                         ],
                                         "startTimeUnixNano": "1660755387092164000",
                                         "timeUnixNano": "1660755387092521000",
-                                        "asDouble": "3"
+                                        "asDouble": "3.12"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.json
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.json
@@ -916,7 +916,7 @@
                                         ],
                                         "startTimeUnixNano": "1660755387092164000",
                                         "timeUnixNano": "1660755387092521000",
-                                        "asInt": "4"
+                                        "asDouble": "4"
                                     },
                                     {
                                         "attributes": [
@@ -929,7 +929,7 @@
                                         ],
                                         "startTimeUnixNano": "1660755387092164000",
                                         "timeUnixNano": "1660755387092521000",
-                                        "asInt": "3"
+                                        "asDouble": "3"
                                     }
                                 ],
                                 "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",


### PR DESCRIPTION
This was previously modeled as an int but should have been been a double, corresponding to `pg_stat_bgwriter.checkpoint_*_time`. ([Relevant docs](https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-BGWRITER-VIEW))

Resolves #14725 

Resolves (partially) #14972