### PR TITLE
[proccessor/spanmetrics] Don't rely on [SpanKind|StatusCode].String

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -419,8 +419,8 @@ func (p *processorImp) buildDimensionKVs(serviceName string, span ptrace.Span, o
 	dims := pcommon.NewMap()
 	dims.PutStr(serviceNameKey, serviceName)
 	dims.PutStr(operationKey, span.Name())
-	dims.PutStr(spanKindKey, span.Kind().String())
-	dims.PutStr(statusCodeKey, span.Status().Code().String())
+	dims.PutStr(spanKindKey, spanKindStr(span.Kind()))
+	dims.PutStr(statusCodeKey, statusCodeStr(span.Status().Code()))
 	for _, d := range optionalDims {
 		if v, ok := getDimensionValue(d, span.Attributes(), resourceAttrs); ok {
 			v.CopyTo(dims.PutEmpty(d.Name))
@@ -491,6 +491,38 @@ func (p *processorImp) cache(serviceName string, span ptrace.Span, k metricKey, 
 	if _, has := p.metricKeyToDimensions.Get(k); !has {
 		p.metricKeyToDimensions.Add(k, p.buildDimensionKVs(serviceName, span, p.dimensions, resourceAttrs))
 	}
+}
+
+// spanKindStr returns the string representation of the SpanKind used as metric attribute value.
+func spanKindStr(sk ptrace.SpanKind) string {
+	switch sk {
+	case ptrace.SpanKindUnspecified:
+		return "SPAN_KIND_UNSPECIFIED"
+	case ptrace.SpanKindInternal:
+		return "SPAN_KIND_INTERNAL"
+	case ptrace.SpanKindServer:
+		return "SPAN_KIND_SERVER"
+	case ptrace.SpanKindClient:
+		return "SPAN_KIND_CLIENT"
+	case ptrace.SpanKindProducer:
+		return "SPAN_KIND_PRODUCER"
+	case ptrace.SpanKindConsumer:
+		return "SPAN_KIND_CONSUMER"
+	}
+	return ""
+}
+
+// statusCodeStr returns the string representation of the StatusCode used as metric attribute value.
+func statusCodeStr(sk ptrace.StatusCode) string {
+	switch sk {
+	case ptrace.StatusCodeUnset:
+		return "STATUS_CODE_UNSET"
+	case ptrace.StatusCodeOk:
+		return "STATUS_CODE_OK"
+	case ptrace.StatusCodeError:
+		return "STATUS_CODE_ERROR"
+	}
+	return ""
 }
 
 // copied from prometheus-go-metric-exporter


### PR DESCRIPTION
Don't use [SpanKind|StatusCode].String() for getting attribute values as the method will likely be changed. Define the attribute values in place.

This PR is one of prerequisites for updating output of the [SpanKind|StatusCode].String() method without breaking functionality of its consumers https://github.com/open-telemetry/opentelemetry-collector/pull/6250