### PR TITLE
docs: add status tables for all components

### DIFF
--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -1,5 +1,11 @@
 # Azure Monitor Exporter
 
+| Status                   |              |
+|--------------------------|--------------|
+| Stability                | [beta]       |
+| Supported pipeline types | logs, traces |
+| Distributions            | [contrib]    |
+
 This exporter sends logs and trace data to [Azure Monitor](https://docs.microsoft.com/azure/azure-monitor/).
 
 ## Configuration
@@ -58,3 +64,6 @@ All attributes are also mapped to custom properties if they are booleans or stri
 ### Logs
 This exporter saves log records to Application Insights `traces` table.
 [TraceId](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-traceid) is mapped to `operation_id` column and [SpanId](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-spanid) is mapped to `operation_parentId` column.
+
+[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/mezmoexporter/README.md
+++ b/exporter/mezmoexporter/README.md
@@ -56,3 +56,6 @@ service:
       processors: [ resourcedetection ]
       exporters: [ mezmo ]
 ```
+
+[stable]: https://github.com/open-telemetry/opentelemetry-collector#stable
+[contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/extension/awsproxy/README.md
+++ b/extension/awsproxy/README.md
@@ -1,6 +1,10 @@
 # AWS Proxy
 
-##
+| Status                   |           |
+|--------------------------|-----------|
+| Stability                | [beta]    |
+| Distributions            | [contrib] |
+
 The AWS proxy accepts requests without any authentication of AWS signatures applied and forwards them to the
 AWS API, applying authentication and signing. This allows applications to avoid needing AWS credentials to access
 a service, instead configuring the AWS exporter and/or proxy in the OpenTelemetry collector and only providing the
@@ -49,3 +53,6 @@ The IAM role used by this proxy when communicating with the AWS service. If non-
 
 ### aws_endpoint (Optional)
 The AWS service endpoint which this proxy forwards requests to. If not set, will default to the AWS X-Ray endpoint.
+
+[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/processor/deltatorateprocessor/README.md
+++ b/processor/deltatorateprocessor/README.md
@@ -1,4 +1,11 @@
 # Delta to Rate Processor
+
+| Status                   |                  |
+|--------------------------|------------------|
+| Stability                | [in development] |
+| Supported pipeline types | metrics          |
+| Distributions            | [contrib]        |
+
 **Status: under development; Not recommended for production usage.**
 
 Supported pipeline types: metrics
@@ -24,3 +31,6 @@ processors:
             .
             - <metric_n_name>
 ```
+
+[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -1,1 +1,12 @@
+# Kubernetes Attributes Processor
+
+| Status                   |                       |
+|--------------------------|-----------------------|
+| Stability                | [beta]                |
+| Supported pipeline types | logs, metrics, traces |
+| Distributions            | [contrib]             |
+
 Documentation is published to [pkg.go.dev](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor?tab=doc)
+
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
+[contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/processor/logstransformprocessor/README.md
+++ b/processor/logstransformprocessor/README.md
@@ -1,9 +1,12 @@
 # Logs Transform Processor
 
-**Status: experimental**
-NOTE - This processor is experimental, with the intention that its functionality will be reimplemented in the [transform processor](../transformprocessor/README.md) in the future.
+| Status                   |                  |
+|--------------------------|------------------|
+| Stability                | [in development] |
+| Supported pipeline types | logs             |
+| Distributions            | none             |
 
-Supported pipeline types: logs
+NOTE - This processor is experimental, with the intention that its functionality will be reimplemented in the [transform processor](../transformprocessor/README.md) in the future.
 
 The logs transform processor can be used to apply [log operators](../../pkg/stanza/docs/operators) to logs coming from any receiver.
 Please refer to [config.go](./config.go) for the config spec.
@@ -25,3 +28,5 @@ processors:
 
 Refer to [config.yaml](./testdata/config.yaml) for detailed
 examples on using the processor.
+
+[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development

--- a/processor/metricsgenerationprocessor/README.md
+++ b/processor/metricsgenerationprocessor/README.md
@@ -1,7 +1,12 @@
 # Metrics Generation Processor
-**Status: under development; Not recommended for production usage.**
 
-Supported pipeline types: metrics
+| Status                   |                  |
+|--------------------------|------------------|
+| Stability                | [in development] |
+| Supported pipeline types | metrics          |
+| Distributions            | [contrib]        |
+
+**Status: under development; Not recommended for production usage.**
 
 ## Description
 
@@ -66,3 +71,6 @@ rules:
       operation: multiply
       scale_by: 1048576
 ```
+
+[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -1,5 +1,11 @@
 # Receiver Creator
 
+| Status                   |                       |
+|--------------------------|-----------------------|
+| Stability                | [beta]                |
+| Supported pipeline types | logs, metrics, traces |
+| Distributions            | [contrib]             |
+
 This receiver can instantiate other receivers at runtime based on whether
 observed endpoints match a configured rule. To use the receiver creator, you
 must first configure one or more
@@ -281,3 +287,6 @@ service:
 
 The full list of settings exposed for this receiver are documented [here](./config.go)
 with detailed sample configurations [here](./testdata/config.yaml).
+
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
+[contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/solacereceiver/README.md
+++ b/receiver/solacereceiver/README.md
@@ -1,8 +1,12 @@
 # Solace Receiver
 
-The Solace receiver receives trace data from a [Solace PubSub+ Event Broker](https://solace.com/products/event-broker/).
+| Status                   |           |
+|--------------------------|-----------|
+| Stability                | [alpha]   |
+| Supported pipeline types | traces    |
+| Distributions            | [contrib] |
 
-Supported pipeline types: `traces`
+The Solace receiver receives trace data from a [Solace PubSub+ Event Broker](https://solace.com/products/event-broker/).
 
 ## Getting Started
 To get started with the Solace receiver, a telemetry queue and authentication details must be configured. If connecting to a broker other than localhost, the `broker` field should be configured.
@@ -87,3 +91,6 @@ service:
     traces/solace:
       receivers: [solace/primary,solace/backup]
 ```
+
+[alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -1,5 +1,11 @@
 # SQL Query Receiver (Alpha)
 
+| Status                   |           |
+|--------------------------|-----------|
+| Stability                | [alpha]   |
+| Supported pipeline types | metrics   |
+| Distributions            | [contrib] |
+
 The SQL Query Receiver uses custom SQL queries to generate metrics from a database connection.
 
 > :construction: This receiver is in **ALPHA**. Behavior, configuration fields, and metric data model are subject to change.
@@ -96,3 +102,6 @@ Refer to the config file [provided](./testdata/oracledb-receiver-config.yaml) fo
 Oracle DB driver to connect and query the same table schema and contents as the example above.
 The Oracle DB driver documentation can be found [here.](https://github.com/sijms/go-ora)
 Another usage example is the `go_ora` example [here.](https://blogs.oracle.com/developers/post/connecting-a-go-application-to-oracle-database)
+
+[alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
Fixes #15654

How I got the details for the status tables for each component:
- Stability - this was the most tricky one; for some of the components, this information is not available. I put "unknown" for those and will kindly ask those components' maintainers to fill in the missing information.
  UPDATE: Thanks to all the code owners, all the missing stability level information is now filled in :tada: 
- Supported pipeline types - I tried to get that from the rest of the description; hopefully got it right. Please comment if you think something needs to be changed.
- Distributions - This was the easiest, I looked at the manifests for [core](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/v0.63.1/distributions/otelcol/manifest.yaml) and [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/v0.63.1/distributions/otelcol-contrib/manifest.yaml) distributions. Hopefully I got this right.