### PR TITLE
[receiver/prometheusreceiver] make assertMetricPresent to fail if metric is not present

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -370,36 +370,40 @@ func doCompare(t *testing.T, name string, want pcommon.Map, got pmetric.Resource
 func assertMetricPresent(name string, metricTypeExpectations metricTypeComparator, dataPointExpectations []dataPointExpectation) testExpectation {
 	return func(t *testing.T, rm pmetric.ResourceMetrics) {
 		allMetrics := getMetrics(rm)
+		var present bool
 		for _, m := range allMetrics {
 			if name != m.Name() {
 				continue
 			}
+
+			present = true
 			metricTypeExpectations(t, m)
 			for i, de := range dataPointExpectations {
 				switch m.Type() {
 				case pmetric.MetricTypeGauge:
 					for _, npc := range de.numberPointComparator {
-						require.Equal(t, m.Gauge().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Gauge metric does not match to testdata")
+						require.Equal(t, m.Gauge().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Gauge metric '%s' does not match to testdata", name)
 						npc(t, m.Gauge().DataPoints().At(i))
 					}
 				case pmetric.MetricTypeSum:
 					for _, npc := range de.numberPointComparator {
-						require.Equal(t, m.Sum().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Sum metric does not match to testdata")
+						require.Equal(t, m.Sum().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Sum metric '%s' does not match to testdata", name)
 						npc(t, m.Sum().DataPoints().At(i))
 					}
 				case pmetric.MetricTypeHistogram:
 					for _, hpc := range de.histogramPointComparator {
-						require.Equal(t, m.Histogram().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Histogram metric does not match to testdata")
+						require.Equal(t, m.Histogram().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Histogram metric '%s' does not match to testdata", name)
 						hpc(t, m.Histogram().DataPoints().At(i))
 					}
 				case pmetric.MetricTypeSummary:
 					for _, spc := range de.summaryPointComparator {
-						require.Equal(t, m.Summary().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Summary metric does not match to testdata")
+						require.Equal(t, m.Summary().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Summary metric '%s' does not match to testdata", name)
 						spc(t, m.Summary().DataPoints().At(i))
 					}
 				}
 			}
 		}
+		require.True(t, present, "expected metric '%s' is not present", name)
 	}
 }
 

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -324,11 +324,11 @@ go_threads 18
 # HELP http_request_duration_seconds A histogram of the request duration.
 # TYPE http_request_duration_seconds histogram
 http_request_duration_seconds_bucket{method="post",code="200",le="1"} 8
-http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 2
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 10
 http_request_duration_seconds_sum{method="post",code="200"} 7
 http_request_duration_seconds_count{method="post",code="200"} 10
 http_request_duration_seconds_bucket{method="post",code="400",le="1"} 30
-http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 20
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 50
 http_request_duration_seconds_sum{method="post",code="400"} 25
 http_request_duration_seconds_count{method="post",code="400"} 50
 
@@ -355,15 +355,15 @@ go_threads 16
 # HELP http_request_duration_seconds A histogram of the request duration.
 # TYPE http_request_duration_seconds histogram
 http_request_duration_seconds_bucket{method="post",code="200",le="1"} 40
-http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 10
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 50
 http_request_duration_seconds_sum{method="post",code="200"} 43
 http_request_duration_seconds_count{method="post",code="200"} 50
 http_request_duration_seconds_bucket{method="post",code="300",le="1"} 3
-http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 0
+http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 3
 http_request_duration_seconds_sum{method="post",code="300"} 2
 http_request_duration_seconds_count{method="post",code="300"} 3
 http_request_duration_seconds_bucket{method="post",code="400",le="1"} 35
-http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 25
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 60
 http_request_duration_seconds_sum{method="post",code="400"} 30
 http_request_duration_seconds_count{method="post",code="400"} 60
 
@@ -394,15 +394,15 @@ go_threads 16
 # HELP http_request_duration_seconds A histogram of the request duration.
 # TYPE http_request_duration_seconds histogram
 http_request_duration_seconds_bucket{method="post",code="200",le="1"} 40
-http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 10
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 50
 http_request_duration_seconds_sum{method="post",code="200"} 43
 http_request_duration_seconds_count{method="post",code="200"} 50
 http_request_duration_seconds_bucket{method="post",code="300",le="1"} 3
-http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 2
+http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 5
 http_request_duration_seconds_sum{method="post",code="300"} 7
 http_request_duration_seconds_count{method="post",code="300"} 5
 http_request_duration_seconds_bucket{method="post",code="400",le="1"} 35
-http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 25
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 60
 http_request_duration_seconds_sum{method="post",code="400"} 30
 http_request_duration_seconds_count{method="post",code="400"} 60
 
@@ -433,15 +433,15 @@ go_threads 16
 # HELP http_request_duration_seconds A histogram of the request duration.
 # TYPE http_request_duration_seconds histogram
 http_request_duration_seconds_bucket{method="post",code="200",le="1"} 40
-http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 9
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 49
 http_request_duration_seconds_sum{method="post",code="200"} 42
 http_request_duration_seconds_count{method="post",code="200"} 49
 http_request_duration_seconds_bucket{method="post",code="300",le="1"} 2
-http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 1
+http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 3
 http_request_duration_seconds_sum{method="post",code="300"} 4
 http_request_duration_seconds_count{method="post",code="300"} 3
 http_request_duration_seconds_bucket{method="post",code="400",le="1"} 34
-http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 25
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 59
 http_request_duration_seconds_sum{method="post",code="400"} 29
 http_request_duration_seconds_count{method="post",code="400"} 59
 
@@ -472,15 +472,15 @@ go_threads 16
 # HELP http_request_duration_seconds A histogram of the request duration.
 # TYPE http_request_duration_seconds histogram
 http_request_duration_seconds_bucket{method="post",code="200",le="1"} 41
-http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 9
+http_request_duration_seconds_bucket{method="post",code="200",le="+Inf"} 50
 http_request_duration_seconds_sum{method="post",code="200"} 43
 http_request_duration_seconds_count{method="post",code="200"} 50
 http_request_duration_seconds_bucket{method="post",code="300",le="1"} 4
-http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 1
+http_request_duration_seconds_bucket{method="post",code="300",le="+Inf"} 5
 http_request_duration_seconds_sum{method="post",code="300"} 4
 http_request_duration_seconds_count{method="post",code="300"} 5
 http_request_duration_seconds_bucket{method="post",code="400",le="1"} 34
-http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 25
+http_request_duration_seconds_bucket{method="post",code="400",le="+Inf"} 59
 http_request_duration_seconds_sum{method="post",code="400"} 29
 http_request_duration_seconds_count{method="post",code="400"} 59
 
@@ -524,7 +524,7 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 					},
 				},
 			}),
-		assertMetricPresent("http_request_duration_seconds_bucket",
+		assertMetricPresent("http_request_duration_seconds",
 			compareMetricType(pmetric.MetricTypeHistogram),
 			[]dataPointExpectation{
 				{
@@ -604,7 +604,7 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 					},
 				},
 			}),
-		assertMetricPresent("http_request_duration_seconds_bucket",
+		assertMetricPresent("http_request_duration_seconds",
 			compareMetricType(pmetric.MetricTypeHistogram),
 			[]dataPointExpectation{
 				{
@@ -708,7 +708,7 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 					},
 				},
 			}),
-		assertMetricPresent("http_request_duration_seconds_bucket",
+		assertMetricPresent("http_request_duration_seconds",
 			compareMetricType(pmetric.MetricTypeHistogram),
 			[]dataPointExpectation{
 				{
@@ -812,7 +812,7 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 					},
 				},
 			}),
-		assertMetricPresent("http_request_duration_seconds_bucket",
+		assertMetricPresent("http_request_duration_seconds",
 			compareMetricType(pmetric.MetricTypeHistogram),
 			[]dataPointExpectation{
 				{
@@ -916,7 +916,7 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 					},
 				},
 			}),
-		assertMetricPresent("http_request_duration_seconds_bucket",
+		assertMetricPresent("http_request_duration_seconds",
 			compareMetricType(pmetric.MetricTypeHistogram),
 			[]dataPointExpectation{
 				{
@@ -1216,7 +1216,7 @@ func verifyTarget4(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 					},
 				},
 			}),
-		assertMetricPresent("foo_info",
+		assertMetricPresent("foo_total",
 			compareMetricIsMonotonic(true),
 			[]dataPointExpectation{
 				{

--- a/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
+++ b/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
@@ -415,7 +415,7 @@ func verifyRenameLabelKeepAction(t *testing.T, td *testData, resourceMetrics []p
 					},
 				},
 			}),
-		assertMetricPresent(" Redis connected clients",
+		assertMetricPresent("redis_http_requests_total",
 			compareMetricType(pmetric.MetricTypeSum),
 			[]dataPointExpectation{
 				{
@@ -433,7 +433,7 @@ func verifyRenameLabelKeepAction(t *testing.T, td *testData, resourceMetrics []p
 					},
 				},
 			}),
-		assertMetricPresent("RPC clients",
+		assertMetricPresent("rpc_duration_total",
 			compareMetricType(pmetric.MetricTypeSum),
 			[]dataPointExpectation{
 				{


### PR DESCRIPTION
**Description:** Prometheus receiver test helper function `assertMetricPresent` was not correctly asserting that a metric was present, leading to incorrect tests that were never checked.

Some of the tests had incorrect metric names, and was not using cumulative histograms.

**Testing:** unit tests and update existing wrong tests.