### PR TITLE
[pkg/winperfcounters] Fix `-race` test failures due to `checkptr` violations

### DIFF
--- a/.chloggen/winperfcounters-convert-utf16ptr.yaml
+++ b/.chloggen/winperfcounters-convert-utf16ptr.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "pkg/winperfcounters"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix testing with `-race` flag for winperfcounters package and winperfcounter based receivers
+
+# One or more tracking issues related to the change
+issues: [10145, 10146, 10149, 10150]

--- a/pkg/winperfcounters/Makefile
+++ b/pkg/winperfcounters/Makefile
@@ -1,6 +1,1 @@
 include ../../Makefile.Common
-
-# Remove "-race" from the default set of test arguments.
-# pkg/winperfcounters tests are failing with the -race check.
-# See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10145
-GOTEST_OPT = -v -timeout 300s --tags=$(GO_BUILD_TAGS)

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
@@ -168,7 +168,7 @@ func (m *PerformanceQueryImpl) GetFormattedCounterArrayDouble(hCounter PDH_HCOUN
 		buff := make([]byte, buffSize)
 
 		if ret = PdhGetFormattedCounterArrayDouble(hCounter, &buffSize, &itemCount, &buff[0]); ret == ERROR_SUCCESS {
-			items := (*[1 << 20]PDH_FMT_COUNTERVALUE_ITEM_DOUBLE)(unsafe.Pointer(&buff[0]))[:itemCount]
+			items := unsafe.Slice((*PDH_FMT_COUNTERVALUE_ITEM_DOUBLE)(unsafe.Pointer(&buff[0])), itemCount)
 			values := make([]CounterValue, 0, itemCount)
 			for _, item := range items {
 				if item.FmtValue.CStatus == PDH_CSTATUS_VALID_DATA || item.FmtValue.CStatus == PDH_CSTATUS_NEW_DATA {
@@ -214,19 +214,29 @@ func UTF16PtrToString(s *uint16) string {
 	if s == nil {
 		return ""
 	}
-	return syscall.UTF16ToString((*[1 << 29]uint16)(unsafe.Pointer(s))[0:])
+
+	len := 0
+	curPtr := unsafe.Pointer(s)
+	for *(*uint16)(curPtr) != 0 {
+		curPtr = unsafe.Pointer(uintptr(curPtr) + unsafe.Sizeof(*s))
+		len++
+	}
+
+	// len+1 to include null byte in the slice
+	slice := unsafe.Slice(s, len+1)
+	return syscall.UTF16ToString(slice)
 }
 
 // UTF16ToStringArray converts list of Windows API NULL terminated strings  to go string array
 func UTF16ToStringArray(buf []uint16) []string {
 	var strings []string
 	nextLineStart := 0
-	stringLine := UTF16PtrToString(&buf[0])
+	stringLine := syscall.UTF16ToString(buf)
 	for stringLine != "" {
 		strings = append(strings, stringLine)
 		nextLineStart += len([]rune(stringLine)) + 1
 		remainingBuf := buf[nextLineStart:]
-		stringLine = UTF16PtrToString(&remainingBuf[0])
+		stringLine = syscall.UTF16ToString(remainingBuf)
 	}
 	return strings
 }

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"syscall"
 	"time"
+	"unicode/utf16"
 	"unsafe"
 )
 
@@ -222,9 +223,8 @@ func UTF16PtrToString(s *uint16) string {
 		len++
 	}
 
-	// len+1 to include null byte in the slice
-	slice := unsafe.Slice(s, len+1)
-	return syscall.UTF16ToString(slice)
+	slice := unsafe.Slice(s, len)
+	return string(utf16.Decode(slice))
 }
 
 // UTF16ToStringArray converts list of Windows API NULL terminated strings  to go string array

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query_test.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query_test.go
@@ -11,12 +11,26 @@ import (
 )
 
 func TestUTF16PtrToString(t *testing.T) {
-	testPtr := (*uint16)(&utf16.Encode([]rune("Hello World\000"))[0])
-	strOut := UTF16PtrToString(testPtr)
-	require.Equal(t, "Hello World", strOut)
+	t.Run("String 'Hello World'", func(t *testing.T) {
+		testPtr := (*uint16)(&utf16.Encode([]rune("Hello World\000"))[0])
+		strOut := UTF16PtrToString(testPtr)
+		require.Equal(t, "Hello World", strOut)
+	})
+
+	t.Run("nil pointer", func(t *testing.T) {
+		strOut := UTF16PtrToString(nil)
+		require.Equal(t, "", strOut)
+	})
 }
 
-func TestUTF16PtrToString_nil(t *testing.T) {
-	strOut := UTF16PtrToString(nil)
-	require.Equal(t, "", strOut)
+func TestUTF16ToStringArray(t *testing.T) {
+	testStr := "First String\000Second String\000Final String\000\000"
+	testStrUTF16 := utf16.Encode([]rune(testStr))
+
+	strs := UTF16ToStringArray(testStrUTF16)
+	require.Equal(t, []string{
+		"First String",
+		"Second String",
+		"Final String",
+	}, strs)
 }

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query_test.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query_test.go
@@ -1,0 +1,19 @@
+package win_perf_counters
+
+import (
+	"testing"
+	"unicode/utf16"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUTF16PtrToString(t *testing.T) {
+	testPtr := (*uint16)(&utf16.Encode([]rune("Hello World\000"))[0])
+	strOut := UTF16PtrToString(testPtr)
+	require.Equal(t, "Hello World", strOut)
+}
+
+func TestUTF16PtrToString_nil(t *testing.T) {
+	strOut := UTF16PtrToString(nil)
+	require.Equal(t, "", strOut)
+}

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query_test.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query_test.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 package win_perf_counters
 
 import (

--- a/receiver/iisreceiver/Makefile
+++ b/receiver/iisreceiver/Makefile
@@ -1,6 +1,1 @@
 include ../../Makefile.Common
-
-# Remove "-race" from the default set of test arguments.
-# receiver/iisreceiver tests are failing with the -race check.
-# See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10146
-GOTEST_OPT = -v -timeout 300s --tags=$(GO_BUILD_TAGS)

--- a/receiver/sqlserverreceiver/Makefile
+++ b/receiver/sqlserverreceiver/Makefile
@@ -1,6 +1,1 @@
 include ../../Makefile.Common
-
-# Remove "-race" from the default set of test arguments.
-# receiver/sqlserverreceiver tests are failing with the -race check.
-# See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10149
-GOTEST_OPT = -v -timeout 300s --tags=$(GO_BUILD_TAGS)

--- a/receiver/windowsperfcountersreceiver/Makefile
+++ b/receiver/windowsperfcountersreceiver/Makefile
@@ -1,6 +1,1 @@
 include ../../Makefile.Common
-
-# Remove "-race" from the default set of test arguments.
-# receiver/windowsperfcountersreceiver tests are failing with the -race check.
-# See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10150
-GOTEST_OPT = -v -timeout 300s --tags=$(GO_BUILD_TAGS)


### PR DESCRIPTION
**Description:**
* Avoid using the custom `UTF16ToStringArray` function if `syscall.UTF16ToString` would work just fine.
* Avoid casting pointers to large arrays in the winperfcounters package
  * The go race detector will error with `checkptr: converted pointer straddles multiple allocations` otherwise

**Link to tracking Issue:** 
* Resolves #10145
* Resolves #10146
* Resolves #10149 
* Resolves #10150

**Testing:**
* Remove make options disabling `-race` flag
* Unit tests for affected functions