### PR TITLE
[exporter/splunkhecexporter] Apply max content length to compressed HEC content

### DIFF
--- a/.chloggen/hec-compressed-max-content-length.yaml
+++ b/.chloggen/hec-compressed-max-content-length.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Apply max content length to compressed HEC content
+
+# One or more tracking issues related to the change
+issues: [13995]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Splunk HEC exporter uses the unzipped content to check the size of the payload to send, instead of the compressed content.
+  The max content length configuration should apply to the zipped content when compression is enabled.

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,25 +37,145 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
+var (
+	errOverCapacity = errors.New("over capacity")
+)
+
+// Minimum number of bytes to compress. 1500 is the MTU of an ethernet frame.
+const minCompressionLen = 1500
+
 // client sends the data to the splunk backend.
 type client struct {
-	config  *Config
-	url     *url.URL
-	client  *http.Client
-	logger  *zap.Logger
-	zippers sync.Pool
-	wg      sync.WaitGroup
-	headers map[string]string
+	config         *Config
+	url            *url.URL
+	client         *http.Client
+	logger         *zap.Logger
+	wg             sync.WaitGroup
+	headers        map[string]string
+	gzipWriterPool *sync.Pool
 }
 
 // bufferState encapsulates intermediate buffer state when pushing data
 type bufferState struct {
-	buf      *bytes.Buffer
-	tmpBuf   *bytes.Buffer
-	bufFront *index
-	bufLen   int
-	resource int
-	library  int
+	compressionAvailable bool
+	compressionEnabled   bool
+	bufferMaxLen         uint
+	writer               io.Writer
+	buf                  *bytes.Buffer
+	bufFront             *index
+	resource             int
+	library              int
+	gzipWriterPool       *sync.Pool
+}
+
+func (b *bufferState) reset() {
+	b.buf.Reset()
+	b.compressionEnabled = false
+	b.writer = &cancellableBytesWriter{innerWriter: b.buf, maxCapacity: b.bufferMaxLen}
+}
+
+func (b *bufferState) Read(p []byte) (n int, err error) {
+	return b.buf.Read(p)
+}
+
+func (b *bufferState) Close() error {
+	if _, ok := b.writer.(*cancellableGzipWriter); ok {
+		return b.writer.(*cancellableGzipWriter).close()
+	}
+	return nil
+}
+
+// accept returns true if data is accepted by the buffer
+func (b *bufferState) accept(data []byte) bool {
+	_, err := b.writer.Write(data)
+	overCapacity := errors.Is(err, errOverCapacity)
+	if b.compressionAvailable && !b.compressionEnabled && b.buf.Len() > minCompressionLen {
+		// switch over to a zip buffer.
+		tmpBuf := bytes.NewBuffer(make([]byte, 0, b.bufferMaxLen+bufCapPadding))
+		writer := b.gzipWriterPool.Get().(*gzip.Writer)
+		writer.Reset(tmpBuf)
+		zipWriter := &cancellableGzipWriter{
+			innerBuffer: tmpBuf,
+			innerWriter: writer,
+			// 8 bytes required for the zip footer.
+			maxCapacity:    b.bufferMaxLen - 8,
+			gzipWriterPool: b.gzipWriterPool,
+		}
+
+		// the new data is so big, even with a zip writer, we are over the max limit.
+		// abandon and return false, so we can send what is already in our buffer.
+		if _, err2 := zipWriter.Write(b.buf.Bytes()); err2 != nil {
+			return false
+		}
+		b.writer = zipWriter
+		b.buf = tmpBuf
+		b.compressionEnabled = true
+		return true
+	}
+	return !overCapacity
+}
+
+type cancellableBytesWriter struct {
+	innerWriter *bytes.Buffer
+	maxCapacity uint
+}
+
+func (c *cancellableBytesWriter) Write(b []byte) (int, error) {
+	if c.maxCapacity == 0 {
+		return c.innerWriter.Write(b)
+	}
+	if c.innerWriter.Len()+len(b) > int(c.maxCapacity) {
+		return 0, errOverCapacity
+	}
+	return c.innerWriter.Write(b)
+}
+
+type cancellableGzipWriter struct {
+	innerBuffer    *bytes.Buffer
+	innerWriter    *gzip.Writer
+	maxCapacity    uint
+	gzipWriterPool *sync.Pool
+	len            int
+}
+
+func (c *cancellableGzipWriter) Write(b []byte) (int, error) {
+	if c.maxCapacity == 0 {
+		return c.innerWriter.Write(b)
+	}
+	c.len += len(b)
+	// if we see that at a 50% compression rate, we'd be over max capacity, start flushing.
+	if (c.len / 2) > int(c.maxCapacity) {
+		// we flush so the length of the underlying buffer is accurate.
+		if err := c.innerWriter.Flush(); err != nil {
+			return 0, err
+		}
+	}
+	// we find that the new content uncompressed, added to our buffer, would overflow our max capacity.
+	if c.innerBuffer.Len()+len(b) > int(c.maxCapacity) {
+		// so we create a copy of our content and add this new data, compressed, to check that it fits.
+		copyBuf := bytes.NewBuffer(make([]byte, 0, c.maxCapacity+4096))
+		copyBuf.Write(c.innerBuffer.Bytes())
+		writerCopy := c.gzipWriterPool.Get().(*gzip.Writer)
+		defer c.gzipWriterPool.Put(writerCopy)
+		writerCopy.Reset(copyBuf)
+		if _, err := writerCopy.Write(b); err != nil {
+			return 0, err
+		}
+		if err := writerCopy.Flush(); err != nil {
+			return 0, err
+		}
+		// we find that even compressed, the data overflows.
+		if copyBuf.Len() > int(c.maxCapacity) {
+			return 0, errOverCapacity
+		}
+	}
+	return c.innerWriter.Write(b)
+}
+
+func (c *cancellableGzipWriter) close() error {
+	err := c.innerWriter.Close()
+	c.gzipWriterPool.Put(c.innerWriter)
+	return err
 }
 
 // Composite index of a record.
@@ -67,9 +188,6 @@ type index struct {
 	record int
 }
 
