### PR TITLE
Add CODEOWNERS for core components

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -14,19 +14,13 @@
 #
 
 cmd/configschema
-examples/demo/client
-examples/demo/server
 exporter/parquetexporter
 extension/fluentbitextension
 extension/httpforwarder
 internal/common
 internal/containertest
-internal/coreinternal
-internal/sharedcomponent
-internal/tools
 pkg/batchperresourceattr
 pkg/experimentalmetricmetadata
 processor/deltatorateprocessor
 processor/metricsgenerationprocessor
 receiver/dotnetdiagnosticsreceiver
-testbed

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,8 @@ cmd/tracegen/                                        @open-telemetry/collector-c
 
 confmap/provider/s3provider/                         @open-telemetry/collector-contrib-approvers @Aneurysm9
 
+examples/demo/                                       @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
+
 exporter/alibabacloudlogserviceexporter/             @open-telemetry/collector-contrib-approvers @shabicheng @kongluoxing @qiansheng91
 exporter/awscloudwatchlogsexporter/                  @open-telemetry/collector-contrib-approvers @boostchicken
 exporter/awsemfexporter/                             @open-telemetry/collector-contrib-approvers @Aneurysm9 @shaochengwang @mxiamxia
@@ -97,6 +99,9 @@ internal/kubelet/                                    @open-telemetry/collector-c
 internal/metadataproviders/                          @open-telemetry/collector-contrib-approvers @jrcamp @Aneurysm9 @dashpole
 internal/scrapertest/                                @open-telemetry/collector-contrib-approvers @djaglowski
 internal/splunk/                                     @open-telemetry/collector-contrib-approvers @pmcollins @dmitryax
+internal/tools/                                      @open-telemetry/collector-contrib-approvers
+internal/coreinternal/                               @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
+internal/sharedcomponent/                            @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 
 pkg/batchpersignal/                                  @open-telemetry/collector-contrib-approvers @jpkrohling
 pkg/resourcetotelemetry/                             @open-telemetry/collector-contrib-approvers @mx-psi
@@ -208,4 +213,6 @@ receiver/windowsperfcountersreceiver/                @open-telemetry/collector-c
 receiver/zipkinreceiver/                             @open-telemetry/collector-contrib-approvers
 receiver/zookeeperreceiver/                          @open-telemetry/collector-contrib-approvers @djaglowski
 
+
+testbed/                                             @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 testbed/mockdatareceivers/mockawsxrayreceiver/       @open-telemetry/collector-contrib-approvers @willarmiros

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -217,6 +217,5 @@ receiver/windowsperfcountersreceiver/                @open-telemetry/collector-c
 receiver/zipkinreceiver/                             @open-telemetry/collector-contrib-approvers
 receiver/zookeeperreceiver/                          @open-telemetry/collector-contrib-approvers @djaglowski
 
-
 testbed/                                             @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 testbed/mockdatareceivers/mockawsxrayreceiver/       @open-telemetry/collector-contrib-approvers @willarmiros


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Add CODEOWNERs for several shared components. For most of them I added core approvers, some are only contrib.

**Link to tracking Issue:** Updates #3870
