### PR TITLE
[pkg/ottl] Update ExprFunc and boolExpressionEvaluator to return an error

### DIFF
--- a/.chloggen/ottl-getsetter-errors.yaml
+++ b/.chloggen/ottl-getsetter-errors.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update `ExprFunc`, `Set`, and `Get` to all return errors.
+
+# One or more tracking issues related to the change
+issues: [15649]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/boolean_value.go
+++ b/pkg/ottl/boolean_value.go
@@ -70,8 +70,8 @@ func (p *Parser[K]) newComparisonEvaluator(comparison *comparison) (boolExpressi
 
 	// The parser ensures that we'll never get an invalid comparison.Op, so we don't have to check that case.
 	return func(ctx K) bool {
-		a := left.Get(ctx)
-		b := right.Get(ctx)
+		a, _ := left.Get(ctx)
+		b, _ := right.Get(ctx)
 		return p.compare(a, b, comparison.Op)
 	}, nil
 

--- a/pkg/ottl/boolean_value.go
+++ b/pkg/ottl/boolean_value.go
@@ -19,39 +19,47 @@ import (
 )
 
 // boolExpressionEvaluator is a function that returns the result.
-type boolExpressionEvaluator[K any] func(ctx K) bool
+type boolExpressionEvaluator[K any] func(ctx K) (bool, error)
 
-func alwaysTrue[K any](K) bool {
-	return true
+func alwaysTrue[K any](K) (bool, error) {
+	return true, nil
 }
 
-func alwaysFalse[K any](K) bool {
-	return false
+func alwaysFalse[K any](K) (bool, error) {
+	return false, nil
 }
 
 // builds a function that returns a short-circuited result of ANDing
 // boolExpressionEvaluator funcs
 func andFuncs[K any](funcs []boolExpressionEvaluator[K]) boolExpressionEvaluator[K] {
-	return func(ctx K) bool {
+	return func(ctx K) (bool, error) {
 		for _, f := range funcs {
-			if !f(ctx) {
-				return false
+			result, err := f(ctx)
+			if err != nil {
+				return false, err
+			}
+			if !result {
+				return false, nil
 			}
 		}
-		return true
+		return true, nil
 	}
 }
 
 // builds a function that returns a short-circuited result of ORing
 // boolExpressionEvaluator funcs
 func orFuncs[K any](funcs []boolExpressionEvaluator[K]) boolExpressionEvaluator[K] {
-	return func(ctx K) bool {
+	return func(ctx K) (bool, error) {
 		for _, f := range funcs {
-			if f(ctx) {
-				return true
+			result, err := f(ctx)
+			if err != nil {
+				return false, err
+			}
+			if result {
+				return true, nil
 			}
 		}
-		return false
+		return false, nil
 	}
 }
 
@@ -69,10 +77,16 @@ func (p *Parser[K]) newComparisonEvaluator(comparison *comparison) (boolExpressi
 	}
 
 	// The parser ensures that we'll never get an invalid comparison.Op, so we don't have to check that case.
-	return func(ctx K) bool {
-		a, _ := left.Get(ctx)
-		b, _ := right.Get(ctx)
-		return p.compare(a, b, comparison.Op)
+	return func(ctx K) (bool, error) {
+		a, leftErr := left.Get(ctx)
+		if leftErr != nil {
+			return false, leftErr
+		}
+		b, rightErr := right.Get(ctx)
+		if rightErr != nil {
+			return false, rightErr
+		}
+		return p.compare(a, b, comparison.Op), nil
 	}, nil
 
 }

--- a/pkg/ottl/boolean_value_test.go
+++ b/pkg/ottl/boolean_value_test.go
@@ -121,7 +121,9 @@ func Test_newComparisonEvaluator(t *testing.T) {
 			comp := comparisonHelper(tt.l, tt.r, tt.op)
 			evaluate, err := p.newComparisonEvaluator(comp)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want, evaluate(tt.item))
+			result, err := evaluate(tt.item)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }
@@ -351,7 +353,9 @@ func Test_newBooleanExpressionEvaluator(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluate, err := p.newBooleanExpressionEvaluator(tt.expr)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want, evaluate(nil))
+			result, err := evaluate(nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }

--- a/pkg/ottl/contexts/internal/ottlcommon/metric.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/metric.go
@@ -64,83 +64,88 @@ func MetricPathGetSetter[K MetricContext](path []ottl.Field) (ottl.GetSetter[K],
 
 func accessMetric[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetMetric()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetMetric(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if newMetric, ok := val.(pmetric.Metric); ok {
 				newMetric.CopyTo(ctx.GetMetric())
 			}
+			return nil
 		},
 	}
 }
 
 func accessName[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetMetric().Name()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetMetric().Name(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if str, ok := val.(string); ok {
 				ctx.GetMetric().SetName(str)
 			}
+			return nil
 		},
 	}
 }
 
 func accessDescription[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetMetric().Description()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetMetric().Description(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if str, ok := val.(string); ok {
 				ctx.GetMetric().SetDescription(str)
 			}
+			return nil
 		},
 	}
 }
 
 func accessUnit[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetMetric().Unit()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetMetric().Unit(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if str, ok := val.(string); ok {
 				ctx.GetMetric().SetUnit(str)
 			}
+			return nil
 		},
 	}
 }
 
 func accessType[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return int64(ctx.GetMetric().Type())
+		Getter: func(ctx K) (interface{}, error) {
+			return int64(ctx.GetMetric().Type()), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			// TODO Implement methods so correctly convert data types.
 			// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10130
+			return nil
 		},
 	}
 }
 
 func accessAggTemporality[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
+		Getter: func(ctx K) (interface{}, error) {
 			metric := ctx.GetMetric()
 			switch metric.Type() {
 			case pmetric.MetricTypeSum:
-				return int64(metric.Sum().AggregationTemporality())
+				return int64(metric.Sum().AggregationTemporality()), nil
 			case pmetric.MetricTypeHistogram:
-				return int64(metric.Histogram().AggregationTemporality())
+				return int64(metric.Histogram().AggregationTemporality()), nil
 			case pmetric.MetricTypeExponentialHistogram:
-				return int64(metric.ExponentialHistogram().AggregationTemporality())
+				return int64(metric.ExponentialHistogram().AggregationTemporality()), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if newAggTemporality, ok := val.(int64); ok {
 				metric := ctx.GetMetric()
 				switch metric.Type() {
@@ -152,49 +157,51 @@ func accessAggTemporality[K MetricContext]() ottl.StandardGetSetter[K] {
 					metric.ExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporality(newAggTemporality))
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessIsMonotonic[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
+		Getter: func(ctx K) (interface{}, error) {
 			metric := ctx.GetMetric()
 			if metric.Type() == pmetric.MetricTypeSum {
-				return metric.Sum().IsMonotonic()
+				return metric.Sum().IsMonotonic(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if newIsMonotonic, ok := val.(bool); ok {
 				metric := ctx.GetMetric()
 				if metric.Type() == pmetric.MetricTypeSum {
 					metric.Sum().SetIsMonotonic(newIsMonotonic)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessDataPoints[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
+		Getter: func(ctx K) (interface{}, error) {
 			metric := ctx.GetMetric()
 			switch metric.Type() {
 			case pmetric.MetricTypeSum:
-				return metric.Sum().DataPoints()
+				return metric.Sum().DataPoints(), nil
 			case pmetric.MetricTypeGauge:
-				return metric.Gauge().DataPoints()
+				return metric.Gauge().DataPoints(), nil
 			case pmetric.MetricTypeHistogram:
-				return metric.Histogram().DataPoints()
+				return metric.Histogram().DataPoints(), nil
 			case pmetric.MetricTypeExponentialHistogram:
-				return metric.ExponentialHistogram().DataPoints()
+				return metric.ExponentialHistogram().DataPoints(), nil
 			case pmetric.MetricTypeSummary:
-				return metric.Summary().DataPoints()
+				return metric.Summary().DataPoints(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			metric := ctx.GetMetric()
 			switch metric.Type() {
 			case pmetric.MetricTypeSum:
@@ -218,6 +225,7 @@ func accessDataPoints[K MetricContext]() ottl.StandardGetSetter[K] {
 					newDataPoints.CopyTo(metric.Summary().DataPoints())
 				}
 			}
+			return nil
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ottlcommon/metric_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/metric_test.go
@@ -142,7 +142,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 			got, _ := accessor.Get(newMetricContext(metric))
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(newMetricContext(metric), tt.newVal)
+			err = accessor.Set(newMetricContext(metric), tt.newVal)
+			assert.Nil(t, err)
 
 			expectedMetric := createMetricTelemetry()
 			tt.modified(expectedMetric)

--- a/pkg/ottl/contexts/internal/ottlcommon/metric_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/metric_test.go
@@ -139,7 +139,7 @@ func Test_MetricPathGetSetter(t *testing.T) {
 
 			metric := createMetricTelemetry()
 
-			got := accessor.Get(newMetricContext(metric))
+			got, _ := accessor.Get(newMetricContext(metric))
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(newMetricContext(metric), tt.newVal)

--- a/pkg/ottl/contexts/internal/ottlcommon/metric_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/metric_test.go
@@ -139,7 +139,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 
 			metric := createMetricTelemetry()
 
-			got, _ := accessor.Get(newMetricContext(metric))
+			got, err := accessor.Get(newMetricContext(metric))
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(newMetricContext(metric), tt.newVal)

--- a/pkg/ottl/contexts/internal/ottlcommon/resource.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource.go
@@ -46,50 +46,54 @@ func ResourcePathGetSetter[K ResourceContext](path []ottl.Field) (ottl.GetSetter
 
 func accessResource[K ResourceContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetResource()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetResource(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if newRes, ok := val.(pcommon.Resource); ok {
 				newRes.CopyTo(ctx.GetResource())
 			}
+			return nil
 		},
 	}
 }
 
 func accessResourceAttributes[K ResourceContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetResource().Attributes()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetResource().Attributes(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(ctx.GetResource().Attributes())
 			}
+			return nil
 		},
 	}
 }
 
 func accessResourceAttributesKey[K ResourceContext](mapKey *string) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return GetMapValue(ctx.GetResource().Attributes(), *mapKey)
+		Getter: func(ctx K) (interface{}, error) {
+			return GetMapValue(ctx.GetResource().Attributes(), *mapKey), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			SetMapValue(ctx.GetResource().Attributes(), *mapKey, val)
+			return nil
 		},
 	}
 }
 
 func accessResourceDroppedAttributesCount[K ResourceContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return int64(ctx.GetResource().DroppedAttributesCount())
+		Getter: func(ctx K) (interface{}, error) {
+			return int64(ctx.GetResource().DroppedAttributesCount()), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetResource().SetDroppedAttributesCount(uint32(i))
 			}
+			return nil
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
@@ -238,7 +238,8 @@ func TestResourcePathGetSetter(t *testing.T) {
 			got, _ := accessor.Get(newResourceContext(resource))
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(newResourceContext(resource), tt.newVal)
+			err = accessor.Set(newResourceContext(resource), tt.newVal)
+			assert.Nil(t, err)
 
 			expectedResource := createResource()
 			tt.modified(expectedResource)

--- a/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
@@ -235,7 +235,7 @@ func TestResourcePathGetSetter(t *testing.T) {
 
 			resource := createResource()
 
-			got := accessor.Get(newResourceContext(resource))
+			got, _ := accessor.Get(newResourceContext(resource))
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(newResourceContext(resource), tt.newVal)

--- a/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
@@ -235,7 +235,8 @@ func TestResourcePathGetSetter(t *testing.T) {
 
 			resource := createResource()
 
-			got, _ := accessor.Get(newResourceContext(resource))
+			got, err := accessor.Get(newResourceContext(resource))
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(newResourceContext(resource), tt.newVal)

--- a/pkg/ottl/contexts/internal/ottlcommon/scope.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope.go
@@ -51,76 +51,82 @@ func ScopePathGetSetter[K InstrumentationScopeContext](path []ottl.Field) (ottl.
 
 func accessInstrumentationScope[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetInstrumentationScope()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetInstrumentationScope(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if newIl, ok := val.(pcommon.InstrumentationScope); ok {
 				newIl.CopyTo(ctx.GetInstrumentationScope())
 			}
+			return nil
 		},
 	}
 }
 
 func accessInstrumentationScopeAttributes[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetInstrumentationScope().Attributes()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetInstrumentationScope().Attributes(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(ctx.GetInstrumentationScope().Attributes())
 			}
+			return nil
 		},
 	}
 }
 
 func accessInstrumentationScopeAttributesKey[K InstrumentationScopeContext](mapKey *string) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return GetMapValue(ctx.GetInstrumentationScope().Attributes(), *mapKey)
+		Getter: func(ctx K) (interface{}, error) {
+			return GetMapValue(ctx.GetInstrumentationScope().Attributes(), *mapKey), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			SetMapValue(ctx.GetInstrumentationScope().Attributes(), *mapKey, val)
+			return nil
 		},
 	}
 }
 
 func accessInstrumentationScopeName[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetInstrumentationScope().Name()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetInstrumentationScope().Name(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if str, ok := val.(string); ok {
 				ctx.GetInstrumentationScope().SetName(str)
 			}
+			return nil
 		},
 	}
 }
 
 func accessInstrumentationScopeVersion[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return ctx.GetInstrumentationScope().Version()
+		Getter: func(ctx K) (interface{}, error) {
+			return ctx.GetInstrumentationScope().Version(), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if str, ok := val.(string); ok {
 				ctx.GetInstrumentationScope().SetVersion(str)
 			}
+			return nil
 		},
 	}
 }
 
 func accessInstrumentationScopeDroppedAttributesCount[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx K) interface{} {
-			return int64(ctx.GetInstrumentationScope().DroppedAttributesCount())
+		Getter: func(ctx K) (interface{}, error) {
+			return int64(ctx.GetInstrumentationScope().DroppedAttributesCount()), nil
 		},
-		Setter: func(ctx K, val interface{}) {
+		Setter: func(ctx K, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetInstrumentationScope().SetDroppedAttributesCount(uint32(i))
 			}
+			return nil
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
@@ -265,7 +265,8 @@ func TestScopePathGetSetter(t *testing.T) {
 
 			is := createInstrumentationScope()
 
-			got, _ := accessor.Get(newInstrumentationScopeContext(is))
+			got, err := accessor.Get(newInstrumentationScopeContext(is))
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(newInstrumentationScopeContext(is), tt.newVal)

--- a/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
@@ -268,7 +268,8 @@ func TestScopePathGetSetter(t *testing.T) {
 			got, _ := accessor.Get(newInstrumentationScopeContext(is))
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(newInstrumentationScopeContext(is), tt.newVal)
+			err = accessor.Set(newInstrumentationScopeContext(is), tt.newVal)
+			assert.Nil(t, err)
 
 			expectedIS := createInstrumentationScope()
 			tt.modified(expectedIS)

--- a/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
@@ -265,7 +265,7 @@ func TestScopePathGetSetter(t *testing.T) {
 
 			is := createInstrumentationScope()
 
-			got := accessor.Get(newInstrumentationScopeContext(is))
+			got, _ := accessor.Get(newInstrumentationScopeContext(is))
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(newInstrumentationScopeContext(is), tt.newVal)

--- a/pkg/ottl/contexts/ottldatapoints/datapoints.go
+++ b/pkg/ottl/contexts/ottldatapoints/datapoints.go
@@ -165,20 +165,20 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 
 func accessAttributes() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetDataPoint().(pmetric.NumberDataPoint).Attributes()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).Attributes(), nil
 			case pmetric.HistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes(), nil
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes(), nil
 			case pmetric.SummaryDataPoint:
-				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes()
+				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
@@ -197,26 +197,27 @@ func accessAttributes() ottl.StandardGetSetter[TransformContext] {
 					attrs.CopyTo(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes())
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessAttributesKey(mapKey *string) ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.NumberDataPoint).Attributes(), *mapKey)
+				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.NumberDataPoint).Attributes(), *mapKey), nil
 			case pmetric.HistogramDataPoint:
-				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes(), *mapKey)
+				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes(), *mapKey), nil
 			case pmetric.ExponentialHistogramDataPoint:
-				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes(), *mapKey)
+				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes(), *mapKey), nil
 			case pmetric.SummaryDataPoint:
-				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes(), *mapKey)
+				return ottlcommon.GetMapValue(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes(), *mapKey), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				ottlcommon.SetMapValue(ctx.GetDataPoint().(pmetric.NumberDataPoint).Attributes(), *mapKey, val)
@@ -227,26 +228,27 @@ func accessAttributesKey(mapKey *string) ottl.StandardGetSetter[TransformContext
 			case pmetric.SummaryDataPoint:
 				ottlcommon.SetMapValue(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes(), *mapKey, val)
 			}
+			return nil
 		},
 	}
 }
 
 func accessStartTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetDataPoint().(pmetric.NumberDataPoint).StartTimestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).StartTimestamp().AsTime().UnixNano(), nil
 			case pmetric.HistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).StartTimestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).StartTimestamp().AsTime().UnixNano(), nil
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).StartTimestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).StartTimestamp().AsTime().UnixNano(), nil
 			case pmetric.SummaryDataPoint:
-				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).StartTimestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).StartTimestamp().AsTime().UnixNano(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newTime, ok := val.(int64); ok {
 				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -259,26 +261,27 @@ func accessStartTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetDataPoint().(pmetric.NumberDataPoint).Timestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).Timestamp().AsTime().UnixNano(), nil
 			case pmetric.HistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Timestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Timestamp().AsTime().UnixNano(), nil
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Timestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Timestamp().AsTime().UnixNano(), nil
 			case pmetric.SummaryDataPoint:
-				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).Timestamp().AsTime().UnixNano()
+				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).Timestamp().AsTime().UnixNano(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newTime, ok := val.(int64); ok {
 				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -291,60 +294,63 @@ func accessTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessDoubleValue() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if numberDataPoint, ok := ctx.GetDataPoint().(pmetric.NumberDataPoint); ok {
-				return numberDataPoint.DoubleValue()
+				return numberDataPoint.DoubleValue(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newDouble, ok := val.(float64); ok {
 				if numberDataPoint, ok := ctx.GetDataPoint().(pmetric.NumberDataPoint); ok {
 					numberDataPoint.SetDoubleValue(newDouble)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessIntValue() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if numberDataPoint, ok := ctx.GetDataPoint().(pmetric.NumberDataPoint); ok {
-				return numberDataPoint.IntValue()
+				return numberDataPoint.IntValue(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newInt, ok := val.(int64); ok {
 				if numberDataPoint, ok := ctx.GetDataPoint().(pmetric.NumberDataPoint); ok {
 					numberDataPoint.SetIntValue(newInt)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessExemplars() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return ctx.GetDataPoint().(pmetric.NumberDataPoint).Exemplars()
+				return ctx.GetDataPoint().(pmetric.NumberDataPoint).Exemplars(), nil
 			case pmetric.HistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Exemplars()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Exemplars(), nil
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Exemplars()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Exemplars(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newExemplars, ok := val.(pmetric.ExemplarSlice); ok {
 				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -355,26 +361,27 @@ func accessExemplars() ottl.StandardGetSetter[TransformContext] {
 					newExemplars.CopyTo(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Exemplars())
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessFlags() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				return int64(ctx.GetDataPoint().(pmetric.NumberDataPoint).Flags())
+				return int64(ctx.GetDataPoint().(pmetric.NumberDataPoint).Flags()), nil
 			case pmetric.HistogramDataPoint:
-				return int64(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Flags())
+				return int64(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Flags()), nil
 			case pmetric.ExponentialHistogramDataPoint:
-				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Flags())
+				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Flags()), nil
 			case pmetric.SummaryDataPoint:
-				return int64(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Flags())
+				return int64(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Flags()), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newFlags, ok := val.(int64); ok {
 				switch ctx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -387,24 +394,25 @@ func accessFlags() ottl.StandardGetSetter[TransformContext] {
 					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetFlags(pmetric.DataPointFlags(newFlags))
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.HistogramDataPoint:
-				return int64(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Count())
+				return int64(ctx.GetDataPoint().(pmetric.HistogramDataPoint).Count()), nil
 			case pmetric.ExponentialHistogramDataPoint:
-				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Count())
+				return int64(ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Count()), nil
 			case pmetric.SummaryDataPoint:
-				return int64(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Count())
+				return int64(ctx.GetDataPoint().(pmetric.SummaryDataPoint).Count()), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newCount, ok := val.(int64); ok {
 				switch ctx.GetDataPoint().(type) {
 				case pmetric.HistogramDataPoint:
@@ -415,24 +423,25 @@ func accessCount() ottl.StandardGetSetter[TransformContext] {
 					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetCount(uint64(newCount))
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessSum() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			switch ctx.GetDataPoint().(type) {
 			case pmetric.HistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Sum()
+				return ctx.GetDataPoint().(pmetric.HistogramDataPoint).Sum(), nil
 			case pmetric.ExponentialHistogramDataPoint:
-				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Sum()
+				return ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Sum(), nil
 			case pmetric.SummaryDataPoint:
-				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).Sum()
+				return ctx.GetDataPoint().(pmetric.SummaryDataPoint).Sum(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newSum, ok := val.(float64); ok {
 				switch ctx.GetDataPoint().(type) {
 				case pmetric.HistogramDataPoint:
@@ -443,204 +452,216 @@ func accessSum() ottl.StandardGetSetter[TransformContext] {
 					ctx.GetDataPoint().(pmetric.SummaryDataPoint).SetSum(newSum)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessExplicitBounds() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if histogramDataPoint, ok := ctx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
-				return histogramDataPoint.ExplicitBounds().AsRaw()
+				return histogramDataPoint.ExplicitBounds().AsRaw(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newExplicitBounds, ok := val.([]float64); ok {
 				if histogramDataPoint, ok := ctx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
 					histogramDataPoint.ExplicitBounds().FromRaw(newExplicitBounds)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessBucketCounts() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if histogramDataPoint, ok := ctx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
-				return histogramDataPoint.BucketCounts().AsRaw()
+				return histogramDataPoint.BucketCounts().AsRaw(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newBucketCount, ok := val.([]uint64); ok {
 				if histogramDataPoint, ok := ctx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
 					histogramDataPoint.BucketCounts().FromRaw(newBucketCount)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessScale() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return int64(expoHistogramDataPoint.Scale())
+				return int64(expoHistogramDataPoint.Scale()), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newScale, ok := val.(int64); ok {
 				if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.SetScale(int32(newScale))
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessZeroCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return int64(expoHistogramDataPoint.ZeroCount())
+				return int64(expoHistogramDataPoint.ZeroCount()), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newZeroCount, ok := val.(int64); ok {
 				if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.SetZeroCount(uint64(newZeroCount))
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessPositive() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return expoHistogramDataPoint.Positive()
+				return expoHistogramDataPoint.Positive(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newPositive, ok := val.(pmetric.ExponentialHistogramDataPointBuckets); ok {
 				if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					newPositive.CopyTo(expoHistogramDataPoint.Positive())
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessPositiveOffset() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return int64(expoHistogramDataPoint.Positive().Offset())
+				return int64(expoHistogramDataPoint.Positive().Offset()), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newPositiveOffset, ok := val.(int64); ok {
 				if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.Positive().SetOffset(int32(newPositiveOffset))
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessPositiveBucketCounts() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return expoHistogramDataPoint.Positive().BucketCounts().AsRaw()
+				return expoHistogramDataPoint.Positive().BucketCounts().AsRaw(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newPositiveBucketCounts, ok := val.([]uint64); ok {
 				if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.Positive().BucketCounts().FromRaw(newPositiveBucketCounts)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessNegative() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return expoHistogramDataPoint.Negative()
+				return expoHistogramDataPoint.Negative(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newNegative, ok := val.(pmetric.ExponentialHistogramDataPointBuckets); ok {
 				if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					newNegative.CopyTo(expoHistogramDataPoint.Negative())
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessNegativeOffset() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return int64(expoHistogramDataPoint.Negative().Offset())
+				return int64(expoHistogramDataPoint.Negative().Offset()), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newNegativeOffset, ok := val.(int64); ok {
 				if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.Negative().SetOffset(int32(newNegativeOffset))
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessNegativeBucketCounts() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return expoHistogramDataPoint.Negative().BucketCounts().AsRaw()
+				return expoHistogramDataPoint.Negative().BucketCounts().AsRaw(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newNegativeBucketCounts, ok := val.([]uint64); ok {
 				if expoHistogramDataPoint, ok := ctx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.Negative().BucketCounts().FromRaw(newNegativeBucketCounts)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessQuantileValues() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if summaryDataPoint, ok := ctx.GetDataPoint().(pmetric.SummaryDataPoint); ok {
-				return summaryDataPoint.QuantileValues()
+				return summaryDataPoint.QuantileValues(), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newQuantileValues, ok := val.(pmetric.SummaryDataPointValueAtQuantileSlice); ok {
 				if summaryDataPoint, ok := ctx.GetDataPoint().(pmetric.SummaryDataPoint); ok {
 					newQuantileValues.CopyTo(summaryDataPoint.QuantileValues())
 				}
 			}
+			return nil
 		},
 	}
 }

--- a/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
+++ b/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
@@ -296,7 +296,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 
 			ctx := NewTransformContext(numberDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got := accessor.Get(ctx)
+			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(ctx, tt.newVal)
@@ -621,7 +621,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 
 			ctx := NewTransformContext(histogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got := accessor.Get(ctx)
+			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(ctx, tt.newVal)
@@ -1042,7 +1042,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 
 			ctx := NewTransformContext(expoHistogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got := accessor.Get(ctx)
+			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(ctx, tt.newVal)
@@ -1348,7 +1348,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 
 			ctx := NewTransformContext(summaryDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got := accessor.Get(ctx)
+			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(ctx, tt.newVal)
@@ -1533,7 +1533,7 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 
 			ctx := NewTransformContext(pmetric.NewNumberDataPoint(), metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got := accessor.Get(ctx)
+			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(ctx, tt.newVal)

--- a/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
+++ b/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
@@ -299,7 +299,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(ctx, tt.newVal)
+			err = accessor.Set(ctx, tt.newVal)
+			assert.Nil(t, err)
 
 			exNumberDataPoint := createNumberDataPointTelemetry(tt.valueType)
 			tt.modified(exNumberDataPoint)
@@ -624,7 +625,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(ctx, tt.newVal)
+			err = accessor.Set(ctx, tt.newVal)
+			assert.Nil(t, err)
 
 			exNumberDataPoint := createHistogramDataPointTelemetry()
 			tt.modified(exNumberDataPoint)
@@ -1045,7 +1047,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(ctx, tt.newVal)
+			err = accessor.Set(ctx, tt.newVal)
+			assert.Nil(t, err)
 
 			exNumberDataPoint := createExpoHistogramDataPointTelemetry()
 			tt.modified(exNumberDataPoint)
@@ -1351,7 +1354,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(ctx, tt.newVal)
+			err = accessor.Set(ctx, tt.newVal)
+			assert.Nil(t, err)
 
 			exNumberDataPoint := createSummaryDataPointTelemetry()
 			tt.modified(exNumberDataPoint)
@@ -1536,7 +1540,8 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(ctx, tt.newVal)
+			err = accessor.Set(ctx, tt.newVal)
+			assert.Nil(t, err)
 
 			exMetric := createMetricTelemetry()
 			tt.modified(exMetric)

--- a/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
+++ b/pkg/ottl/contexts/ottldatapoints/datapoints_test.go
@@ -296,7 +296,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 
 			ctx := NewTransformContext(numberDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got, _ := accessor.Get(ctx)
+			got, err := accessor.Get(ctx)
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(ctx, tt.newVal)
@@ -622,7 +623,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 
 			ctx := NewTransformContext(histogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got, _ := accessor.Get(ctx)
+			got, err := accessor.Get(ctx)
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(ctx, tt.newVal)
@@ -1044,7 +1046,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 
 			ctx := NewTransformContext(expoHistogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got, _ := accessor.Get(ctx)
+			got, err := accessor.Get(ctx)
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(ctx, tt.newVal)
@@ -1351,7 +1354,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 
 			ctx := NewTransformContext(summaryDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got, _ := accessor.Get(ctx)
+			got, err := accessor.Get(ctx)
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(ctx, tt.newVal)
@@ -1537,7 +1541,8 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 
 			ctx := NewTransformContext(pmetric.NewNumberDataPoint(), metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got, _ := accessor.Get(ctx)
+			got, err := accessor.Get(ctx)
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(ctx, tt.newVal)

--- a/pkg/ottl/contexts/ottllogs/logs.go
+++ b/pkg/ottl/contexts/ottllogs/logs.go
@@ -153,169 +153,182 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 
 func accessTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetLogRecord().Timestamp().AsTime().UnixNano()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetLogRecord().Timestamp().AsTime().UnixNano(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetLogRecord().SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, i)))
 			}
+			return nil
 		},
 	}
 }
 
 func accessObservedTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetLogRecord().ObservedTimestamp().AsTime().UnixNano()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetLogRecord().ObservedTimestamp().AsTime().UnixNano(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetLogRecord().SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, i)))
 			}
+			return nil
 		},
 	}
 }
 
 func accessSeverityNumber() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return int64(ctx.GetLogRecord().SeverityNumber())
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return int64(ctx.GetLogRecord().SeverityNumber()), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetLogRecord().SetSeverityNumber(plog.SeverityNumber(i))
 			}
+			return nil
 		},
 	}
 }
 
 func accessSeverityText() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetLogRecord().SeverityText()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetLogRecord().SeverityText(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if s, ok := val.(string); ok {
 				ctx.GetLogRecord().SetSeverityText(s)
 			}
+			return nil
 		},
 	}
 }
 
 func accessBody() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ottlcommon.GetValue(ctx.GetLogRecord().Body())
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ottlcommon.GetValue(ctx.GetLogRecord().Body()), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			ottlcommon.SetValue(ctx.GetLogRecord().Body(), val)
+			return nil
 		},
 	}
 }
 
 func accessAttributes() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetLogRecord().Attributes()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetLogRecord().Attributes(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(ctx.GetLogRecord().Attributes())
 			}
+			return nil
 		},
 	}
 }
 
 func accessAttributesKey(mapKey *string) ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ottlcommon.GetMapValue(ctx.GetLogRecord().Attributes(), *mapKey)
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ottlcommon.GetMapValue(ctx.GetLogRecord().Attributes(), *mapKey), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			ottlcommon.SetMapValue(ctx.GetLogRecord().Attributes(), *mapKey, val)
+			return nil
 		},
 	}
 }
 
 func accessDroppedAttributesCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return int64(ctx.GetLogRecord().DroppedAttributesCount())
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return int64(ctx.GetLogRecord().DroppedAttributesCount()), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetLogRecord().SetDroppedAttributesCount(uint32(i))
 			}
+			return nil
 		},
 	}
 }
 
 func accessFlags() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return int64(ctx.GetLogRecord().Flags())
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return int64(ctx.GetLogRecord().Flags()), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetLogRecord().SetFlags(plog.LogRecordFlags(i))
 			}
+			return nil
 		},
 	}
 }
 
 func accessTraceID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetLogRecord().TraceID()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetLogRecord().TraceID(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newTraceID, ok := val.(pcommon.TraceID); ok {
 				ctx.GetLogRecord().SetTraceID(newTraceID)
 			}
+			return nil
 		},
 	}
 }
 
 func accessStringTraceID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetLogRecord().TraceID().HexString()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetLogRecord().TraceID().HexString(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
 				if traceID, err := parseTraceID(str); err == nil {
 					ctx.GetLogRecord().SetTraceID(traceID)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessSpanID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetLogRecord().SpanID()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetLogRecord().SpanID(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newSpanID, ok := val.(pcommon.SpanID); ok {
 				ctx.GetLogRecord().SetSpanID(newSpanID)
 			}
+			return nil
 		},
 	}
 }
 
 func accessStringSpanID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetLogRecord().SpanID().HexString()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetLogRecord().SpanID().HexString(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
 				if spanID, err := parseSpanID(str); err == nil {
 					ctx.GetLogRecord().SetSpanID(spanID)
 				}
 			}
+			return nil
 		},
 	}
 }

--- a/pkg/ottl/contexts/ottllogs/logs_test.go
+++ b/pkg/ottl/contexts/ottllogs/logs_test.go
@@ -398,7 +398,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			log, il, resource := createTelemetry()
 
-			got, _ := accessor.Get(NewTransformContext(log, il, resource))
+			got, err := accessor.Get(NewTransformContext(log, il, resource))
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(NewTransformContext(log, il, resource), tt.newVal)

--- a/pkg/ottl/contexts/ottllogs/logs_test.go
+++ b/pkg/ottl/contexts/ottllogs/logs_test.go
@@ -398,7 +398,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			log, il, resource := createTelemetry()
 
-			got := accessor.Get(NewTransformContext(log, il, resource))
+			got, _ := accessor.Get(NewTransformContext(log, il, resource))
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(NewTransformContext(log, il, resource), tt.newVal)

--- a/pkg/ottl/contexts/ottllogs/logs_test.go
+++ b/pkg/ottl/contexts/ottllogs/logs_test.go
@@ -401,7 +401,8 @@ func Test_newPathGetSetter(t *testing.T) {
 			got, _ := accessor.Get(NewTransformContext(log, il, resource))
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(NewTransformContext(log, il, resource), tt.newVal)
+			err = accessor.Set(NewTransformContext(log, il, resource), tt.newVal)
+			assert.Nil(t, err)
 
 			exSpan, exIl, exRes := createTelemetry()
 			tt.modified(exSpan, exIl, exRes)

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -143,7 +143,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			ctx := NewTransformContext(metric, pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got := accessor.Get(ctx)
+			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(ctx, tt.newVal)

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -143,7 +143,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			ctx := NewTransformContext(metric, pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
-			got, _ := accessor.Get(ctx)
+			got, err := accessor.Get(ctx)
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(ctx, tt.newVal)

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -146,7 +146,8 @@ func Test_newPathGetSetter(t *testing.T) {
 			got, _ := accessor.Get(ctx)
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(ctx, tt.newVal)
+			err = accessor.Set(ctx, tt.newVal)
+			assert.Nil(t, err)
 
 			exMetric := createMetricTelemetry()
 			tt.modified(exMetric)

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -229,7 +229,8 @@ func Test_newPathGetSetter(t *testing.T) {
 			got, _ := accessor.Get(NewTransformContext(resource))
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(NewTransformContext(resource), tt.newVal)
+			err = accessor.Set(NewTransformContext(resource), tt.newVal)
+			assert.Nil(t, err)
 
 			exRes := createTelemetry()
 			tt.modified(exRes)

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -226,7 +226,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			resource := createTelemetry()
 
-			got := accessor.Get(NewTransformContext(resource))
+			got, _ := accessor.Get(NewTransformContext(resource))
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(NewTransformContext(resource), tt.newVal)

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -226,7 +226,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			resource := createTelemetry()
 
-			got, _ := accessor.Get(NewTransformContext(resource))
+			got, err := accessor.Get(NewTransformContext(resource))
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(NewTransformContext(resource), tt.newVal)

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -265,7 +265,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			il, resource := createTelemetry()
 
-			got := accessor.Get(NewTransformContext(il, resource))
+			got, _ := accessor.Get(NewTransformContext(il, resource))
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(NewTransformContext(il, resource), tt.newVal)

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -265,7 +265,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			il, resource := createTelemetry()
 
-			got, _ := accessor.Get(NewTransformContext(il, resource))
+			got, err := accessor.Get(NewTransformContext(il, resource))
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(NewTransformContext(il, resource), tt.newVal)

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -268,7 +268,8 @@ func Test_newPathGetSetter(t *testing.T) {
 			got, _ := accessor.Get(NewTransformContext(il, resource))
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(NewTransformContext(il, resource), tt.newVal)
+			err = accessor.Set(NewTransformContext(il, resource), tt.newVal)
+			assert.Nil(t, err)
 
 			exIl, exRes := createTelemetry()
 			tt.modified(exIl, exRes)

--- a/pkg/ottl/contexts/ottltraces/traces.go
+++ b/pkg/ottl/contexts/ottltraces/traces.go
@@ -162,82 +162,87 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 
 func accessTraceID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().TraceID()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().TraceID(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newTraceID, ok := val.(pcommon.TraceID); ok {
 				ctx.GetSpan().SetTraceID(newTraceID)
 			}
+			return nil
 		},
 	}
 }
 
 func accessStringTraceID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().TraceID().HexString()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().TraceID().HexString(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
 				if traceID, err := parseTraceID(str); err == nil {
 					ctx.GetSpan().SetTraceID(traceID)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessSpanID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().SpanID()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().SpanID(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newSpanID, ok := val.(pcommon.SpanID); ok {
 				ctx.GetSpan().SetSpanID(newSpanID)
 			}
+			return nil
 		},
 	}
 }
 
 func accessStringSpanID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().SpanID().HexString()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().SpanID().HexString(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
 				if spanID, err := parseSpanID(str); err == nil {
 					ctx.GetSpan().SetSpanID(spanID)
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessTraceState() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().TraceState().AsRaw()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().TraceState().AsRaw(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
 				ctx.GetSpan().TraceState().FromRaw(str)
 			}
+			return nil
 		},
 	}
 }
 
 func accessTraceStateKey(mapKey *string) ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
+		Getter: func(ctx TransformContext) (interface{}, error) {
 			if ts, err := trace.ParseTraceState(ctx.GetSpan().TraceState().AsRaw()); err == nil {
-				return ts.Get(*mapKey)
+				return ts.Get(*mapKey), nil
 			}
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
 				if ts, err := trace.ParseTraceState(ctx.GetSpan().TraceState().AsRaw()); err == nil {
 					if updated, err := ts.Insert(*mapKey, str); err == nil {
@@ -245,205 +250,221 @@ func accessTraceStateKey(mapKey *string) ottl.StandardGetSetter[TransformContext
 					}
 				}
 			}
+			return nil
 		},
 	}
 }
 
 func accessParentSpanID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().ParentSpanID()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().ParentSpanID(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if newParentSpanID, ok := val.(pcommon.SpanID); ok {
 				ctx.GetSpan().SetParentSpanID(newParentSpanID)
 			}
+			return nil
 		},
 	}
 }
 
 func accessName() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().Name()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().Name(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
 				ctx.GetSpan().SetName(str)
 			}
+			return nil
 		},
 	}
 }
 
 func accessKind() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return int64(ctx.GetSpan().Kind())
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return int64(ctx.GetSpan().Kind()), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetSpan().SetKind(ptrace.SpanKind(i))
 			}
