### PR TITLE
[pkg/stanza] Remove converter options

### DIFF
--- a/.chloggen/filelog-rm-converter-config.yaml
+++ b/.chloggen/filelog-rm-converter-config.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza, filelog, journald, syslog, tcplog, udplog, windowseventlog, logstransform
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove ability to configure `converter`.
+
+# One or more tracking issues related to the change
+issues: [15696]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The design of the converter is opaque and its behavior may change in the future.
+  Because of this, the `converter` settings are deemed unstable. The actual behavior of the
+  converter remains unchanged, but will always use the former default values.

--- a/pkg/stanza/adapter/config.go
+++ b/pkg/stanza/adapter/config.go
@@ -15,8 +15,6 @@
 package adapter // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 
 import (
-	"time"
-
 	"go.opentelemetry.io/collector/config"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -26,21 +24,5 @@ import (
 type BaseConfig struct {
 	config.ReceiverSettings `mapstructure:",squash"`
 	Operators               []operator.Config   `mapstructure:"operators"`
-	Converter               ConverterConfig     `mapstructure:"converter"`
 	StorageID               *config.ComponentID `mapstructure:"storage"`
-}
-
-// ConverterConfig controls how the internal entry.Entry to plog.Logs converter
-// works.
-type ConverterConfig struct {
-	// MaxFlushCount defines the maximum number of entries that can be
-	// accumulated before flushing them for further processing.
-	MaxFlushCount uint `mapstructure:"max_flush_count"`
-	// FlushInterval defines how often to flush the converted and accumulated
-	// log entries.
-	FlushInterval time.Duration `mapstructure:"flush_interval"`
-	// WorkerCount defines how many worker goroutines used for entry.Entry to
-	// log records translation should be spawned.
-	// By default: math.Max(1, runtime.NumCPU()/4) workers are spawned.
-	WorkerCount int `mapstructure:"worker_count"`
 }

--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -98,44 +98,16 @@ type Converter struct {
 	logger *zap.Logger
 }
 
-type ConverterOption interface {
-	apply(*Converter)
-}
-
-type optionFunc func(*Converter)
-
-func (f optionFunc) apply(c *Converter) {
-	f(c)
-}
-
-func WithLogger(logger *zap.Logger) ConverterOption {
-	return optionFunc(func(c *Converter) {
-		c.logger = logger
-	})
-}
-
-func WithWorkerCount(workerCount int) ConverterOption {
-	return optionFunc(func(c *Converter) {
-		c.workerCount = workerCount
-	})
-}
-
-func NewConverter(opts ...ConverterOption) *Converter {
-	c := &Converter{
+func NewConverter(logger *zap.Logger) *Converter {
+	return &Converter{
 		workerChan:      make(chan []*entry.Entry),
 		workerCount:     int(math.Max(1, float64(runtime.NumCPU()/4))),
 		aggregationChan: make(chan []workerItem),
 		pLogsChan:       make(chan plog.Logs),
 		stopChan:        make(chan struct{}),
-		logger:          zap.NewNop(),
 		flushChan:       make(chan plog.Logs),
+		logger:          logger,
 	}
-
-	for _, opt := range opts {
-		opt.apply(c)
-	}
-
-	return c
 }
 
 func (c *Converter) Start() {

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 )
@@ -434,9 +435,7 @@ func TestAllConvertedEntriesAreSentAndReceived(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			converter := NewConverter(
-				WithWorkerCount(1),
-			)
+			converter := NewConverter(zap.NewNop())
 			converter.Start()
 			defer converter.Stop()
 
@@ -498,7 +497,7 @@ func TestAllConvertedEntriesAreSentAndReceived(t *testing.T) {
 }
 
 func TestConverterCancelledContextCancellsTheFlush(t *testing.T) {
-	converter := NewConverter()
+	converter := NewConverter(zap.NewNop())
 	converter.Start()
 	defer converter.Stop()
 	var wg sync.WaitGroup
@@ -890,9 +889,7 @@ func BenchmarkConverter(b *testing.B) {
 		b.Run(fmt.Sprintf("worker_count=%d", wc), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 
-				converter := NewConverter(
-					WithWorkerCount(wc),
-				)
+				converter := NewConverter(zap.NewNop())
 				converter.Start()
 				defer converter.Stop()
 				b.ResetTimer()

--- a/pkg/stanza/adapter/emitter.go
+++ b/pkg/stanza/adapter/emitter.go
@@ -39,43 +39,19 @@ type LogEmitter struct {
 	flushInterval time.Duration
 }
 
-type LogEmitterOption func(*LogEmitter)
-
 var (
 	defaultFlushInterval      = 100 * time.Millisecond
 	defaultMaxBatchSize  uint = 100
 )
 
-// LogEmitterWithMaxBatchSize returns an option that makes the LogEmitter use the specified max batch size
-func LogEmitterWithMaxBatchSize(maxBatchSize uint) LogEmitterOption {
-	return LogEmitterOption(func(le *LogEmitter) {
-		le.maxBatchSize = maxBatchSize
-		le.batch = make([]*entry.Entry, 0, maxBatchSize)
-	})
-}
-
-// LogEmitterWithFlushInterval returns an option that makes the LogEmitter use the specified flush interval
-func LogEmitterWithFlushInterval(flushInterval time.Duration) LogEmitterOption {
-	return LogEmitterOption(func(le *LogEmitter) {
-		le.flushInterval = flushInterval
-	})
-}
-
-// LogEmitterWithLogger returns an option that makes the LogEmitter use the specified logger
-func LogEmitterWithLogger(logger *zap.SugaredLogger) LogEmitterOption {
-	return LogEmitterOption(func(le *LogEmitter) {
-		le.OutputOperator.BasicOperator.SugaredLogger = logger
-	})
-}
-
 // NewLogEmitter creates a new receiver output
-func NewLogEmitter(opts ...LogEmitterOption) *LogEmitter {
-	le := &LogEmitter{
+func NewLogEmitter(logger *zap.SugaredLogger) *LogEmitter {
+	return &LogEmitter{
 		OutputOperator: helper.OutputOperator{
 			BasicOperator: helper.BasicOperator{
 				OperatorID:    "log_emitter",
 				OperatorType:  "log_emitter",
-				SugaredLogger: zap.NewNop().Sugar(),
+				SugaredLogger: logger,
 			},
 		},
 		logChan:       make(chan []*entry.Entry),
@@ -84,12 +60,6 @@ func NewLogEmitter(opts ...LogEmitterOption) *LogEmitter {
 		flushInterval: defaultFlushInterval,
 		cancel:        func() {},
 	}
-
-	for _, opt := range opts {
-		opt(le)
-	}
-
-	return le
 }
 
 // Start starts the goroutine(s) required for this operator

--- a/pkg/stanza/adapter/factory.go
+++ b/pkg/stanza/adapter/factory.go
@@ -55,19 +55,7 @@ func createLogsReceiver(logReceiverType LogReceiverType) component.CreateLogsRec
 
 		operators := append([]operator.Config{inputCfg}, baseCfg.Operators...)
 
-		emitterOpts := []LogEmitterOption{
-			LogEmitterWithLogger(params.Logger.Sugar()),
-		}
-
-		if baseCfg.Converter.MaxFlushCount > 0 {
-			emitterOpts = append(emitterOpts, LogEmitterWithMaxBatchSize(baseCfg.Converter.MaxFlushCount))
-		}
-
-		if baseCfg.Converter.FlushInterval > 0 {
-			emitterOpts = append(emitterOpts, LogEmitterWithFlushInterval(baseCfg.Converter.FlushInterval))
-		}
-
-		emitter := NewLogEmitter(emitterOpts...)
+		emitter := NewLogEmitter(params.Logger.Sugar())
 		pipe, err := pipeline.Config{
 			Operators:     operators,
 			DefaultOutput: emitter,
@@ -76,14 +64,7 @@ func createLogsReceiver(logReceiverType LogReceiverType) component.CreateLogsRec
 			return nil, err
 		}
 
-		opts := []ConverterOption{
-			WithLogger(params.Logger),
-		}
-
-		if baseCfg.Converter.WorkerCount > 0 {
-			opts = append(opts, WithWorkerCount(baseCfg.Converter.WorkerCount))
-		}
-		converter := NewConverter(opts...)
+		converter := NewConverter(params.Logger)
 		obsrecv := obsreport.MustNewReceiver(obsreport.ReceiverSettings{
 			ReceiverID:             cfg.ID(),
 			ReceiverCreateSettings: params,

--- a/pkg/stanza/adapter/factory_test.go
+++ b/pkg/stanza/adapter/factory_test.go
@@ -17,7 +17,6 @@ package adapter
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -37,18 +36,6 @@ func TestCreateReceiver(t *testing.T) {
 			{
 				Builder: json.NewConfig(),
 			},
-		}
-		receiver, err := factory.CreateLogsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, consumertest.NewNop())
-		require.NoError(t, err, "receiver creation failed")
-		require.NotNil(t, receiver, "receiver creation failed")
-	})
-
-	t.Run("Success with ConverterConfig", func(t *testing.T) {
-		factory := NewFactory(TestReceiverType{}, component.StabilityLevelInDevelopment)
-		cfg := factory.CreateDefaultConfig().(*TestConfig)
-		cfg.Converter = ConverterConfig{
-			MaxFlushCount: 1,
-			FlushInterval: 3 * time.Second,
 		}
 		receiver, err := factory.CreateLogsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, consumertest.NewNop())
 		require.NoError(t, err, "receiver creation failed")

--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -17,7 +17,6 @@ package adapter
 import (
 	"context"
 	"errors"
-	"time"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -96,10 +95,6 @@ func (f TestReceiverType) CreateDefaultConfig() config.Receiver {
 		BaseConfig: BaseConfig{
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(testType)),
 			Operators:        []operator.Config{},
-			Converter: ConverterConfig{
-				MaxFlushCount: 1,
-				FlushInterval: 100 * time.Millisecond,
-			},
 		},
 		Input: operator.NewConfig(noop.NewConfig()),
 	}

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -116,9 +116,7 @@ func BenchmarkReadLine(b *testing.B) {
 	var operatorCfgs []operator.Config
 	require.NoError(b, yaml.Unmarshal([]byte(pipelineYaml), &operatorCfgs))
 
-	emitter := NewLogEmitter(
-		LogEmitterWithLogger(zap.NewNop().Sugar()),
-	)
+	emitter := NewLogEmitter(zap.NewNop().Sugar())
 	defer func() {
 		require.NoError(b, emitter.Stop())
 	}()
@@ -183,9 +181,7 @@ func BenchmarkParseAndMap(b *testing.B) {
 	var operatorCfgs []operator.Config
 	require.NoError(b, yaml.Unmarshal([]byte(pipelineYaml), &operatorCfgs))
 
-	emitter := NewLogEmitter(
-		LogEmitterWithLogger(zap.NewNop().Sugar()),
-	)
+	emitter := NewLogEmitter(zap.NewNop().Sugar())
 	defer func() {
 		require.NoError(b, emitter.Stop())
 	}()

--- a/processor/logstransformprocessor/config_test.go
+++ b/processor/logstransformprocessor/config_test.go
@@ -17,7 +17,6 @@ package logstransformprocessor
 import (
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,10 +57,6 @@ func TestLoadConfig(t *testing.T) {
 						return cfg
 					}(),
 				},
-			},
-			Converter: adapter.ConverterConfig{
-				MaxFlushCount: 100,
-				FlushInterval: 100 * time.Millisecond,
 			},
 		},
 	}, cfg)

--- a/processor/logstransformprocessor/factory.go
+++ b/processor/logstransformprocessor/factory.go
@@ -17,7 +17,6 @@ package logstransformprocessor // import "github.com/open-telemetry/opentelemetr
 import (
 	"context"
 	"errors"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -51,10 +50,6 @@ func createDefaultConfig() config.Processor {
 		ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
 		BaseConfig: adapter.BaseConfig{
 			Operators: []operator.Config{},
-			Converter: adapter.ConverterConfig{
-				MaxFlushCount: 100,
-				FlushInterval: 100 * time.Millisecond,
-			},
 		},
 	}
 }

--- a/processor/logstransformprocessor/factory_test.go
+++ b/processor/logstransformprocessor/factory_test.go
@@ -17,7 +17,6 @@ package logstransformprocessor
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -61,10 +60,6 @@ func TestCreateProcessor(t *testing.T) {
 						return cfg
 					}(),
 				},
-			},
-			Converter: adapter.ConverterConfig{
-				MaxFlushCount: 500,
-				FlushInterval: 13 * time.Millisecond,
 			},
 		},
 	}

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -57,10 +57,6 @@ var (
 					}(),
 				},
 			},
-			Converter: adapter.ConverterConfig{
-				MaxFlushCount: 100,
-				FlushInterval: 100 * time.Millisecond,
-			},
 		},
 	}
 )

