### PR TITLE
[chore] add CI check for gendependabot

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -152,6 +152,10 @@ jobs:
         run: |
           make gotidy
           git diff --exit-code || (echo 'go.mod/go.sum deps changes detected, please run "make gotidy" and commit the changes in this PR.' && exit 1)
+      - name: Gen dependabot
+        run: |
+          make gendependabot
+          git diff -s --exit-code || (echo 'ALL_MODULES have been changed, please run "make gendependabot" and commit the changes in this PR.' && exit 1)
       - name: CodeGen
         run: |
           make generate


### PR DESCRIPTION
This is the same check that runs in core, needed in this repo as well.
