### PR TITLE
[processor/spanmetrics] Fix getting key from cache error

### DIFF
--- a/processor/spanmetricsprocessor/internal/cache/cache.go
+++ b/processor/spanmetricsprocessor/internal/cache/cache.go
@@ -25,7 +25,7 @@ import (
 // batch of spans.
 type Cache struct {
 	*lru.Cache
-	evictedItems map[interface{}]interface{}
+	EvictedItems map[interface{}]interface{}
 }
 
 // NewCache creates a Cache.
@@ -40,15 +40,15 @@ func NewCache(size int) (*Cache, error) {
 
 	return &Cache{
 		Cache:        lruCache,
-		evictedItems: evictedItems,
+		EvictedItems: evictedItems,
 	}, nil
 }
 
 // RemoveEvictedItems cleans all the evicted items.
 func (c *Cache) RemoveEvictedItems() {
 	// we need to keep the original pointer to evictedItems map as it is used in the closure of lru.NewWithEvict
-	for k := range c.evictedItems {
-		delete(c.evictedItems, k)
+	for k := range c.EvictedItems {
+		delete(c.EvictedItems, k)
 	}
 }
 
@@ -57,7 +57,7 @@ func (c *Cache) Get(key interface{}) (interface{}, bool) {
 	if val, ok := c.Cache.Get(key); ok {
 		return val, ok
 	}
-	val, ok := c.evictedItems[key]
+	val, ok := c.EvictedItems[key]
 	return val, ok
 }
 

--- a/processor/spanmetricsprocessor/internal/cache/cache_test.go
+++ b/processor/spanmetricsprocessor/internal/cache/cache_test.go
@@ -69,16 +69,16 @@ func TestCache_Get(t *testing.T) {
 	tests := []struct {
 		name         string
 		lruCache     func() *Cache
-		evictedItems map[interface{}]interface{}
+		EvictedItems map[interface{}]interface{}
 		key          interface{}
 		wantValue    interface{}
 		wantOk       bool
 	}{
 		{
-			name: "if key is not found in LRUCache, will get key from evictedItems",
+			name: "if key is not found in LRUCache, will get key from EvictedItems",
 			lruCache: func() *Cache {
 				cache, _ := NewCache(1)
-				cache.evictedItems["key"] = "val"
+				cache.EvictedItems["key"] = "val"
 				return cache
 			},
 			key:       "key",
@@ -90,7 +90,7 @@ func TestCache_Get(t *testing.T) {
 			lruCache: func() *Cache {
 				cache, _ := NewCache(1)
 				cache.Add("key", "val_from_LRU")
-				cache.evictedItems["key"] = "val_from_evicted_items"
+				cache.EvictedItems["key"] = "val_from_evicted_items"
 				return cache
 			},
 			key:       "key",
@@ -142,8 +142,8 @@ func TestCache_RemoveEvictedItems(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				cache.evictedItems["key0"] = "val0"
-				cache.evictedItems["key1"] = "val1"
+				cache.EvictedItems["key0"] = "val0"
+				cache.EvictedItems["key1"] = "val1"
 				return cache, nil
 			},
 		},
@@ -155,7 +155,7 @@ func TestCache_RemoveEvictedItems(t *testing.T) {
 			cache, err := tt.lruCache()
 			assert.NoError(t, err)
 			cache.RemoveEvictedItems()
-			assert.Empty(t, cache.evictedItems)
+			assert.Empty(t, cache.EvictedItems)
 		})
 	}
 }
@@ -178,8 +178,8 @@ func TestCache_PurgeItems(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				cache.evictedItems["key0"] = "val0"
-				cache.evictedItems["key1"] = "val1"
+				cache.EvictedItems["key0"] = "val0"
+				cache.EvictedItems["key1"] = "val1"
 				return cache, nil
 			},
 		},
@@ -192,8 +192,8 @@ func TestCache_PurgeItems(t *testing.T) {
 				}
 				cache.Add("key", "val")
 				cache.Add("key2", "val2")
-				cache.evictedItems["key0"] = "val0"
-				cache.evictedItems["key1"] = "val1"
+				cache.EvictedItems["key0"] = "val0"
+				cache.EvictedItems["key1"] = "val1"
 				return cache, nil
 			},
 		},
@@ -206,7 +206,7 @@ func TestCache_PurgeItems(t *testing.T) {
 			assert.NoError(t, err)
 			cache.Purge()
 			assert.Zero(t, cache.Len())
-			assert.Empty(t, cache.evictedItems)
+			assert.Empty(t, cache.EvictedItems)
 		})
 	}
 }

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -339,8 +339,13 @@ func (p *processorImp) getDimensionsByMetricKey(k metricKey) (*pcommon.Map, erro
 		}
 		return nil, fmt.Errorf("type assertion of metricKeyToDimensions attributes failed, the key is %q", k)
 	}
+	if item, ok := p.metricKeyToDimensions.EvictedItems[k]; ok {
+		if attributeMap, ok := item.(pcommon.Map); ok {
+			return &attributeMap, nil
+		}
+	}
 
-	return nil, fmt.Errorf("value not found in metricKeyToDimensions cache by key %q", k)
+	return nil, fmt.Errorf("value not found in metricKeyToDimensions cache and EvictedItems by key %q", k)
 }
 
 // aggregateMetrics aggregates the raw metrics from the input trace data.

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -345,7 +345,7 @@ func (p *processorImp) getDimensionsByMetricKey(k metricKey) (*pcommon.Map, erro
 		}
 	}
 
-	return nil, fmt.Errorf("value not found in metricKeyToDimensions cache and EvictedItems by key %q", k)
+	return nil, fmt.Errorf("value not found in metricKeyToDimensions cache and its EvictedItems by key %q", k)
 }
 
 // aggregateMetrics aggregates the raw metrics from the input trace data.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
I get an error in my app when it sent span to a otel collector which configed a  spanmetrics processor with `defaultDimensionsCacheSize`:
```
2022/10/27 02:37:46 rpc error: code = Unknown desc = value not found in metricKeyToDimensions cache by key "amamba\x00amamba.io.api.pipeline.v1alpha1.Pipelines/ReplayPipelineRun\x00SPAN_KIND_SERVER\x00STATUS_CODE_OK\x00cd7b102e-fbc5-4556-a0fd-718298df3de9\x00amamba-system\x00demo-dev-worker-03\x00amamba-apiserver-66c9486b55-5l4n8"
```

I trick the error to:
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/92ad54f707a967386b764b6fdaea5a2ba4377319/processor/spanmetricsprocessor/processor.go#L335-L344

I think the error will occur when the added keys are more than `processorImp.defaultDimensionsCacheSize` however the `processorImp.callSum` doesn't have any limitation, it contains the key and the key's value. I add a patch to get key from the `metricKeyToDimensions.EvictedItems` to handle this scene.