### PR TITLE
[processor/{deltatorate, metricsgeneration}] Add CODEOWNERS

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -26,6 +26,5 @@ internal/sharedcomponent
 internal/tools
 pkg/batchperresourceattr
 pkg/experimentalmetricmetadata
-processor/metricsgenerationprocessor
 receiver/dotnetdiagnosticsreceiver
 testbed

--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -26,7 +26,6 @@ internal/sharedcomponent
 internal/tools
 pkg/batchperresourceattr
 pkg/experimentalmetricmetadata
-processor/deltatorateprocessor
 processor/metricsgenerationprocessor
 receiver/dotnetdiagnosticsreceiver
 testbed

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,13 +113,13 @@ pkg/winperfcounters/                                 @open-telemetry/collector-c
 
 processor/attributesprocessor/                       @open-telemetry/collector-contrib-approvers @boostchicken
 processor/cumulativetodeltaprocessor/                @open-telemetry/collector-contrib-approvers @TylerHelmuth
-processor/deltatorateprocessor/                      @open-telemetry/collector-contrib-approvers @hossain-rayhan @Aneurysm9
+processor/deltatorateprocessor/                      @open-telemetry/collector-contrib-approvers @Aneurysm9
 processor/filterprocessor/                           @open-telemetry/collector-contrib-approvers @boostchicken
 processor/groupbyattrsprocessor/                     @open-telemetry/collector-contrib-approvers
 processor/groupbytraceprocessor/                     @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/k8sattributesprocessor/                    @open-telemetry/collector-contrib-approvers @owais @dmitryax
 processor/logstransformprocessor/                    @open-telemetry/collector-contrib-approvers @djaglowski @dehaansa
-processor/metricsgenerationprocessor/                @open-telemetry/collector-contrib-approvers @hossain-rayhan @Aneurysm9
+processor/metricsgenerationprocessor/                @open-telemetry/collector-contrib-approvers @Aneurysm9
 processor/metricstransformprocessor/                 @open-telemetry/collector-contrib-approvers @dmitryax
 processor/probabilisticsamplerprocessor/             @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/redactionprocessor/                        @open-telemetry/collector-contrib-approvers @leonsp-ai @dmitryax @mx-psi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,6 +113,7 @@ pkg/winperfcounters/                                 @open-telemetry/collector-c
 
 processor/attributesprocessor/                       @open-telemetry/collector-contrib-approvers @boostchicken
 processor/cumulativetodeltaprocessor/                @open-telemetry/collector-contrib-approvers @TylerHelmuth
+processor/deltatorateprocessor/                      @open-telemetry/collector-contrib-approvers @hossain-rayhan @Aneurysm9
 processor/filterprocessor/                           @open-telemetry/collector-contrib-approvers @boostchicken
 processor/groupbyattrsprocessor/                     @open-telemetry/collector-contrib-approvers
 processor/groupbytraceprocessor/                     @open-telemetry/collector-contrib-approvers @jpkrohling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,6 +119,7 @@ processor/groupbyattrsprocessor/                     @open-telemetry/collector-c
 processor/groupbytraceprocessor/                     @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/k8sattributesprocessor/                    @open-telemetry/collector-contrib-approvers @owais @dmitryax
 processor/logstransformprocessor/                    @open-telemetry/collector-contrib-approvers @djaglowski @dehaansa
+processor/metricsgenerationprocessor/                @open-telemetry/collector-contrib-approvers @hossain-rayhan @Aneurysm9
 processor/metricstransformprocessor/                 @open-telemetry/collector-contrib-approvers @dmitryax
 processor/probabilisticsamplerprocessor/             @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/redactionprocessor/                        @open-telemetry/collector-contrib-approvers @leonsp-ai @dmitryax @mx-psi


### PR DESCRIPTION
Description:

Add CODEOWNERs for the deltatorate and metricsgeneration processors, based on the authors of #4218 and #3266 respectively.

Link to tracking Issue: Updates #3870
