### PR TITLE
[pkg/ottl] Remove incorrect entry in docs

### DIFF
--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -6,7 +6,6 @@ Factory Functions
 - [Concat](#concat)
 - [Int](#int)
 - [IsMatch](#ismatch)
-- [Join](#join)
 - [SpanID](#spanid)
 - [Split](#split)
 - [TraceID](#traceid)


### PR DESCRIPTION
**Description:**
Removes `Join` from the functions table of contents since `Join` was renamed to `Concat`.