### PR TITLE
Bump kentaro-m/auto-assign-action from 1.2.3 to 1.2.4

### DIFF
--- a/.github/workflows/auto-assign-owners.yml
+++ b/.github/workflows/auto-assign-owners.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: run
-        uses: kentaro-m/auto-assign-action@v1.2.3
+        uses: kentaro-m/auto-assign-action@v1.2.4
         with:
           configuration-path: ".github/auto_assign.yml"
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/auto-assign-owners.yml
+++ b/.github/workflows/auto-assign-owners.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: run
-        uses: kentaro-m/auto-assign-action@v1.2.4
+        uses: kentaro-m/auto-assign-action@v1
         with:
           configuration-path: ".github/auto_assign.yml"
           repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Replaces #15088 since CI won't run for dependabot-created PRs
