### PR TITLE
[syslogreceiver] Add for RFC 6587 octet counting and non-transparent-framing

### DIFF
--- a/.chloggen/syslogreceiver-rfc6587-support.yaml
+++ b/.chloggen/syslogreceiver-rfc6587-support.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: syslogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added RFC 6587 Octet Counting and Non-Transparent-Framing support.
+
+# One or more tracking issues related to the change
+issues: [8390]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -273,6 +273,7 @@ require (
 	github.com/knadh/koanf v1.4.3 // indirect
 	github.com/kolo/xmlrpc v0.0.0-20201022064351-38db28db192b // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 // indirect
 	github.com/leoluk/perflib_exporter v0.2.0 // indirect
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -1363,6 +1363,7 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+sBqGZrRkMwPgg=
 github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353 h1:X/79QL0b4YJVO5+OsPH9rF2u428CIrGL/jLmPsoOQQ4=
+github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 h1:bCiVCRCs1Heq84lurVinUPy19keqGEe4jh5vtK37jcg=
 github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165/go.mod h1:WZxr2/6a/Ar9bMDc2rN/LJrE/hF6bXE4LPyDSIxwAfg=
 github.com/leoluk/perflib_exporter v0.2.0 h1:WJU7N3AIHxfc3CjoEJcBgG3i2ltF5Yz1ADVY9T6f1BY=
 github.com/leoluk/perflib_exporter v0.2.0/go.mod h1:MinSWm88jguXFFrGsP56PtleUb4Qtm4tNRH/wXNXRTI=

--- a/go.mod
+++ b/go.mod
@@ -425,6 +425,7 @@ require (
 	github.com/knadh/koanf v1.4.3 // indirect
 	github.com/kolo/xmlrpc v0.0.0-20201022064351-38db28db192b // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 // indirect
 	github.com/leoluk/perflib_exporter v0.2.0 // indirect
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1360,6 +1360,7 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+sBqGZrRkMwPgg=
 github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353 h1:X/79QL0b4YJVO5+OsPH9rF2u428CIrGL/jLmPsoOQQ4=
+github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 h1:bCiVCRCs1Heq84lurVinUPy19keqGEe4jh5vtK37jcg=
 github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165/go.mod h1:WZxr2/6a/Ar9bMDc2rN/LJrE/hF6bXE4LPyDSIxwAfg=
 github.com/leoluk/perflib_exporter v0.2.0 h1:WJU7N3AIHxfc3CjoEJcBgG3i2ltF5Yz1ADVY9T6f1BY=
 github.com/leoluk/perflib_exporter v0.2.0/go.mod h1:MinSWm88jguXFFrGsP56PtleUb4Qtm4tNRH/wXNXRTI=

--- a/pkg/stanza/docs/operators/syslog_parser.md
+++ b/pkg/stanza/docs/operators/syslog_parser.md
@@ -4,18 +4,20 @@ The `syslog_parser` operator parses the string-type field selected by `parse_fro
 
 ### Configuration Fields
 
-| Field         | Default          | Description |
-| ---           | ---              | ---         |
-| `id`          | `syslog_parser`  | A unique identifier for the operator. |
-| `output`      | Next in pipeline | The connected operator(s) that will receive all outbound entries. |
-| `parse_from`  | `body`           | The [field](../types/field.md) from which the value will be parsed. |
-| `parse_to`    | `attributes`     | The [field](../types/field.md) to which the value will be parsed. |
-| `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
-| `protocol`    | required         | The protocol to parse the syslog messages as. Options are `rfc3164` and `rfc5424`. |
-| `location`    | `UTC`            | The geographic location (timezone) to use when parsing the timestamp (Syslog RFC 3164 only). The available locations depend on the local IANA Time Zone database. [This page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) contains many examples, such as `America/New_York`. |
-| `timestamp`   | `nil`            | An optional [timestamp](../types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator                                                                                               |
-| `severity`    | `nil`            | An optional [severity](../types/severity.md) block which will parse a severity field before passing the entry to the output operator                                                                                                  |
-| `if`          |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
+| Field                                | Default          | Description |
+| ---                                  | ---              | ---         |
+| `id`                                 | `syslog_parser`  | A unique identifier for the operator. |
+| `output`                             | Next in pipeline | The connected operator(s) that will receive all outbound entries. |
+| `parse_from`                         | `body`           | The [field](../types/field.md) from which the value will be parsed. |
+| `parse_to`                           | `attributes`     | The [field](../types/field.md) to which the value will be parsed. |
+| `on_error`                           | `send`           | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
+| `protocol`                           | required         | The protocol to parse the syslog messages as. Options are `rfc3164` and `rfc5424`. |
+| `location`                           | `UTC`            | The geographic location (timezone) to use when parsing the timestamp (Syslog RFC 3164 only). The available locations depend on the local IANA Time Zone database. [This page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) contains many examples, such as `America/New_York`. |
+| `enable_octet_counting`              | `false`          | Wether or not to enable [RFC 6587](https://www.rfc-editor.org/rfc/rfc6587#section-3.4.1) Octet Counting on syslog parsing (Syslog RFC 5424 only).  |
+| `non_transparent_framing_trailer`    | `nil`            | The framing trailer, either `LF` or `NUL`, when using [RFC 6587](https://www.rfc-editor.org/rfc/rfc6587#section-3.4.2) Non-Transparent-Framing (Syslog RFC 5424 only). |
+| `timestamp`                          | `nil`            | An optional [timestamp](../types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator                                                                                               |
+| `severity`                           | `nil`            | An optional [severity](../types/severity.md) block which will parse a severity field before passing the entry to the output operator                                                                                                  |
+| `if`                                 |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
 
 ### Embedded Operations
 

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/knadh/koanf v1.4.3 // indirect
+	github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/pkg/stanza/go.sum
+++ b/pkg/stanza/go.sum
@@ -184,6 +184,7 @@ github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 h1:bCiVCRCs1Heq84lurVinUPy19keqGEe4jh5vtK37jcg=
 github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165/go.mod h1:WZxr2/6a/Ar9bMDc2rN/LJrE/hF6bXE4LPyDSIxwAfg=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=

--- a/pkg/stanza/operator/input/syslog/syslog_test.go
+++ b/pkg/stanza/operator/input/syslog/syslog_test.go
@@ -40,12 +40,17 @@ func TestInput(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tc := range cases {
-		t.Run(fmt.Sprintf("TCP-%s", tc.Name), func(t *testing.T) {
-			InputTest(t, NewConfigWithTCP(&tc.Config.BaseConfig), tc)
-		})
-		t.Run(fmt.Sprintf("UDP-%s", tc.Name), func(t *testing.T) {
-			InputTest(t, NewConfigWithUDP(&tc.Config.BaseConfig), tc)
-		})
+		if tc.ValidForTCP {
+			t.Run(fmt.Sprintf("TCP-%s", tc.Name), func(t *testing.T) {
+				InputTest(t, NewConfigWithTCP(&tc.Config.BaseConfig), tc)
+			})
+		}
+
+		if tc.ValidForUDP {
+			t.Run(fmt.Sprintf("UDP-%s", tc.Name), func(t *testing.T) {
+				InputTest(t, NewConfigWithUDP(&tc.Config.BaseConfig), tc)
+			})
+		}
 	}
 }
 

--- a/pkg/stanza/operator/parser/syslog/config_test.go
+++ b/pkg/stanza/operator/parser/syslog/config_test.go
@@ -142,6 +142,98 @@ func TestParserMissingProtocol(t *testing.T) {
 	require.Contains(t, err.Error(), "missing field 'protocol'")
 }
 
+func TestRFC6587ConfigOptions(t *testing.T) {
+	validFramingTrailer := NULTrailer
+	invalidFramingTrailer := "bad"
+	testCases := []struct {
+		desc        string
+		cfg         *Config
+		errContents string
+	}{
+		{
+			desc: "Octet Counting with RFC3164",
+			cfg: &Config{
+				ParserConfig: helper.NewParserConfig(operatorType, operatorType),
+				BaseConfig: BaseConfig{
+					Protocol:            RFC3164,
+					EnableOctetCounting: true,
+				},
+			},
+			errContents: "octet_counting and non_transparent_framing are only compatible with protocol rfc5424",
+		},
+		{
+			desc: "Non-Transparent-Framing with RFC3164",
+			cfg: &Config{
+				ParserConfig: helper.NewParserConfig(operatorType, operatorType),
+				BaseConfig: BaseConfig{
+					Protocol:                     RFC3164,
+					NonTransparentFramingTrailer: &validFramingTrailer,
+				},
+			},
+			errContents: "octet_counting and non_transparent_framing are only compatible with protocol rfc5424",
+		},
+		{
+			desc: "Non-Transparent-Framing and Octet counting both enabled with RFC5424",
+			cfg: &Config{
+				ParserConfig: helper.NewParserConfig(operatorType, operatorType),
+				BaseConfig: BaseConfig{
+					Protocol:                     RFC5424,
+					NonTransparentFramingTrailer: &validFramingTrailer,
+					EnableOctetCounting:          true,
+				},
+			},
+			errContents: "only one of octet_counting or non_transparent_framing can be enabled",
+		},
+		{
+			desc: "Valid Octet Counting",
+			cfg: &Config{
+				ParserConfig: helper.NewParserConfig(operatorType, operatorType),
+				BaseConfig: BaseConfig{
+					Protocol:                     RFC5424,
+					NonTransparentFramingTrailer: nil,
+					EnableOctetCounting:          true,
+				},
+			},
+			errContents: "",
+		},
+		{
+			desc: "Valid Non-Transparent-Framing Trailer",
+			cfg: &Config{
+				ParserConfig: helper.NewParserConfig(operatorType, operatorType),
+				BaseConfig: BaseConfig{
+					Protocol:                     RFC5424,
+					NonTransparentFramingTrailer: &validFramingTrailer,
+					EnableOctetCounting:          false,
+				},
+			},
+			errContents: "",
+		},
+		{
+			desc: "Invalid Non-Transparent-Framing Trailer",
+			cfg: &Config{
+				ParserConfig: helper.NewParserConfig(operatorType, operatorType),
+				BaseConfig: BaseConfig{
+					Protocol:                     RFC5424,
+					NonTransparentFramingTrailer: &invalidFramingTrailer,
+					EnableOctetCounting:          false,
+				},
+			},
+			errContents: "invalid non_transparent_framing_trailer",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := tc.cfg.Build(testutil.Logger(t))
+			if tc.errContents != "" {
+				require.ErrorContains(t, err, tc.errContents)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestParserInvalidLocation(t *testing.T) {
 	config := NewConfig()
 	config.Location = "not_a_location"

--- a/pkg/stanza/operator/parser/syslog/syslog.go
+++ b/pkg/stanza/operator/parser/syslog/syslog.go
@@ -126,8 +126,7 @@ func (s *Parser) buildParseFunc() (parseFunc, error) {
 	switch s.protocol {
 	case RFC3164:
 		return func(input []byte) (sl.Message, error) {
-			machine := rfc3164.NewMachine(rfc3164.WithLocaleTimezone(s.location))
-			return machine.Parse(input)
+			return rfc3164.NewMachine(rfc3164.WithLocaleTimezone(s.location)).Parse(input)
 		}, nil
 	case RFC5424:
 		switch {
@@ -140,8 +139,7 @@ func (s *Parser) buildParseFunc() (parseFunc, error) {
 		// Raw RFC5424 parsing
 		default:
 			return func(input []byte) (sl.Message, error) {
-				machine := rfc5424.NewMachine()
-				return machine.Parse(input)
+				return rfc5424.NewMachine().Parse(input)
 			}, nil
 		}
 

--- a/pkg/stanza/operator/parser/syslog/syslog.go
+++ b/pkg/stanza/operator/parser/syslog/syslog.go
@@ -96,8 +96,8 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	case c.Protocol == RFC5424 && (c.NonTransparentFramingTrailer != nil && c.EnableOctetCounting):
 		return nil, errors.New("only one of octet_counting or non_transparent_framing can be enabled")
 	case c.Protocol == RFC5424 && c.NonTransparentFramingTrailer != nil:
-		if err := validateNonTransparentFramingTrailer(c.NonTransparentFramingTrailer); err != nil {
-			return nil, err
+		if validationErr := validateNonTransparentFramingTrailer(c.NonTransparentFramingTrailer); validationErr != nil {
+			return nil, validationErr
 		}
 	}
 

--- a/receiver/syslogreceiver/README.md
+++ b/receiver/syslogreceiver/README.md
@@ -16,6 +16,8 @@ Parses Syslogs received over TCP or UDP.
 | `udp`      |`nil`                | Defined udp_input operator. (see the UDP configuration section)  |
 | `protocol`    | required         | The protocol to parse the syslog messages as. Options are `rfc3164` and `rfc5424` |
 | `location`    | `UTC`            | The geographic location (timezone) to use when parsing the timestamp (Syslog RFC 3164 only). The available locations depend on the local IANA Time Zone database. [This page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) contains many examples, such as `America/New_York`. |
+| `enable_octet_counting`              | `false`          | Wether or not to enable [RFC 6587](https://www.rfc-editor.org/rfc/rfc6587#section-3.4.1) Octet Counting on syslog parsing (Syslog RFC 5424 and TCP only).  |
+| `non_transparent_framing_trailer`    | `nil`            | The framing trailer, either `LF` or `NUL`, when using [RFC 6587](https://www.rfc-editor.org/rfc/rfc6587#section-3.4.2) Non-Transparent-Framing (Syslog RFC 5424 and TCP only). |
 | `timestamp`   | `nil`            | An optional [timestamp](../../pkg/stanza/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator                                                                                               |
 | `severity`    | `nil`            | An optional [severity](../../pkg/stanza/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator
 | `attributes`   | {}               | A map of `key: value` labels to add to the entry's attributes    |

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.4.3 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
+	github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/receiver/syslogreceiver/go.sum
+++ b/receiver/syslogreceiver/go.sum
@@ -183,6 +183,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 h1:bCiVCRCs1Heq84lurVinUPy19keqGEe4jh5vtK37jcg=
 github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165/go.mod h1:WZxr2/6a/Ar9bMDc2rN/LJrE/hF6bXE4LPyDSIxwAfg=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=


### PR DESCRIPTION
**Description:** Added support for RFC 6587 [octet counting](https://www.rfc-editor.org/rfc/rfc6587#section-3.4.1) and [non-transparent-framing](https://www.rfc-editor.org/rfc/rfc6587#section-3.4.2)

**Link to tracking Issue:** Resolves #8390

**Testing:** Added new unit tests for each mode.

**Documentation:** Updated configuration documentation for syslogreceiver and corresponding stanza operators.