### PR TITLE
[receiver/postgresql] Fix issue where WAL lag stats could cause conversion error

### DIFF
--- a/.chloggen/postgresql-wal-lag-null.yaml
+++ b/.chloggen/postgresql-wal-lag-null.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where WAL lag stats could cause panic
+
+# One or more tracking issues related to the change
+issues: [14972]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -288,15 +288,15 @@ type tableIOStats struct {
 }
 
 func (c *postgreSQLClient) getBlocksReadByTable(ctx context.Context, db string) (map[tableIdentifier]tableIOStats, error) {
-	query := `SELECT schemaname || '.' || relname AS table, 
-	coalesce(heap_blks_read, 0) AS heap_read, 
-	coalesce(heap_blks_hit, 0) AS heap_hit, 
-	coalesce(idx_blks_read, 0) AS idx_read, 
-	coalesce(idx_blks_hit, 0) AS idx_hit, 
-	coalesce(toast_blks_read, 0) AS toast_read, 
-	coalesce(toast_blks_hit, 0) AS toast_hit, 
-	coalesce(tidx_blks_read, 0) AS tidx_read, 
-	coalesce(tidx_blks_hit, 0) AS tidx_hit 
+	query := `SELECT schemaname || '.' || relname AS table,
+	coalesce(heap_blks_read, 0) AS heap_read,
+	coalesce(heap_blks_hit, 0) AS heap_hit,
+	coalesce(idx_blks_read, 0) AS idx_read,
+	coalesce(idx_blks_hit, 0) AS idx_hit,
+	coalesce(toast_blks_read, 0) AS toast_read,
+	coalesce(toast_blks_hit, 0) AS toast_hit,
+	coalesce(tidx_blks_read, 0) AS tidx_read,
+	coalesce(tidx_blks_hit, 0) AS tidx_hit
 	FROM pg_statio_user_tables;`
 
 	tios := map[tableIdentifier]tableIOStats{}
@@ -388,7 +388,7 @@ type bgStat struct {
 }
 
 func (c *postgreSQLClient) getBGWriterStats(ctx context.Context) (*bgStat, error) {
-	query := `SELECT 
+	query := `SELECT
 	checkpoints_req AS checkpoint_req,
 	checkpoints_timed AS checkpoint_scheduled,
 	checkpoint_write_time AS checkpoint_duration_write,
@@ -455,12 +455,12 @@ type replicationStats struct {
 }
 
 func (c *postgreSQLClient) getReplicationStats(ctx context.Context) ([]replicationStats, error) {
-	query := `SELECT 
+	query := `SELECT
 	client_addr,
-	coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn), 0) AS replication_bytes_pending,
-	write_lag,
-	flush_lag,
-	replay_lag
+	coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn), -1) AS replication_bytes_pending,
+	coalesce(write_lag, -1),
+	coalesce(flush_lag, -1),
+	coalesce(replay_lag, -1)
 	FROM pg_stat_replication;
 	`
 	rows, err := c.client.QueryContext(ctx, query)

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -350,10 +350,18 @@ func (p *postgreSQLScraper) collectReplicationStats(
 		return
 	}
 	for _, rs := range rss {
-		p.mb.RecordPostgresqlReplicationDataDelayDataPoint(now, rs.pendingBytes, rs.clientAddr)
-		p.mb.RecordPostgresqlWalLagDataPoint(now, rs.writeLag, metadata.AttributeWalOperationLagWrite, rs.clientAddr)
-		p.mb.RecordPostgresqlWalLagDataPoint(now, rs.replayLag, metadata.AttributeWalOperationLagReplay, rs.clientAddr)
-		p.mb.RecordPostgresqlWalLagDataPoint(now, rs.flushLag, metadata.AttributeWalOperationLagFlush, rs.clientAddr)
+		if rs.pendingBytes >= 0 {
+			p.mb.RecordPostgresqlReplicationDataDelayDataPoint(now, rs.pendingBytes, rs.clientAddr)
+		}
+		if rs.writeLag >= 0 {
+			p.mb.RecordPostgresqlWalLagDataPoint(now, rs.writeLag, metadata.AttributeWalOperationLagWrite, rs.clientAddr)
+		}
+		if rs.replayLag >= 0 {
+			p.mb.RecordPostgresqlWalLagDataPoint(now, rs.replayLag, metadata.AttributeWalOperationLagReplay, rs.clientAddr)
+		}
+		if rs.flushLag >= 0 {
+			p.mb.RecordPostgresqlWalLagDataPoint(now, rs.flushLag, metadata.AttributeWalOperationLagFlush, rs.clientAddr)
+		}
 	}
 }
 

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -263,6 +263,13 @@ func (m *mockClient) initMocks(database string, databases []string, index int) {
 				replayLag:    700,
 				writeLag:     800,
 			},
+			{
+				clientAddr:   "nulls",
+				pendingBytes: -1,
+				flushLag:     -1,
+				replayLag:    -1,
+				writeLag:     -1,
+			},
 		}, nil)
 	} else {
 		table1 := "public.table1"


### PR DESCRIPTION
Resolves #14972

An easier implementation would use coalesce to return 0 when the stats are empty, but this would report phantom data points. Instead, this uses coalesce to return -1 and the scraper must use this value to determine whether or not to report a data point. 