### PR TITLE
[receiver/snmp] SNMP Receiver client refactor

### DIFF
--- a/.chloggen/snmpreceiver-client-refactor.yaml
+++ b/.chloggen/snmpreceiver-client-refactor.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: snmpreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: changes the client of the SNMP metric receiver to only return data in its functions rather than try to process that data
+
+# One or more tracking issues related to the change
+issues: [13409]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/snmpreceiver/goSNMPWrapper.go
+++ b/receiver/snmpreceiver/goSNMPWrapper.go
@@ -37,18 +37,17 @@ type goSNMPWrapper interface {
 	// Get sends an SNMP GET request
 	Get(oids []string) (result *gosnmp.SnmpPacket, err error)
 
-	// Walk retrieves a subtree of values using GETNEXT - a request is made for each
-	// value, unlike BulkWalk which does this operation in batches. As the tree is
-	// walked walkFn is called for each new value. The function immediately returns
-	// an error if either there is an underlaying SNMP error (e.g. GetNext fails),
-	// or if walkFn returns an error.
-	Walk(rootOid string, walkFn gosnmp.WalkFunc) error
+	// WalkAll is similar to Walk but returns a filled array of all values rather
+	// than using a callback function to stream results. Caution: if you have set
+	// x.AppOpts to 'c', WalkAll may loop indefinitely and cause an Out Of Memory -
+	// use Walk instead.
+	WalkAll(rootOid string) (results []gosnmp.SnmpPDU, err error)
 
-	// BulkWalk retrieves a subtree of values using GETBULK. As the tree is
-	// walked walkFn is called for each new value. The function immediately returns
-	// an error if either there is an underlaying SNMP error (e.g. GetBulk fails),
-	// or if walkFn returns an error.
-	BulkWalk(rootOid string, walkFn gosnmp.WalkFunc) error
+	// BulkWalkAll is similar to BulkWalk but returns a filled array of all values
+	// rather than using a callback function to stream results. Caution: if you
+	// have set x.AppOpts to 'c', BulkWalkAll may loop indefinitely and cause an
+	// Out Of Memory - use BulkWalk instead.
+	BulkWalkAll(rootOid string) (results []gosnmp.SnmpPDU, err error)
 
 	// GetTransport gets the Transport
 	GetTransport() string

--- a/receiver/snmpreceiver/internal/mocks/goSNMPWrapper.go
+++ b/receiver/snmpreceiver/internal/mocks/goSNMPWrapper.go
@@ -14,18 +14,27 @@ type MockGoSNMPWrapper struct {
 	mock.Mock
 }
 
-// BulkWalk provides a mock function with given fields: rootOid, walkFn
-func (_m *MockGoSNMPWrapper) BulkWalk(rootOid string, walkFn gosnmp.WalkFunc) error {
-	ret := _m.Called(rootOid, walkFn)
+// BulkWalkAll provides a mock function with given fields: rootOid
+func (_m *MockGoSNMPWrapper) BulkWalkAll(rootOid string) ([]gosnmp.SnmpPDU, error) {
+	ret := _m.Called(rootOid)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, gosnmp.WalkFunc) error); ok {
-		r0 = rf(rootOid, walkFn)
+	var r0 []gosnmp.SnmpPDU
+	if rf, ok := ret.Get(0).(func(string) []gosnmp.SnmpPDU); ok {
+		r0 = rf(rootOid)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]gosnmp.SnmpPDU)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(rootOid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Close provides a mock function with given fields:
@@ -271,18 +280,27 @@ func (_m *MockGoSNMPWrapper) SetVersion(version gosnmp.SnmpVersion) {
 	_m.Called(version)
 }
 
-// Walk provides a mock function with given fields: rootOid, walkFn
-func (_m *MockGoSNMPWrapper) Walk(rootOid string, walkFn gosnmp.WalkFunc) error {
-	ret := _m.Called(rootOid, walkFn)
+// WalkAll provides a mock function with given fields: rootOid
+func (_m *MockGoSNMPWrapper) WalkAll(rootOid string) ([]gosnmp.SnmpPDU, error) {
+	ret := _m.Called(rootOid)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, gosnmp.WalkFunc) error); ok {
-		r0 = rf(rootOid, walkFn)
+	var r0 []gosnmp.SnmpPDU
+	if rf, ok := ret.Get(0).(func(string) []gosnmp.SnmpPDU); ok {
+		r0 = rf(rootOid)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]gosnmp.SnmpPDU)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(rootOid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 type mockNewGoSNMPWrapperT interface {


### PR DESCRIPTION
**Description:**
SNMP Metric Receiver client has been refactored to now simply return snmp data. Its methods no longer take a process function to be run on each piece of data

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13409

**Testing:**
Unit tests added for new client functionality

**Documentation:**
No new documentation needed