### PR TITLE
[chore] spanmetricsprocessor: use generics for the cache implementation

### DIFF
--- a/processor/spanmetricsprocessor/internal/cache/cache_test.go
+++ b/processor/spanmetricsprocessor/internal/cache/cache_test.go
@@ -55,7 +55,7 @@ func TestNewCache(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := NewCache(tt.args.size)
+			_, err := NewCache[string, string](tt.args.size)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -68,16 +68,16 @@ func TestNewCache(t *testing.T) {
 func TestCache_Get(t *testing.T) {
 	tests := []struct {
 		name         string
-		lruCache     func() *Cache
-		evictedItems map[interface{}]interface{}
-		key          interface{}
-		wantValue    interface{}
+		lruCache     func() *Cache[string, string]
+		evictedItems map[string]string
+		key          string
+		wantValue    string
 		wantOk       bool
 	}{
 		{
 			name: "if key is not found in LRUCache, will get key from evictedItems",
-			lruCache: func() *Cache {
-				cache, _ := NewCache(1)
+			lruCache: func() *Cache[string, string] {
+				cache, _ := NewCache[string, string](1)
 				cache.evictedItems["key"] = "val"
 				return cache
 			},
@@ -87,8 +87,8 @@ func TestCache_Get(t *testing.T) {
 		},
 		{
 			name: "if key is found in LRUCache, return the found item",
-			lruCache: func() *Cache {
-				cache, _ := NewCache(1)
+			lruCache: func() *Cache[string, string] {
+				cache, _ := NewCache[string, string](1)
 				cache.Add("key", "val_from_LRU")
 				cache.evictedItems["key"] = "val_from_evicted_items"
 				return cache
@@ -99,12 +99,12 @@ func TestCache_Get(t *testing.T) {
 		},
 		{
 			name: "if key is not found either in LRUCache or evicted items, return nothing",
-			lruCache: func() *Cache {
-				cache, _ := NewCache(1)
+			lruCache: func() *Cache[string, string] {
+				cache, _ := NewCache[string, string](1)
 				return cache
 			},
 			key:       "key",
-			wantValue: nil,
+			wantValue: "",
 			wantOk:    false,
 		},
 	}
@@ -127,18 +127,18 @@ func TestCache_Get(t *testing.T) {
 func TestCache_RemoveEvictedItems(t *testing.T) {
 	tests := []struct {
 		name     string
-		lruCache func() (*Cache, error)
+		lruCache func() (*Cache[string, string], error)
 	}{
 		{
 			name: "no panic when there is no evicted item to remove",
-			lruCache: func() (*Cache, error) {
-				return NewCache(1)
+			lruCache: func() (*Cache[string, string], error) {
+				return NewCache[string, string](1)
 			},
 		},
 		{
 			name: "evicted items should be removed",
-			lruCache: func() (*Cache, error) {
-				cache, err := NewCache(1)
+			lruCache: func() (*Cache[string, string], error) {
+				cache, err := NewCache[string, string](1)
 				if err != nil {
 					return nil, err
 				}
@@ -163,18 +163,18 @@ func TestCache_RemoveEvictedItems(t *testing.T) {
 func TestCache_PurgeItems(t *testing.T) {
 	tests := []struct {
 		name     string
-		lruCache func() (*Cache, error)
+		lruCache func() (*Cache[string, string], error)
 	}{
 		{
 			name: "no panic when there is no item to remove",
-			lruCache: func() (*Cache, error) {
-				return NewCache(1)
+			lruCache: func() (*Cache[string, string], error) {
+				return NewCache[string, string](1)
 			},
 		},
 		{
 			name: "remove items from the lru cache",
-			lruCache: func() (*Cache, error) {
-				cache, err := NewCache(1)
+			lruCache: func() (*Cache[string, string], error) {
+				cache, err := NewCache[string, string](1)
 				if err != nil {
 					return nil, err
 				}
@@ -185,8 +185,8 @@ func TestCache_PurgeItems(t *testing.T) {
 		},
 		{
 			name: "remove all the items from lru cache and the evicted items",
-			lruCache: func() (*Cache, error) {
-				cache, err := NewCache(10)
+			lruCache: func() (*Cache[string, string], error) {
+				cache, err := NewCache[string, string](10)
 				if err != nil {
 					return nil, err
 				}

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -369,7 +369,7 @@ func BenchmarkProcessorConsumeTraces(b *testing.B) {
 func newProcessorImp(mexp *mocks.MetricsExporter, tcon *mocks.TracesConsumer, defaultNullValue *string, temporality string, logger *zap.Logger) *processorImp {
 	defaultNotInSpanAttrVal := "defaultNotInSpanAttrVal"
 	// use size 2 for LRU cache for testing purpose
-	metricKeyToDimensions, err := cache.NewCache(DimensionsCacheSize)
+	metricKeyToDimensions, err := cache.NewCache[metricKey, pcommon.Map](DimensionsCacheSize)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Avoid dealing with "interface{}" or "any" in the implementation, type safer.