### PR TITLE
[chore] Accelerate process of marking issues as stale

### DIFF
--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -17,6 +17,6 @@ jobs:
           days-before-pr-stale: 14
           days-before-issue-stale: -1 # Stale label is applied by mark-issues-as-stale.yml
           days-before-pr-close: 14
-          days-before-issue-close: 120
+          days-before-issue-close: 60
           exempt-issue-labels: 'never stale'
 

--- a/.github/workflows/mark-issues-as-stale.yml
+++ b/.github/workflows/mark-issues-as-stale.yml
@@ -1,7 +1,7 @@
 name: 'Mark issues as stale'
 on:
   schedule:
-    - cron: "27 3 * * 1" # Run once a week to ease into marking issues as stale.
+    - cron: "27 3 * * 1-5" # Run at an arbitrary time on weekdays.
 
 jobs:
   mark-issues-as-stale:
@@ -14,7 +14,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DAYS_BEFORE_STALE: 60
-          DAYS_BEFORE_CLOSE: 120 # Only used for the stale message.
+          DAYS_BEFORE_CLOSE: 60 # Only used for the stale message.
           STALE_LABEL: 'Stale'
           EXEMPT_LABEL: 'never stale'
 

--- a/.github/workflows/scripts/mark-issues-as-stale.sh
+++ b/.github/workflows/scripts/mark-issues-as-stale.sh
@@ -33,11 +33,11 @@ if [[ -z ${DAYS_BEFORE_STALE} || -z ${DAYS_BEFORE_CLOSE} || -z ${STALE_LABEL} ||
     exit 0
 fi
 
-STALE_MESSAGE="This issue has been inactive for ${DAYS_BEFORE_STALE} days. It will be closed in ${DAYS_BEFORE_CLOSE} days if there is no activity."
+STALE_MESSAGE="This issue has been inactive for ${DAYS_BEFORE_STALE} days. It will be closed in ${DAYS_BEFORE_CLOSE} days if there is no activity. To ping code owners by adding a component label, see [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments), or if you are unsure of which component this issue relates to, please ping \`@open-telemetry/collector-contrib-triagers\`. If this issue is still relevant, please ping the code owners or leave a comment explaining why it is still relevant. Otherwise, please close it."
 
 # Check for the least recently-updated issues that aren't currently stale.
 # If no issues in this list are stale, the repo has no stale issues.
-ISSUES=(`gh issue list --search "is:issue is:open -label:${STALE_LABEL} -label:\"${EXEMPT_LABEL}\" sort:updated-asc" --json number --jq '.[].number'`)
+ISSUES=(`gh issue list --limit 100 --search "is:issue is:open -label:${STALE_LABEL} -label:\"${EXEMPT_LABEL}\" sort:updated-asc" --json number --jq '.[].number'`)
 
 for ISSUE in "${ISSUES[@]}"; do
     OWNERS=''
@@ -81,7 +81,7 @@ for ISSUE in "${ISSUES[@]}"; do
         echo "Pinging code owners for issue #${ISSUE}."
 
         # The GitHub CLI only offers multiline strings through file input.
-        printf "${STALE_MESSAGE} Pinging code owners:\n${OWNERS}\nSee [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself." \
+        printf "${STALE_MESSAGE}\nPinging code owners:\n${OWNERS}\nSee [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself." \
           | gh issue comment ${ISSUE} -F -
     fi
 


### PR DESCRIPTION
**Description:**

This PR temporarily shortens the time between an issue being marked stale and closed to 60 days to expedite closing out the very old issues in the backlog. This should close out the oldest issues roughly by the start of next year. Issues that are determined to still be relevant after this period can be reopened. After the current backlog of stale issues is processed, we can restore the 120 day period between being marked stale and being closed.

This is a follow-up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/15719, which will allow issue openers to easily add labels for issues without a component label with a CODEOWNERS file entry and notify the code owners if they think their issue is still relevant. Code owners can also add any labels they feel are relevant to their issue.

**Link to tracking Issue:**

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15684