### PR TITLE
[pkg/ottl] Standardize trace/span access

### DIFF
--- a/.chloggen/ottl-improve-docs.yaml
+++ b/.chloggen/ottl-improve-docs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `parent_span_id.string` accessor.
+
+# One or more tracking issues related to the change
+issues: [16041]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/contexts/internal/ottlcommon/span_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/span_test.go
@@ -155,6 +155,22 @@ func TestSpanPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "parent_span_id string",
+			path: []ottl.Field{
+				{
+					Name: "parent_span_id",
+				},
+				{
+					Name: "string",
+				},
+			},
+			orig:   hex.EncodeToString(spanID2[:]),
+			newVal: hex.EncodeToString(spanID[:]),
+			modified: func(span ptrace.Span) {
+				span.SetParentSpanID(spanID)
+			},
+		},
+		{
 			name: "name",
 			path: []ottl.Field{
 				{

--- a/pkg/ottl/contexts/ottllogs/README.md
+++ b/pkg/ottl/contexts/ottllogs/README.md
@@ -5,6 +5,8 @@ The Logs Context is a Context implementation for [pdata Logs](https://github.com
 ## Paths
 In general, the Logs Context supports accessing pdata using the field names from the [logs proto](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto).  All integers are returned and set via `int64`.  All doubles are returned and set via `float64`.
 
+All TraceIDs and SpanIDs are returned as pdata [SpanID](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/pcommon/spanid.go) and [TraceID](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/pcommon/traceid.go) types.  Use the [SpanID function](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#spanid) and [TraceID function](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#traceid) when interacting with pdata representations of SpanID and TraceID.  When checking for nil, instead check against an empty byte slice (`SpanID(0x0000000000000000)` and `TraceID(0x00000000000000000000000000000000)`).
+
 The following fields are the exception.
 
 | path                                           | field accessed                                                                       | type                                                                    |
@@ -21,7 +23,9 @@ The following fields are the exception.
 | instrumentation_scope.attributes\[""\]         | the value of the instrumentation scope attribute of the data point being processed   | string, bool, int64, float64, pcommon.Map, pcommon.Slice, []byte or nil |
 | attributes                                     | attributes of the log being processed                                                | pcommon.Map                                                             |
 | attributes\[""\]                               | the value of the attribute of the log being processed                                | string, bool, int64, float64, pcommon.Map, pcommon.Slice, []byte or nil |
+| trace_id                                       | a byte slice representation of the trace id                                          | pcommon.TraceID                                                         |
 | trace_id.string                                | a string representation of the trace id                                              | string                                                                  |
+| span_id                                        | a byte slice representation of the span id                                           | pcommon.SpanID                                                          |
 | span_id.string                                 | a string representation of the span id                                               | string                                                                  |
 
 ## Enums

--- a/pkg/ottl/contexts/ottltraces/README.md
+++ b/pkg/ottl/contexts/ottltraces/README.md
@@ -5,6 +5,8 @@ The Traces Context is a Context implementation for [pdata Traces](https://github
 ## Paths
 In general, the Traces Context supports accessing pdata using the field names from the [traces proto](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto).  All integers are returned and set via `int64`.  All doubles are returned and set via `float64`.
 
+All TraceIDs and SpanIDs are returned as pdata [SpanID](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/pcommon/spanid.go) and [TraceID](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/pcommon/traceid.go) types.  Use the [SpanID function](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#spanid) and [TraceID function](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#traceid) when interacting with pdata representations of SpanID and TraceID.  When checking for nil, instead check against an empty byte slice (`SpanID(0x0000000000000000)` and `TraceID(0x00000000000000000000000000000000)`).  
+
 The following fields are the exception.
 
 | path                                           | field accessed                                                                        | type                                                                    |
@@ -21,11 +23,16 @@ The following fields are the exception.
 | instrumentation_scope.attributes\[""\]         | the value of the instrumentation scope attribute of the span being processed          | string, bool, int64, float64, pcommon.Map, pcommon.Slice, []byte or nil |
 | attributes                                     | attributes of the span being processed                                                | pcommon.Map                                                             |
 | attributes\[""\]                               | the value of the attribute of the span being processed                                | string, bool, int64, float64, pcommon.Map, pcommon.Slice, []byte or nil |
+| trace_id                                       | a byte slice representation of the trace id                                           | pcommon.TraceID                                                         |
 | trace_id.string                                | a string representation of the trace id                                               | string                                                                  |
+| span_id                                        | a byte slice representation of the span id                                            | pcommon.SpanID                                                          |
 | span_id.string                                 | a string representation of the span id                                                | string                                                                  |
+| parent_span_id                                 | a byte slice representation of the parent span id                                     | pcommon.SpanID                                                          |
+| parent_span_id.string                          | a string representation of the parent span id                                         | string                                                                  |
 | trace_state\[""\]                              | an individual entry in the trace state                                                | string                                                                  |
 | status.code                                    | the status code of the span being processed                                           | int64                                                                   |
 | status.message                                 | the status message of the span being processed                                        | string                                                                  |
+
 ## Enums
 
 The Traces Context supports the enum names from the traces proto.

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -234,6 +234,12 @@ func TestProcess(t *testing.T) {
 			statement: `set(attributes["test"], Split(attributes["not_exist"], "|"))`,
 			want:      func(td ptrace.Traces) {},
 		},
+		{
+			statement: `set(attributes["entrypoint"], name) where parent_span_id == SpanID(0x0000000000000000)`,
+			want: func(td ptrace.Traces) {
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Attributes().PutStr("entrypoint", "operationB")
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:** 
Updates the span accessor to allow Get and Set of the parent_span_id via a string.  Also updates the trace_id and span_id documentation to make it clearer how these types of fields should be interacted with.

**Testing:** 
Added new unit test

**Documentation:**
Updated documentation