### PR TITLE
[chore][exporter/loki] Skip flaky test TestFactory_CreateLogsExporter.

### DIFF
--- a/exporter/lokiexporter/legacy_factory_test.go
+++ b/exporter/lokiexporter/legacy_factory_test.go
@@ -49,6 +49,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 }
 
 func TestFactory_CreateLogsExporter(t *testing.T) {
+	skip(t, "Flaky Test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15365")
 	tests := []struct {
 		name         string
 		config       Config
@@ -116,4 +117,9 @@ func TestFactory_CreateLogsExporter(t *testing.T) {
 			assert.NotNil(t, exp)
 		})
 	}
+}
+
+// This abstraction prevents skipped function from causing "unused" lint errors
+var skip = func(t *testing.T, why string) {
+	t.Skip(why)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Skip flaky test `TestFactory_CreateLogsExporter` in the Loki exporter. This is a test for the legacy logic of the Loki exporter, I'll open a PR for removing this logic and relevant tests after https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/15388 get merged. For now, just disabling this test.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15365 