+			return nil
 		},
 	}
 }
 
 func accessStartTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().StartTimestamp().AsTime().UnixNano()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().StartTimestamp().AsTime().UnixNano(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetSpan().SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, i)))
 			}
+			return nil
 		},
 	}
 }
 
 func accessEndTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().EndTimestamp().AsTime().UnixNano()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().EndTimestamp().AsTime().UnixNano(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetSpan().SetEndTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, i)))
 			}
+			return nil
 		},
 	}
 }
 
 func accessAttributes() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().Attributes()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().Attributes(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(ctx.GetSpan().Attributes())
 			}
+			return nil
 		},
 	}
 }
 
 func accessAttributesKey(mapKey *string) ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ottlcommon.GetMapValue(ctx.GetSpan().Attributes(), *mapKey)
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ottlcommon.GetMapValue(ctx.GetSpan().Attributes(), *mapKey), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			ottlcommon.SetMapValue(ctx.GetSpan().Attributes(), *mapKey, val)
+			return nil
 		},
 	}
 }
 
 func accessDroppedAttributesCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return int64(ctx.GetSpan().DroppedAttributesCount())
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return int64(ctx.GetSpan().DroppedAttributesCount()), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetSpan().SetDroppedAttributesCount(uint32(i))
 			}
+			return nil
 		},
 	}
 }
 
 func accessEvents() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().Events()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().Events(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if slc, ok := val.(ptrace.SpanEventSlice); ok {
 				ctx.GetSpan().Events().RemoveIf(func(event ptrace.SpanEvent) bool {
 					return true
 				})
 				slc.CopyTo(ctx.GetSpan().Events())
 			}
+			return nil
 		},
 	}
 }
 
 func accessDroppedEventsCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return int64(ctx.GetSpan().DroppedEventsCount())
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return int64(ctx.GetSpan().DroppedEventsCount()), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetSpan().SetDroppedEventsCount(uint32(i))
 			}
+			return nil
 		},
 	}
 }
 
 func accessLinks() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().Links()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().Links(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if slc, ok := val.(ptrace.SpanLinkSlice); ok {
 				ctx.GetSpan().Links().RemoveIf(func(event ptrace.SpanLink) bool {
 					return true
 				})
 				slc.CopyTo(ctx.GetSpan().Links())
 			}
+			return nil
 		},
 	}
 }
 
 func accessDroppedLinksCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return int64(ctx.GetSpan().DroppedLinksCount())
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return int64(ctx.GetSpan().DroppedLinksCount()), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetSpan().SetDroppedLinksCount(uint32(i))
 			}
+			return nil
 		},
 	}
 }
 
 func accessStatus() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().Status()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().Status(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if status, ok := val.(ptrace.Status); ok {
 				status.CopyTo(ctx.GetSpan().Status())
 			}
+			return nil
 		},
 	}
 }
 
 func accessStatusCode() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return int64(ctx.GetSpan().Status().Code())
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return int64(ctx.GetSpan().Status().Code()), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				ctx.GetSpan().Status().SetCode(ptrace.StatusCode(i))
 			}
+			return nil
 		},
 	}
 }
 
 func accessStatusMessage() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx TransformContext) interface{} {
-			return ctx.GetSpan().Status().Message()
+		Getter: func(ctx TransformContext) (interface{}, error) {
+			return ctx.GetSpan().Status().Message(), nil
 		},
-		Setter: func(ctx TransformContext, val interface{}) {
+		Setter: func(ctx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
 				ctx.GetSpan().Status().SetMessage(str)
 			}
+			return nil
 		},
 	}
 }

--- a/pkg/ottl/contexts/ottltraces/traces_test.go
+++ b/pkg/ottl/contexts/ottltraces/traces_test.go
@@ -524,7 +524,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			span, il, resource := createTelemetry()
 
