### PR TITLE
[receiver/vcenter] Print the correct error message if VM fetch fails

### DIFF
--- a/.chloggen/vcenter-err.yaml
+++ b/.chloggen/vcenter-err.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Print the correct error message if VM fetch fails.
+
+# One or more tracking issues related to the change
+issues: [15682]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -101,7 +101,7 @@ func (vc *vcenterClient) Clusters(ctx context.Context, datacenter *object.Datace
 	vc.finder = vc.finder.SetDatacenter(datacenter)
 	clusters, err := vc.finder.ClusterComputeResourceList(ctx, "*")
 	if err != nil {
-		return []*object.ClusterComputeResource{}, err
+		return []*object.ClusterComputeResource{}, fmt.Errorf("unable to get cluster lists: %w", err)
 	}
 	return clusters, nil
 }
@@ -118,7 +118,7 @@ func (vc *vcenterClient) ResourcePools(ctx context.Context) ([]*object.ResourceP
 func (vc *vcenterClient) VMs(ctx context.Context) ([]*object.VirtualMachine, error) {
 	vms, err := vc.finder.VirtualMachineList(ctx, "*")
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve resource pools: %w", err)
+		return nil, fmt.Errorf("unable to retrieve vms: %w", err)
 	}
 	return vms, err
 }


### PR DESCRIPTION
**Description:** Print the correct string(VM) and not resource pool when error is returned while fetching VM list. Also wrapped cluster error message for consistency with other errors.


**Link to tracking Issue:** #15682

**Testing:** NA

**Documentation:** NA