### PR TITLE
[receiver/kubelet] Return an error if metadata containerID is empty

### DIFF
--- a/.chloggen/kubeletstats-receiver.yaml
+++ b/.chloggen/kubeletstats-receiver.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kubeletstatsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: return an error if metadata containerID is empty and log a warning message
+
+# One or more tracking issues related to the change
+issues: [16061]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The kubelet apiserver /pod metadata endpoint might not have the containerID set for newly created containers.
+  Mark these datapoints as failed and don't process them. The issue should be resolved on the nexy poll.
+        
+

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
@@ -174,6 +174,28 @@ func TestSetExtraLabels(t *testing.T) {
 			wantError: "pod \"uid-1234\" with container \"container1\" not found in the fetched metadata",
 		},
 		{
+			name: "set_container_id_is_empty",
+			metadata: NewMetadata([]MetadataLabel{MetadataLabelContainerID}, &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							UID: "uid-1234",
+						},
+						Status: v1.PodStatus{
+							ContainerStatuses: []v1.ContainerStatus{
+								{
+									Name:        "container1",
+									ContainerID: "",
+								},
+							},
+						},
+					},
+				},
+			}, nil),
+			args:      []string{"uid-1234", "container.id", "container1"},
+			wantError: "pod \"uid-1234\" with container \"container1\" has an empty containerID",
+		},
+		{
 			name:      "set_volume_type_no_metadata",
 			metadata:  NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, nil, nil),
 			args:      []string{"uid-1234", "k8s.volume.type", "volume0"},


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

**Description:** 
For newly created containers, the apiserver `/pod` endpoint might not have the `containerID` field set.
example:
```
Resource attributes:
     -> cloud.account.id: Str(906383545488)
     -> cloud.availability_zone: Str(us-west-1a)
     -> cloud.platform: Str(aws_ec2)
     -> cloud.provider: Str(aws)
     -> cloud.region: Str(us-west-1)
     -> container.id: Str()
     -> host.id: Str(i-0b108c6dca31b4831)
     -> host.image.id: Str(ami-0049dbc6bb50b032f)
     -> host.name: Str(ip-10-0-248-113.us-west-1.compute.internal)
     -> host.type: Str(m6i.2xlarge)
     -> k8s.cluster.name: Str(containeridtestcluster)
     -> k8s.container.name: Str(pods-complex-9)
     -> k8s.namespace.name: Str(default)
     -> k8s.node.name: Str(ip-10-0-248-113.us-west-1.compute.internal)
     -> k8s.pod.name: Str(pods-complex-9)
     -> k8s.pod.uid: Str(76af9496-7cd7-46c6-885a-dc8c6238cf36)
     -> os.type: Str(linux)
ScopeMetrics #0
ScopeMetrics SchemaURL:
InstrumentationScope otelcol/kubeletstatsreceiver v0.62.0
Metric #0
Descriptor:
     -> Name: container.cpu.time
     -> Description: Container CPU time
     -> Unit: s
     -> DataType: Sum
     -> IsMonotonic: true
```
This causes an issue where user will end up with 2 MTSes.

This fix checks if the containerID is empty, return an error which will log a warning

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
added a unit test and validated that I can no longer repro the problem

**Documentation:** <Describe the documentation added.>