-// Minimum number of bytes to compress. 1500 is the MTU of an ethernet frame.
-const minCompressionLen = 1500
-
 func (c *client) pushMetricsData(
 	ctx context.Context,
 	md pmetric.Metrics,
@@ -77,14 +195,8 @@ func (c *client) pushMetricsData(
 	c.wg.Add(1)
 	defer c.wg.Done()
 
-	gzipWriter := c.zippers.Get().(*gzip.Writer)
-	defer c.zippers.Put(gzipWriter)
-
-	gzipBuffer := bytes.NewBuffer(make([]byte, 0, c.config.MaxContentLengthMetrics))
-	gzipWriter.Reset(gzipBuffer)
-
 	// Callback when each batch is to be sent.
-	send := func(ctx context.Context, buf *bytes.Buffer) (err error) {
+	send := func(ctx context.Context, bufState *bufferState) (err error) {
 		localHeaders := map[string]string{}
 		if md.ResourceMetrics().Len() != 0 {
 			accessToken, found := md.ResourceMetrics().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
@@ -92,25 +204,10 @@ func (c *client) pushMetricsData(
 				localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
 			}
 		}
-
-		shouldCompress := buf.Len() >= minCompressionLen && !c.config.DisableCompression
-
-		if shouldCompress {
-			gzipBuffer.Reset()
-			gzipWriter.Reset(gzipBuffer)
-
-			if _, err = io.Copy(gzipWriter, buf); err != nil {
-				return fmt.Errorf("failed copying buffer to gzip writer: %w", err)
-			}
-
-			if err = gzipWriter.Close(); err != nil {
-				return fmt.Errorf("failed flushing compressed data to gzip writer: %w", err)
-			}
-
-			return c.postEvents(ctx, gzipBuffer, localHeaders, shouldCompress)
+		if err := bufState.Close(); err != nil {
+			return err
 		}
-
-		return c.postEvents(ctx, buf, localHeaders, shouldCompress)
+		return c.postEvents(ctx, bufState, localHeaders, bufState.compressionEnabled, bufState.buf.Len())
 	}
 
 	return c.pushMetricsDataInBatches(ctx, md, send)
@@ -123,14 +220,8 @@ func (c *client) pushTraceData(
 	c.wg.Add(1)
 	defer c.wg.Done()
 
-	gzipWriter := c.zippers.Get().(*gzip.Writer)
-	defer c.zippers.Put(gzipWriter)
-
-	gzipBuffer := bytes.NewBuffer(make([]byte, 0, c.config.MaxContentLengthTraces))
-	gzipWriter.Reset(gzipBuffer)
-
 	// Callback when each batch is to be sent.
-	send := func(ctx context.Context, buf *bytes.Buffer) (err error) {
+	send := func(ctx context.Context, bufState *bufferState) (err error) {
 		localHeaders := map[string]string{}
 		if td.ResourceSpans().Len() != 0 {
 			accessToken, found := td.ResourceSpans().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
@@ -138,50 +229,21 @@ func (c *client) pushTraceData(
 				localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
 			}
 		}
-
-		shouldCompress := buf.Len() >= minCompressionLen && !c.config.DisableCompression
-
-		if shouldCompress {
-			gzipBuffer.Reset()
-			gzipWriter.Reset(gzipBuffer)
-
-			if _, err = io.Copy(gzipWriter, buf); err != nil {
-				return fmt.Errorf("failed copying buffer to gzip writer: %w", err)
-			}
-
-			if err = gzipWriter.Close(); err != nil {
-				return fmt.Errorf("failed flushing compressed data to gzip writer: %w", err)
-			}
-
-			return c.postEvents(ctx, gzipBuffer, localHeaders, shouldCompress)
+		if err := bufState.Close(); err != nil {
+			return err
 		}
-
-		return c.postEvents(ctx, buf, localHeaders, shouldCompress)
+		return c.postEvents(ctx, bufState, localHeaders, bufState.compressionEnabled, bufState.buf.Len())
 	}
 
 	return c.pushTracesDataInBatches(ctx, td, send)
-}
-
-func (c *client) sendSplunkEvents(ctx context.Context, splunkEvents []*splunk.Event) error {
-	body, compressed, err := encodeBodyEvents(&c.zippers, splunkEvents, c.config.DisableCompression)
-	if err != nil {
-		return consumererror.NewPermanent(err)
-	}
-	return c.postEvents(ctx, body, nil, compressed)
 }
 
 func (c *client) pushLogData(ctx context.Context, ld plog.Logs) error {
 	c.wg.Add(1)
 	defer c.wg.Done()
 
-	gzipWriter := c.zippers.Get().(*gzip.Writer)
-	defer c.zippers.Put(gzipWriter)
-
-	gzipBuffer := bytes.NewBuffer(make([]byte, 0, c.config.MaxContentLengthLogs))
-	gzipWriter.Reset(gzipBuffer)
-
 	// Callback when each batch is to be sent.
-	send := func(ctx context.Context, buf *bytes.Buffer, headers map[string]string) (err error) {
+	send := func(ctx context.Context, bufState *bufferState, headers map[string]string) (err error) {
 		localHeaders := headers
 		if ld.ResourceLogs().Len() != 0 {
 			accessToken, found := ld.ResourceLogs().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
@@ -193,25 +255,10 @@ func (c *client) pushLogData(ctx context.Context, ld plog.Logs) error {
 				localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
 			}
 		}
-
-		shouldCompress := buf.Len() >= minCompressionLen && !c.config.DisableCompression
-
-		if shouldCompress {
-			gzipBuffer.Reset()
-			gzipWriter.Reset(gzipBuffer)
-
-			if _, err = io.Copy(gzipWriter, buf); err != nil {
-				return fmt.Errorf("failed copying buffer to gzip writer: %w", err)
-			}
-
-			if err = gzipWriter.Close(); err != nil {
-				return fmt.Errorf("failed flushing compressed data to gzip writer: %w", err)
-			}
-
-			return c.postEvents(ctx, gzipBuffer, localHeaders, shouldCompress)
+		if err := bufState.Close(); err != nil {
+			return err
 		}
-
-		return c.postEvents(ctx, buf, localHeaders, shouldCompress)
+		return c.postEvents(ctx, bufState, localHeaders, bufState.compressionEnabled, bufState.buf.Len())
 	}
 
 	return c.pushLogDataInBatches(ctx, ld, send)
@@ -231,20 +278,20 @@ func isProfilingData(sl plog.ScopeLogs) bool {
 	return sl.Scope().Name() == profilingLibraryName
 }
 
-func makeBlankBufferState(bufCap uint) bufferState {
+func makeBlankBufferState(bufCap uint, compressionAvailable bool, pool *sync.Pool) *bufferState {
 	// Buffer of JSON encoded Splunk events, last record is expected to overflow bufCap, hence the padding
-	var buf = bytes.NewBuffer(make([]byte, 0, bufCap+bufCapPadding))
+	buf := bytes.NewBuffer(make([]byte, 0, bufCap+bufCapPadding))
 
-	// Buffer for overflown records that do not fit in the main buffer
-	var tmpBuf = bytes.NewBuffer(make([]byte, 0, bufCapPadding))
-
-	return bufferState{
-		buf:      buf,
-		tmpBuf:   tmpBuf,
-		bufFront: nil, // Index of the log record of the first unsent event in buffer.
-		bufLen:   0,   // Length of data in buffer excluding the last record if it overflows bufCap
-		resource: 0,   // Index of currently processed Resource
-		library:  0,   // Index of currently processed Library
+	return &bufferState{
+		compressionAvailable: compressionAvailable,
+		compressionEnabled:   false,
+		writer:               &cancellableBytesWriter{innerWriter: buf, maxCapacity: bufCap},
+		buf:                  buf,
+		bufferMaxLen:         bufCap,
+		bufFront:             nil, // Index of the log record of the first unsent event in buffer.
+		resource:             0,   // Index of currently processed Resource
+		library:              0,   // Index of currently processed Library
+		gzipWriterPool:       pool,
 	}
 }
 
@@ -253,9 +300,9 @@ func makeBlankBufferState(bufCap uint) bufferState {
 // ld log records are parsed to Splunk events.
 // The input data may contain both logs and profiling data.
 // They are batched separately and sent with different HTTP headers
-func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, send func(context.Context, *bytes.Buffer, map[string]string) error) error {
-	var bufState = makeBlankBufferState(c.config.MaxContentLengthLogs)
-	var profilingBufState = makeBlankBufferState(c.config.MaxContentLengthLogs)
+func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, send func(context.Context, *bufferState, map[string]string) error) error {
+	var bufState = makeBlankBufferState(c.config.MaxContentLengthLogs, !c.config.DisableCompression, c.gzipWriterPool)
+	var profilingBufState = makeBlankBufferState(c.config.MaxContentLengthLogs, !c.config.DisableCompression, c.gzipWriterPool)
 	var permanentErrors []error
 
 	var rls = ld.ResourceLogs()
@@ -272,14 +319,14 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, send fu
 					continue
 				}
 				profilingBufState.resource, profilingBufState.library = i, j
-				newPermanentErrors, err = c.pushLogRecords(ctx, rls, &profilingBufState, profilingHeaders, send)
+				newPermanentErrors, err = c.pushLogRecords(ctx, rls, profilingBufState, profilingHeaders, send)
 			} else {
 				if !c.config.LogDataEnabled {
 					droppedLogRecords += ills.At(j).LogRecords().Len()
 					continue
 				}
 				bufState.resource, bufState.library = i, j
-				newPermanentErrors, err = c.pushLogRecords(ctx, rls, &bufState, nil, send)
+				newPermanentErrors, err = c.pushLogRecords(ctx, rls, bufState, nil, send)
 			}
 
 			if err != nil {
@@ -299,14 +346,15 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, send fu
 
 	// There's some leftover unsent non-profiling data
 	if bufState.buf.Len() > 0 {
-		if err := send(ctx, bufState.buf, nil); err != nil {
+
+		if err := send(ctx, bufState, nil); err != nil {
 			return consumererror.NewLogs(err, c.subLogs(ld, bufState.bufFront, profilingBufState.bufFront))
 		}
 	}
 
 	// There's some leftover unsent profiling data
 	if profilingBufState.buf.Len() > 0 {
-		if err := send(ctx, profilingBufState.buf, profilingHeaders); err != nil {
+		if err := send(ctx, profilingBufState, profilingHeaders); err != nil {
 			// Non-profiling bufFront is set to nil because all non-profiling data was flushed successfully above.
 			return consumererror.NewLogs(err, c.subLogs(ld, nil, profilingBufState.bufFront))
 		}
@@ -315,10 +363,9 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, send fu
 	return multierr.Combine(permanentErrors...)
 }
 
-func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice, state *bufferState, headers map[string]string, send func(context.Context, *bytes.Buffer, map[string]string) error) (permanentErrors []error, sendingError error) {
+func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice, state *bufferState, headers map[string]string, send func(context.Context, *bufferState, map[string]string) error) (permanentErrors []error, sendingError error) {
 	res := lds.At(state.resource)
 	logs := res.ScopeLogs().At(state.library).LogRecords()
-	bufCap := int(c.config.MaxContentLengthLogs)
 
 	for k := 0; k < logs.Len(); k++ {
 		if state.bufFront == nil {
@@ -333,42 +380,26 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf("dropped log event: %v, error: %w", event, err)))
 			continue
 		}
-		state.buf.Write(b)
 
 		// Continue adding events to buffer up to capacity.
 		// 0 capacity is interpreted as unknown/unbound consistent with ContentLength in http.Request.
-		if state.buf.Len() <= bufCap || bufCap == 0 {
-			// Tracking length of event bytes below capacity in buffer.
-			state.bufLen = state.buf.Len()
+		if state.accept(b) {
 			continue
 		}
 
-		state.tmpBuf.Reset()
-		// Storing event bytes over capacity in buffer before truncating.
-		if bufCap > 0 {
-			if over := state.buf.Len() - state.bufLen; over <= bufCap {
-				state.tmpBuf.Write(state.buf.Bytes()[state.bufLen:state.buf.Len()])
-			} else {
-				permanentErrors = append(permanentErrors, consumererror.NewPermanent(
-					fmt.Errorf("dropped log event: %s, error: event size %d bytes larger than configured max content length %d bytes", string(state.buf.Bytes()[state.bufLen:state.buf.Len()]), over, bufCap)))
-			}
-		}
-
-		// Truncating buffer at tracked length below capacity and sending.
-		state.buf.Truncate(state.bufLen)
 		if state.buf.Len() > 0 {
-			if err = send(ctx, state.buf, headers); err != nil {
+			if err = send(ctx, state, headers); err != nil {
 				return permanentErrors, err
 			}
 		}
-		state.buf.Reset()
+		state.reset()
 
 		// Writing truncated bytes back to buffer.
-		if _, err = state.tmpBuf.WriteTo(state.buf); err != nil {
+		if !state.accept(b) {
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(
-				fmt.Errorf("write truncated bytes back to buffer failed, error: %w", err)))
+				fmt.Errorf("dropped log event error: event size %d bytes larger than configured max content length %d bytes", len(b), state.bufferMaxLen)))
+			continue
 		}
-
 		if state.buf.Len() > 0 {
 			// This means that the current record had overflown the buffer and was not sent
 			state.bufFront = &index{resource: state.resource, library: state.library, record: k}
@@ -377,16 +408,14 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 			state.bufFront = nil
 		}
 
-		state.bufLen = state.buf.Len()
 	}
 
 	return permanentErrors, nil
 }
 
-func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMetricsSlice, state *bufferState, send func(context.Context, *bytes.Buffer) error) (permanentErrors []error, sendingError error) {
+func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMetricsSlice, state *bufferState, send func(context.Context, *bufferState) error) (permanentErrors []error, sendingError error) {
 	res := mds.At(state.resource)
 	metrics := res.ScopeMetrics().At(state.library).Metrics()
-	bufCap := int(c.config.MaxContentLengthMetrics)
 
 	for k := 0; k < metrics.Len(); k++ {
 		if state.bufFront == nil {
@@ -395,6 +424,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 
 		// Parsing metric record to Splunk event.
 		events := mapMetricToSplunkEvent(res.Resource(), metrics.At(k), c.config, c.logger)
+		buf := bytes.NewBuffer(make([]byte, 0, c.config.MaxContentLengthMetrics))
 		for _, event := range events {
 			// JSON encoding event and writing to buffer.
 			b, err := jsoniter.Marshal(event)
@@ -402,41 +432,28 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 				permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf("dropped metric event: %v, error: %w", event, err)))
 				continue
 			}
-			state.buf.Write(b)
+			buf.Write(b)
 		}
 
 		// Continue adding events to buffer up to capacity.
 		// 0 capacity is interpreted as unknown/unbound consistent with ContentLength in http.Request.
-		if state.buf.Len() <= bufCap || bufCap == 0 {
-			// Tracking length of event bytes below capacity in buffer.
-			state.bufLen = state.buf.Len()
+		b := buf.Bytes()
+		if state.accept(b) {
 			continue
 		}
 
-		state.tmpBuf.Reset()
-		// Storing event bytes over capacity in buffer before truncating.
-		if bufCap > 0 {
-			if over := state.buf.Len() - state.bufLen; over <= bufCap {
-				state.tmpBuf.Write(state.buf.Bytes()[state.bufLen:state.buf.Len()])
-			} else {
-				permanentErrors = append(permanentErrors, consumererror.NewPermanent(
-					fmt.Errorf("dropped metric event: %s, error: event size %d bytes larger than configured max content length %d bytes", string(state.buf.Bytes()[state.bufLen:state.buf.Len()]), over, bufCap)))
-			}
-		}
-
-		// Truncating buffer at tracked length below capacity and sending.
-		state.buf.Truncate(state.bufLen)
 		if state.buf.Len() > 0 {
-			if err := send(ctx, state.buf); err != nil {
+			if err := send(ctx, state); err != nil {
 				return permanentErrors, err
 			}
 		}
-		state.buf.Reset()
+		state.reset()
 
 		// Writing truncated bytes back to buffer.
-		if _, err := state.tmpBuf.WriteTo(state.buf); err != nil {
+		if !state.accept(b) {
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(
-				fmt.Errorf("write truncated bytes back to buffer failed, error: %w", err)))
+				fmt.Errorf("dropped metric event: error: event size %d bytes larger than configured max content length %d bytes", len(b), state.bufferMaxLen)))
+			continue
 		}
 
 		if state.buf.Len() > 0 {
@@ -447,16 +464,14 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 			state.bufFront = nil
 		}
 
-		state.bufLen = state.buf.Len()
 	}
 
 	return permanentErrors, nil
 }
 
-func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSlice, state *bufferState, send func(context.Context, *bytes.Buffer) error) (permanentErrors []error, sendingError error) {
+func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSlice, state *bufferState, send func(context.Context, *bufferState) error) (permanentErrors []error, sendingError error) {
 	res := tds.At(state.resource)
 	spans := res.ScopeSpans().At(state.library).Spans()
-	bufCap := int(c.config.MaxContentLengthTraces)
 
 	for k := 0; k < spans.Len(); k++ {
 		if state.bufFront == nil {
@@ -471,40 +486,24 @@ func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSli
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf("dropped span events: %v, error: %w", event, err)))
 			continue
 		}
-		state.buf.Write(b)
 
 		// Continue adding events to buffer up to capacity.
-		// 0 capacity is interpreted as unknown/unbound consistent with ContentLength in http.Request.
-		if state.buf.Len() <= bufCap || bufCap == 0 {
-			// Tracking length of event bytes below capacity in buffer.
-			state.bufLen = state.buf.Len()
+		if state.accept(b) {
 			continue
 		}
 
-		state.tmpBuf.Reset()
-		// Storing event bytes over capacity in buffer before truncating.
-		if bufCap > 0 {
-			if over := state.buf.Len() - state.bufLen; over <= bufCap {
-				state.tmpBuf.Write(state.buf.Bytes()[state.bufLen:state.buf.Len()])
-			} else {
-				permanentErrors = append(permanentErrors, consumererror.NewPermanent(
-					fmt.Errorf("dropped span event: %s, error: event size %d bytes larger than configured max content length %d bytes", string(state.buf.Bytes()[state.bufLen:state.buf.Len()]), over, bufCap)))
-			}
-		}
-
-		// Truncating buffer at tracked length below capacity and sending.
-		state.buf.Truncate(state.bufLen)
 		if state.buf.Len() > 0 {
-			if err = send(ctx, state.buf); err != nil {
+			if err = send(ctx, state); err != nil {
 				return permanentErrors, err
 			}
 		}
-		state.buf.Reset()
+		state.reset()
 
 		// Writing truncated bytes back to buffer.
-		if _, err = state.tmpBuf.WriteTo(state.buf); err != nil {
+		if !state.accept(b) {
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(
-				fmt.Errorf("write truncated bytes back to buffer failed, error: %w", err)))
+				fmt.Errorf("dropped trace event error: event size %d bytes larger than configured max content length %d bytes", len(b), state.bufferMaxLen)))
+			continue
 		}
 
 		if state.buf.Len() > 0 {
@@ -515,7 +514,6 @@ func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSli
 			state.bufFront = nil
 		}
 
-		state.bufLen = state.buf.Len()
 	}
 
 	return permanentErrors, nil
@@ -524,8 +522,8 @@ func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSli
 // pushMetricsDataInBatches sends batches of Splunk events in JSON format.
 // The batch content length is restricted to MaxContentLengthMetrics.
 // md metrics are parsed to Splunk events.
-func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metrics, send func(context.Context, *bytes.Buffer) error) error {
-	var bufState = makeBlankBufferState(c.config.MaxContentLengthMetrics)
+func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metrics, send func(context.Context, *bufferState) error) error {
+	var bufState = makeBlankBufferState(c.config.MaxContentLengthMetrics, !c.config.DisableCompression, c.gzipWriterPool)
 	var permanentErrors []error
 
 	var rms = md.ResourceMetrics()
@@ -536,7 +534,7 @@ func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metric
 			var newPermanentErrors []error
 
 			bufState.resource, bufState.library = i, j
-			newPermanentErrors, err = c.pushMetricsRecords(ctx, rms, &bufState, send)
+			newPermanentErrors, err = c.pushMetricsRecords(ctx, rms, bufState, send)
 
 			if err != nil {
 				return consumererror.NewMetrics(err, subMetrics(md, bufState.bufFront))
@@ -548,7 +546,7 @@ func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metric
 
 	// There's some leftover unsent metrics
 	if bufState.buf.Len() > 0 {
-		if err := send(ctx, bufState.buf); err != nil {
+		if err := send(ctx, bufState); err != nil {
 			return consumererror.NewMetrics(err, subMetrics(md, bufState.bufFront))
 		}
 	}
@@ -559,8 +557,8 @@ func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metric
 // pushTracesDataInBatches sends batches of Splunk events in JSON format.
 // The batch content length is restricted to MaxContentLengthMetrics.
 // td traces are parsed to Splunk events.
-func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, send func(context.Context, *bytes.Buffer) error) error {
-	var bufState = makeBlankBufferState(c.config.MaxContentLengthTraces)
+func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, send func(context.Context, *bufferState) error) error {
+	bufState := makeBlankBufferState(c.config.MaxContentLengthTraces, !c.config.DisableCompression, c.gzipWriterPool)
 	var permanentErrors []error
 
 	var rts = td.ResourceSpans()
@@ -571,7 +569,7 @@ func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, 
 			var newPermanentErrors []error
 
 			bufState.resource, bufState.library = i, j
-			newPermanentErrors, err = c.pushTracesData(ctx, rts, &bufState, send)
+			newPermanentErrors, err = c.pushTracesData(ctx, rts, bufState, send)
 
 			if err != nil {
 				return consumererror.NewTraces(err, subTraces(td, bufState.bufFront))
@@ -583,7 +581,7 @@ func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, 
 
 	// There's some leftover unsent traces
 	if bufState.buf.Len() > 0 {
-		if err := send(ctx, bufState.buf); err != nil {
+		if err := send(ctx, bufState); err != nil {
 			return consumererror.NewTraces(err, subTraces(td, bufState.bufFront))
 		}
 	}
@@ -591,11 +589,12 @@ func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, 
 	return multierr.Combine(permanentErrors...)
 }
 
-func (c *client) postEvents(ctx context.Context, events io.Reader, headers map[string]string, compressed bool) error {
+func (c *client) postEvents(ctx context.Context, events io.Reader, headers map[string]string, compressed bool, contentLength int) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", c.url.String(), events)
 	if err != nil {
 		return consumererror.NewPermanent(err)
 	}
+	req.ContentLength = int64(contentLength)
 
 	// Set the headers configured for the client
 	for k, v := range c.headers {
@@ -785,37 +784,6 @@ func subTracesByType(src ptrace.Traces, from *index, dst ptrace.Traces) {
 			}
 		}
 	}
-}
-
-func encodeBodyEvents(zippers *sync.Pool, evs []*splunk.Event, disableCompression bool) (bodyReader io.Reader, compressed bool, err error) {
-	buf := new(bytes.Buffer)
-	for _, e := range evs {
-		b, err := jsoniter.Marshal(e)
-		if err != nil {
-			return nil, false, err
-		}
-		buf.Write(b)
-	}
-	return getReader(zippers, buf, disableCompression)
-}
-
-// avoid attempting to compress things that fit into a single ethernet frame
-func getReader(zippers *sync.Pool, b *bytes.Buffer, disableCompression bool) (io.Reader, bool, error) {
-	var err error
-	if !disableCompression && b.Len() > minCompressionLen {
-		buf := new(bytes.Buffer)
-		w := zippers.Get().(*gzip.Writer)
-		defer zippers.Put(w)
-		w.Reset(buf)
-		_, err = w.Write(b.Bytes())
-		if err == nil {
-			err = w.Close()
-			if err == nil {
-				return buf, true, nil
-			}
-		}
-	}
-	return b, false, err
 }
 
 func (c *client) stop(context.Context) error {

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -729,7 +729,7 @@ func TestReceiveBatchedMetrics(t *testing.T) {
 			want: wantType{
 				batches: [][]string{
 					{`"time":1.001`, `"time":2.002`, `"time":3.003`, `"time":4.004`, `"time":5.005`, `"time":6.006`},
-					{`"time":82.082`, `"time":99.099`},
+					{`"time":85.085`, `"time":99.099`},
 				},
 				numBatches: 2,
 				compressed: true,

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -199,7 +200,7 @@ func (c *CapturingData) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(c.statusCode)
 }
 
-func runMetricsExport(cfg *Config, metrics pmetric.Metrics, t *testing.T) ([]receivedRequest, error) {
+func runMetricsExport(cfg *Config, metrics pmetric.Metrics, expectedBatchesNum int, t *testing.T) ([]receivedRequest, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
@@ -233,7 +234,10 @@ func runMetricsExport(cfg *Config, metrics pmetric.Metrics, t *testing.T) ([]rec
 		select {
 		case request := <-rr:
 			requests = append(requests, request)
-		case <-time.After(1 * time.Second):
+			if len(requests) == expectedBatchesNum {
+				return requests, nil
+			}
+		case <-time.After(5 * time.Second):
 			if len(requests) == 0 {
 				err = errors.New("timeout")
 			}
@@ -242,7 +246,7 @@ func runMetricsExport(cfg *Config, metrics pmetric.Metrics, t *testing.T) ([]rec
 	}
 }
 
-func runTraceExport(testConfig *Config, traces ptrace.Traces, t *testing.T) ([]receivedRequest, error) {
+func runTraceExport(testConfig *Config, traces ptrace.Traces, expectedBatchesNum int, t *testing.T) ([]receivedRequest, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
@@ -279,28 +283,30 @@ func runTraceExport(testConfig *Config, traces ptrace.Traces, t *testing.T) ([]r
 		select {
 		case request := <-rr:
 			requests = append(requests, request)
-		case <-time.After(1 * time.Second):
-			if len(requests) == 0 {
-				err = errors.New("timeout")
+			if len(requests) == expectedBatchesNum {
+				// sort the requests according to the traces we received, reordering them so we can assert on their size.
+				sort.Slice(requests, func(i, j int) bool {
+					imatch := requestTimeRegex.FindSubmatch(requests[i].body)
+					jmatch := requestTimeRegex.FindSubmatch(requests[j].body)
+					// no matches mean it's compressed, just leave as is
+					if len(imatch) == 0 {
+						return i < j
+					}
+					return string(imatch[1]) <= string(jmatch[1])
+				})
+				return requests, nil
 			}
-
-			// sort the requests according to the traces we received, reordering them so we can assert on their size.
-			sort.Slice(requests, func(i, j int) bool {
-				imatch := requestTimeRegex.FindSubmatch(requests[i].body)
-				jmatch := requestTimeRegex.FindSubmatch(requests[j].body)
-				// no matches mean it's compressed, just leave as is
-				if len(imatch) == 0 {
-					return i < j
-				}
-				return string(imatch[1]) <= string(jmatch[1])
-			})
+		case <-time.After(5 * time.Second):
+			if len(requests) == 0 {
+				return nil, errors.New("timeout")
+			}
 
 			return requests, err
 		}
 	}
 }
 
-func runLogExport(cfg *Config, ld plog.Logs, t *testing.T) ([]receivedRequest, error) {
+func runLogExport(cfg *Config, ld plog.Logs, expectedBatchesNum int, t *testing.T) ([]receivedRequest, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
@@ -334,7 +340,10 @@ func runLogExport(cfg *Config, ld plog.Logs, t *testing.T) ([]receivedRequest, e
 		select {
 		case request := <-rr:
 			requests = append(requests, request)
-		case <-time.After(1 * time.Second):
+			if len(requests) == expectedBatchesNum {
+				return requests, nil
+			}
+		case <-time.After(5 * time.Second):
 			if len(requests) == 0 {
 				err = errors.New("timeout")
 			}
@@ -427,17 +436,17 @@ func TestReceiveTracesBatches(t *testing.T) {
 			},
 		},
 		{
-			name:   "2 compressed batches - 1832 bytes each, make sure the log size is more than minCompressionLen=1500 to trigger compression",
-			traces: createTraceData(22),
+			name:   "100 events, make sure that we produce more than one compressed batch",
+			traces: createTraceData(100),
 			conf: func() *Config {
 				cfg := NewFactory().CreateDefaultConfig().(*Config)
-				cfg.MaxContentLengthTraces = 3520
+				cfg.MaxContentLengthTraces = minCompressionLen + 500
 				return cfg
 			}(),
 			want: wantType{
 				batches: [][]string{
-					{`"start_time":1`, `"start_time":2`, `"start_time":5`, `"start_time":6`, `"start_time":7`, `"start_time":8`, `"start_time":9`, `"start_time":10`, `"start_time":11`},
-					{`"start_time":15`, `"start_time":16`, `"start_time":17`, `"start_time":18`, `"start_time":19`, `"start_time":20`, `"start_time":21`},
+					{`"start_time":1`, `"start_time":2`, `"start_time":3`, `"start_time":4`, `"start_time":7`, `"start_time":8`, `"start_time":9`, `"start_time":20`, `"start_time":40`},
+					{`"start_time":85`, `"start_time":98`, `"start_time":99`},
 				},
 				numBatches: 2,
 				compressed: true,
@@ -447,13 +456,16 @@ func TestReceiveTracesBatches(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := runTraceExport(test.conf, test.traces, t)
+			got, err := runTraceExport(test.conf, test.traces, test.want.numBatches, t)
 
 			require.NoError(t, err)
-			require.Len(t, got, test.want.numBatches)
+			require.Len(t, got, test.want.numBatches, "expected exact number of batches")
 
 			for i := 0; i < test.want.numBatches; i++ {
 				require.NotZero(t, got[i])
+				if test.conf.MaxContentLengthTraces != 0 {
+					require.True(t, int(test.conf.MaxContentLengthTraces) > len(got[i].body))
+				}
 				if test.want.compressed {
 					validateCompressedContains(t, test.want.batches[i], got[i].body)
 				} else {
@@ -550,17 +562,17 @@ func TestReceiveLogs(t *testing.T) {
 			},
 		},
 		{
-			name: "2 compressed batches - 1832 bytes each, make sure the log size is more than minCompressionLen=1500 to trigger compression",
-			logs: createLogData(1, 1, 22),
+			name: "150 events, make sure that we produce more than one compressed batch",
+			logs: createLogData(1, 1, 150),
 			conf: func() *Config {
 				cfg := NewFactory().CreateDefaultConfig().(*Config)
-				cfg.MaxContentLengthLogs = 1916
+				cfg.MaxContentLengthLogs = minCompressionLen + 150
 				return cfg
 			}(),
 			want: wantType{
 				batches: [][]string{
-					{`"otel.log.name":"0_0_0"`, `"otel.log.name":"0_0_1"`, `"otel.log.name":"0_0_5"`, `"otel.log.name":"0_0_6"`, `"otel.log.name":"0_0_7"`, `"otel.log.name":"0_0_8"`, `"otel.log.name":"0_0_9"`, `"otel.log.name":"0_0_10"`, `"otel.log.name":"0_0_11"`},
-					{`"otel.log.name":"0_0_15"`, `"otel.log.name":"0_0_16"`, `"otel.log.name":"0_0_17"`, `"otel.log.name":"0_0_18"`, `"otel.log.name":"0_0_19"`, `"otel.log.name":"0_0_20"`, `"otel.log.name":"0_0_21"`},
+					{`"otel.log.name":"0_0_0"`, `"otel.log.name":"0_0_90"`},
+					{`"otel.log.name":"0_0_110"`, `"otel.log.name":"0_0_149"`},
 				},
 				numBatches: 2,
 				compressed: true,
@@ -570,13 +582,16 @@ func TestReceiveLogs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := runLogExport(test.conf, test.logs, t)
+			got, err := runLogExport(test.conf, test.logs, test.want.numBatches, t)
 
 			require.NoError(t, err)
 			require.Len(t, got, test.want.numBatches)
 
 			for i := 0; i < test.want.numBatches; i++ {
 				require.NotZero(t, got[i])
+				if test.conf.MaxContentLengthLogs != 0 {
+					require.True(t, int(test.conf.MaxContentLengthLogs) > len(got[i].body))
+				}
 				if test.want.compressed {
 					validateCompressedContains(t, test.want.batches[i], got[i].body)
 				} else {
@@ -593,7 +608,7 @@ func TestReceiveMetrics(t *testing.T) {
 	md := createMetricsData(3)
 	cfg := NewFactory().CreateDefaultConfig().(*Config)
 	cfg.DisableCompression = true
-	actual, err := runMetricsExport(cfg, md, t)
+	actual, err := runMetricsExport(cfg, md, 1, t)
 	assert.Len(t, actual, 1)
 	assert.NoError(t, err)
 	msg := string(actual[0].body)
@@ -683,17 +698,17 @@ func TestReceiveBatchedMetrics(t *testing.T) {
 			},
 		},
 		{
-			name:    "2 compressed batches - 2211 bytes each, make sure the event size is more than minCompressionLen=1500 to trigger compression",
-			metrics: createMetricsData(22),
+			name:    "200 events, make sure that we produce more than one compressed batch",
+			metrics: createMetricsData(100),
 			conf: func() *Config {
 				cfg := NewFactory().CreateDefaultConfig().(*Config)
-				cfg.MaxContentLengthMetrics = 2211
+				cfg.MaxContentLengthMetrics = minCompressionLen + 150
 				return cfg
 			}(),
 			want: wantType{
 				batches: [][]string{
-					{`"k1":"v1"`, `"time":1.001`, `"time":2.002`, `"time":3.003`, `"time":4.004`, `"time":5.005`, `"time":7.007`, `"time":8.008`, `"time":9.009`, `"time":10.01`},
-					{`"time":11.011`, `"time":15.015`, `"time":16.016`, `"time":17.017`, `"time":18.018`, `"time":19.019`, `"time":20.02`, `"time":21.021`},
+					{`"time":1.001`, `"time":2.002`, `"time":3.003`, `"time":4.004`, `"time":5.005`, `"time":6.006`},
+					{`"time":82.082`, `"time":99.099`},
 				},
 				numBatches: 2,
 				compressed: true,
@@ -703,13 +718,16 @@ func TestReceiveBatchedMetrics(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := runMetricsExport(test.conf, test.metrics, t)
+			got, err := runMetricsExport(test.conf, test.metrics, test.want.numBatches, t)
 
 			require.NoError(t, err)
 			require.Len(t, got, test.want.numBatches)
 
 			for i := 0; i < test.want.numBatches; i++ {
 				require.NotZero(t, got[i])
+				if test.conf.MaxContentLengthMetrics != 0 {
+					require.True(t, int(test.conf.MaxContentLengthMetrics) > len(got[i].body))
+				}
 				if test.want.compressed {
 					validateCompressedContains(t, test.want.batches[i], got[i].body)
 				} else {
@@ -732,15 +750,12 @@ func Test_PushMetricsData_Histogram_NaN_Sum(t *testing.T) {
 	dp.SetSum(math.NaN())
 
 	c := client{
-		url: &url.URL{Scheme: "http", Host: "splunk"},
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
+		url:    &url.URL{Scheme: "http", Host: "splunk"},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zap.NewNop(),
 	}
 
-	sender := func(ctx context.Context, buffer *bytes.Buffer) error {
+	sender := func(ctx context.Context, state *bufferState) error {
 		return nil
 	}
 
@@ -758,15 +773,12 @@ func Test_PushMetricsData_Summary_NaN_Sum(t *testing.T) {
 	dp.SetSum(math.NaN())
 
 	c := client{
-		url: &url.URL{Scheme: "http", Host: "splunk"},
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
+		url:    &url.URL{Scheme: "http", Host: "splunk"},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zap.NewNop(),
 	}
 
-	sender := func(ctx context.Context, buffer *bytes.Buffer) error {
+	sender := func(ctx context.Context, state *bufferState) error {
 		return nil
 	}
 
@@ -776,8 +788,10 @@ func Test_PushMetricsData_Summary_NaN_Sum(t *testing.T) {
 
 func TestReceiveMetricsWithCompression(t *testing.T) {
 	cfg := NewFactory().CreateDefaultConfig().(*Config)
-	request, err := runMetricsExport(cfg, createMetricsData(1000), t)
+	cfg.MaxContentLengthMetrics = 1800
+	request, err := runMetricsExport(cfg, createMetricsData(100), 1, t)
 	assert.NoError(t, err)
+	assert.Equal(t, "gzip", request[0].headers.Get("Content-Encoding"))
 	assert.NotEqual(t, "", request)
 }
 
@@ -828,13 +842,13 @@ func TestErrorReceived(t *testing.T) {
 func TestInvalidLogs(t *testing.T) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
 	config.DisableCompression = false
-	_, err := runLogExport(config, createLogData(1, 1, 0), t)
+	_, err := runLogExport(config, createLogData(1, 1, 0), 1, t)
 	assert.Error(t, err)
 }
 
 func TestInvalidMetrics(t *testing.T) {
 	cfg := NewFactory().CreateDefaultConfig().(*Config)
-	_, err := runMetricsExport(cfg, pmetric.NewMetrics(), t)
+	_, err := runMetricsExport(cfg, pmetric.NewMetrics(), 1, t)
 	assert.Error(t, err)
 }
 
@@ -869,56 +883,14 @@ func TestInvalidJson(t *testing.T) {
 	badEvent := badJSON{
 		Foo: math.Inf(1),
 	}
-	syncPool := sync.Pool{New: func() interface{} {
-		return gzip.NewWriter(nil)
-	}}
-	evs := []*splunk.Event{
-		{
-			Event: badEvent,
-		},
-		nil,
-	}
-	reader, _, err := encodeBodyEvents(&syncPool, evs, false)
-	assert.Error(t, err, reader)
+	_, err := jsoniter.Marshal(badEvent)
+	assert.Error(t, err)
 }
 
 func TestStartAlwaysReturnsNil(t *testing.T) {
 	c := client{}
 	err := c.start(context.Background(), componenttest.NewNopHost())
 	assert.NoError(t, err)
-}
-
-func TestInvalidJsonClient(t *testing.T) {
-	badEvent := badJSON{
-		Foo: math.Inf(1),
-	}
-	evs := []*splunk.Event{
-		{
-			Event: badEvent,
-		},
-		nil,
-	}
-	c := client{
-		url: nil,
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
-		config: &Config{},
-	}
-	err := c.sendSplunkEvents(context.Background(), evs)
-	assert.EqualError(t, err, "Permanent error: splunk.Event.Event: splunkhecexporter.badJSON.Foo: unsupported value: +Inf")
-}
-
-func TestInvalidURLClient(t *testing.T) {
-	c := client{
-		url: &url.URL{Host: "in va lid"},
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
-		config: &Config{},
-	}
-	err := c.sendSplunkEvents(context.Background(), []*splunk.Event{})
-	assert.EqualError(t, err, "Permanent error: parse \"//in%20va%20lid\": invalid URL escape \"%20\"")
 }
 
 func Test_pushLogData_nil_Logs(t *testing.T) {
@@ -968,11 +940,11 @@ func Test_pushLogData_nil_Logs(t *testing.T) {
 	}
 
 	c := client{
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zaptest.NewLogger(t),
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}
 
 	for _, test := range tests {
@@ -989,9 +961,6 @@ func Test_pushLogData_nil_Logs(t *testing.T) {
 
 func Test_pushLogData_InvalidLog(t *testing.T) {
 	c := client{
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zaptest.NewLogger(t),
 	}
@@ -1008,12 +977,12 @@ func Test_pushLogData_InvalidLog(t *testing.T) {
 
 func Test_pushLogData_PostError(t *testing.T) {
 	c := client{
-		url: &url.URL{Host: "in va lid"},
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
+		url:    &url.URL{Host: "in va lid"},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zaptest.NewLogger(t),
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}
 
 	// 2000 log records -> ~371888 bytes when JSON encoded.
@@ -1051,12 +1020,12 @@ func Test_pushLogData_PostError(t *testing.T) {
 
 func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	splunkClient := client{
-		url: &url.URL{Scheme: "http", Host: "splunk"},
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
+		url:    &url.URL{Scheme: "http", Host: "splunk"},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zaptest.NewLogger(t),
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}
 	logs := createLogData(1, 1, 1)
 
@@ -1086,12 +1055,12 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
 	c := client{
-		url: &url.URL{Scheme: "http", Host: "splunk"},
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
+		url:    &url.URL{Scheme: "http", Host: "splunk"},
 		config: config,
 		logger: zaptest.NewLogger(t),
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}
 
 	// Just two records
@@ -1116,12 +1085,12 @@ func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 
 func Test_pushLogData_ShouldAddHeadersForProfilingData(t *testing.T) {
 	c := client{
-		url: &url.URL{Scheme: "http", Host: "splunk"},
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
+		url:    &url.URL{Scheme: "http", Host: "splunk"},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zaptest.NewLogger(t),
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}
 
 	logs := createLogDataWithCustomLibraries(1, []string{"otel.logs", "otel.profiling"}, []int{10, 20})
@@ -1185,12 +1154,12 @@ func Benchmark_pushLogData_10_1_1_1024(b *testing.B) {
 
 func benchPushLogData(b *testing.B, numResources int, numProfiling int, numNonProfiling int, bufSize uint) {
 	c := client{
-		url: &url.URL{Scheme: "http", Host: "splunk"},
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
+		url:    &url.URL{Scheme: "http", Host: "splunk"},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zaptest.NewLogger(b),
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}
 
 	c.client, _ = newTestClient(200, "OK")
@@ -1207,11 +1176,13 @@ func benchPushLogData(b *testing.B, numResources int, numProfiling int, numNonPr
 
 func Test_pushLogData_Small_MaxContentLength(t *testing.T) {
 	c := client{
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zaptest.NewLogger(t),
+		url:    &url.URL{Scheme: "http", Host: "splunk"},
+		client: http.DefaultClient,
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}
 	c.config.MaxContentLengthLogs = 1
 
@@ -1230,11 +1201,9 @@ func Test_pushLogData_Small_MaxContentLength(t *testing.T) {
 
 func TestAllowedLogDataTypes(t *testing.T) {
 	tests := []struct {
-		name                 string
-		allowProfilingData   bool
-		allowLogData         bool
-		wantProfilingRecords int
-		wantLogRecords       int
+		name               string
+		allowProfilingData bool
+		allowLogData       bool
 	}{
 		{
 			name:               "both_allowed",
@@ -1260,7 +1229,12 @@ func TestAllowedLogDataTypes(t *testing.T) {
 			cfg.LogDataEnabled = test.allowLogData
 			cfg.ProfilingDataEnabled = test.allowProfilingData
 
-			requests, err := runLogExport(cfg, logs, t)
+			numBatches := 1
+			if test.allowLogData && test.allowProfilingData {
+				numBatches = 2
+			}
+
+			requests, err := runLogExport(cfg, logs, numBatches, t)
 			assert.NoError(t, err)
 
 			seenLogs := false
@@ -1284,6 +1258,9 @@ func TestSubLogs(t *testing.T) {
 
 	c := client{
 		config: NewFactory().CreateDefaultConfig().(*Config),
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}
 
 	// Logs subset from leftmost index (resource 0, library 0, record 0).
@@ -1358,7 +1335,6 @@ func validateCompressedContains(t *testing.T, expected []string, got []byte) {
 
 	p, err := io.ReadAll(z)
 	require.NoError(t, err)
-
 	for _, e := range expected {
 		assert.Contains(t, string(p), e)
 	}
@@ -1368,19 +1344,21 @@ func validateCompressedContains(t *testing.T, expected []string, got []byte) {
 func BenchmarkPushLogRecords(b *testing.B) {
 	logs := createLogData(1, 1, 1)
 	c := client{
-		url: &url.URL{Scheme: "http", Host: "splunk"},
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
+		url:    &url.URL{Scheme: "http", Host: "splunk"},
 		config: NewFactory().CreateDefaultConfig().(*Config),
 		logger: zap.NewNop(),
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}
-	sender := func(ctx context.Context, buffer *bytes.Buffer, headers map[string]string) error {
+	sender := func(ctx context.Context, state *bufferState, headers map[string]string) error {
 		return nil
 	}
-	state := makeBlankBufferState(4096)
+	state := makeBlankBufferState(4096, true, &sync.Pool{New: func() interface{} {
+		return gzip.NewWriter(nil)
+	}})
 	for n := 0; n < b.N; n++ {
-		permanentErrs, sendingErr := c.pushLogRecords(context.Background(), logs.ResourceLogs(), &state, map[string]string{}, sender)
+		permanentErrs, sendingErr := c.pushLogRecords(context.Background(), logs.ResourceLogs(), state, map[string]string{}, sender)
 		assert.NoError(b, sendingErr)
 		for _, permanentErr := range permanentErrs {
 			assert.NoError(b, permanentErr)

--- a/exporter/splunkhecexporter/exporter.go
+++ b/exporter/splunkhecexporter/exporter.go
@@ -120,9 +120,6 @@ func buildClient(options *exporterOptions, config *Config, logger *zap.Logger) (
 			},
 		},
 		logger: logger,
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
 		headers: map[string]string{
 			"Connection":           "keep-alive",
 			"Content-Type":         "application/json",
@@ -132,5 +129,8 @@ func buildClient(options *exporterOptions, config *Config, logger *zap.Logger) (
 			"__splunk_app_version": config.SplunkAppVersion,
 		},
 		config: config,
+		gzipWriterPool: &sync.Pool{New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}},
 	}, nil
 }


### PR DESCRIPTION
**Description:**
The Splunk HEC exporter uses the unzipped content to check the size of the payload to send, instead of the compressed content.
The max content length configuration should apply to the zipped content when compression is enabled.

**Link to tracking Issue:**
#13995

**Testing:**
Unit tests.

**Documentation:** 
N/A

I ran benchmarks:

*main*:
```
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_100_10_10_1024
Benchmark_pushLogData_100_10_10_1024-10     	     482	   2342800 ns/op
Benchmark_pushLogData_10_100_100_1024
Benchmark_pushLogData_10_100_100_1024-10    	     463	   2368735 ns/op
Benchmark_pushLogData_10_0_100_1024
Benchmark_pushLogData_10_0_100_1024-10      	     937	   1247481 ns/op
Benchmark_pushLogData_10_100_0_1024
Benchmark_pushLogData_10_100_0_1024-10      	     889	   1205706 ns/op
Benchmark_pushLogData_10_10_10_256
Benchmark_pushLogData_10_10_10_256-10       	    2557	    408924 ns/op
Benchmark_pushLogData_10_10_10_1024
Benchmark_pushLogData_10_10_10_1024-10      	    4906	    238229 ns/op
Benchmark_pushLogData_10_10_10_8K
Benchmark_pushLogData_10_10_10_8K-10        	    3135	    379311 ns/op
Benchmark_pushLogData_10_10_10_1M
Benchmark_pushLogData_10_10_10_1M-10        	    1810	    645938 ns/op
Benchmark_pushLogData_10_1_1_1024
Benchmark_pushLogData_10_1_1_1024-10        	   42817	     26248 ns/op
```

*compress_hec:*
```
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_100_10_10_1024
Benchmark_pushLogData_100_10_10_1024-10     	     484	   2338198 ns/op
Benchmark_pushLogData_10_100_100_1024
Benchmark_pushLogData_10_100_100_1024-10    	     469	   2350264 ns/op
Benchmark_pushLogData_10_0_100_1024
Benchmark_pushLogData_10_0_100_1024-10      	     915	   1241020 ns/op
Benchmark_pushLogData_10_100_0_1024
Benchmark_pushLogData_10_100_0_1024-10      	     909	   1192078 ns/op
Benchmark_pushLogData_10_10_10_256
Benchmark_pushLogData_10_10_10_256-10       	    2659	    390920 ns/op
Benchmark_pushLogData_10_10_10_1024
Benchmark_pushLogData_10_10_10_1024-10      	    4821	    237825 ns/op
Benchmark_pushLogData_10_10_10_8K
Benchmark_pushLogData_10_10_10_8K-10        	    3202	    367205 ns/op
Benchmark_pushLogData_10_10_10_1M
Benchmark_pushLogData_10_10_10_1M-10        	    2090	    635778 ns/op
Benchmark_pushLogData_10_1_1_1024
Benchmark_pushLogData_10_1_1_1024-10        	   45020	     24131 ns/op
```