### PR TITLE
[exporter/prometheusremotewrite] Add timeout to prevent deadlock

### DIFF
--- a/.chloggen/prometheusremotewrite-wal-deadlock.yaml
+++ b/.chloggen/prometheusremotewrite-wal-deadlock.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a deadlock issue that can happen when reading and writing from the WAL
+
+# One or more tracking issues related to the change
+issues: [15728]

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -421,6 +421,9 @@ func (prwe *prweWAL) readPrompbFromWAL(ctx context.Context, index uint64) (wreq 
 				if ok {
 					wErr = eerr
 				}
+
+			case <-time.After(1 * time.Millisecond):
+				wErr = nil
 			}
 		}()
 


### PR DESCRIPTION
**Description:** 
Adds a timeout when reading from the WAL, as it shares a lock with the process that also writes to the WAL, creating a deadlock.

**Link to tracking Issue:** #15277

**Testing:** Adding this change allows metrics to be forwarded properly