### PR TITLE
[chore][exporter/loki] Replace deprecated format param with format hint.

### DIFF
--- a/exporter/lokiexporter/README.md
+++ b/exporter/lokiexporter/README.md
@@ -19,7 +19,6 @@ The following options are now deprecated:
 - `labels.{attributes/resource}`. Deprecated and will be removed by v0.59.0. See the [Labels](#labels) section for more information.
 - `labels.record`. Deprecated and will be removed by v0.59.0. See the [Labels](#labels) section for more information.
 - `tenant`: Deprecated and will be removed by v0.59.0. See the [Labels](#tenant-information) section for more information.
-- `format` Deprecated without replacement. If you rely on this, let us know by opening an issue before v0.59.0 and we'll assist you in finding a solution.
 
 Example:
 ```yaml
@@ -81,6 +80,25 @@ processors:
       key: loki.resource.labels
       value: pod.name
 ```
+
+## Format
+
+To choose the format used for writing log lines by the exporter use the `loki.format` hint. For example:
+
+```yaml
+processors:
+  resource:
+    attributes:
+    - action: insert
+      key: loki.format
+      value: logfmt
+```
+
+The following formats are supported:
+
+- `logfmt`: Write logs as [logfmt](https://brandur.org/logfmt) lines.
+- `json`: Write logs as JSON objects. It is the default format if no hint is present.
+
 
 ## Tenant information
 

--- a/exporter/lokiexporter/config.go
+++ b/exporter/lokiexporter/config.go
@@ -40,12 +40,6 @@ type Config struct {
 	// See this component's documentation for more information on how to specify the hint.
 	Labels *LabelsConfig `mapstructure:"labels"`
 
-	// Allows you to choose the entry format in the exporter.
-	// Deprecated: [v0.57.0] Only the JSON format will be supported in the future. If you rely on the
-	// "body" format and can't change to JSON, let us know before v0.59.0 by opening a GitHub issue
-	// and we'll work with you to find a solution.
-	Format *string `mapstructure:"format"`
-
 	// Tenant defines how to obtain the tenant ID
 	// Deprecated: [v0.57.0] use the attribute processor to add a `loki.tenant` hint.
 	// See this component's documentation for more information on how to specify the hint.
@@ -80,10 +74,6 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) isLegacy() bool {
-	if c.Format != nil && *c.Format == "body" {
-		return true
-	}
-
 	if c.Labels != nil {
 		return true
 	}

--- a/exporter/lokiexporter/config_test.go
+++ b/exporter/lokiexporter/config_test.go
@@ -106,16 +106,6 @@ func TestIsLegacy(t *testing.T) {
 			outcome: false,
 		},
 		{
-			desc: "format is set to body",
-			cfg: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
-					Endpoint: "https://loki.example.com",
-				},
-				Format: stringp("body"),
-			},
-			outcome: true,
-		},
-		{
 			desc: "a label is specified",
 			cfg: &Config{
 				HTTPClientSettings: confighttp.HTTPClientSettings{

--- a/exporter/lokiexporter/legacy_config_test.go
+++ b/exporter/lokiexporter/legacy_config_test.go
@@ -125,7 +125,6 @@ func TestLoadConfig(t *testing.T) {
 						"traceID": "traceid",
 					},
 				},
-				Format: stringp("json"),
 			},
 		},
 	}

--- a/exporter/lokiexporter/legacy_exporter_test.go
+++ b/exporter/lokiexporter/legacy_exporter_test.go
@@ -561,38 +561,6 @@ func TestExporter_convertAttributesToLabels(t *testing.T) {
 	})
 }
 
-func TestExporter_convertLogBodyToEntry(t *testing.T) {
-	res := pcommon.NewResource()
-	res.Attributes().PutStr("host.name", "something")
-	res.Attributes().PutStr("pod.name", "something123")
-
-	lr := plog.NewLogRecord()
-	lr.Body().SetStr("Payment succeeded")
-	lr.SetTraceID([16]byte{1, 2, 3, 4})
-	lr.SetSpanID([8]byte{5, 6, 7, 8})
-	lr.SetSeverityText("DEBUG")
-	lr.SetSeverityNumber(plog.SeverityNumberDebug)
-	lr.Attributes().PutStr("payment_method", "credit_card")
-
-	ts := pcommon.Timestamp(int64(1) * time.Millisecond.Nanoseconds())
-	lr.SetTimestamp(ts)
-
-	exp := newLegacyExporter(&Config{
-		Labels: &LabelsConfig{
-			Attributes:         map[string]string{"payment_method": "payment_method"},
-			ResourceAttributes: map[string]string{"pod.name": "pod.name"},
-		},
-	}, componenttest.NewNopTelemetrySettings())
-	entry, _ := exp.convertLogBodyToEntry(lr, res)
-
-	expEntry := &logproto.Entry{
-		Timestamp: time.Unix(0, int64(lr.Timestamp())),
-		Line:      "severity=DEBUG severityN=5 traceID=01020304000000000000000000000000 spanID=0506070800000000 host.name=something Payment succeeded",
-	}
-	require.NotNil(t, entry)
-	require.Equal(t, expEntry, entry)
-}
-
 type badProtoForCoverage struct {
 	Foo string `protobuf:"bytes,1,opt,name=labels,proto3" json:"foo"`
 }

--- a/exporter/lokiexporter/testdata/config_legacy.yaml
+++ b/exporter/lokiexporter/testdata/config_legacy.yaml
@@ -9,7 +9,6 @@ loki:
 loki/json:
   endpoint: "https://loki:3100/loki/api/v1/push"
   tenant_id: "example"
-  format: "json"
   labels:
     record:
       traceID: traceid


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Replace the deprecated format configuration parameter (we planned to remove it after v0.59.0) with the format hint.
It is a follow-up on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/15286

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15351

**Testing:** <Describe what testing was performed and which tests were added.>
Added by https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15351 

**Documentation:** <Describe the documentation added.>
Readme