### PR TITLE
[chore] Update the testbed to use 127.0.0.1 vs localhost or 0.0.0.0

### DIFF
--- a/testbed/datareceivers/carbon.go
+++ b/testbed/datareceivers/carbon.go
@@ -45,7 +45,7 @@ func NewCarbonDataReceiver(port int) *CarbonDataReceiver {
 
 // Start the receiver.
 func (cr *CarbonDataReceiver) Start(_ consumer.Traces, mc consumer.Metrics, _ consumer.Logs) error {
-	addr := fmt.Sprintf("localhost:%d", cr.Port)
+	addr := fmt.Sprintf("127.0.0.1:%d", cr.Port)
 	config := carbonreceiver.Config{
 		NetAddr: confignet.NetAddr{
 			Endpoint: addr,
@@ -74,7 +74,7 @@ func (cr *CarbonDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   carbon:
-    endpoint: "localhost:%d"`, cr.Port)
+    endpoint: "127.0.0.1:%d"`, cr.Port)
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.

--- a/testbed/datareceivers/jaeger.go
+++ b/testbed/datareceivers/jaeger.go
@@ -44,7 +44,7 @@ func (jr *jaegerDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics, _ co
 	factory := jaegerreceiver.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*jaegerreceiver.Config)
 	cfg.Protocols.GRPC = &configgrpc.GRPCServerSettings{
-		NetAddr: confignet.NetAddr{Endpoint: fmt.Sprintf("localhost:%d", jr.Port), Transport: "tcp"},
+		NetAddr: confignet.NetAddr{Endpoint: fmt.Sprintf("127.0.0.1:%d", jr.Port), Transport: "tcp"},
 	}
 	var err error
 	set := componenttest.NewNopReceiverCreateSettings()
@@ -64,7 +64,7 @@ func (jr *jaegerDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   jaeger:
-    endpoint: "localhost:%d"
+    endpoint: "127.0.0.1:%d"
     tls:
       insecure: true`, jr.Port)
 }

--- a/testbed/datareceivers/mockawsxraydatareceiver.go
+++ b/testbed/datareceivers/mockawsxraydatareceiver.go
@@ -63,7 +63,7 @@ func (ar *MockAwsXrayDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics,
 	}
 
 	mockDatareceiverCFG := mockawsxrayreceiver.Config{
-		Endpoint: fmt.Sprintf("localhost:%d", ar.Port),
+		Endpoint: fmt.Sprintf("127.0.0.1:%d", ar.Port),
 		TLSCredentials: &configtls.TLSSetting{
 			CertFile: "../mockdatareceivers/mockawsxrayreceiver/server.crt",
 			KeyFile:  "../mockdatareceivers/mockawsxrayreceiver/server.key",
@@ -87,7 +87,7 @@ func (ar *MockAwsXrayDataReceiver) GenConfigYAMLStr() string {
 	return fmt.Sprintf(`
   awsxray:
     local_mode: true
-    endpoint: localhost:%d
+    endpoint: 127.0.0.1:%d
     no_verify_ssl: true
     region: us-west-2`, ar.Port)
 }

--- a/testbed/datareceivers/opencensus.go
+++ b/testbed/datareceivers/opencensus.go
@@ -43,7 +43,7 @@ func NewOCDataReceiver(port int) testbed.DataReceiver {
 func (or *ocDataReceiver) Start(tc consumer.Traces, mc consumer.Metrics, _ consumer.Logs) error {
 	factory := opencensusreceiver.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*opencensusreceiver.Config)
-	cfg.NetAddr = confignet.NetAddr{Endpoint: fmt.Sprintf("localhost:%d", or.Port), Transport: "tcp"}
+	cfg.NetAddr = confignet.NetAddr{Endpoint: fmt.Sprintf("127.0.0.1:%d", or.Port), Transport: "tcp"}
 	var err error
 	set := componenttest.NewNopReceiverCreateSettings()
 	if or.traceReceiver, err = factory.CreateTracesReceiver(context.Background(), set, cfg, tc); err != nil {
@@ -69,7 +69,7 @@ func (or *ocDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   opencensus:
-    endpoint: "localhost:%d"
+    endpoint: "127.0.0.1:%d"
     tls:
       insecure: true`, or.Port)
 }

--- a/testbed/datareceivers/prometheus.go
+++ b/testbed/datareceivers/prometheus.go
@@ -42,7 +42,7 @@ func NewPrometheusDataReceiver(port int) testbed.DataReceiver {
 func (dr *prometheusDataReceiver) Start(_ consumer.Traces, mc consumer.Metrics, _ consumer.Logs) error {
 	factory := prometheusreceiver.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*prometheusreceiver.Config)
-	addr := fmt.Sprintf("0.0.0.0:%d", dr.Port)
+	addr := fmt.Sprintf("127.0.0.1:%d", dr.Port)
 	cfg.PrometheusConfig = &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{{
 			JobName:        "testbed-job",
@@ -77,7 +77,7 @@ func (dr *prometheusDataReceiver) Stop() error {
 func (dr *prometheusDataReceiver) GenConfigYAMLStr() string {
 	format := `
   prometheus:
-    endpoint: "localhost:%d"
+    endpoint: "127.0.0.1:%d"
 `
 	return fmt.Sprintf(format, dr.Port)
 }

--- a/testbed/datareceivers/sapm.go
+++ b/testbed/datareceivers/sapm.go
@@ -43,7 +43,7 @@ func NewSapmDataReceiver(port int) *SapmDataReceiver {
 func (sr *SapmDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics, _ consumer.Logs) error {
 	sapmCfg := sapmreceiver.Config{
 		HTTPServerSettings: confighttp.HTTPServerSettings{
-			Endpoint: fmt.Sprintf("localhost:%d", sr.Port),
+			Endpoint: fmt.Sprintf("127.0.0.1:%d", sr.Port),
 		},
 		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{AccessTokenPassthrough: true},
 	}
@@ -70,7 +70,7 @@ func (sr *SapmDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   sapm:
-    endpoint: "http://localhost:%d/v2/trace"
+    endpoint: "http://127.0.0.1:%d/v2/trace"
     disable_compression: true
     access_token_passthrough: true`, sr.Port)
 }

--- a/testbed/datareceivers/signalfx.go
+++ b/testbed/datareceivers/signalfx.go
@@ -46,7 +46,7 @@ func NewSFxMetricsDataReceiver(port int) *SFxMetricsDataReceiver {
 func (sr *SFxMetricsDataReceiver) Start(_ consumer.Traces, mc consumer.Metrics, _ consumer.Logs) error {
 	config := signalfxreceiver.Config{
 		HTTPServerSettings: confighttp.HTTPServerSettings{
-			Endpoint: fmt.Sprintf("localhost:%d", sr.Port),
+			Endpoint: fmt.Sprintf("127.0.0.1:%d", sr.Port),
 		},
 	}
 	var err error
@@ -69,8 +69,8 @@ func (sr *SFxMetricsDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
     signalfx:
-      ingest_url: "http://localhost:%d"
-      api_url: "http://localhost/"
+      ingest_url: "http://127.0.0.1:%d"
+      api_url: "http://127.0.0.1/"
       access_token: "access_token"`, sr.Port)
 }
 

--- a/testbed/datareceivers/splunk.go
+++ b/testbed/datareceivers/splunk.go
@@ -46,7 +46,7 @@ func NewSplunkHECDataReceiver(port int) *SplunkHECDataReceiver {
 func (sr *SplunkHECDataReceiver) Start(_ consumer.Traces, _ consumer.Metrics, lc consumer.Logs) error {
 	config := splunkhecreceiver.Config{
 		HTTPServerSettings: confighttp.HTTPServerSettings{
-			Endpoint: fmt.Sprintf("localhost:%d", sr.Port),
+			Endpoint: fmt.Sprintf("127.0.0.1:%d", sr.Port),
 		},
 	}
 	var err error
@@ -69,7 +69,7 @@ func (sr *SplunkHECDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
     splunk_hec:
-      endpoint: "http://localhost:%d"
+      endpoint: "http://127.0.0.1:%d"
       token: "token"`, sr.Port)
 }
 

--- a/testbed/datareceivers/zipkin.go
+++ b/testbed/datareceivers/zipkin.go
@@ -41,7 +41,7 @@ func NewZipkinDataReceiver(port int) testbed.DataReceiver {
 func (zr *zipkinDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics, _ consumer.Logs) error {
 	factory := zipkinreceiver.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*zipkinreceiver.Config)
-	cfg.Endpoint = fmt.Sprintf("localhost:%d", zr.Port)
+	cfg.Endpoint = fmt.Sprintf("127.0.0.1:%d", zr.Port)
 
 	set := componenttest.NewNopReceiverCreateSettings()
 	var err error
@@ -62,7 +62,7 @@ func (zr *zipkinDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   zipkin:
-    endpoint: http://localhost:%d/api/v2/spans
+    endpoint: http://127.0.0.1:%d/api/v2/spans
     format: json`, zr.Port)
 }
 

--- a/testbed/datasenders/fluent.go
+++ b/testbed/datasenders/fluent.go
@@ -168,7 +168,7 @@ func (f *FluentLogsForwarder) Flush() {
 func (f *FluentLogsForwarder) GenConfigYAMLStr() string {
 	return fmt.Sprintf(`
   fluentforward:
-    endpoint: localhost:%d`, f.Port)
+    endpoint: 127.0.0.1:%d`, f.Port)
 }
 
 func (f *FluentLogsForwarder) ProtocolName() string {

--- a/testbed/datasenders/signalfx.go
+++ b/testbed/datasenders/signalfx.go
@@ -53,7 +53,7 @@ func (sf *SFxMetricsDataSender) Start() error {
 	cfg := &signalfxexporter.Config{
 		ExporterSettings: config.NewExporterSettings(config.NewComponentID(factory.Type())),
 		IngestURL:        fmt.Sprintf("http://%s", sf.GetEndpoint()),
-		APIURL:           "http://localhost",
+		APIURL:           "http://127.0.0.1",
 		AccessToken:      "access_token",
 	}
 	params := componenttest.NewNopExporterCreateSettings()

--- a/testbed/datasenders/syslog.go
+++ b/testbed/datasenders/syslog.go
@@ -109,7 +109,7 @@ func (f *SyslogWriter) Send(lr plog.LogRecord) error {
 		sdid.WriteString(fmt.Sprintf("%s=\"%s\" ", k, v.Str()))
 		return true
 	})
-	msg := fmt.Sprintf("<166> %s localhost - - - [%s] %s\n", ts, sdid.String(), lr.Body().Str())
+	msg := fmt.Sprintf("<166> %s 127.0.0.1 - - - [%s] %s\n", ts, sdid.String(), lr.Body().Str())
 
 	f.buf = append(f.buf, msg)
 	return f.SendCheck()

--- a/testbed/datasenders/tcpudp.go
+++ b/testbed/datasenders/tcpudp.go
@@ -107,7 +107,7 @@ func (f *TCPUDPWriter) Send(lr plog.LogRecord) error {
 		sdid.WriteString(fmt.Sprintf("%s=\"%s\" ", k, v.Str()))
 		return true
 	})
-	msg := fmt.Sprintf("<166> %s localhost - - - [%s] %s\n", ts, sdid.String(), lr.Body().Str())
+	msg := fmt.Sprintf("<166> %s 127.0.0.1 - - - [%s] %s\n", ts, sdid.String(), lr.Body().Str())
 
 	f.buf = append(f.buf, msg)
 	return f.SendCheck()

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -69,10 +69,10 @@ func (bor *BaseOTLPDataReceiver) Start(tc consumer.Traces, mc consumer.Metrics, 
 	factory := otlpreceiver.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*otlpreceiver.Config)
 	if bor.exporterType == "otlp" {
-		cfg.GRPC.NetAddr = confignet.NetAddr{Endpoint: fmt.Sprintf("localhost:%d", bor.Port), Transport: "tcp"}
+		cfg.GRPC.NetAddr = confignet.NetAddr{Endpoint: fmt.Sprintf("127.0.0.1:%d", bor.Port), Transport: "tcp"}
 		cfg.HTTP = nil
 	} else {
-		cfg.HTTP.Endpoint = fmt.Sprintf("localhost:%d", bor.Port)
+		cfg.HTTP.Endpoint = fmt.Sprintf("127.0.0.1:%d", bor.Port)
 		cfg.GRPC = nil
 	}
 	var err error
@@ -116,7 +116,7 @@ func (bor *BaseOTLPDataReceiver) ProtocolName() string {
 }
 
 func (bor *BaseOTLPDataReceiver) GenConfigYAMLStr() string {
-	addr := fmt.Sprintf("localhost:%d", bor.Port)
+	addr := fmt.Sprintf("127.0.0.1:%d", bor.Port)
 	if bor.exporterType == "otlphttp" {
 		addr = "http://" + addr
 	}

--- a/testbed/tests/testdata/agent-config.yaml
+++ b/testbed/tests/testdata/agent-config.yaml
@@ -2,11 +2,11 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: "localhost:4317"
+        endpoint: "127.0.0.1:4317"
 
 exporters:
   otlp:
-    endpoint: "localhost:55680"
+    endpoint: "127.0.0.1:55680"
     tls:
       insecure: true
   logging:

--- a/testbed/tests/testdata/memory-limiter.yaml
+++ b/testbed/tests/testdata/memory-limiter.yaml
@@ -2,11 +2,11 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: "localhost:4317"
+        endpoint: "127.0.0.1:4317"
 
 exporters:
   otlp:
-    endpoint: "localhost:55680"
+    endpoint: "127.0.0.1:55680"
     tls:
       insecure: true
 


### PR DESCRIPTION
**Description:** 
There are many tests in `./testbed` that currently bind to `localhost` or `0.0.0.0`. This triggers firewalls unnecessarily. I believe that in tests, 127.0.0.1 is more correct.
