### PR TITLE
[chore] Use `grep -E` instead of `egrep` in the root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GROUP ?= all
 FOR_GROUP_TARGET=for-$(GROUP)-target
 
 FIND_MOD_ARGS=-type f -name "go.mod"
-TO_MOD_DIR=dirname {} \; | sort | egrep  '^./'
+TO_MOD_DIR=dirname {} \; | sort | grep -E '^./'
 EX_COMPONENTS=-not -path "./receiver/*" -not -path "./processor/*" -not -path "./exporter/*" -not -path "./extension/*"
 EX_INTERNAL=-not -path "./internal/*"
 


### PR DESCRIPTION
**Description:**

egrep is considered [deprecated by POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xcu_chap04.html#tag_23_04_02) and in GNU Grep. GNU Grep now [prints a warning message](https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html) when egrep is used. The deprecation itself isn't particularly urgent, but the messages printed while building on Linux systems with GNU packages are pretty noisy.

The `-E` flag is supported by all major Grep implementations I can think of:
- [GNU](https://www.gnu.org/software/grep/manual/grep.html#grep-Programs)
- [BusyBox](https://www.busybox.net/BusyBox.html)
- [macOS](https://www.unix.com/man-page/osx/1/grep/)
- [FreeBSD](https://www.unix.com/man-page/FreeBSD/1/grep/)
- [OpenBSD](https://man.openbsd.org/grep)
- Cygwin on Windows supports packages that provide Grep through BusyBox or through GNU Grep.

I think this covers all systems we expect Collector contrib developers may use. In CI `grep -E` should be supported without any issue.

**Testing:**

I've tested this on an up-to-date Linux machine with a standard set of GNU utilities and on macOS. For other operating systems I checked the Grep manuals to verify support for the `-E` flag. 