### PR TITLE
[chore] add Ziqi Zhao to triager list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Triagers ([@open-telemetry/collector-contrib-triagers](https://github.com/orgs/o
 
 - [Evan Bradley](https://github.com/evan-bradley), Dynatrace
 - [Goutham Veeramachaneni](https://github.com/gouthamve), Grafana
+- [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
 - Actively seeking contributors to triage issues
 
 Emeritus Triagers:


### PR DESCRIPTION
Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>

Description:

Add myself as a triager in the contrib repo.

Link to tracking Issue:

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15241