### PR TITLE
[pkg/stanza] Skip active file moving tests on windows

### DIFF
--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -35,7 +35,6 @@ const windowsOS = "windows"
 func TestMultiFileRotate(t *testing.T) {
 	if runtime.GOOS == windowsOS {
 		// Windows has very poor support for moving active files, so rotation is less commonly used
-		// This may possibly be handled better in Go 1.16: https://github.com/golang/go/issues/35358
 		t.Skip()
 	}
 	t.Parallel()
@@ -94,7 +93,6 @@ func TestMultiFileRotate(t *testing.T) {
 func TestMultiFileRotateSlow(t *testing.T) {
 	if runtime.GOOS == windowsOS {
 		// Windows has very poor support for moving active files, so rotation is less commonly used
-		// This may possibly be handled better in Go 1.16: https://github.com/golang/go/issues/35358
 		t.Skip()
 	}
 
@@ -347,7 +345,6 @@ func TestRotation(t *testing.T) {
 	for _, tc := range cases {
 		if runtime.GOOS != windowsOS {
 			// Windows has very poor support for moving active files, so rotation is less commonly used
-			// This may possibly be handled better in Go 1.16: https://github.com/golang/go/issues/35358
 			t.Run(fmt.Sprintf("%s/MoveCreateTimestamped", tc.name), tc.run(tc, false, false))
 			t.Run(fmt.Sprintf("%s/MoveCreateSequential", tc.name), tc.run(tc, false, true))
 		}

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -141,20 +142,25 @@ func TestReadRotatingFiles(t *testing.T) {
 			sequential:   false,
 		},
 		{
-			name:         "MoveCreateTimestamped",
-			copyTruncate: false,
-			sequential:   false,
-		},
-		{
 			name:         "CopyTruncateSequential",
 			copyTruncate: true,
 			sequential:   true,
 		},
-		{
-			name:         "MoveCreateSequential",
-			copyTruncate: false,
-			sequential:   true,
-		},
+	}
+	if runtime.GOOS != "windows" {
+		// Windows has very poor support for moving active files, so rotation is less commonly used
+		tests = append(tests, []rotationTest{
+			{
+				name:         "MoveCreateTimestamped",
+				copyTruncate: false,
+				sequential:   false,
+			},
+			{
+				name:         "MoveCreateSequential",
+				copyTruncate: false,
+				sequential:   true,
+			},
+		}...)
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This change aligns the flaky `filelog` test with other tests in the underlying `fileconsumer` package.

Resolves #12982 