### PR TITLE
Validate entries in ALLOWLIST are not owned

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -19,8 +19,6 @@ examples/demo/server
 exporter/parquetexporter
 extension/fluentbitextension
 extension/httpforwarder
-extension/sigv4authextension
-extension/storage
 internal/common
 internal/containertest
 internal/coreinternal

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,6 +59,8 @@ jobs:
         run: ./.github/workflows/scripts/check-codeowners.sh check_code_owner_existence
       - name: Check Component Existence
         run: ./.github/workflows/scripts/check-codeowners.sh check_component_existence
+      - name: Validate Allowlist entries
+        run: ./.github/workflows/scripts/check-codeowners.sh check_entries_in_allowlist
   lint-matrix:
     strategy:
       matrix:

--- a/.github/workflows/scripts/check-codeowners.sh
+++ b/.github/workflows/scripts/check-codeowners.sh
@@ -86,8 +86,29 @@ check_component_existence() {
   fi
 }
 
+check_entries_in_allowlist() {
+  NOT_ORPHANED=0
+  while IFS= read -r line
+  do
+    if [[ $line =~ ^[^#] ]]; then
+      COMPONENT_PATH=$(echo "$line" | cut -d" " -f1)
+      if grep -wq "^$COMPONENT_PATH/ " "$CODEOWNERS"; then
+        echo "\"$COMPONENT_PATH\" has an entry in CODEOWNERS file"
+        ((NOT_ORPHANED=NOT_ORPHANED+1))
+      fi
+    fi
+  done <"$ALLOWLIST"
+  echo "There are $NOT_ORPHANED component(s) that have owners but are present in ALLOWLIST file"
+  if [ "$NOT_ORPHANED" -gt 0 ]; then
+    exit 1
+  fi
+}
+
 if [[ "$1" == "check_code_owner_existence" ]];  then
   check_code_owner_existence
 elif [[ "$1" == "check_component_existence" ]]; then
   check_component_existence
+elif [[ "$1" == "check_entries_in_allowlist" ]]; then
+  check_entries_in_allowlist
 fi
+


### PR DESCRIPTION
Signed-off-by: Maureen <amaka013@gmail.com>

**Description:** I created a function in .github/workflows/scripts/check-codeowners.sh file that validates if the modules in the OWNERLIST are owned, it prints out the modules in ownerlist that are contained in the codeowners file.


**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12629
