### PR TITLE
[elasticexporter] Fix nil panic when setting custom headers

### DIFF
--- a/.chloggen/elasticexporter-fix-custom-header.yaml
+++ b/.chloggen/elasticexporter-fix-custom-header.yaml
@@ -8,7 +8,7 @@ component: elasticsearchexporter
 note: Fixed nil panic error when setting custom headers in elasticsearch exporter
 
 # One or more tracking issues related to the change
-issues: []
+issues: [16017]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/elasticexporter-fix-custom-header.yaml
+++ b/.chloggen/elasticexporter-fix-custom-header.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed nil panic error when setting custom headers in elasticsearch exporter
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/elasticsearchexporter/elasticsearch_bulk.go
+++ b/exporter/elasticsearchexporter/elasticsearch_bulk.go
@@ -84,7 +84,7 @@ func newElasticsearchClient(logger *zap.Logger, config *Config) (*esClientCurren
 
 	transport := newTransport(config, tlsCfg)
 
-	var headers http.Header
+	headers := make(http.Header)
 	for k, v := range config.Headers {
 		headers.Add(k, v)
 	}

--- a/exporter/elasticsearchexporter/logs_exporter_test.go
+++ b/exporter/elasticsearchexporter/logs_exporter_test.go
@@ -110,6 +110,15 @@ func TestExporter_New(t *testing.T) {
 			}),
 			want: failWithMessage("Addresses and CloudID are set"),
 		},
+		"create with custom request header": {
+			config: withDefaultConfig(func(cfg *Config) {
+				cfg.Endpoints = []string{"test:9200"}
+				cfg.Headers = map[string]string{
+					"foo": "bah",
+				}
+			}),
+			want: success,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
When setting custom headers in elasticexporter, such as:
```
  elasticsearch:
    endpoints: ['http://127.0.0.1:9211']
    logs_index: "example-index-01"
    headers:
      header-foo: bah
```

the latest version `0.63.0` throws the following panic:

```
panic: assignment to entry in nil map

goroutine 1 [running]:
net/textproto.MIMEHeader.Add(...)
	net/textproto/header.go:15
net/http.Header.Add(...)
	net/http/header.go:31
github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter.newElasticsearchClient(0x40009c53b0, 0x4001240000)
	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter@v0.63.0/elasticsearch_bulk.go:89 +0x138
github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter.newLogsExporter(0x40009c53b0, 0x4001240000)
	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter@v0.63.0/logs_exporter.go:49 +0x38
```
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Added the unittest `TestExporter_New/create_with_custom_request_header` to cover this fix.

**Documentation:** <Describe the documentation added.>