--- a/receiver/filelogreceiver/filelog.go
+++ b/receiver/filelogreceiver/filelog.go
@@ -51,7 +51,6 @@ func createDefaultConfig() *FileLogConfig {
 		BaseConfig: adapter.BaseConfig{
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        []operator.Config{},
-			Converter:        adapter.ConverterConfig{},
 		},
 		InputConfig: *file.NewConfig(),
 	}

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.63.2-0.20221103164255-2ed41215f324
 	go.opentelemetry.io/collector/pdata v0.63.2-0.20221103164255-2ed41215f324
+	go.uber.org/zap v1.23.0
 )
 
 require (
@@ -33,7 +34,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.11.1 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	go.uber.org/zap v1.23.0 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	golang.org/x/text v0.4.0 // indirect

--- a/receiver/filelogreceiver/testdata/config.yaml
+++ b/receiver/filelogreceiver/testdata/config.yaml
@@ -9,6 +9,3 @@ filelog:
         layout: '%Y-%m-%d'
       severity:
         parse_from: attributes.sev
-  converter:
-    max_flush_count: 100
-    flush_interval: 100ms

--- a/receiver/syslogreceiver/syslog_test.go
+++ b/receiver/syslogreceiver/syslog_test.go
@@ -106,10 +106,6 @@ func testdataConfigYaml() *SysLogConfig {
 		BaseConfig: adapter.BaseConfig{
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        []operator.Config{},
-			Converter: adapter.ConverterConfig{
-				FlushInterval: 100 * time.Millisecond,
-				WorkerCount:   1,
-			},
 		},
 		InputConfig: func() syslog.Config {
 			c := syslog.NewConfig()
@@ -126,10 +122,6 @@ func testdataUDPConfig() *SysLogConfig {
 		BaseConfig: adapter.BaseConfig{
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        []operator.Config{},
-			Converter: adapter.ConverterConfig{
-				FlushInterval: 100 * time.Millisecond,
-				WorkerCount:   1,
-			},
 		},
 		InputConfig: func() syslog.Config {
 			c := syslog.NewConfig()

--- a/receiver/syslogreceiver/testdata/config.yaml
+++ b/receiver/syslogreceiver/testdata/config.yaml
@@ -2,6 +2,3 @@ syslog:
   tcp:
     listen_address: "127.0.0.1:29018"
   protocol: rfc5424
-  converter:
-    flush_interval: 100ms
-    worker_count: 1

--- a/receiver/tcplogreceiver/tcp_test.go
+++ b/receiver/tcplogreceiver/tcp_test.go
@@ -92,9 +92,6 @@ func testdataConfigYaml() *TCPLogConfig {
 		BaseConfig: adapter.BaseConfig{
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        []operator.Config{},
-			Converter: adapter.ConverterConfig{
-				WorkerCount: 1,
-			},
 		},
 		InputConfig: func() tcp.Config {
 			c := tcp.NewConfig()

--- a/receiver/tcplogreceiver/testdata/config.yaml
+++ b/receiver/tcplogreceiver/testdata/config.yaml
@@ -1,4 +1,2 @@
 tcplog:
   listen_address: "127.0.0.1:29018"
-  converter:
-    worker_count: 1

--- a/receiver/windowseventlogreceiver/receiver_windows.go
+++ b/receiver/windowseventlogreceiver/receiver_windows.go
@@ -51,7 +51,6 @@ func (f ReceiverType) CreateDefaultConfig() config.Receiver {
 		BaseConfig: adapter.BaseConfig{
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        []operator.Config{},
-			Converter:        adapter.ConverterConfig{},
 		},
 		InputConfig: *windows.NewConfig(),
 	}


### PR DESCRIPTION
This change would remove the `converter` block from the configuration of `pkg/stanza` components. It does _not_ remove the converter or change its default batching and flushing behaviors.

The `filelog` receiver has a stable configuration aside from the open question about whether this converter's batching and flushing functionality will be changed in the future. Additional context [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/15355#issuecomment-1286191419). 

This is a breaking change, but will allow the filelog receiver to move to beta.