### PR TITLE
Windows tests remove setup stage, every job has its own cache

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -16,28 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup-environment:
-    runs-on: windows-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-      - name: Cache Go Mod
-        id: go-mod-cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~\go\pkg\mod
-          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-      - name: Install dependencies
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        run: make -j2 gomoddownload
   windows-unittest-matrix:
-    needs: [setup-environment]
     strategy:
       matrix:
         group:
@@ -69,15 +48,13 @@ jobs:
         with:
           path: |
             ~\go\pkg\mod
-          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-      - name: Cache Go Build
-        uses: actions/cache@v3
-        with:
-          path: |
             ~\AppData\Local\go-build
           key: go-build-cache-${{ runner.os }}-${{ matrix.group }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Install dependencies
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        run: make -j2 gomoddownload GROUP=${{ matrix.group }}
       - name: Run Unit tests
-        run: make gotest GROUP=${{ matrix.group }}
+        run: make -j2 gotest GROUP=${{ matrix.group }}
   windows-unittest:
     if: ${{ always() }}
     runs-on: windows-latest


### PR DESCRIPTION
Revert previous experiment to configure a setup stage for windows since it takes way too much even when hitting the cache (more than 15mins). This is a bit different than before, now every job has its own independent cache.
