### PR TITLE
[chore][receiver] modify deprecated label

### DIFF
--- a/receiver/receivercreator/fixtures_test.go
+++ b/receiver/receivercreator/fixtures_test.go
@@ -95,8 +95,8 @@ var k8sNodeEndpoint = observer.Endpoint{
 		InternalIP:          "2.3.4.5",
 		KubeletEndpointPort: 10250,
 		Labels: map[string]string{
-			"beta.kubernetes.io/arch": "amd64",
-			"beta.kubernetes.io/os":   "linux",
+			"kubernetes.io/arch": "amd64",
+			"kubernetes.io/os":   "linux",
 		},
 		Name: "a.name",
 		UID:  "b344f2a7-1ec1-40f0-8557-8a9bfd8b6f99",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
"beta.kubernetes.io/arch" and "beta.kubernetes.io/os" have been deprecated in k8s 1.14

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>