### PR TITLE
Azuremonitorexporter: Severity Level mapping

### DIFF
--- a/.chloggen/azure-monitor-exporter-log.yaml
+++ b/.chloggen/azure-monitor-exporter-log.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Application Insights Severity Level mapping was incorrectly based on SeverityText which was unique for every language/SDK.
+
+# One or more tracking issues related to the change
+issues: [15275]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Application Insights Severity Level mapping was incorrectly based on SeverityText which was unique for every language/SDK. The mapping approach has been changed to analyze SeverityNumber, which is supposed to be common across languages/SDKs.

--- a/exporter/azuremonitorexporter/logexporter_test.go
+++ b/exporter/azuremonitorexporter/logexporter_test.go
@@ -105,7 +105,7 @@ func TestLogRecordToEnvelope(t *testing.T) {
 	}
 }
 
-// Test conversion from logRecord.SeverityText() to contracts.SeverityLevel()
+// Test conversion from logRecord.SeverityNumber() to contracts.SeverityLevel()
 func TestToAiSeverityLevel(t *testing.T) {
 	logPacker := getLogPacker()
 	for sn, expectedSeverityLevel := range severityLevelMap {

--- a/exporter/azuremonitorexporter/logexporter_test.go
+++ b/exporter/azuremonitorexporter/logexporter_test.go
@@ -36,7 +36,20 @@ const (
 )
 
 var (
-	testLogs = []byte(`{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"dotnet"}}]},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1643240673066096200","severityText":"Information","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"},{"timeUnixNano":"0","observedTimeUnixNano":"1643240673066096200","severityText":"Information","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"},{"timeUnixNano":"0","observedTimeUnixNano":"0","severityText":"Information","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"}]}]}]}`)
+	testLogs         = []byte(`{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"dotnet"}}]},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1643240673066096200","severityText":"Information","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"},{"timeUnixNano":"0","observedTimeUnixNano":"1643240673066096200","severityText":"Information","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"},{"timeUnixNano":"0","observedTimeUnixNano":"0","severityText":"Information","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"}]}]}]}`)
+	severityLevelMap = map[plog.SeverityNumber]contracts.SeverityLevel{
+		plog.SeverityNumberTrace:       contracts.Verbose,
+		plog.SeverityNumberDebug4:      contracts.Verbose,
+		plog.SeverityNumberInfo:        contracts.Information,
+		plog.SeverityNumberInfo4:       contracts.Information,
+		plog.SeverityNumberWarn:        contracts.Warning,
+		plog.SeverityNumberWarn4:       contracts.Warning,
+		plog.SeverityNumberError:       contracts.Error,
+		plog.SeverityNumberError4:      contracts.Error,
+		plog.SeverityNumberFatal:       contracts.Critical,
+		plog.SeverityNumberFatal4:      contracts.Critical,
+		plog.SeverityNumberUnspecified: contracts.Information,
+	}
 )
 
 // Tests proper wrapping of a log record to an envelope
@@ -95,8 +108,8 @@ func TestLogRecordToEnvelope(t *testing.T) {
 // Test conversion from logRecord.SeverityText() to contracts.SeverityLevel()
 func TestToAiSeverityLevel(t *testing.T) {
 	logPacker := getLogPacker()
-	for severityText, expectedSeverityLevel := range severityLevelMap {
-		severityLevel := logPacker.toAiSeverityLevel(severityText)
+	for sn, expectedSeverityLevel := range severityLevelMap {
+		severityLevel := logPacker.toAiSeverityLevel(sn)
 		assert.Equal(t, severityLevel, expectedSeverityLevel)
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fixes #15275 

Application Insights Severity Level mapping was based on SeverityText which was unique for every language/SDK. The mapping approach has been changed to analyze [SeverityNumber](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#displaying-severity), which is supposed to be common across languages/SDKs.
