### PR TITLE
SNMP Receiver metric config now takes double as valid value instead o…

### DIFF
--- a/.chloggen/snmpreceiver-double-config-option.yaml
+++ b/.chloggen/snmpreceiver-double-config-option.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: snmpreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: changes the config of the SNMP Metric Receiver to have "`double`" as an option in place of "`float`"
+
+# One or more tracking issues related to the change
+issues: [13409]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/snmpreceiver/README.md
+++ b/receiver/snmpreceiver/README.md
@@ -102,13 +102,13 @@ Attribute configurations are used to define what resource attributes will be use
 
 | Field Name  | Description                                                    | Value                       | Default |
 | --          | --                                                             | --                          | --      |
-| `value_type`  | The value type of this metric's data. Can be either `int` or `float` | string              | float   |
+| `value_type`  | The value type of this metric's data. Can be either `int` or `double` | string             | double   |
 
 #### SumMetric Configuration
 
 | Field Name  | Description                                                    | Value                       | Default |
 | --          | --                                                             | --                          | --      |
-| `value_type` | The value type of this metric's data. Can be either `int` or `float` | string               | float   |
+| `value_type` | The value type of this metric's data. Can be either `int` or `double` | string              | double   |
 | `monotonic` | Whether this is a monotonic sum or not                         | bool                        | false   |
 | `aggregation` | The aggregation type of this metric's data. Can be either `cumulative` or `delta` | string | cumulative |
 
@@ -206,7 +206,7 @@ receivers:
         sum:
           aggregation: delta
           monotonic: false
-          value_type: float
+          value_type: double
         scalar_oids:
           - oid: "4.4.4.4.0"  
             attributes:

