### PR TITLE
[processor/transform] Add support for parsing json log bodies

### DIFF
--- a/.chloggen/json_log_parse_for_transform_processor.yaml
+++ b/.chloggen/json_log_parse_for_transform_processor.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: transformprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support extracting values from json log bodies
+
+# One or more tracking issues related to the change
+issues: [14938]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
- Adding support for getting nested values in json log bodies
- This allows us to read values that are nested in json and use them for operations

**Link to tracking Issue:** #14938 

**Testing:**

tested with this config
```
processors:
    transform:
        logs:
          statements:
            - set(attributes["log_type"], json_body["log_type"])
```

**Documentation:** <Describe the documentation added.>
None