### PR TITLE
[exporter/mezmo] Add self as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,7 +57,7 @@ exporter/kafkaexporter/                              @open-telemetry/collector-c
 exporter/loadbalancingexporter/                      @open-telemetry/collector-contrib-approvers @jpkrohling
 exporter/logzioexporter/                             @open-telemetry/collector-contrib-approvers @jkowall @Doron-Bargo @yotamloe
 exporter/lokiexporter/                               @open-telemetry/collector-contrib-approvers @gramidt @gouthamve @jpkrohling @kovrus @mar4uk
-exporter/mezmoexporter/                              @open-telemetry/collector-contrib-approvers @dashpole @billmeyer @gjanco
+exporter/mezmoexporter/                              @open-telemetry/collector-contrib-approvers @dashpole @billmeyer @gjanco @jsumners
 exporter/opencensusexporter/                         @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 exporter/parquetexporter/                            @open-telemetry/collector-contrib-approvers @atoulme
 exporter/prometheusexporter/                         @open-telemetry/collector-contrib-approvers @Aneurysm9


### PR DESCRIPTION
At @gjanco's request, this PR adds myself as a code owner on the Mezmo exporter. I assume a changelog entry is not necessary for this PR. If I am mistaken, let me know and I'll correct it.