### PR TITLE
[exporter/signalfxexporter] allow export of k8s.container.cpu_request and k8s.container.memory_request metrics

### DIFF
--- a/.chloggen/remove-excludes-for-k8s-requests-metrics-signalfx.yaml
+++ b/.chloggen/remove-excludes-for-k8s-requests-metrics-signalfx.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow 2 additional metrics to be included when exporting to SignalFx, k8s.container.cpu_request and k8s.container.memory_request.
+
+# One or more tracking issues related to the change
+issues: [16009]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -695,7 +695,7 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	require.NoError(t, err)
 
 	md := getMetrics(metrics)
-	require.Equal(t, 71, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, 69, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	dps := converter.MetricsToSignalFxV2(md)
 	require.Equal(t, 0, len(dps))
 }

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -118,7 +118,10 @@ exclude_metrics:
   - '!k8s.container.memory_limit'
   - '!k8s.container.cpu_limit'
 
+  # matches all container request metrics but k8s.container.cpu_request and k8s.container.memory_request
   - /^k8s\.container\..+_request$/
+  - '!k8s.container.memory_request'
+  - '!k8s.container.cpu_request'
 
   # matches any node condition but k8s.node.condition_ready
   - /^k8s\.node\.condition_.+$/

--- a/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
+++ b/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
@@ -102,16 +102,10 @@
     "k8s.hpa.desired_replicas": null
   },
   {
-    "k8s.container.cpu_request": null
-  },
-  {
     "k8s.container.ephemeral-storage_limit": null
   },
   {
     "k8s.container.ephemeral-storage_request": null
-  },
-  {
-    "k8s.container.memory_request": null
   },
   {
     "k8s.node.condition_memory_pressure": null


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:**
#16009 

**Testing:**
Unit tests changes.

**Documentation:**
N/A