### PR TITLE
[metricstransformprocessor] Add support for scaling histograms

### DIFF
--- a/.chloggen/metricstransform-scale-histogram.yaml
+++ b/.chloggen/metricstransform-scale-histogram.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricstransformprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for scaling histogram metrics
+
+# One or more tracking issues related to the change
+issues: [15690]

--- a/processor/metricstransformprocessor/metrics_testcase_builder_test.go
+++ b/processor/metricstransformprocessor/metrics_testcase_builder_test.go
@@ -99,6 +99,29 @@ func (b builder) addHistogramDatapoint(start, ts pcommon.Timestamp, count uint64
 	return b
 }
 
+func (b builder) addHistogramDatapointWithMinMaxAndExemplars(start, ts pcommon.Timestamp, count uint64, sum, min, max float64,
+	bounds []float64, buckets []uint64, exemplarValues []float64, attrValues ...string) builder {
+	if b.metric.Type() != pmetric.MetricTypeHistogram {
+		panic(b.metric.Type().String())
+	}
+	dp := b.metric.Histogram().DataPoints().AppendEmpty()
+	b.setAttrs(dp.Attributes(), attrValues)
+	dp.SetCount(count)
+	dp.SetSum(sum)
+	dp.SetMin(min)
+	dp.SetMax(max)
+	dp.ExplicitBounds().FromRaw(bounds)
+	dp.BucketCounts().FromRaw(buckets)
+	for ei := 0; ei < len(exemplarValues); ei++ {
+		exemplar := dp.Exemplars().AppendEmpty()
+		exemplar.SetTimestamp(ts)
+		exemplar.SetDoubleValue(exemplarValues[ei])
+	}
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	return b
+}
+
 // setUnit sets the unit of this metric
 func (b builder) setUnit(unit string) builder {
 	b.metric.SetUnit(unit)

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -1457,12 +1457,16 @@ var (
 				},
 			},
 			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1").addHistogramDatapoint(1, 1, 1, 1, []float64{1}, []uint64{1, 1}).build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric2").addHistogramDatapoint(1, 1, 2, 400, []float64{200}, []uint64{1, 2}).build(),
+				metricBuilder(pmetric.MetricTypeHistogram, "metric1").
+					addHistogramDatapoint(1, 1, 1, 1, []float64{1}, []uint64{1, 1}).build(),
+				metricBuilder(pmetric.MetricTypeHistogram, "metric2").
+					addHistogramDatapoint(1, 1, 2, 400, []float64{200}, []uint64{1, 2}).build(),
 			},
 			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1").addHistogramDatapoint(1, 1, 1, 100, []float64{100}, []uint64{1, 1}).build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric2").addHistogramDatapoint(1, 1, 2, 40, []float64{20}, []uint64{1, 2}).build(),
+				metricBuilder(pmetric.MetricTypeHistogram, "metric1").
+					addHistogramDatapoint(1, 1, 1, 100, []float64{100}, []uint64{1, 1}).build(),
+				metricBuilder(pmetric.MetricTypeHistogram, "metric2").
+					addHistogramDatapoint(1, 1, 2, 40, []float64{20}, []uint64{1, 2}).build(),
 			},
 		},
 		{
@@ -1489,7 +1493,7 @@ var (
 						{
 							configOperation: Operation{
 								Action: ScaleValue,
-								Scale:  100,
+								Scale:  10,
 							},
 						},
 					},
@@ -1499,7 +1503,7 @@ var (
 				metricBuilder(pmetric.MetricTypeSum, "metric1", "label1").
 					addIntDatapoint(1, 1, 1, "value1").
 					addIntDatapoint(1, 1, 3, "value2").build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1").
+				metricBuilder(pmetric.MetricTypeHistogram, "metric2", "label1").
 					addHistogramDatapoint(1, 1, 1, 1, []float64{1}, []uint64{1, 1}, "value1").
 					addHistogramDatapoint(1, 1, 2, 4, []float64{2}, []uint64{1, 2}, "value2").build(),
 			},
@@ -1507,8 +1511,8 @@ var (
 				metricBuilder(pmetric.MetricTypeSum, "metric1", "label1").
 					addIntDatapoint(1, 1, 100, "value1").
 					addIntDatapoint(1, 1, 3, "value2").build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1").
-					addHistogramDatapoint(1, 1, 1, 100, []float64{100}, []uint64{1, 1}, "value1").
+				metricBuilder(pmetric.MetricTypeHistogram, "metric2", "label1").
+					addHistogramDatapoint(1, 1, 1, 10, []float64{10}, []uint64{1, 1}, "value1").
 					addHistogramDatapoint(1, 1, 2, 4, []float64{2}, []uint64{1, 2}, "value2").build(),
 			},
 		},

--- a/processor/metricstransformprocessor/operation_scale_value.go
+++ b/processor/metricstransformprocessor/operation_scale_value.go
@@ -18,7 +18,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-// scaleValueOp scales a numeric metric value. Applicable to sum and gauge metrics only.
+// scaleValueOp scales the numeric metric value of sum and gauge metrics.
+// For histograms it scales the value of the sum and the explicit bounds.
 func scaleValueOp(metric pmetric.Metric, op internalOperation, f internalFilter) {
 	var dps pmetric.NumberDataPointSlice
 	switch metric.Type() {
@@ -26,6 +27,9 @@ func scaleValueOp(metric pmetric.Metric, op internalOperation, f internalFilter)
 		dps = metric.Gauge().DataPoints()
 	case pmetric.MetricTypeSum:
 		dps = metric.Sum().DataPoints()
+	case pmetric.MetricTypeHistogram:
+		scaleHistogramOp(metric, op, f)
+		return
 	default:
 		return
 	}
@@ -40,6 +44,21 @@ func scaleValueOp(metric pmetric.Metric, op internalOperation, f internalFilter)
 			dp.SetIntValue(int64(float64(dp.IntValue()) * op.configOperation.Scale))
 		case pmetric.NumberDataPointValueTypeDouble:
 			dp.SetDoubleValue(dp.DoubleValue() * op.configOperation.Scale)
+		}
+	}
+}
+
+func scaleHistogramOp(metric pmetric.Metric, op internalOperation, f internalFilter) {
+	var dps = metric.Histogram().DataPoints()
+
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		if !f.matchAttrs(dp.Attributes()) {
+			continue
+		}
+		dp.SetSum(dp.Sum() * op.configOperation.Scale)
+		for bounds, bi := dp.ExplicitBounds(), 0; bi < bounds.Len(); bi++ {
+			bounds.SetAt(bi, bounds.At(bi)*op.configOperation.Scale)
 		}
 	}
 }


### PR DESCRIPTION
**Description:** Add support for scaling histogram metrics

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15690

**Testing:**
Tested locally with a pipeline looking roughly like this:
zipkin receiver -> spanmetrics processor -> prometheus exporter -> prometheus receiver -> metricstransform processor -> prometheus exporter