-			got, _ := accessor.Get(NewTransformContext(span, il, resource))
+			got, err := accessor.Get(NewTransformContext(span, il, resource))
+			assert.Nil(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(NewTransformContext(span, il, resource), tt.newVal)

--- a/pkg/ottl/contexts/ottltraces/traces_test.go
+++ b/pkg/ottl/contexts/ottltraces/traces_test.go
@@ -524,7 +524,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			span, il, resource := createTelemetry()
 
-			got := accessor.Get(NewTransformContext(span, il, resource))
+			got, _ := accessor.Get(NewTransformContext(span, il, resource))
 			assert.Equal(t, tt.orig, got)
 
 			accessor.Set(NewTransformContext(span, il, resource), tt.newVal)

--- a/pkg/ottl/contexts/ottltraces/traces_test.go
+++ b/pkg/ottl/contexts/ottltraces/traces_test.go
@@ -527,7 +527,8 @@ func Test_newPathGetSetter(t *testing.T) {
 			got, _ := accessor.Get(NewTransformContext(span, il, resource))
 			assert.Equal(t, tt.orig, got)
 
-			accessor.Set(NewTransformContext(span, il, resource), tt.newVal)
+			err = accessor.Set(NewTransformContext(span, il, resource), tt.newVal)
+			assert.Nil(t, err)
 
 			exSpan, exIl, exRes := createTelemetry()
 			tt.modified(exSpan, exIl, exRes)

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -18,14 +18,14 @@ import (
 	"fmt"
 )
 
-type ExprFunc[K any] func(ctx K) interface{}
+type ExprFunc[K any] func(ctx K) (interface{}, error)
 
 type Getter[K any] interface {
-	Get(ctx K) interface{}
+	Get(ctx K) (interface{}, error)
 }
 
 type Setter[K any] interface {
-	Set(ctx K, val interface{})
+	Set(ctx K, val interface{}) error
 }
 
 type GetSetter[K any] interface {
@@ -34,31 +34,31 @@ type GetSetter[K any] interface {
 }
 
 type StandardGetSetter[K any] struct {
-	Getter func(ctx K) interface{}
-	Setter func(ctx K, val interface{})
+	Getter func(ctx K) (interface{}, error)
+	Setter func(ctx K, val interface{}) error
 }
 
-func (path StandardGetSetter[K]) Get(ctx K) interface{} {
+func (path StandardGetSetter[K]) Get(ctx K) (interface{}, error) {
 	return path.Getter(ctx)
 }
 
-func (path StandardGetSetter[K]) Set(ctx K, val interface{}) {
-	path.Setter(ctx, val)
+func (path StandardGetSetter[K]) Set(ctx K, val interface{}) error {
+	return path.Setter(ctx, val)
 }
 
 type literal[K any] struct {
 	value interface{}
 }
 
-func (l literal[K]) Get(K) interface{} {
-	return l.value
+func (l literal[K]) Get(K) (interface{}, error) {
+	return l.value, nil
 }
 
 type exprGetter[K any] struct {
 	expr ExprFunc[K]
 }
 
-func (g exprGetter[K]) Get(ctx K) interface{} {
+func (g exprGetter[K]) Get(ctx K) (interface{}, error) {
 	return g.expr(ctx)
 }
 

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 func hello[K any]() (ExprFunc[K], error) {
-	return func(ctx K) interface{} {
-		return "world"
+	return func(ctx K) (interface{}, error) {
+		return "world", nil
 	}, nil
 }
 
@@ -121,7 +121,7 @@ func Test_newGetter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			reader, err := p.newGetter(tt.val)
 			assert.NoError(t, err)
-			val := reader.Get(tt.want)
+			val, _ := reader.Get(tt.want)
 			assert.Equal(t, tt.want, val)
 		})
 	}

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -620,118 +620,119 @@ func Test_NewFunctionCall(t *testing.T) {
 			assert.NoError(t, err)
 
 			if tt.want != nil {
-				assert.Equal(t, tt.want, fn(nil))
+				result, _ := fn(nil)
+				assert.Equal(t, tt.want, result)
 			}
 		})
 	}
 }
 
 func functionWithStringSlice(strs []string) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return len(strs)
+	return func(interface{}) (interface{}, error) {
+		return len(strs), nil
 	}, nil
 }
 
 func functionWithFloatSlice(floats []float64) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return len(floats)
+	return func(interface{}) (interface{}, error) {
+		return len(floats), nil
 	}, nil
 }
 
 func functionWithIntSlice(ints []int64) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return len(ints)
+	return func(interface{}) (interface{}, error) {
+		return len(ints), nil
 	}, nil
 }
 
 func functionWithByteSlice(bytes []byte) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return len(bytes)
+	return func(interface{}) (interface{}, error) {
+		return len(bytes), nil
 	}, nil
 }
 
 func functionWithGetterSlice(getters []Getter[interface{}]) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return len(getters)
+	return func(interface{}) (interface{}, error) {
+		return len(getters), nil
 	}, nil
 }
 
 func functionWithSetter(Setter[interface{}]) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithGetSetter(GetSetter[interface{}]) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithGetter(Getter[interface{}]) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithString(string) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithFloat(float64) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithInt(int64) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithBool(bool) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithMultipleArgs(GetSetter[interface{}], string, float64, int64) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionThatHasAnError() (ExprFunc[interface{}], error) {
 	err := errors.New("testing")
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, err
 }
 
 func functionWithEnum(Enum) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithTelemetrySettingsFirst(component.TelemetrySettings, string, string, int64) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithTelemetrySettingsMiddle(string, string, component.TelemetrySettings, int64) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 
 func functionWithTelemetrySettingsLast(string, string, int64, component.TelemetrySettings) (ExprFunc[interface{}], error) {
-	return func(interface{}) interface{} {
-		return "anything"
+	return func(interface{}) (interface{}, error) {
+		return "anything", nil
 	}, nil
 }
 

--- a/pkg/ottl/ottlfuncs/func_concat.go
+++ b/pkg/ottl/ottlfuncs/func_concat.go
@@ -25,7 +25,10 @@ func Concat[K any](vals []ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], e
 	return func(ctx K) (interface{}, error) {
 		builder := strings.Builder{}
 		for i, rv := range vals {
-			val, _ := rv.Get(ctx)
+			val, err := rv.Get(ctx)
+			if err != nil {
+				return nil, err
+			}
 			switch v := val.(type) {
 			case string:
 				builder.WriteString(v)

--- a/pkg/ottl/ottlfuncs/func_concat.go
+++ b/pkg/ottl/ottlfuncs/func_concat.go
@@ -26,19 +26,19 @@ func Concat[K any](vals []ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], e
 		builder := strings.Builder{}
 		for i, rv := range vals {
 			val, _ := rv.Get(ctx)
-			switch val.(type) {
+			switch v := val.(type) {
 			case string:
-				builder.WriteString(val.(string))
+				builder.WriteString(v)
 			case []byte:
-				builder.WriteString(fmt.Sprintf("%x", val))
+				builder.WriteString(fmt.Sprintf("%x", v))
 			case int64:
-				builder.WriteString(fmt.Sprint(val))
+				builder.WriteString(fmt.Sprint(v))
 			case float64:
-				builder.WriteString(fmt.Sprint(val))
+				builder.WriteString(fmt.Sprint(v))
 			case bool:
-				builder.WriteString(fmt.Sprint(val))
+				builder.WriteString(fmt.Sprint(v))
 			case nil:
-				builder.WriteString(fmt.Sprint(val))
+				builder.WriteString(fmt.Sprint(v))
 			}
 
 			if i != len(vals)-1 {

--- a/pkg/ottl/ottlfuncs/func_concat.go
+++ b/pkg/ottl/ottlfuncs/func_concat.go
@@ -22,12 +22,13 @@ import (
 )
 
 func Concat[K any](vals []ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], error) {
-	return func(ctx K) interface{} {
+	return func(ctx K) (interface{}, error) {
 		builder := strings.Builder{}
 		for i, rv := range vals {
-			switch val := rv.Get(ctx).(type) {
+			val, _ := rv.Get(ctx)
+			switch val.(type) {
 			case string:
-				builder.WriteString(val)
+				builder.WriteString(val.(string))
 			case []byte:
 				builder.WriteString(fmt.Sprintf("%x", val))
 			case int64:
@@ -44,6 +45,6 @@ func Concat[K any](vals []ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], e
 				builder.WriteString(delimiter)
 			}
 		}
-		return builder.String()
+		return builder.String(), nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -234,8 +233,9 @@ func Test_concat(t *testing.T) {
 			}
 
 			exprFunc, err := Concat(getters, tt.delimiter)
-			require.NoError(t, err)
-			result, _ := exprFunc(nil)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -34,13 +34,13 @@ func Test_concat(t *testing.T) {
 			name: "concat strings",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "hello"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "world"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "world", nil
 					},
 				},
 			},
@@ -51,18 +51,18 @@ func Test_concat(t *testing.T) {
 			name: "nil",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "hello"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return nil
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return nil, nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "world"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "world", nil
 					},
 				},
 			},
@@ -73,13 +73,13 @@ func Test_concat(t *testing.T) {
 			name: "integers",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "hello"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return int64(1)
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return int64(1), nil
 					},
 				},
 			},
@@ -90,13 +90,13 @@ func Test_concat(t *testing.T) {
 			name: "floats",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "hello"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return 3.14159
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return 3.14159, nil
 					},
 				},
 			},
@@ -107,13 +107,13 @@ func Test_concat(t *testing.T) {
 			name: "booleans",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "hello"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return true
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return true, nil
 					},
 				},
 			},
@@ -124,8 +124,8 @@ func Test_concat(t *testing.T) {
 			name: "byte slices",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8}
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8}, nil
 					},
 				},
 			},
@@ -136,8 +136,8 @@ func Test_concat(t *testing.T) {
 			name: "non-byte slices",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, nil
 					},
 				},
 			},
@@ -148,8 +148,8 @@ func Test_concat(t *testing.T) {
 			name: "maps",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return map[string]string{"key": "value"}
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return map[string]string{"key": "value"}, nil
 					},
 				},
 			},
@@ -160,18 +160,18 @@ func Test_concat(t *testing.T) {
 			name: "unprintable value in the middle",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "hello"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return map[string]string{"key": "value"}
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return map[string]string{"key": "value"}, nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "world"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "world", nil
 					},
 				},
 			},
@@ -182,18 +182,18 @@ func Test_concat(t *testing.T) {
 			name: "empty string values",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return ""
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "", nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return ""
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "", nil
 					},
 				},
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return ""
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "", nil
 					},
 				},
 			},
