### PR TITLE
[chore] [gh-actions] Ping code owners on labeled PRs and discussions

### DIFF
--- a/.github/workflows/ping-codeowners.yml
+++ b/.github/workflows/ping-codeowners.yml
@@ -7,7 +7,6 @@ on:
   discussion:
     types: [labeled]
 
-
 jobs:
   ping-owner:
     if: ${{ contains(github.event.label.name, 'cmd/') || contains(github.event.label.name, 'exporter/') || contains(github.event.label.name, 'extension/') || contains(github.event.label.name, 'pkg/') || contains(github.event.label.name, 'processor/') || contains(github.event.label.name, 'receiver/') }}


### PR DESCRIPTION
Currently we only ping code owner when issues are labeled, but would be super useful to have the same thing in PRs and discussions