### PR TITLE
[chore] Set go 1.18 for snowflake receiver.

### DIFF
--- a/receiver/snowflakereceiver/go.mod
+++ b/receiver/snowflakereceiver/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
 
-go 1.19
+go 1.18


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Go version was set to 1.19 https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14778 which seems to break tests on new PRs.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>