@@ -204,8 +204,8 @@ func Test_concat(t *testing.T) {
 			name: "single argument",
 			vals: []ottl.StandardGetSetter[interface{}]{
 				{
-					Getter: func(ctx interface{}) interface{} {
-						return "hello"
+					Getter: func(ctx interface{}) (interface{}, error) {
+						return "hello", nil
 					},
 				},
 			},
@@ -235,7 +235,8 @@ func Test_concat(t *testing.T) {
 
 			exprFunc, err := Concat(getters, tt.delimiter)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, exprFunc(nil))
+			result, _ := exprFunc(nil)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_delete_key.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key.go
@@ -21,15 +21,15 @@ import (
 )
 
 func DeleteKey[K any](target ottl.Getter[K], key string) (ottl.ExprFunc[K], error) {
-	return func(ctx K) interface{} {
-		val := target.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		val, _ := target.Get(ctx)
 		if val == nil {
-			return nil
+			return nil, nil
 		}
 
 		if attrs, ok := val.(pcommon.Map); ok {
 			attrs.Remove(key)
 		}
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_delete_key.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key.go
@@ -22,7 +22,10 @@ import (
 
 func DeleteKey[K any](target ottl.Getter[K], key string) (ottl.ExprFunc[K], error) {
 	return func(ctx K) (interface{}, error) {
-		val, _ := target.Get(ctx)
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if val == nil {
 			return nil, nil
 		}

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -77,7 +76,7 @@ func Test_deleteKey(t *testing.T) {
 			input.CopyTo(scenarioMap)
 
 			exprFunc, err := DeleteKey(tt.target, tt.key)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			_, err = exprFunc(scenarioMap)
 			assert.Nil(t, err)
@@ -105,8 +104,9 @@ func Test_deleteKey_bad_input(t *testing.T) {
 	key := "anything"
 
 	exprFunc, err := DeleteKey[interface{}](target, key)
-	require.NoError(t, err)
-	result, _ := exprFunc(input)
+	assert.NoError(t, err)
+	result, err := exprFunc(input)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }
@@ -125,7 +125,8 @@ func Test_deleteKey_get_nil(t *testing.T) {
 	key := "anything"
 
 	exprFunc, err := DeleteKey[interface{}](target, key)
-	require.NoError(t, err)
-	result, _ := exprFunc(nil)
+	assert.NoError(t, err)
+	result, err := exprFunc(nil)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -78,7 +78,9 @@ func Test_deleteKey(t *testing.T) {
 
 			exprFunc, err := DeleteKey(tt.target, tt.key)
 			require.NoError(t, err)
-			exprFunc(scenarioMap)
+
+			_, err = exprFunc(scenarioMap)
+			assert.Nil(t, err)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -31,8 +31,8 @@ func Test_deleteKey(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardGetSetter[pcommon.Map]{
-		Getter: func(ctx pcommon.Map) interface{} {
-			return ctx
+		Getter: func(ctx pcommon.Map) (interface{}, error) {
+			return ctx, nil
 		},
 	}
 
@@ -91,11 +91,12 @@ func Test_deleteKey(t *testing.T) {
 func Test_deleteKey_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
@@ -103,17 +104,19 @@ func Test_deleteKey_bad_input(t *testing.T) {
 
 	exprFunc, err := DeleteKey[interface{}](target, key)
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(input))
+	result, _ := exprFunc(input)
+	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }
 
 func Test_deleteKey_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
@@ -121,5 +124,6 @@ func Test_deleteKey_get_nil(t *testing.T) {
 
 	exprFunc, err := DeleteKey[interface{}](target, key)
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(nil))
+	result, _ := exprFunc(nil)
+	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
@@ -28,10 +28,10 @@ func DeleteMatchingKeys[K any](target ottl.Getter[K], pattern string) (ottl.Expr
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to delete_matching_keys is not a valid pattern: %w", err)
 	}
-	return func(ctx K) interface{} {
-		val := target.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		val, _ := target.Get(ctx)
 		if val == nil {
-			return nil
+			return nil, nil
 		}
 
 		if attrs, ok := val.(pcommon.Map); ok {
@@ -39,6 +39,6 @@ func DeleteMatchingKeys[K any](target ottl.Getter[K], pattern string) (ottl.Expr
 				return compiledPattern.MatchString(key)
 			})
 		}
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
@@ -29,7 +29,10 @@ func DeleteMatchingKeys[K any](target ottl.Getter[K], pattern string) (ottl.Expr
 		return nil, fmt.Errorf("the regex pattern supplied to delete_matching_keys is not a valid pattern: %w", err)
 	}
 	return func(ctx K) (interface{}, error) {
-		val, _ := target.Get(ctx)
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if val == nil {
 			return nil, nil
 		}

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -76,7 +76,9 @@ func Test_deleteMatchingKeys(t *testing.T) {
 
 			exprFunc, err := DeleteMatchingKeys(tt.target, tt.pattern)
 			require.NoError(t, err)
-			exprFunc(scenarioMap)
+
+			_, err = exprFunc(scenarioMap)
+			assert.Nil(t, err)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -96,7 +98,9 @@ func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 
 	exprFunc, err := DeleteMatchingKeys[interface{}](target, "anything")
 	require.NoError(t, err)
-	exprFunc(input)
+
+	_, err = exprFunc(input)
+	assert.Nil(t, err)
 
 	assert.Equal(t, pcommon.NewValueInt(1), input)
 }

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -31,8 +31,8 @@ func Test_deleteMatchingKeys(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardGetSetter[pcommon.Map]{
-		Getter: func(ctx pcommon.Map) interface{} {
-			return ctx
+		Getter: func(ctx pcommon.Map) (interface{}, error) {
+			return ctx, nil
 		},
 	}
 
@@ -89,8 +89,8 @@ func Test_deleteMatchingKeys(t *testing.T) {
 func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
 	}
 
@@ -103,21 +103,22 @@ func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 
 func Test_deleteMatchingKeys_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
 	}
 
 	exprFunc, err := DeleteMatchingKeys[interface{}](target, "anything")
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(nil))
+	result, _ := exprFunc(nil)
+	assert.Nil(t, result)
 }
 
 func Test_deleteMatchingKeys_invalid_pattern(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
+		Getter: func(ctx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
-			return nil
+			return nil, nil
 		},
 	}
 

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -75,7 +75,7 @@ func Test_deleteMatchingKeys(t *testing.T) {
 			input.CopyTo(scenarioMap)
 
 			exprFunc, err := DeleteMatchingKeys(tt.target, tt.pattern)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			_, err = exprFunc(scenarioMap)
 			assert.Nil(t, err)
@@ -97,7 +97,7 @@ func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 	}
 
 	exprFunc, err := DeleteMatchingKeys[interface{}](target, "anything")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	_, err = exprFunc(input)
 	assert.Nil(t, err)
@@ -113,8 +113,9 @@ func Test_deleteMatchingKeys_get_nil(t *testing.T) {
 	}
 
 	exprFunc, err := DeleteMatchingKeys[interface{}](target, "anything")
-	require.NoError(t, err)
-	result, _ := exprFunc(nil)
+	assert.NoError(t, err)
+	result, err := exprFunc(nil)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 }
 

--- a/pkg/ottl/ottlfuncs/func_int.go
+++ b/pkg/ottl/ottlfuncs/func_int.go
@@ -21,27 +21,27 @@ import (
 )
 
 func Int[K any](target ottl.Getter[K]) (ottl.ExprFunc[K], error) {
-	return func(ctx K) interface{} {
-		value := target.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		value, _ := target.Get(ctx)
 		switch value := value.(type) {
 		case int64:
-			return value
+			return value, nil
 		case string:
 			intValue, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
-				return nil
+				return nil, nil
 			}
 
-			return intValue
+			return intValue, nil
 		case float64:
-			return (int64)(value)
+			return (int64)(value), nil
 		case bool:
 			if value {
-				return int64(1)
+				return int64(1), nil
 			}
-			return int64(0)
+			return int64(0), nil
 		default:
-			return nil
+			return nil, nil
 		}
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_int.go
+++ b/pkg/ottl/ottlfuncs/func_int.go
@@ -22,7 +22,10 @@ import (
 
 func Int[K any](target ottl.Getter[K]) (ottl.ExprFunc[K], error) {
 	return func(ctx K) (interface{}, error) {
-		value, _ := target.Get(ctx)
+		value, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		switch value := value.(type) {
 		case int64:
 			return value, nil

--- a/pkg/ottl/ottlfuncs/func_int_test.go
+++ b/pkg/ottl/ottlfuncs/func_int_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -87,8 +86,9 @@ func Test_Int(t *testing.T) {
 					return tt.value, nil
 				},
 			})
-			require.NoError(t, err)
-			result, _ := exprFunc(nil)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/ottl/ottlfuncs/func_int_test.go
+++ b/pkg/ottl/ottlfuncs/func_int_test.go
@@ -83,12 +83,13 @@ func Test_Int(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := Int[interface{}](&ottl.StandardGetSetter[interface{}]{
-				Getter: func(interface{}) interface{} {
-					return tt.value
+				Getter: func(interface{}) (interface{}, error) {
+					return tt.value, nil
 				},
 			})
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, exprFunc(nil))
+			result, _ := exprFunc(nil)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_is_match.go
+++ b/pkg/ottl/ottlfuncs/func_is_match.go
@@ -26,12 +26,12 @@ func IsMatch[K any](target ottl.Getter[K], pattern string) (ottl.ExprFunc[K], er
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to IsMatch is not a valid regexp pattern: %w", err)
 	}
-	return func(ctx K) interface{} {
-		if val := target.Get(ctx); val != nil {
+	return func(ctx K) (interface{}, error) {
+		if val, _ := target.Get(ctx); val != nil {
 			if valStr, ok := val.(string); ok {
-				return compiledPattern.MatchString(valStr)
+				return compiledPattern.MatchString(valStr), nil
 			}
 		}
-		return false
+		return false, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_is_match.go
+++ b/pkg/ottl/ottlfuncs/func_is_match.go
@@ -27,7 +27,11 @@ func IsMatch[K any](target ottl.Getter[K], pattern string) (ottl.ExprFunc[K], er
 		return nil, fmt.Errorf("the pattern supplied to IsMatch is not a valid regexp pattern: %w", err)
 	}
 	return func(ctx K) (interface{}, error) {
-		if val, _ := target.Get(ctx); val != nil {
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if val != nil {
 			if valStr, ok := val.(string); ok {
 				return compiledPattern.MatchString(valStr), nil
 			}

--- a/pkg/ottl/ottlfuncs/func_is_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_match_test.go
@@ -33,8 +33,8 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "replace match true",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return "hello world"
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return "hello world", nil
 				},
 			},
 			pattern:  "hello.*",
@@ -43,8 +43,8 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "replace match false",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return "goodbye world"
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return "goodbye world", nil
 				},
 			},
 			pattern:  "hello.*",
@@ -53,8 +53,8 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "replace match complex",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return "-12.001"
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return "-12.001", nil
 				},
 			},
 			pattern:  "[-+]?\\d*\\.\\d+([eE][-+]?\\d+)?",
@@ -63,8 +63,8 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target not a string",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return 1
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return 1, nil
 				},
 			},
 			pattern:  "doesnt matter will be false",
@@ -73,8 +73,8 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target nil",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return nil
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return nil, nil
 				},
 			},
 			pattern:  "doesnt matter will be false",
@@ -85,15 +85,16 @@ func Test_isMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := IsMatch(tt.target, tt.pattern)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, exprFunc(nil))
+			result, _ := exprFunc(nil)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
 func Test_isMatch_validation(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return "anything"
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return "anything", nil
 		},
 	}
 	_, err := IsMatch[interface{}](target, "\\K")

--- a/pkg/ottl/ottlfuncs/func_is_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_match_test.go
@@ -84,8 +84,9 @@ func Test_isMatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := IsMatch(tt.target, tt.pattern)
-			require.NoError(t, err)
-			result, _ := exprFunc(nil)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/ottl/ottlfuncs/func_keep_keys.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys.go
@@ -26,10 +26,10 @@ func KeepKeys[K any](target ottl.GetSetter[K], keys []string) (ottl.ExprFunc[K],
 		keySet[key] = struct{}{}
 	}
 
-	return func(ctx K) interface{} {
-		val := target.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		val, _ := target.Get(ctx)
 		if val == nil {
-			return nil
+			return nil, nil
 		}
 
 		if attrs, ok := val.(pcommon.Map); ok {
@@ -41,6 +41,6 @@ func KeepKeys[K any](target ottl.GetSetter[K], keys []string) (ottl.ExprFunc[K],
 				attrs.Clear()
 			}
 		}
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_keep_keys.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys.go
@@ -27,7 +27,10 @@ func KeepKeys[K any](target ottl.GetSetter[K], keys []string) (ottl.ExprFunc[K],
 	}
 
 	return func(ctx K) (interface{}, error) {
-		val, _ := target.Get(ctx)
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if val == nil {
 			return nil, nil
 		}

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -88,7 +87,7 @@ func Test_keepKeys(t *testing.T) {
 			input.CopyTo(scenarioMap)
 
 			exprFunc, err := KeepKeys(tt.target, tt.keys)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			_, err = exprFunc(scenarioMap)
 			assert.Nil(t, err)
@@ -116,7 +115,7 @@ func Test_keepKeys_bad_input(t *testing.T) {
 	keys := []string{"anything"}
 
 	exprFunc, err := KeepKeys[interface{}](target, keys)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	_, err = exprFunc(input)
 	assert.Nil(t, err)
@@ -138,7 +137,8 @@ func Test_keepKeys_get_nil(t *testing.T) {
 	keys := []string{"anything"}
 
 	exprFunc, err := KeepKeys[interface{}](target, keys)
-	require.NoError(t, err)
-	result, _ := exprFunc(nil)
+	assert.NoError(t, err)
+	result, err := exprFunc(nil)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -89,7 +89,9 @@ func Test_keepKeys(t *testing.T) {
 
 			exprFunc, err := KeepKeys(tt.target, tt.keys)
 			require.NoError(t, err)
-			exprFunc(scenarioMap)
+
+			_, err = exprFunc(scenarioMap)
+			assert.Nil(t, err)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -115,7 +117,9 @@ func Test_keepKeys_bad_input(t *testing.T) {
 
 	exprFunc, err := KeepKeys[interface{}](target, keys)
 	require.NoError(t, err)
-	exprFunc(input)
+
+	_, err = exprFunc(input)
+	assert.Nil(t, err)
 
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -31,11 +31,12 @@ func Test_keepKeys(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardGetSetter[pcommon.Map]{
-		Getter: func(ctx pcommon.Map) interface{} {
-			return ctx
+		Getter: func(ctx pcommon.Map) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx pcommon.Map, val interface{}) {
+		Setter: func(ctx pcommon.Map, val interface{}) error {
 			val.(pcommon.Map).CopyTo(ctx)
+			return nil
 		},
 	}
 
@@ -101,11 +102,12 @@ func Test_keepKeys(t *testing.T) {
 func Test_keepKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
@@ -120,11 +122,12 @@ func Test_keepKeys_bad_input(t *testing.T) {
 
 func Test_keepKeys_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
@@ -132,5 +135,6 @@ func Test_keepKeys_get_nil(t *testing.T) {
 
 	exprFunc, err := KeepKeys[interface{}](target, keys)
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(nil))
+	result, _ := exprFunc(nil)
+	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_limit.go
+++ b/pkg/ottl/ottlfuncs/func_limit.go
@@ -38,7 +38,10 @@ func Limit[K any](target ottl.GetSetter[K], limit int64, priorityKeys []string) 
 	}
 
 	return func(ctx K) (interface{}, error) {
-		val, _ := target.Get(ctx)
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if val == nil {
 			return nil, nil
 		}

--- a/pkg/ottl/ottlfuncs/func_limit.go
+++ b/pkg/ottl/ottlfuncs/func_limit.go
@@ -37,19 +37,19 @@ func Limit[K any](target ottl.GetSetter[K], limit int64, priorityKeys []string) 
 		keep[key] = struct{}{}
 	}
 
-	return func(ctx K) interface{} {
-		val := target.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		val, _ := target.Get(ctx)
 		if val == nil {
-			return nil
+			return nil, nil
 		}
 
 		attrs, ok := val.(pcommon.Map)
 		if !ok {
-			return nil
+			return nil, nil
 		}
 
 		if int64(attrs.Len()) <= limit {
-			return nil
+			return nil, nil
 		}
 
 		count := int64(0)
@@ -71,6 +71,6 @@ func Limit[K any](target ottl.GetSetter[K], limit int64, priorityKeys []string) 
 		})
 		// TODO: Write log when limiting is performed
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_limit_test.go
+++ b/pkg/ottl/ottlfuncs/func_limit_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -129,9 +128,10 @@ func Test_limit(t *testing.T) {
 			input.CopyTo(scenarioMap)
 
 			exprFunc, err := Limit(tt.target, tt.limit, tt.keep)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
-			result, _ := exprFunc(scenarioMap)
+			result, err := exprFunc(scenarioMap)
+			assert.NoError(t, err)
 			assert.Nil(t, result)
 
 			expected := pcommon.NewMap()
@@ -182,8 +182,9 @@ func Test_limit_bad_input(t *testing.T) {
 	}
 
 	exprFunc, err := Limit[interface{}](target, 1, []string{})
-	require.NoError(t, err)
-	result, _ := exprFunc(input)
+	assert.NoError(t, err)
+	result, err := exprFunc(input)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }
@@ -200,8 +201,9 @@ func Test_limit_get_nil(t *testing.T) {
 	}
 
 	exprFunc, err := Limit[interface{}](target, 1, []string{})
-	require.NoError(t, err)
-	result, _ := exprFunc(nil)
+	assert.NoError(t, err)
+	result, err := exprFunc(nil)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_limit_test.go
+++ b/pkg/ottl/ottlfuncs/func_limit_test.go
@@ -130,6 +130,7 @@ func Test_limit(t *testing.T) {
 
 			exprFunc, err := Limit(tt.target, tt.limit, tt.keep)
 			require.NoError(t, err)
+
 			result, _ := exprFunc(scenarioMap)
 			assert.Nil(t, result)
 

--- a/pkg/ottl/ottlfuncs/func_limit_test.go
+++ b/pkg/ottl/ottlfuncs/func_limit_test.go
@@ -31,11 +31,12 @@ func Test_limit(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardGetSetter[pcommon.Map]{
-		Getter: func(ctx pcommon.Map) interface{} {
-			return ctx
+		Getter: func(ctx pcommon.Map) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx pcommon.Map, val interface{}) {
+		Setter: func(ctx pcommon.Map, val interface{}) error {
 			val.(pcommon.Map).CopyTo(ctx)
+			return nil
 		},
 	}
 
@@ -129,7 +130,8 @@ func Test_limit(t *testing.T) {
 
 			exprFunc, err := Limit(tt.target, tt.limit, tt.keep)
 			require.NoError(t, err)
-			assert.Nil(t, exprFunc(scenarioMap))
+			result, _ := exprFunc(scenarioMap)
+			assert.Nil(t, result)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -169,31 +171,36 @@ func Test_limit_validation(t *testing.T) {
 func Test_limit_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := Limit[interface{}](target, 1, []string{})
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(input))
+	result, _ := exprFunc(input)
+	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }
 
 func Test_limit_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := Limit[interface{}](target, 1, []string{})
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(nil))
+	result, _ := exprFunc(nil)
+	assert.Nil(t, result)
+	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -29,7 +29,10 @@ func ReplaceAllMatches[K any](target ottl.GetSetter[K], pattern string, replacem
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
 	return func(ctx K) (interface{}, error) {
-		val, _ := target.Get(ctx)
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if val == nil {
 			return nil, nil
 		}
@@ -45,7 +48,10 @@ func ReplaceAllMatches[K any](target ottl.GetSetter[K], pattern string, replacem
 			}
 			return true
 		})
-		_ = target.Set(ctx, updated)
+		err = target.Set(ctx, updated)
+		if err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -28,14 +28,14 @@ func ReplaceAllMatches[K any](target ottl.GetSetter[K], pattern string, replacem
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
-	return func(ctx K) interface{} {
-		val := target.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		val, _ := target.Get(ctx)
 		if val == nil {
-			return nil
+			return nil, nil
 		}
 		attrs, ok := val.(pcommon.Map)
 		if !ok {
-			return nil
+			return nil, nil
 		}
 		updated := pcommon.NewMap()
 		attrs.CopyTo(updated)
@@ -46,6 +46,6 @@ func ReplaceAllMatches[K any](target ottl.GetSetter[K], pattern string, replacem
 			return true
 		})
 		target.Set(ctx, updated)
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -45,7 +45,7 @@ func ReplaceAllMatches[K any](target ottl.GetSetter[K], pattern string, replacem
 			}
 			return true
 		})
-		target.Set(ctx, updated)
+		_ = target.Set(ctx, updated)
 		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
@@ -31,11 +31,12 @@ func Test_replaceAllMatches(t *testing.T) {
 	input.PutStr("test3", "goodbye")
 
 	target := &ottl.StandardGetSetter[pcommon.Map]{
-		Getter: func(ctx pcommon.Map) interface{} {
-			return ctx
+		Getter: func(ctx pcommon.Map) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx pcommon.Map, val interface{}) {
+		Setter: func(ctx pcommon.Map, val interface{}) error {
 			val.(pcommon.Map).CopyTo(ctx)
+			return nil
 		},
 	}
 
@@ -76,7 +77,8 @@ func Test_replaceAllMatches(t *testing.T) {
 
 			exprFunc, err := ReplaceAllMatches(tt.target, tt.pattern, tt.replacement)
 			require.NoError(t, err)
-			assert.Nil(t, exprFunc(scenarioMap))
+			result, _ := exprFunc(scenarioMap)
+			assert.Nil(t, result)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -89,31 +91,35 @@ func Test_replaceAllMatches(t *testing.T) {
 func Test_replaceAllMatches_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := ReplaceAllMatches[interface{}](target, "*", "{replacement}")
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(input))
+	result, _ := exprFunc(input)
+	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }
 
 func Test_replaceAllMatches_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := ReplaceAllMatches[interface{}](target, "*", "{anything}")
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(nil))
+	result, _ := exprFunc(nil)
+	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -76,9 +75,10 @@ func Test_replaceAllMatches(t *testing.T) {
 			input.CopyTo(scenarioMap)
 
 			exprFunc, err := ReplaceAllMatches(tt.target, tt.pattern, tt.replacement)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
-			result, _ := exprFunc(scenarioMap)
+			result, err := exprFunc(scenarioMap)
+			assert.NoError(t, err)
 			assert.Nil(t, result)
 
 			expected := pcommon.NewMap()
@@ -102,8 +102,9 @@ func Test_replaceAllMatches_bad_input(t *testing.T) {
 	}
 
 	exprFunc, err := ReplaceAllMatches[interface{}](target, "*", "{replacement}")
-	require.NoError(t, err)
-	result, _ := exprFunc(input)
+	assert.NoError(t, err)
+	result, err := exprFunc(input)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }
@@ -120,7 +121,8 @@ func Test_replaceAllMatches_get_nil(t *testing.T) {
 	}
 
 	exprFunc, err := ReplaceAllMatches[interface{}](target, "*", "{anything}")
-	require.NoError(t, err)
-	result, _ := exprFunc(nil)
+	assert.NoError(t, err)
+	result, err := exprFunc(nil)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
@@ -77,6 +77,7 @@ func Test_replaceAllMatches(t *testing.T) {
 
 			exprFunc, err := ReplaceAllMatches(tt.target, tt.pattern, tt.replacement)
 			require.NoError(t, err)
+
 			result, _ := exprFunc(scenarioMap)
 			assert.Nil(t, result)
 

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -37,14 +37,14 @@ func ReplaceAllPatterns[K any](target ottl.GetSetter[K], mode string, regexPatte
 		return nil, fmt.Errorf("invalid mode %v, must be either 'key' or 'value'", mode)
 	}
 
-	return func(ctx K) interface{} {
-		val := target.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		val, _ := target.Get(ctx)
 		if val == nil {
-			return nil
+			return nil, nil
 		}
 		attrs, ok := val.(pcommon.Map)
 		if !ok {
-			return nil
+			return nil, nil
 		}
 		updated := pcommon.NewMap()
 		updated.EnsureCapacity(attrs.Len())
@@ -69,6 +69,6 @@ func ReplaceAllPatterns[K any](target ottl.GetSetter[K], mode string, regexPatte
 		})
 		target.Set(ctx, updated)
 
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -67,7 +67,7 @@ func ReplaceAllPatterns[K any](target ottl.GetSetter[K], mode string, regexPatte
 			}
 			return true
 		})
-		target.Set(ctx, updated)
+		_ = target.Set(ctx, updated)
 
 		return nil, nil
 	}, nil

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -38,7 +38,10 @@ func ReplaceAllPatterns[K any](target ottl.GetSetter[K], mode string, regexPatte
 	}
 
 	return func(ctx K) (interface{}, error) {
-		val, _ := target.Get(ctx)
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if val == nil {
 			return nil, nil
 		}
@@ -67,7 +70,10 @@ func ReplaceAllPatterns[K any](target ottl.GetSetter[K], mode string, regexPatte
 			}
 			return true
 		})
-		_ = target.Set(ctx, updated)
+		err = target.Set(ctx, updated)
+		if err != nil {
+			return nil, err
+		}
 
 		return nil, nil
 	}, nil

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -130,7 +130,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 			input.CopyTo(scenarioMap)
 
 			exprFunc, err := ReplaceAllPatterns[pcommon.Map](tt.target, tt.mode, tt.pattern, tt.replacement)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			_, err = exprFunc(scenarioMap)
 			assert.Nil(t, err)
@@ -177,7 +177,7 @@ func Test_replaceAllPatterns_get_nil(t *testing.T) {
 	}
 
 	exprFunc, err := ReplaceAllPatterns[interface{}](target, modeValue, "regexp", "{anything}")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	_, err = exprFunc(nil)
 	assert.Nil(t, err)

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -31,11 +31,12 @@ func Test_replaceAllPatterns(t *testing.T) {
 	input.PutStr("test3", "goodbye world1 and world2")
 
 	target := &ottl.StandardGetSetter[pcommon.Map]{
-		Getter: func(ctx pcommon.Map) interface{} {
-			return ctx
+		Getter: func(ctx pcommon.Map) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx pcommon.Map, val interface{}) {
+		Setter: func(ctx pcommon.Map, val interface{}) error {
 			val.(pcommon.Map).CopyTo(ctx)
+			return nil
 		},
 	}
 
@@ -144,11 +145,12 @@ func Test_replaceAllPatterns_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
@@ -162,11 +164,12 @@ func Test_replaceAllPatterns_bad_input(t *testing.T) {
 
 func Test_replaceAllPatterns_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
@@ -177,12 +180,13 @@ func Test_replaceAllPatterns_get_nil(t *testing.T) {
 
 func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
+		Getter: func(ctx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
@@ -195,12 +199,13 @@ func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {
 
 func Test_replaceAllPatterns_invalid_model(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
+		Getter: func(ctx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -131,7 +131,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 
 			exprFunc, err := ReplaceAllPatterns[pcommon.Map](tt.target, tt.mode, tt.pattern, tt.replacement)
 			require.NoError(t, err)
-			exprFunc(scenarioMap)
+
+			_, err = exprFunc(scenarioMap)
+			assert.Nil(t, err)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -157,7 +159,8 @@ func Test_replaceAllPatterns_bad_input(t *testing.T) {
 	exprFunc, err := ReplaceAllPatterns[interface{}](target, modeValue, "regexpattern", "{replacement}")
 	assert.Nil(t, err)
 
-	exprFunc(input)
+	_, err = exprFunc(input)
+	assert.Nil(t, err)
 
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }
@@ -175,7 +178,9 @@ func Test_replaceAllPatterns_get_nil(t *testing.T) {
 
 	exprFunc, err := ReplaceAllPatterns[interface{}](target, modeValue, "regexp", "{anything}")
 	require.NoError(t, err)
-	exprFunc(nil)
+
+	_, err = exprFunc(nil)
+	assert.Nil(t, err)
 }
 
 func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {

--- a/pkg/ottl/ottlfuncs/func_replace_match.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match.go
@@ -34,7 +34,7 @@ func ReplaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement s
 		}
 		if valStr, ok := val.(string); ok {
 			if glob.Match(valStr) {
-				target.Set(ctx, replacement)
+				_ = target.Set(ctx, replacement)
 			}
 		}
 		return nil, nil

--- a/pkg/ottl/ottlfuncs/func_replace_match.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match.go
@@ -27,16 +27,16 @@ func ReplaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement s
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
-	return func(ctx K) interface{} {
-		val := target.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		val, _ := target.Get(ctx)
 		if val == nil {
-			return nil
+			return nil, nil
 		}
 		if valStr, ok := val.(string); ok {
 			if glob.Match(valStr) {
 				target.Set(ctx, replacement)
 			}
 		}
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_match.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match.go
@@ -28,13 +28,19 @@ func ReplaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement s
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
 	return func(ctx K) (interface{}, error) {
-		val, _ := target.Get(ctx)
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if val == nil {
 			return nil, nil
 		}
 		if valStr, ok := val.(string); ok {
 			if glob.Match(valStr) {
-				_ = target.Set(ctx, replacement)
+				err = target.Set(ctx, replacement)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		return nil, nil

--- a/pkg/ottl/ottlfuncs/func_replace_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match_test.go
@@ -28,11 +28,12 @@ func Test_replaceMatch(t *testing.T) {
 	input := pcommon.NewValueStr("hello world")
 
 	target := &ottl.StandardGetSetter[pcommon.Value]{
-		Getter: func(ctx pcommon.Value) interface{} {
-			return ctx.Str()
+		Getter: func(ctx pcommon.Value) (interface{}, error) {
+			return ctx.Str(), nil
 		},
-		Setter: func(ctx pcommon.Value, val interface{}) {
+		Setter: func(ctx pcommon.Value, val interface{}) error {
 			ctx.SetStr(val.(string))
+			return nil
 		},
 	}
 
@@ -68,7 +69,8 @@ func Test_replaceMatch(t *testing.T) {
 
 			exprFunc, err := ReplaceMatch(tt.target, tt.pattern, tt.replacement)
 			require.NoError(t, err)
-			assert.Nil(t, exprFunc(scenarioValue))
+			result, _ := exprFunc(scenarioValue)
+			assert.Nil(t, result)
 
 			expected := pcommon.NewValueStr("")
 			tt.want(expected)
@@ -81,32 +83,38 @@ func Test_replaceMatch(t *testing.T) {
 func Test_replaceMatch_bad_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := ReplaceMatch[interface{}](target, "*", "{replacement}")
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(input))
+
+	result, _ := exprFunc(input)
+	assert.Nil(t, result)
 
 	assert.Equal(t, pcommon.NewValueInt(1), input)
 }
 
 func Test_replaceMatch_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := ReplaceMatch[interface{}](target, "*", "{anything}")
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(nil))
+
+	result, _ := exprFunc(nil)
+	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_replace_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -68,8 +67,9 @@ func Test_replaceMatch(t *testing.T) {
 			scenarioValue := pcommon.NewValueStr(input.Str())
 
 			exprFunc, err := ReplaceMatch(tt.target, tt.pattern, tt.replacement)
-			require.NoError(t, err)
-			result, _ := exprFunc(scenarioValue)
+			assert.NoError(t, err)
+			result, err := exprFunc(scenarioValue)
+			assert.NoError(t, err)
 			assert.Nil(t, result)
 
 			expected := pcommon.NewValueStr("")
@@ -93,9 +93,10 @@ func Test_replaceMatch_bad_input(t *testing.T) {
 	}
 
 	exprFunc, err := ReplaceMatch[interface{}](target, "*", "{replacement}")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
-	result, _ := exprFunc(input)
+	result, err := exprFunc(input)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 
 	assert.Equal(t, pcommon.NewValueInt(1), input)
@@ -113,8 +114,9 @@ func Test_replaceMatch_get_nil(t *testing.T) {
 	}
 
 	exprFunc, err := ReplaceMatch[interface{}](target, "*", "{anything}")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
-	result, _ := exprFunc(nil)
+	result, err := exprFunc(nil)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -27,14 +27,20 @@ func ReplacePattern[K any](target ottl.GetSetter[K], regexPattern string, replac
 		return nil, fmt.Errorf("the regex pattern supplied to replace_pattern is not a valid pattern: %w", err)
 	}
 	return func(ctx K) (interface{}, error) {
-		originalVal, _ := target.Get(ctx)
+		originalVal, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if originalVal == nil {
 			return nil, nil
 		}
 		if originalValStr, ok := originalVal.(string); ok {
 			if compiledPattern.MatchString(originalValStr) {
 				updatedStr := compiledPattern.ReplaceAllLiteralString(originalValStr, replacement)
-				_ = target.Set(ctx, updatedStr)
+				err = target.Set(ctx, updatedStr)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		return nil, nil

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -26,10 +26,10 @@ func ReplacePattern[K any](target ottl.GetSetter[K], regexPattern string, replac
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to replace_pattern is not a valid pattern: %w", err)
 	}
-	return func(ctx K) interface{} {
-		originalVal := target.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		originalVal, _ := target.Get(ctx)
 		if originalVal == nil {
-			return nil
+			return nil, nil
 		}
 		if originalValStr, ok := originalVal.(string); ok {
 			if compiledPattern.MatchString(originalValStr) {
@@ -37,6 +37,6 @@ func ReplacePattern[K any](target ottl.GetSetter[K], regexPattern string, replac
 				target.Set(ctx, updatedStr)
 			}
 		}
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -34,7 +34,7 @@ func ReplacePattern[K any](target ottl.GetSetter[K], regexPattern string, replac
 		if originalValStr, ok := originalVal.(string); ok {
 			if compiledPattern.MatchString(originalValStr) {
 				updatedStr := compiledPattern.ReplaceAllLiteralString(originalValStr, replacement)
-				target.Set(ctx, updatedStr)
+				_ = target.Set(ctx, updatedStr)
 			}
 		}
 		return nil, nil

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -77,9 +77,10 @@ func Test_replacePattern(t *testing.T) {
 			scenarioValue := pcommon.NewValueStr(input.Str())
 
 			exprFunc, err := ReplacePattern(tt.target, tt.pattern, tt.replacement)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
-			result, _ := exprFunc(scenarioValue)
+			result, err := exprFunc(scenarioValue)
+			assert.NoError(t, err)
 			assert.Nil(t, result)
 
 			expected := pcommon.NewValueStr("")
@@ -103,9 +104,10 @@ func Test_replacePattern_bad_input(t *testing.T) {
 	}
 
 	exprFunc, err := ReplacePattern[interface{}](target, "regexp", "{replacement}")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
-	result, _ := exprFunc(input)
+	result, err := exprFunc(input)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueInt(1), input)
 }
@@ -122,9 +124,10 @@ func Test_replacePattern_get_nil(t *testing.T) {
 	}
 
 	exprFunc, err := ReplacePattern[interface{}](target, `nomatch\=[^\s]*(\s?)`, "{anything}")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
-	result, _ := exprFunc(nil)
+	result, err := exprFunc(nil)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 }
 

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -28,11 +28,12 @@ func Test_replacePattern(t *testing.T) {
 	input := pcommon.NewValueStr("application passwd=sensitivedtata otherarg=notsensitive key1 key2")
 
 	target := &ottl.StandardGetSetter[pcommon.Value]{
-		Getter: func(ctx pcommon.Value) interface{} {
-			return ctx.Str()
+		Getter: func(ctx pcommon.Value) (interface{}, error) {
+			return ctx.Str(), nil
 		},
-		Setter: func(ctx pcommon.Value, val interface{}) {
+		Setter: func(ctx pcommon.Value, val interface{}) error {
 			ctx.SetStr(val.(string))
+			return nil
 		},
 	}
 
@@ -77,7 +78,9 @@ func Test_replacePattern(t *testing.T) {
 
 			exprFunc, err := ReplacePattern(tt.target, tt.pattern, tt.replacement)
 			require.NoError(t, err)
-			assert.Nil(t, exprFunc(scenarioValue))
+
+			result, _ := exprFunc(scenarioValue)
+			assert.Nil(t, result)
 
 			expected := pcommon.NewValueStr("")
 			tt.want(expected)
@@ -90,43 +93,50 @@ func Test_replacePattern(t *testing.T) {
 func Test_replacePattern_bad_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := ReplacePattern[interface{}](target, "regexp", "{replacement}")
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(input))
+
+	result, _ := exprFunc(input)
+	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueInt(1), input)
 }
 
 func Test_replacePattern_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := ReplacePattern[interface{}](target, `nomatch\=[^\s]*(\s?)`, "{anything}")
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(nil))
+
+	result, _ := exprFunc(nil)
+	assert.Nil(t, result)
 }
 
 func Test_replacePatterns_invalid_pattern(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
+		Getter: func(ctx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
-			return nil
+			return nil, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 

--- a/pkg/ottl/ottlfuncs/func_set.go
+++ b/pkg/ottl/ottlfuncs/func_set.go
@@ -17,13 +17,13 @@ package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-c
 import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 
 func Set[K any](target ottl.Setter[K], value ottl.Getter[K]) (ottl.ExprFunc[K], error) {
-	return func(ctx K) interface{} {
-		val := value.Get(ctx)
+	return func(ctx K) (interface{}, error) {
+		val, _ := value.Get(ctx)
 
 		// No fields currently support `null` as a valid type.
 		if val != nil {
 			target.Set(ctx, val)
 		}
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_set.go
+++ b/pkg/ottl/ottlfuncs/func_set.go
@@ -18,11 +18,17 @@ import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 
 func Set[K any](target ottl.Setter[K], value ottl.Getter[K]) (ottl.ExprFunc[K], error) {
 	return func(ctx K) (interface{}, error) {
-		val, _ := value.Get(ctx)
+		val, err := value.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 
 		// No fields currently support `null` as a valid type.
 		if val != nil {
-			_ = target.Set(ctx, val)
+			err = target.Set(ctx, val)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return nil, nil
 	}, nil

--- a/pkg/ottl/ottlfuncs/func_set.go
+++ b/pkg/ottl/ottlfuncs/func_set.go
@@ -22,7 +22,7 @@ func Set[K any](target ottl.Setter[K], value ottl.Getter[K]) (ottl.ExprFunc[K], 
 
 		// No fields currently support `null` as a valid type.
 		if val != nil {
-			target.Set(ctx, val)
+			_ = target.Set(ctx, val)
 		}
 		return nil, nil
 	}, nil

--- a/pkg/ottl/ottlfuncs/func_set_test.go
+++ b/pkg/ottl/ottlfuncs/func_set_test.go
@@ -28,8 +28,9 @@ func Test_set(t *testing.T) {
 	input := pcommon.NewValueStr("original name")
 
 	target := &ottl.StandardGetSetter[pcommon.Value]{
-		Setter: func(ctx pcommon.Value, val interface{}) {
+		Setter: func(ctx pcommon.Value, val interface{}) error {
 			ctx.SetStr(val.(string))
+			return nil
 		},
 	}
 
@@ -43,8 +44,8 @@ func Test_set(t *testing.T) {
 			name:   "set name",
 			setter: target,
 			getter: ottl.StandardGetSetter[pcommon.Value]{
-				Getter: func(ctx pcommon.Value) interface{} {
-					return "new name"
+				Getter: func(ctx pcommon.Value) (interface{}, error) {
+					return "new name", nil
 				},
 			},
 			want: func(expectedValue pcommon.Value) {
@@ -55,8 +56,8 @@ func Test_set(t *testing.T) {
 			name:   "set nil value",
 			setter: target,
 			getter: ottl.StandardGetSetter[pcommon.Value]{
-				Getter: func(ctx pcommon.Value) interface{} {
-					return nil
+				Getter: func(ctx pcommon.Value) (interface{}, error) {
+					return nil, nil
 				},
 			},
 			want: func(expectedValue pcommon.Value) {
@@ -70,7 +71,9 @@ func Test_set(t *testing.T) {
 
 			exprFunc, err := Set(tt.setter, tt.getter)
 			require.NoError(t, err)
-			assert.Nil(t, exprFunc(scenarioValue))
+
+			result, _ := exprFunc(scenarioValue)
+			assert.Nil(t, result)
 
 			expected := pcommon.NewValueStr("")
 			tt.want(expected)
@@ -82,18 +85,21 @@ func Test_set(t *testing.T) {
 
 func Test_set_get_nil(t *testing.T) {
 	setter := &ottl.StandardGetSetter[interface{}]{
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	getter := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
 	}
 
 	exprFunc, err := Set[interface{}](setter, getter)
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(nil))
+
+	result, _ := exprFunc(nil)
+	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_set_test.go
+++ b/pkg/ottl/ottlfuncs/func_set_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -70,9 +69,10 @@ func Test_set(t *testing.T) {
 			scenarioValue := pcommon.NewValueStr(input.Str())
 
 			exprFunc, err := Set(tt.setter, tt.getter)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
-			result, _ := exprFunc(scenarioValue)
+			result, err := exprFunc(scenarioValue)
+			assert.NoError(t, err)
 			assert.Nil(t, result)
 
 			expected := pcommon.NewValueStr("")
@@ -98,8 +98,9 @@ func Test_set_get_nil(t *testing.T) {
 	}
 
 	exprFunc, err := Set[interface{}](setter, getter)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
-	result, _ := exprFunc(nil)
+	result, err := exprFunc(nil)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_span_id.go
+++ b/pkg/ottl/ottlfuncs/func_span_id.go
@@ -29,7 +29,7 @@ func SpanID[K any](bytes []byte) (ottl.ExprFunc[K], error) {
 	var idArr [8]byte
 	copy(idArr[:8], bytes)
 	id := pcommon.SpanID(idArr)
-	return func(K) interface{} {
-		return id
+	return func(K) (interface{}, error) {
+		return id, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_span_id_test.go
+++ b/pkg/ottl/ottlfuncs/func_span_id_test.go
@@ -38,7 +38,8 @@ func Test_spanID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := SpanID[interface{}](tt.bytes)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, exprFunc(nil))
+			result, _ := exprFunc(nil)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_span_id_test.go
+++ b/pkg/ottl/ottlfuncs/func_span_id_test.go
@@ -37,8 +37,9 @@ func Test_spanID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := SpanID[interface{}](tt.bytes)
-			require.NoError(t, err)
-			result, _ := exprFunc(nil)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, result)
 		})
 	}

--- a/pkg/ottl/ottlfuncs/func_split.go
+++ b/pkg/ottl/ottlfuncs/func_split.go
@@ -22,7 +22,11 @@ import (
 
 func Split[K any](target ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], error) {
 	return func(ctx K) (interface{}, error) {
-		if val, _ := target.Get(ctx); val != nil {
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if val != nil {
 			if valStr, ok := val.(string); ok {
 				return strings.Split(valStr, delimiter), nil
 			}

--- a/pkg/ottl/ottlfuncs/func_split.go
+++ b/pkg/ottl/ottlfuncs/func_split.go
@@ -21,12 +21,12 @@ import (
 )
 
 func Split[K any](target ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], error) {
-	return func(ctx K) interface{} {
-		if val := target.Get(ctx); val != nil {
+	return func(ctx K) (interface{}, error) {
+		if val, _ := target.Get(ctx); val != nil {
 			if valStr, ok := val.(string); ok {
-				return strings.Split(valStr, delimiter)
+				return strings.Split(valStr, delimiter), nil
 			}
 		}
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_split_test.go
+++ b/pkg/ottl/ottlfuncs/func_split_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -84,8 +83,9 @@ func Test_split(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := Split(tt.target, tt.delimiter)
-			require.NoError(t, err)
-			result, _ := exprFunc(nil)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/ottl/ottlfuncs/func_split_test.go
+++ b/pkg/ottl/ottlfuncs/func_split_test.go
@@ -33,8 +33,8 @@ func Test_split(t *testing.T) {
 		{
 			name: "split string",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return "A|B|C"
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return "A|B|C", nil
 				},
 			},
 			delimiter: "|",
@@ -43,8 +43,8 @@ func Test_split(t *testing.T) {
 		{
 			name: "split empty string",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return ""
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return "", nil
 				},
 			},
 			delimiter: "|",
@@ -53,8 +53,8 @@ func Test_split(t *testing.T) {
 		{
 			name: "split empty delimiter",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return "A|B|C"
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return "A|B|C", nil
 				},
 			},
 			delimiter: "",
@@ -63,8 +63,8 @@ func Test_split(t *testing.T) {
 		{
 			name: "split empty string and empty delimiter",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return ""
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return "", nil
 				},
 			},
 			delimiter: "",
@@ -73,8 +73,8 @@ func Test_split(t *testing.T) {
 		{
 			name: "split non-string",
 			target: &ottl.StandardGetSetter[interface{}]{
-				Getter: func(ctx interface{}) interface{} {
-					return 123
+				Getter: func(ctx interface{}) (interface{}, error) {
+					return 123, nil
 				},
 			},
 			delimiter: "|",
@@ -85,7 +85,8 @@ func Test_split(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := Split(tt.target, tt.delimiter)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, exprFunc(nil))
+			result, _ := exprFunc(nil)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_trace_id.go
+++ b/pkg/ottl/ottlfuncs/func_trace_id.go
@@ -29,7 +29,7 @@ func TraceID[K any](bytes []byte) (ottl.ExprFunc[K], error) {
 	var idArr [16]byte
 	copy(idArr[:16], bytes)
 	id := pcommon.TraceID(idArr)
-	return func(K) interface{} {
-		return id
+	return func(K) (interface{}, error) {
+		return id, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_trace_id_test.go
+++ b/pkg/ottl/ottlfuncs/func_trace_id_test.go
@@ -37,8 +37,9 @@ func Test_traceID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := TraceID[interface{}](tt.bytes)
-			require.NoError(t, err)
-			result, _ := exprFunc(nil)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, result)
 		})
 	}

--- a/pkg/ottl/ottlfuncs/func_trace_id_test.go
+++ b/pkg/ottl/ottlfuncs/func_trace_id_test.go
@@ -38,7 +38,8 @@ func Test_traceID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := TraceID[interface{}](tt.bytes)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, exprFunc(nil))
+			result, _ := exprFunc(nil)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -50,7 +50,7 @@ func TruncateAll[K any](target ottl.GetSetter[K], limit int64) (ottl.ExprFunc[K]
 			}
 			return true
 		})
-		target.Set(ctx, updated)
+		_ = target.Set(ctx, updated)
 		// TODO: Write log when truncation is performed
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
 		return nil, nil

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -31,7 +31,10 @@ func TruncateAll[K any](target ottl.GetSetter[K], limit int64) (ottl.ExprFunc[K]
 			return nil, nil
 		}
 
-		val, _ := target.Get(ctx)
+		val, err := target.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if val == nil {
 			return nil, nil
 		}
@@ -50,7 +53,10 @@ func TruncateAll[K any](target ottl.GetSetter[K], limit int64) (ottl.ExprFunc[K]
 			}
 			return true
 		})
-		_ = target.Set(ctx, updated)
+		err = target.Set(ctx, updated)
+		if err != nil {
+			return nil, err
+		}
 		// TODO: Write log when truncation is performed
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
 		return nil, nil

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -26,19 +26,19 @@ func TruncateAll[K any](target ottl.GetSetter[K], limit int64) (ottl.ExprFunc[K]
 	if limit < 0 {
 		return nil, fmt.Errorf("invalid limit for truncate_all function, %d cannot be negative", limit)
 	}
-	return func(ctx K) interface{} {
+	return func(ctx K) (interface{}, error) {
 		if limit < 0 {
-			return nil
+			return nil, nil
 		}
 
-		val := target.Get(ctx)
+		val, _ := target.Get(ctx)
 		if val == nil {
-			return nil
+			return nil, nil
 		}
 
 		attrs, ok := val.(pcommon.Map)
 		if !ok {
-			return nil
+			return nil, nil
 		}
 
 		updated := pcommon.NewMap()
@@ -53,6 +53,6 @@ func TruncateAll[K any](target ottl.GetSetter[K], limit int64) (ottl.ExprFunc[K]
 		target.Set(ctx, updated)
 		// TODO: Write log when truncation is performed
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_truncate_all_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all_test.go
@@ -93,9 +93,10 @@ func Test_truncateAll(t *testing.T) {
 			input.CopyTo(scenarioMap)
 
 			exprFunc, err := TruncateAll(tt.target, tt.limit)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
-			result, _ := exprFunc(scenarioMap)
+			result, err := exprFunc(scenarioMap)
+			assert.NoError(t, err)
 			assert.Nil(t, result)
 
 			expected := pcommon.NewMap()
@@ -125,9 +126,10 @@ func Test_truncateAll_bad_input(t *testing.T) {
 	}
 
 	exprFunc, err := TruncateAll[interface{}](target, 1)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
-	result, _ := exprFunc(input)
+	result, err := exprFunc(input)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }
@@ -144,8 +146,9 @@ func Test_truncateAll_get_nil(t *testing.T) {
 	}
 
 	exprFunc, err := TruncateAll[interface{}](target, 1)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
-	result, _ := exprFunc(nil)
+	result, err := exprFunc(nil)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_truncate_all_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all_test.go
@@ -31,11 +31,12 @@ func Test_truncateAll(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardGetSetter[pcommon.Map]{
-		Getter: func(ctx pcommon.Map) interface{} {
-			return ctx
+		Getter: func(ctx pcommon.Map) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx pcommon.Map, val interface{}) {
+		Setter: func(ctx pcommon.Map, val interface{}) error {
 			val.(pcommon.Map).CopyTo(ctx)
+			return nil
 		},
 	}
 
@@ -93,7 +94,8 @@ func Test_truncateAll(t *testing.T) {
 
 			exprFunc, err := TruncateAll(tt.target, tt.limit)
 			require.NoError(t, err)
-			assert.Nil(t, exprFunc(scenarioMap))
+			result, _ := exprFunc(scenarioMap)
+			assert.Nil(t, result)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -112,31 +114,37 @@ func Test_truncateAll_validation(t *testing.T) {
 func Test_truncateAll_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := TruncateAll[interface{}](target, 1)
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(input))
+
+	result, _ := exprFunc(input)
+	assert.Nil(t, result)
 	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
 }
 
 func Test_truncateAll_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[interface{}]{
-		Getter: func(ctx interface{}) interface{} {
-			return ctx
+		Getter: func(ctx interface{}) (interface{}, error) {
+			return ctx, nil
 		},
-		Setter: func(ctx interface{}, val interface{}) {
+		Setter: func(ctx interface{}, val interface{}) error {
 			t.Errorf("nothing should be set in this scenario")
+			return nil
 		},
 	}
 
 	exprFunc, err := TruncateAll[interface{}](target, 1)
 	require.NoError(t, err)
-	assert.Nil(t, exprFunc(nil))
+
+	result, _ := exprFunc(nil)
+	assert.Nil(t, result)
 }

--- a/pkg/ottl/ottlfuncs/func_truncate_all_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all_test.go
@@ -94,6 +94,7 @@ func Test_truncateAll(t *testing.T) {
 
 			exprFunc, err := TruncateAll(tt.target, tt.limit)
 			require.NoError(t, err)
+
 			result, _ := exprFunc(scenarioMap)
 			assert.Nil(t, result)
 

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -41,7 +41,7 @@ func (s *Statement[K]) Execute(ctx K) (any, bool) {
 	condition := s.condition(ctx)
 	var result any
 	if condition {
-		result = s.function(ctx)
+		result, _ = s.function(ctx)
 	}
 	return result, condition
 }

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -37,13 +37,19 @@ type Statement[K any] struct {
 // Returns true if the function was run, returns false otherwise.
 // If the statement contains no condition, the function will run and true will be returned.
 // In addition, the functions return value is always returned.
-func (s *Statement[K]) Execute(ctx K) (any, bool) {
-	condition := s.condition(ctx)
+func (s *Statement[K]) Execute(ctx K) (any, bool, error) {
+	condition, err := s.condition(ctx)
+	if err != nil {
+		return nil, false, err
+	}
 	var result any
 	if condition {
-		result, _ = s.function(ctx)
+		result, err = s.function(ctx)
+		if err != nil {
+			return nil, true, err
+		}
 	}
-	return result, condition
+	return result, condition, nil
 }
 
 func NewParser[K any](functions map[string]interface{}, pathParser PathExpressionParser[K], enumParser EnumParser, telemetrySettings component.TelemetrySettings) Parser[K] {

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -1056,8 +1056,8 @@ func Test_Execute(t *testing.T) {
 				function:  tt.function,
 			}
 
-			result, condition := statement.Execute(nil)
-
+			result, condition, err := statement.Execute(nil)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedCondition, condition)
 			assert.Equal(t, tt.expectedResult, result)
 		})

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -640,11 +640,12 @@ func Test_parse_failure(t *testing.T) {
 func testParsePath(val *Path) (GetSetter[interface{}], error) {
 	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "name" {
 		return &StandardGetSetter[interface{}]{
-			Getter: func(ctx interface{}) interface{} {
-				return ctx
+			Getter: func(ctx interface{}) (interface{}, error) {
+				return ctx, nil
 			},
-			Setter: func(ctx interface{}, val interface{}) {
+			Setter: func(ctx interface{}, val interface{}) error {
 				reflect.DeepEqual(ctx, val)
+				return nil
 			},
 		}, nil
 	}
@@ -1023,8 +1024,8 @@ func Test_Execute(t *testing.T) {
 		{
 			name:      "Condition matched",
 			condition: alwaysTrue[interface{}],
-			function: func(ctx interface{}) interface{} {
-				return 1
+			function: func(ctx interface{}) (interface{}, error) {
+				return 1, nil
 			},
 			expectedCondition: true,
 			expectedResult:    1,
@@ -1032,8 +1033,8 @@ func Test_Execute(t *testing.T) {
 		{
 			name:      "Condition not matched",
 			condition: alwaysFalse[interface{}],
-			function: func(ctx interface{}) interface{} {
-				return 1
+			function: func(ctx interface{}) (interface{}, error) {
+				return 1, nil
 			},
 			expectedCondition: false,
 			expectedResult:    nil,
@@ -1041,8 +1042,8 @@ func Test_Execute(t *testing.T) {
 		{
 			name:      "No result",
 			condition: alwaysTrue[interface{}],
-			function: func(ctx interface{}) interface{} {
-				return nil
+			function: func(ctx interface{}) (interface{}, error) {
+				return nil, nil
 			},
 			expectedCondition: true,
 			expectedResult:    nil,

--- a/processor/routingprocessor/internal/common/functions.go
+++ b/processor/routingprocessor/internal/common/functions.go
@@ -27,8 +27,8 @@ func Functions[K any]() map[string]interface{} {
 		// noop function, it is required since the parsing of conditions is not implemented yet,
 		// see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545
 		"route": func() (ottl.ExprFunc[K], error) {
-			return func(K) interface{} {
-				return true
+			return func(K) (interface{}, error) {
+				return true, nil
 			}, nil
 		},
 	}

--- a/processor/routingprocessor/logs.go
+++ b/processor/routingprocessor/logs.go
@@ -101,7 +101,11 @@ func (p *logProcessor) route(ctx context.Context, l plog.Logs) error {
 
 		matchCount := len(p.router.routes)
 		for key, route := range p.router.routes {
-			if _, isMatch := route.statement.Execute(ltx); !isMatch {
+			_, isMatch, err := route.statement.Execute(ltx)
+			if err != nil {
+				return err
+			}
+			if !isMatch {
 				matchCount--
 				continue
 			}

--- a/processor/routingprocessor/metrics.go
+++ b/processor/routingprocessor/metrics.go
@@ -103,7 +103,11 @@ func (p *metricsProcessor) route(ctx context.Context, tm pmetric.Metrics) error 
 
 		matchCount := len(p.router.routes)
 		for key, route := range p.router.routes {
-			if _, isMatch := route.statement.Execute(mtx); !isMatch {
+			_, isMatch, err := route.statement.Execute(mtx)
+			if err != nil {
+				return err
+			}
+			if !isMatch {
 				matchCount--
 				continue
 			}

--- a/processor/routingprocessor/traces.go
+++ b/processor/routingprocessor/traces.go
@@ -101,7 +101,11 @@ func (p *tracesProcessor) route(ctx context.Context, t ptrace.Traces) error {
 
 		matchCount := len(p.router.routes)
 		for key, route := range p.router.routes {
-			if _, isMatch := route.statement.Execute(stx); !isMatch {
+			_, isMatch, err := route.statement.Execute(stx)
+			if err != nil {
+				return err
+			}
+			if !isMatch {
 				matchCount--
 				continue
 			}

--- a/processor/transformprocessor/internal/logs/processor.go
+++ b/processor/transformprocessor/internal/logs/processor.go
@@ -48,7 +48,10 @@ func (p *Processor) ProcessLogs(_ context.Context, td plog.Logs) (plog.Logs, err
 			for k := 0; k < logs.Len(); k++ {
 				ctx := ottllogs.NewTransformContext(logs.At(k), slogs.Scope(), rlogs.Resource())
 				for _, statement := range p.statements {
-					statement.Execute(ctx)
+					_, _, err := statement.Execute(ctx)
+					if err != nil {
+						return td, err
+					}
 				}
 			}
 		}

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
@@ -34,10 +34,10 @@ func convertGaugeToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc[ottl
 		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
 	}
 
-	return func(ctx ottldatapoints.TransformContext) interface{} {
+	return func(ctx ottldatapoints.TransformContext) (interface{}, error) {
 		metric := ctx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeGauge {
-			return nil
+			return nil, nil
 		}
 
 		dps := metric.Gauge().DataPoints()
@@ -48,6 +48,6 @@ func convertGaugeToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc[ottl
 		// Setting the data type removed all the data points, so we must copy them back to the metric.
 		dps.CopyTo(metric.Sum().DataPoints())
 
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
@@ -129,7 +129,9 @@ func Test_convertGaugeToSum(t *testing.T) {
 			ctx := ottldatapoints.NewTransformContext(pmetric.NewNumberDataPoint(), metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			exprFunc, _ := convertGaugeToSum(tt.stringAggTemp, tt.monotonic)
-			exprFunc(ctx)
+
+			_, err := exprFunc(ctx)
+			assert.Nil(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge.go
@@ -22,10 +22,10 @@ import (
 )
 
 func convertSumToGauge() (ottl.ExprFunc[ottldatapoints.TransformContext], error) {
-	return func(ctx ottldatapoints.TransformContext) interface{} {
+	return func(ctx ottldatapoints.TransformContext) (interface{}, error) {
 		metric := ctx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSum {
-			return nil
+			return nil, nil
 		}
 
 		dps := metric.Sum().DataPoints()
@@ -33,6 +33,6 @@ func convertSumToGauge() (ottl.ExprFunc[ottldatapoints.TransformContext], error)
 		// Setting the data type removed all the data points, so we must copy them back to the metric.
 		dps.CopyTo(metric.SetEmptyGauge().DataPoints())
 
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
@@ -97,7 +97,9 @@ func Test_convertSumToGauge(t *testing.T) {
 			ctx := ottldatapoints.NewTransformContext(pmetric.NewNumberDataPoint(), metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			exprFunc, _ := convertSumToGauge()
-			exprFunc(ctx)
+
+			_, err := exprFunc(ctx)
+			assert.Nil(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
@@ -33,10 +33,10 @@ func convertSummaryCountValToSum(stringAggTemp string, monotonic bool) (ottl.Exp
 	default:
 		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
 	}
-	return func(ctx ottldatapoints.TransformContext) interface{} {
+	return func(ctx ottldatapoints.TransformContext) (interface{}, error) {
 		metric := ctx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSummary {
-			return nil
+			return nil, nil
 		}
 
 		sumMetric := ctx.GetMetrics().AppendEmpty()
@@ -56,6 +56,6 @@ func convertSummaryCountValToSum(stringAggTemp string, monotonic bool) (ottl.Exp
 			sumDp.SetStartTimestamp(dp.StartTimestamp())
 			sumDp.SetTimestamp(dp.Timestamp())
 		}
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
@@ -108,7 +108,8 @@ func Test_ConvertSummaryCountValToSum(t *testing.T) {
 			evaluate, err := convertSummaryCountValToSum(tt.temporality, tt.monotonicity)
 			assert.NoError(t, err)
 
-			evaluate(ottldatapoints.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource()))
+			_, err = evaluate(ottldatapoints.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource()))
+			assert.Nil(t, err)
 
 			expected := pmetric.NewMetricSlice()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
@@ -33,10 +33,10 @@ func convertSummarySumValToSum(stringAggTemp string, monotonic bool) (ottl.ExprF
 	default:
 		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
 	}
-	return func(ctx ottldatapoints.TransformContext) interface{} {
+	return func(ctx ottldatapoints.TransformContext) (interface{}, error) {
 		metric := ctx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSummary {
-			return nil
+			return nil, nil
 		}
 
 		sumMetric := ctx.GetMetrics().AppendEmpty()
@@ -56,6 +56,6 @@ func convertSummarySumValToSum(stringAggTemp string, monotonic bool) (ottl.ExprF
 			sumDp.SetStartTimestamp(dp.StartTimestamp())
 			sumDp.SetTimestamp(dp.Timestamp())
 		}
-		return nil
+		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
@@ -161,7 +161,8 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 			evaluate, err := convertSummarySumValToSum(tt.temporality, tt.monotonicity)
 			assert.NoError(t, err)
 
-			evaluate(ottldatapoints.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource()))
+			_, err = evaluate(ottldatapoints.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource()))
+			assert.Nil(t, err)
 
 			expected := pmetric.NewMetricSlice()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/traces/processor.go
+++ b/processor/transformprocessor/internal/traces/processor.go
@@ -48,7 +48,10 @@ func (p *Processor) ProcessTraces(_ context.Context, td ptrace.Traces) (ptrace.T
 			for k := 0; k < spans.Len(); k++ {
 				ctx := ottltraces.NewTransformContext(spans.At(k), sspan.Scope(), rspans.Resource())
 				for _, statement := range p.statements {
-					statement.Execute(ctx)
+					_, _, err := statement.Execute(ctx)
+					if err != nil {
+						return td, err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**Description:**
Changes `ExprFunc`,`Get` and `Set`.  This allows errors from contexts to be propagated upward to a place where they can be better handled.

This PR only adds the capability to return errors.  It does not update any error handling.  

**Link to tracking Issue:** 
Related to #13690

**Testing:** 
Updated unit tests