### PR TITLE
[chore] Automate creation of component labels

### DIFF
--- a/.github/workflows/generate-component-labels.yml
+++ b/.github/workflows/generate-component-labels.yml
@@ -6,6 +6,7 @@ on:
       - .github/CODEOWNERS
       - ./.github/workflows/generate-component-labels.yml
       - ./.github/workflows/scripts/generate-component-labels.sh
+    workflow_dispatch:
 
 jobs:
   generate-component-labels:

--- a/.github/workflows/generate-component-labels.yml
+++ b/.github/workflows/generate-component-labels.yml
@@ -1,7 +1,7 @@
 name: 'Generate component labels'
 on:
-  schedule:
-    - cron: "55 2 * * 1-5" # Run at a random time on weekdays
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Generate component labels
-        run: ./.github/workflows/scripts/generate-component-labels.sh
+        run: git diff --quiet HEAD~ HEAD -- .github/CODEOWNERS || ./.github/workflows/scripts/generate-component-labels.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/generate-component-labels.yml
+++ b/.github/workflows/generate-component-labels.yml
@@ -1,0 +1,17 @@
+name: 'Generate component labels'
+on:
+  schedule:
+    - cron: "55 2 * * 1-5" # Run at a random time on weekdays
+  workflow_dispatch:
+
+jobs:
+  generate-component-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Generate component labels
+        run: ./.github/workflows/scripts/generate-component-labels.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/generate-component-labels.yml
+++ b/.github/workflows/generate-component-labels.yml
@@ -2,7 +2,9 @@ name: 'Generate component labels'
 on:
   push:
     branches: [main]
-  workflow_dispatch:
+    paths:
+      - .github/CODEOWNERS
+      - ./.github/workflows/scripts/generate-component-labels.sh
 
 jobs:
   generate-component-labels:
@@ -11,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Generate component labels
-        run: git diff --quiet HEAD~ HEAD -- .github/CODEOWNERS || ./.github/workflows/scripts/generate-component-labels.sh
+        run: ./.github/workflows/scripts/generate-component-labels.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/generate-component-labels.yml
+++ b/.github/workflows/generate-component-labels.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
     paths:
       - .github/CODEOWNERS
+      - ./.github/workflows/generate-component-labels.yml
       - ./.github/workflows/scripts/generate-component-labels.sh
 
 jobs:

--- a/.github/workflows/scripts/generate-component-labels.sh
+++ b/.github/workflows/scripts/generate-component-labels.sh
@@ -17,22 +17,30 @@
 
 set -euo pipefail
 
-generate-labels() {
-	TYPE=$1
-	COLOR=$2
+declare -A COLORS
 
-	echo "Generating labels for ${TYPE}"
-	COMPONENTS=$(find "./${TYPE}" -maxdepth 1 -mindepth 1 -type d -exec basename \{\} \;)
-	for COMPONENT in ${COMPONENTS}; do
-		NAME=${COMPONENT//"${TYPE}"}
-		gh label create "${TYPE}/${NAME}" -c "${COLOR}" --force
-	done
-}
+COLORS["cmd"]="#483C32"
+COLORS["confmap"]="#6666FF"
+COLORS["examples"]="#1A8CFF"
+COLORS["exporter"]="#50C878"
+COLORS["extension"]="#FF794D"
+COLORS["internal"]="#B30059"
+COLORS["pkg"]="#F9DE22"
+COLORS["processor"]="#800080"
+COLORS["receiver"]="#E91B7B"
+COLORS["testbed"]="#336600"
 
-generate-labels "cmd" "#483C32"
-generate-labels "pkg" "#F9DE22"
-generate-labels "extension" "#FF794D"
-generate-labels "receiver" "#E91B7B"
-generate-labels "processor" "#800080"
-generate-labels "exporter" "#50C878"
+FALLBACK_COLOR="#999966"
+
+# Match only components with a type and name, i.e. no top-level
+# directories.
+COMPONENTS=$(grep -oE '^[a-z]+/[a-z/]+ ' < .github/CODEOWNERS)
+
+for COMPONENT in ${COMPONENTS}; do
+		COMPONENT=$(echo "${COMPONENT}" | sed -E 's%/$%%')
+		TYPE=$(echo "${COMPONENT}" | cut -f1 -d '/' )
+		NAME=$(echo "${COMPONENT}" | cut -f2- -d '/' | sed -E "s%${TYPE}\$%%")
+
+		gh label create "${TYPE}/${NAME}" -c "${COLORS["${TYPE}"]:-${FALLBACK_COLOR}}" --force
+done
 

--- a/.github/workflows/scripts/generate-component-labels.sh
+++ b/.github/workflows/scripts/generate-component-labels.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+#   Copyright The OpenTelemetry Authors.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+set -euo pipefail
+
+generate-labels() {
+	TYPE=$1
+	COLOR=$2
+
+	echo "Generating labels for ${TYPE}"
+	COMPONENTS=$(find "./${TYPE}" -maxdepth 1 -mindepth 1 -type d -exec basename \{\} \;)
+	for COMPONENT in ${COMPONENTS}; do
+		NAME=${COMPONENT//"${TYPE}"}
+		gh label create "${TYPE}/${NAME}" -c "${COLOR}" --force
+	done
+}
+
+generate-labels "cmd" "#483C32"
+generate-labels "pkg" "#F9DE22"
+generate-labels "extension" "#FF794D"
+generate-labels "receiver" "#E91B7B"
+generate-labels "processor" "#800080"
+generate-labels "exporter" "#50C878"
+

--- a/Makefile
+++ b/Makefile
@@ -395,29 +395,6 @@ clean:
 genconfigdocs:
 	cd cmd/configschema && $(GOCMD) run ./docsgen all
 
-.PHONY: generate-all-labels
-generate-all-labels:
-	$(MAKE) generate-labels TYPE="cmd" COLOR="#483C32"
-	$(MAKE) generate-labels TYPE="pkg" COLOR="#F9DE22"
-	$(MAKE) generate-labels TYPE="extension" COLOR="#FF794D"
-	$(MAKE) generate-labels TYPE="receiver" COLOR="#E91B7B"
-	$(MAKE) generate-labels TYPE="processor" COLOR="#800080"
-	$(MAKE) generate-labels TYPE="exporter" COLOR="#50C878"
-
-.PHONY: generate-labels
-generate-labels:
-	if [ -z $${TYPE+x} ] || [ -z $${COLOR+x} ]; then \
-		echo "Must provide a TYPE and COLOR"; \
-		exit 1; \
-	fi; \
-	echo "Generating labels for $${TYPE}" ; \
-	COMPONENTS=$$(find ./$${TYPE} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
-	for comp in $${COMPONENTS}; do \
-		NAME=$${comp//"$${TYPE}"}; \
-		gh label create "$${TYPE}/$${NAME}" -c "$${COLOR}"; \
-	done; \
-	exit 0
-
 .PHONY: generate-gh-issue-templates
 generate-gh-issue-templates:
 	for FILE in bug_report feature_request other; do \


### PR DESCRIPTION
**Description:**

This generates all component labels through a workflow that runs on weekdays.

Calling the Make target invoked `go list` as part of evaluating the Makefile and triggered downloading dependencies, so I moved it to run in a workflow script and made it so the workflow can be manually triggered if needed.

**Testing:**

I tested this on my personal fork. The generated labels in the script are identical to those produced by the Make target.