### PR TITLE
[receiver/filelog] Promote component to beta

### DIFF
--- a/.chloggen/filelog-beta.yaml
+++ b/.chloggen/filelog-beta.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote component to Beta status
+
+# One or more tracking issues related to the change
+issues: [15355]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |           |
 | ------------------------ |-----------|
-| Stability                | [alpha]   |
+| Stability                | [beta]    |
 | Supported pipeline types | logs      |
 | Distributions            | [contrib] |
 
@@ -91,5 +91,5 @@ receivers:
           layout: '%Y-%m-%d %H:%M:%S'
 ```
 
-[alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/filelogreceiver/filelog.go
+++ b/receiver/filelogreceiver/filelog.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	typeStr   = "filelog"
-	stability = component.StabilityLevelAlpha
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for filelog receiver


### PR DESCRIPTION
This is a proposal to move `filelogreceiver` to beta status.

I believe this receiver is sufficiently stable, that it has been extensively used in many real world workloads, and that there are no breaking changes expected.

There are two points in particular that I would like to discuss to ensure other stakeholders are in agreement.
1. Batching. The receiver reads log entries one at a time, but emits them in batches because it has some performance benefits. This is not strictly necessary and I can image there is a case to be made against it. If this were to be removed, it would require removal of the associated configuration section. My opinion is that this should stay, but if there are objections I would appreciate hearing them now.
2. Operators. There is an intention to enhance the `transformprocessor` with functionality equivalent to the `pkg/stanza` operators. While this would provide an alternative approach to parsing logs, I do not believe it invalidates the rationale for keeping operators in the receiver. The main reason to embed these operators is that it empowers the receiver to meaningfully interpret logs _into the OTel data model_. Resource attributes, scope, severity, timestamp, etc, are commonly extracted at the time of ingest. I believe this is appropriate and that users naturally expect that the receiver can be configured to represent their logs according to the OTel data model.

2a. Operator stability. It is worth noting that their stability is directly relevant to the stability of the receiver, assuming they are not removed. While there are no anticipated breaking changes to operators, I believe that the operator framework provides a reasonable escape hatch for the case where a breaking change is necessary. Specifically, an existing operator can be forked, corrected, and made available as a new operator.