### PR TITLE
[chore] update tests to bind to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/extension/pprofextension/config_test.go
+++ b/extension/pprofextension/config_test.go
@@ -40,7 +40,7 @@ func TestLoadConfig(t *testing.T) {
 			id: config.NewComponentIDWithName(typeStr, "1"),
 			expected: &Config{
 				ExtensionSettings:    config.NewExtensionSettings(config.NewComponentID(typeStr)),
-				TCPAddr:              confignet.TCPAddr{Endpoint: "0.0.0.0:1777"},
+				TCPAddr:              confignet.TCPAddr{Endpoint: "127.0.0.1:1777"},
 				BlockProfileFraction: 3,
 				MutexProfileFraction: 5,
 			},

--- a/extension/pprofextension/testdata/config.yaml
+++ b/extension/pprofextension/testdata/config.yaml
@@ -1,5 +1,5 @@
 pprof:
 pprof/1:
-  endpoint: "0.0.0.0:1777"
+  endpoint: "127.0.0.1:1777"
   block_profile_fraction: 3
   mutex_profile_fraction: 5

--- a/receiver/syslogreceiver/syslog_test.go
+++ b/receiver/syslogreceiver/syslog_test.go
@@ -56,10 +56,10 @@ func testSyslog(t *testing.T, cfg *SysLogConfig) {
 
 	var conn net.Conn
 	if cfg.InputConfig.TCP != nil {
-		conn, err = net.Dial("tcp", "0.0.0.0:29018")
+		conn, err = net.Dial("tcp", "127.0.0.1:29018")
 		require.NoError(t, err)
 	} else {
-		conn, err = net.Dial("udp", "0.0.0.0:29018")
+		conn, err = net.Dial("udp", "127.0.0.1:29018")
 		require.NoError(t, err)
 	}
 
@@ -114,7 +114,7 @@ func testdataConfigYaml() *SysLogConfig {
 		InputConfig: func() syslog.Config {
 			c := syslog.NewConfig()
 			c.TCP = &tcp.NewConfig().BaseConfig
-			c.TCP.ListenAddress = "0.0.0.0:29018"
+			c.TCP.ListenAddress = "127.0.0.1:29018"
 			c.Protocol = "rfc5424"
 			return *c
 		}(),
@@ -134,7 +134,7 @@ func testdataUDPConfig() *SysLogConfig {
 		InputConfig: func() syslog.Config {
 			c := syslog.NewConfig()
 			c.UDP = &udp.NewConfig().BaseConfig
-			c.UDP.ListenAddress = "0.0.0.0:29018"
+			c.UDP.ListenAddress = "127.0.0.1:29018"
 			c.Protocol = "rfc5424"
 			return *c
 		}(),

--- a/receiver/syslogreceiver/testdata/config.yaml
+++ b/receiver/syslogreceiver/testdata/config.yaml
@@ -1,6 +1,6 @@
 syslog:
   tcp:
-    listen_address: "0.0.0.0:29018"
+    listen_address: "127.0.0.1:29018"
   protocol: rfc5424
   converter:
     flush_interval: 100ms

--- a/receiver/tcplogreceiver/tcp_test.go
+++ b/receiver/tcplogreceiver/tcp_test.go
@@ -48,7 +48,7 @@ func testTCP(t *testing.T, cfg *TCPLogConfig) {
 	require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
 
 	var conn net.Conn
-	conn, err = net.Dial("tcp", "0.0.0.0:29018")
+	conn, err = net.Dial("tcp", "127.0.0.1:29018")
 	require.NoError(t, err)
 
 	for i := 0; i < numLogs; i++ {
@@ -98,7 +98,7 @@ func testdataConfigYaml() *TCPLogConfig {
 		},
 		InputConfig: func() tcp.Config {
 			c := tcp.NewConfig()
-			c.ListenAddress = "0.0.0.0:29018"
+			c.ListenAddress = "127.0.0.1:29018"
 			return *c
 		}(),
 	}

--- a/receiver/tcplogreceiver/testdata/config.yaml
+++ b/receiver/tcplogreceiver/testdata/config.yaml
@@ -1,4 +1,4 @@
 tcplog:
-  listen_address: "0.0.0.0:29018"
+  listen_address: "127.0.0.1:29018"
   converter:
     worker_count: 1

--- a/receiver/udplogreceiver/testdata/config.yaml
+++ b/receiver/udplogreceiver/testdata/config.yaml
@@ -1,2 +1,2 @@
 udplog:
-  listen_address: "0.0.0.0:29018"
+  listen_address: "127.0.0.1:29018"

--- a/receiver/udplogreceiver/udp_test.go
+++ b/receiver/udplogreceiver/udp_test.go
@@ -48,7 +48,7 @@ func testUDP(t *testing.T, cfg *UDPLogConfig) {
 	require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
 
 	var conn net.Conn
-	conn, err = net.Dial("udp", "0.0.0.0:29018")
+	conn, err = net.Dial("udp", "127.0.0.1:29018")
 	require.NoError(t, err)
 
 	for i := 0; i < numLogs; i++ {
@@ -99,7 +99,7 @@ func testdataConfigYaml() *UDPLogConfig {
 		},
 		InputConfig: func() udp.Config {
 			c := udp.NewConfig()
-			c.ListenAddress = "0.0.0.0:29018"
+			c.ListenAddress = "127.0.0.1:29018"
 			return *c
 		}(),
 	}


### PR DESCRIPTION
There are many tests in this repository that currently bind to 0.0.0.0. This is not necessary.