--- a/receiver/snmpreceiver/config.go
+++ b/receiver/snmpreceiver/config.go
@@ -44,8 +44,8 @@ var (
 	errMsgMetricNoUnit                     = `metric '%s' must have a unit`
 	errMsgMetricNoGaugeOrSum               = `metric '%s' must have one of either a gauge or sum`
 	errMsgMetricNoOIDs                     = `metric '%s' must have one of either scalar_oids or indexed_oids`
-	errMsgGaugeBadValueType                = `metric '%s' gauge value_type must be either int, float, or bool`
-	errMsgSumBadValueType                  = `metric '%s' sum value_type must be either int, float, or bool`
+	errMsgGaugeBadValueType                = `metric '%s' gauge value_type must be either int or double`
+	errMsgSumBadValueType                  = `metric '%s' sum value_type must be either int or double`
 	errMsgSumBadAggregation                = `metric '%s' sum aggregation value must be either cumulative or delta`
 	errMsgScalarOIDNoOID                   = `metric '%s' scalar_oid must contain an oid`
 	errMsgScalarAttributeNoName            = `metric '%s' scalar_oid attribute must contain a name`
@@ -192,7 +192,7 @@ type MetricConfig struct {
 
 // GaugeMetric contains info about the value of the gauge metric
 type GaugeMetric struct {
-	// ValueType is required can can be either int or float
+	// ValueType is required can can be either int or double
 	ValueType string `mapstructure:"value_type"`
 }
 
@@ -202,7 +202,7 @@ type SumMetric struct {
 	Aggregation string `mapstructure:"aggregation"`
 	// Monotonic is required and can be true or false
 	Monotonic bool `mapstructure:"monotonic"`
-	// ValueType is required can can be either int or float
+	// ValueType is required can can be either int or double
 	ValueType string `mapstructure:"value_type"`
 }
 
@@ -518,7 +518,7 @@ func validateScalarOID(metricName string, scalarOID ScalarOID, cfg *Config) erro
 func validateGauge(metricName string, gauge *GaugeMetric) error {
 	// Ensure valid values for ValueType
 	upperValType := strings.ToUpper(gauge.ValueType)
-	if upperValType != "INT" && upperValType != "FLOAT" {
+	if upperValType != "INT" && upperValType != "DOUBLE" {
 		return fmt.Errorf(errMsgGaugeBadValueType, metricName)
 	}
 
@@ -531,7 +531,7 @@ func validateSum(metricName string, sum *SumMetric) error {
 
 	// Ensure valid values for ValueType
 	upperValType := strings.ToUpper(sum.ValueType)
-	if upperValType != "INT" && upperValType != "FLOAT" {
+	if upperValType != "INT" && upperValType != "DOUBLE" {
 		combinedErr = multierr.Append(combinedErr, fmt.Errorf(errMsgSumBadValueType, metricName))
 	}
 

--- a/receiver/snmpreceiver/config_test.go
+++ b/receiver/snmpreceiver/config_test.go
@@ -42,7 +42,7 @@ func TestLoadConfigConnectionConfigs(t *testing.T) {
 		"m3": {
 			Unit: "By",
 			Gauge: &GaugeMetric{
-				ValueType: "float",
+				ValueType: "double",
 			},
 			ScalarOIDs: []ScalarOID{
 				{
@@ -283,13 +283,13 @@ func getBaseMetricConfig(gauge bool, scalar bool) map[string]*MetricConfig {
 
 	if gauge {
 		metricCfg["m3"].Gauge = &GaugeMetric{
-			ValueType: "float",
+			ValueType: "double",
 		}
 	} else {
 		metricCfg["m3"].Sum = &SumMetric{
 			Aggregation: "cumulative",
 			Monotonic:   true,
-			ValueType:   "float",
+			ValueType:   "double",
 		}
 	}
 
@@ -876,7 +876,7 @@ func TestValidate(t *testing.T) {
 					"m3": {
 						Unit: "By",
 						Gauge: &GaugeMetric{
-							ValueType: "float",
+							ValueType: "double",
 						},
 						ScalarOIDs: []ScalarOID{
 							{
@@ -897,7 +897,7 @@ func TestValidate(t *testing.T) {
 					"m3": {
 						Unit: "By",
 						Gauge: &GaugeMetric{
-							ValueType: "float",
+							ValueType: "double",
 						},
 						ScalarOIDs: []ScalarOID{
 							{
@@ -919,7 +919,7 @@ func TestValidate(t *testing.T) {
 					"m3": {
 						Unit: "By",
 						Gauge: &GaugeMetric{
-							ValueType: "float",
+							ValueType: "double",
 						},
 						ScalarOIDs: []ScalarOID{
 							{
@@ -943,7 +943,7 @@ func TestValidate(t *testing.T) {
 					"m3": {
 						Unit: "By",
 						Gauge: &GaugeMetric{
-							ValueType: "float",
+							ValueType: "double",
 						},
 						ScalarOIDs: []ScalarOID{
 							{
@@ -969,7 +969,7 @@ func TestValidate(t *testing.T) {
 					"m3": {
 						Unit: "By",
 						Gauge: &GaugeMetric{
-							ValueType: "float",
+							ValueType: "double",
 						},
 						ScalarOIDs: []ScalarOID{
 							{

--- a/receiver/snmpreceiver/factory.go
+++ b/receiver/snmpreceiver/factory.go
@@ -106,11 +106,11 @@ func addMissingConfigDefaults(cfg *Config) error {
 			metricCfg.Unit = "1"
 		}
 		if metricCfg.Gauge != nil && metricCfg.Gauge.ValueType == "" {
-			metricCfg.Gauge.ValueType = "float"
+			metricCfg.Gauge.ValueType = "double"
 		}
 		if metricCfg.Sum != nil {
 			if metricCfg.Sum.ValueType == "" {
-				metricCfg.Sum.ValueType = "float"
+				metricCfg.Sum.ValueType = "double"
 			}
 			if metricCfg.Sum.Aggregation == "" {
 				metricCfg.Sum.Aggregation = "cumulative"

--- a/receiver/snmpreceiver/factory_test.go
+++ b/receiver/snmpreceiver/factory_test.go
@@ -174,7 +174,7 @@ func TestNewFactory(t *testing.T) {
 			},
 		},
 		{
-			desc: "CreateMetricsReceiver adds missing metric gauge value type as float",
+			desc: "CreateMetricsReceiver adds missing metric gauge value type as double",
 			testFunc: func(t *testing.T) {
 				factory := NewFactory()
 				cfg := factory.CreateDefaultConfig()
@@ -194,11 +194,11 @@ func TestNewFactory(t *testing.T) {
 					consumertest.NewNop(),
 				)
 				require.NoError(t, err)
-				require.Equal(t, "float", snmpCfg.Metrics["m1"].Gauge.ValueType)
+				require.Equal(t, "double", snmpCfg.Metrics["m1"].Gauge.ValueType)
 			},
 		},
 		{
-			desc: "CreateMetricsReceiver adds missing metric sum value type as float",
+			desc: "CreateMetricsReceiver adds missing metric sum value type as double",
 			testFunc: func(t *testing.T) {
 				factory := NewFactory()
 				cfg := factory.CreateDefaultConfig()
@@ -218,7 +218,7 @@ func TestNewFactory(t *testing.T) {
 					consumertest.NewNop(),
 				)
 				require.NoError(t, err)
-				require.Equal(t, "float", snmpCfg.Metrics["m1"].Sum.ValueType)
+				require.Equal(t, "double", snmpCfg.Metrics["m1"].Sum.ValueType)
 			},
 		},
 		{

--- a/receiver/snmpreceiver/go.mod
+++ b/receiver/snmpreceiver/go.mod
@@ -19,12 +19,14 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.4.3 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/otel v1.11.0 // indirect
@@ -40,3 +42,5 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest => ../../internal/scrapertest

--- a/receiver/snmpreceiver/go.sum
+++ b/receiver/snmpreceiver/go.sum
@@ -36,6 +36,7 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -165,11 +166,13 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -238,6 +241,9 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
@@ -435,8 +441,10 @@ google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/receiver/snmpreceiver/testdata/config.yaml
+++ b/receiver/snmpreceiver/testdata/config.yaml
@@ -7,7 +7,7 @@ snmp/v2c_connection_good:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/no_endpoint:
@@ -18,7 +18,7 @@ snmp/no_endpoint:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/invalid_endpoint:
@@ -30,7 +30,7 @@ snmp/invalid_endpoint:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"
 snmp/no_port:
@@ -42,7 +42,7 @@ snmp/no_port:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/no_port_trailing_colon:
@@ -54,7 +54,7 @@ snmp/no_port_trailing_colon:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/bad_endpoint_scheme:
@@ -66,7 +66,7 @@ snmp/bad_endpoint_scheme:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/no_endpoint_scheme:
@@ -78,7 +78,7 @@ snmp/no_endpoint_scheme:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/no_version:
@@ -89,7 +89,7 @@ snmp/no_version:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1" 
 snmp/bad_version:
@@ -101,7 +101,7 @@ snmp/bad_version:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_connection_good:
@@ -118,7 +118,7 @@ snmp/v3_connection_good:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_no_user:
@@ -130,7 +130,7 @@ snmp/v3_no_user:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_no_security_level:
@@ -142,7 +142,7 @@ snmp/v3_no_security_level:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_bad_security_level:
@@ -155,7 +155,7 @@ snmp/v3_bad_security_level:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_no_auth_type:
@@ -169,7 +169,7 @@ snmp/v3_no_auth_type:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_bad_auth_type:
@@ -184,7 +184,7 @@ snmp/v3_bad_auth_type:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_no_auth_password:
@@ -198,7 +198,7 @@ snmp/v3_no_auth_password:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_no_privacy_type:
@@ -214,7 +214,7 @@ snmp/v3_no_privacy_type:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_bad_privacy_type:
@@ -231,7 +231,7 @@ snmp/v3_bad_privacy_type:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/v3_no_privacy_password:
@@ -247,7 +247,7 @@ snmp/v3_no_privacy_password:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/no_metric_config:
@@ -263,7 +263,7 @@ snmp/no_metric_unit:
   metrics:
     m3:
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/no_metric_gauge_or_sum:
@@ -285,7 +285,7 @@ snmp/no_metric_oids:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
 snmp/no_metric_gauge_type:
   collection_interval: 10s
   endpoint: udp://localhost:161
@@ -347,7 +347,7 @@ snmp/no_metric_sum_aggregation:
       unit: "By"
       sum:
         monotonic: true
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/bad_metric_sum_aggregation:
@@ -361,7 +361,7 @@ snmp/bad_metric_sum_aggregation:
       sum:
         aggregation: Counter
         monotonic: true
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
 snmp/no_scalar_oid_oid:
@@ -373,7 +373,7 @@ snmp/no_scalar_oid_oid:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       scalar_oids:
         - attributes:
 snmp/no_attribute_oid_prefix_or_enums:
@@ -387,7 +387,7 @@ snmp/no_attribute_oid_prefix_or_enums:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       scalar_oids:
         - oid: "1"
 snmp/no_scalar_oid_attribute_name:
@@ -399,7 +399,7 @@ snmp/no_scalar_oid_attribute_name:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       scalar_oids:
         - oid: "1"
           attributes:
@@ -418,7 +418,7 @@ snmp/bad_scalar_oid_attribute_name:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       scalar_oids:
         - oid: "1"
           attributes:
@@ -436,7 +436,7 @@ snmp/bad_scalar_oid_attribute:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       scalar_oids:
         - oid: "1"
           attributes:
@@ -456,7 +456,7 @@ snmp/bad_scalar_oid_attribute_value:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       scalar_oids:
         - oid: "1"
           attributes:
@@ -471,7 +471,7 @@ snmp/no_column_oid_oid:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       column_oids:
         - attributes:
 snmp/no_column_oid_attribute_name:
@@ -483,7 +483,7 @@ snmp/no_column_oid_attribute_name:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       column_oids:
         - oid: "1"
           attributes:
@@ -500,7 +500,7 @@ snmp/bad_column_oid_attribute_name:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       column_oids:
         - oid: "1"
           attributes:
@@ -519,7 +519,7 @@ snmp/bad_column_oid_attribute_value:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       column_oids:
         - oid: "1"
           attributes:
@@ -537,7 +537,7 @@ snmp/bad_column_oid_resource_attribute_name:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       column_oids:
         - oid: "1"
           resource_attributes:
@@ -556,7 +556,7 @@ snmp/column_oid_no_indexed_attribute_or_resource_attribute:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       column_oids:
         - oid: "1"
           attributes:
@@ -573,7 +573,7 @@ snmp/no_resource_attribute_oid_or_prefix:
     m3:
       unit: "By"
       gauge:
-        value_type: "float"
+        value_type: "double"
       column_oids:
         - oid: "1"
           resource_attributes:
@@ -630,7 +630,7 @@ snmp/complex_good:
     m3:
       unit: "By"
       gauge:
-        value_type: float
+        value_type: double
       scalar_oids:
         - oid: "1"  
           attributes:


### PR DESCRIPTION
**Description:**
SNMP Receiver Config now uses double as an option for value type rather than float

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13409

**Testing:**
Unit tests modified for new scraper functionality

**Documentation:**
README updated with this info