### PR TITLE
[chore] [gh-actions] Ping code owners on labeled PRs and discussions

### DIFF
--- a/.github/workflows/ping-codeowners.yml
+++ b/.github/workflows/ping-codeowners.yml
@@ -2,6 +2,10 @@ name: 'Ping code owners'
 on:
   issues:
     types: [labeled]
+  pull_request:
+    types: [labeled]
+  discussion:
+    types: [labeled]
 
 jobs:
   ping-owner:


### PR DESCRIPTION
Currently we only ping code owner when issues are labeled, but would be super useful to have the same thing in PRs and discussions

@evan-bradley PTAL