### PR TITLE
[exporter/clickhouse] remove unnecessary SQL function

### DIFF
--- a/.chloggen/clickhouseexporter-remove-toDateTime.yaml
+++ b/.chloggen/clickhouseexporter-remove-toDateTime.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: clickhouseexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: remove unnecessary function in trace table creation SQL
+
+# One or more tracking issues related to the change
+issues: [15679]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/clickhouseexporter/exporter_traces.go
+++ b/exporter/clickhouseexporter/exporter_traces.go
@@ -294,8 +294,7 @@ func renderCreateTracesTableSQL(cfg *Config) string {
 	if cfg.TTLDays > 0 {
 		ttlExpr = fmt.Sprintf(`TTL toDateTime(Timestamp) + toIntervalDay(%d)`, cfg.TTLDays)
 	}
-	sql := fmt.Sprintf(createTracesTableSQL, cfg.TracesTableName, ttlExpr)
-	return sql
+	return fmt.Sprintf(createTracesTableSQL, cfg.TracesTableName, ttlExpr)
 }
 
 func renderCreateTraceIDTsTableSQL(cfg *Config) string {
@@ -303,13 +302,11 @@ func renderCreateTraceIDTsTableSQL(cfg *Config) string {
 	if cfg.TTLDays > 0 {
 		ttlExpr = fmt.Sprintf(`TTL toDateTime(Start) + toIntervalDay(%d)`, cfg.TTLDays)
 	}
-	sql := fmt.Sprintf(createTraceIDTsTableSQL, cfg.TracesTableName, ttlExpr)
-	return sql
+	return fmt.Sprintf(createTraceIDTsTableSQL, cfg.TracesTableName, ttlExpr)
 }
 
 func renderTraceIDTsMaterializedViewSQL(cfg *Config) string {
 	database, _ := parseDSNDatabase(cfg.DSN)
-	sql := fmt.Sprintf(createTraceIDTsMaterializedViewSQL, cfg.TracesTableName,
+	return fmt.Sprintf(createTraceIDTsMaterializedViewSQL, cfg.TracesTableName,
 		database, cfg.TracesTableName, database, cfg.TracesTableName)
-	return sql
 }

--- a/exporter/clickhouseexporter/exporter_traces.go
+++ b/exporter/clickhouseexporter/exporter_traces.go
@@ -250,8 +250,8 @@ const (
 	createTraceIDTsTableSQL = `
 create table IF NOT EXISTS %s_trace_id_ts (
      TraceId String CODEC(ZSTD(1)),
-     Start DateTime CODEC(ZSTD(1)),
-     End DateTime CODEC(ZSTD(1)),
+     Start DateTime64(9) CODEC(Delta, ZSTD(1)),
+     End DateTime64(9) CODEC(Delta, ZSTD(1)),
      INDEX idx_trace_id TraceId TYPE bloom_filter(0.01) GRANULARITY 1
 ) ENGINE MergeTree()
 %s
@@ -263,8 +263,8 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS %s_trace_id_ts_mv
 TO %s.%s_trace_id_ts
 AS SELECT
 TraceId,
-min(toDateTime(Timestamp)) as Start,
-max(toDateTime(Timestamp)) as End
+min(Timestamp) as Start,
+max(Timestamp) as End
 FROM
 %s.%s
 WHERE TraceId!=''
@@ -294,7 +294,8 @@ func renderCreateTracesTableSQL(cfg *Config) string {
 	if cfg.TTLDays > 0 {
 		ttlExpr = fmt.Sprintf(`TTL toDateTime(Timestamp) + toIntervalDay(%d)`, cfg.TTLDays)
 	}
-	return fmt.Sprintf(createTracesTableSQL, cfg.TracesTableName, ttlExpr)
+	sql := fmt.Sprintf(createTracesTableSQL, cfg.TracesTableName, ttlExpr)
+	return sql
 }
 
 func renderCreateTraceIDTsTableSQL(cfg *Config) string {
@@ -302,11 +303,13 @@ func renderCreateTraceIDTsTableSQL(cfg *Config) string {
 	if cfg.TTLDays > 0 {
 		ttlExpr = fmt.Sprintf(`TTL toDateTime(Start) + toIntervalDay(%d)`, cfg.TTLDays)
 	}
-	return fmt.Sprintf(createTraceIDTsTableSQL, cfg.TracesTableName, ttlExpr)
+	sql := fmt.Sprintf(createTraceIDTsTableSQL, cfg.TracesTableName, ttlExpr)
+	return sql
 }
 
 func renderTraceIDTsMaterializedViewSQL(cfg *Config) string {
 	database, _ := parseDSNDatabase(cfg.DSN)
-	return fmt.Sprintf(createTraceIDTsMaterializedViewSQL, cfg.TracesTableName,
+	sql := fmt.Sprintf(createTraceIDTsMaterializedViewSQL, cfg.TracesTableName,
 		database, cfg.TracesTableName, database, cfg.TracesTableName)
+	return sql
 }


### PR DESCRIPTION
**Description:** remove unnecessary SQL function
current create table SQL use toDateTime() function on Timestamp, It will cause loss of precision：

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/92ad54f707a967386b764b6fdaea5a2ba4377319/exporter/clickhouseexporter/exporter_traces.go#L261-L273

my test show:
<img width="1396" alt="image" src="https://user-images.githubusercontent.com/35491170/198160512-6fcc2618-d785-4d06-bb02-5419d2d026bc.png">
