### PR TITLE
[processor/cumulativetodelta] Switch feature gate to be enabled by default

### DIFF
--- a/.chloggen/c2d-remove-featuregate.yaml
+++ b/.chloggen/c2d-remove-featuregate.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/cumulativetodelta
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Sets the `processor.cumulativetodeltaprocessor.EnableHistogramSupport` feature gate to enabled by default.  Histograms will be converted by default if they match include rules.
+
+# One or more tracking issues related to the change
+issues: [15288]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/cumulativetodeltaprocessor/README.md
+++ b/processor/cumulativetodeltaprocessor/README.md
@@ -11,7 +11,7 @@
 
 The cumulative to delta processor (`cumulativetodeltaprocessor`) converts monotonic, cumulative sum and histogram metrics to monotonic, delta metrics. Non-monotonic sums and exponential histograms are excluded.
 
-Histogram conversion is currently behind a [feature gate](#feature-gate-configurations) and will only be converted if the feature flag is set.
+Histogram conversion is currently behind a [feature gate](#feature-gate-configurations), and is enabled by default. The feature gate will be completely removed in version 0.64.0.
 
 ## Configuration
 
@@ -79,11 +79,11 @@ processors:
 
 ## Feature gate configurations
 
-The **processor.cumulativetodeltaprocessor.EnableHistogramSupport** feature flag controls whether cumulative histograms delta conversion is supported or not. It is disabled by default, meaning histograms will not be modified by the processor.  If enabled, which histograms are converted is still subjected to the processor's include/exclude filtering.
+The **processor.cumulativetodeltaprocessor.EnableHistogramSupport** feature flag controls whether cumulative histograms delta conversion is supported or not. It is enabled by default, meaning histograms will be modified by the processor.  When enabled, histograms conversion is still subjected to the processor's include/exclude filtering.
 
-Pass `--feature-gates processor.cumulativetodeltaprocessor.EnableHistogramSupport` to enable this feature.
+Pass `--feature-gates -processor.cumulativetodeltaprocessor.EnableHistogramSupport` to disable this feature.
 
-This feature flag will be removed, and histograms will be enabled by default in release v0.60.0, September 2022.
+This feature flag will be removed in release v0.64.0.
 
 ## Warnings
 

--- a/processor/cumulativetodeltaprocessor/processor.go
+++ b/processor/cumulativetodeltaprocessor/processor.go
@@ -30,8 +30,8 @@ const enableHistogramSupportGateID = "processor.cumulativetodeltaprocessor.Enabl
 
 var enableHistogramSupportGate = featuregate.Gate{
 	ID:          enableHistogramSupportGateID,
-	Enabled:     false,
-	Description: "wip",
+	Enabled:     true,
+	Description: "Enables histogram conversion support",
 }
 
 func init() {


### PR DESCRIPTION
**Description:**
Switches the histogram feature gate to be enabled by default.  Will completely remove in 0.64.0.

**Testing:**
Ran unit tests

**Documentation:** 
Updated README