### PR TITLE
[receiver/zipkinreceiver] Fix Zipkin V1 receiver creating invalid timestamps

### DIFF
--- a/.chloggen/fix-zipkin-v1.yaml
+++ b/.chloggen/fix-zipkin-v1.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: zipkinreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix invalid timestamps when using Zipkin V1 receiver
+
+# One or more tracking issues related to the change
+issues: [15720]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/translator/zipkin/zipkinv1/json.go
+++ b/pkg/translator/zipkin/zipkinv1/json.go
@@ -359,7 +359,7 @@ func epochMicrosecondsToTimestamp(msecs int64) pcommon.Timestamp {
 	if msecs <= 0 {
 		return pcommon.Timestamp(0)
 	}
-	return pcommon.Timestamp(uint64(msecs) * 1e6)
+	return pcommon.Timestamp(uint64(msecs) * 1e3)
 }
 
 func getOrCreateNodeRequest(m map[string]ptrace.SpanSlice, td ptrace.Traces, endpoint *endpoint) ptrace.SpanSlice {

--- a/pkg/translator/zipkin/zipkinv1/json_test.go
+++ b/pkg/translator/zipkin/zipkinv1/json_test.go
@@ -490,6 +490,29 @@ func TestSpanWithoutTimestampGetsTag(t *testing.T) {
 	assert.EqualValues(t, wantAttributes, gs.Attributes())
 }
 
+func TestSpanWithTimestamp(t *testing.T) {
+	timestampMicroseconds := int64(1667492727795000)
+	timestamp := pcommon.NewTimestampFromTime(time.UnixMicro(timestampMicroseconds))
+
+	fakeTraceID := "00000000000000010000000000000002"
+	fakeSpanID := "0000000000000001"
+	zSpans := []*jsonSpan{
+		{
+			ID:        fakeSpanID,
+			TraceID:   fakeTraceID,
+			Timestamp: timestampMicroseconds,
+		},
+	}
+	zBytes, err := json.Marshal(zSpans)
+	require.NoError(t, err)
+
+	td, err := jsonBatchToTraces(zBytes, false)
+	require.NoError(t, err)
+
+	gs := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, timestamp, gs.StartTimestamp())
+}
+
 func TestJSONHTTPToStatusCode(t *testing.T) {
 	fakeTraceID := "00000000000000010000000000000002"
 	fakeSpanID := "0000000000000001"


### PR DESCRIPTION
I think this issue was introduced in d31a5c3f446fa1c5beec5381e923c9ff470ba632.

I [noticed a memory leak][1] in DataDog exporter but after a lot of debugging, it turned out that the OpenTelemetry gateway was receiving invalid timestamps:

```
ScopeSpans #0
ScopeSpans SchemaURL:
InstrumentationScope
Span #0
    Trace ID       : 0000000000000000c20a2b82c179228a
    Parent ID      :
    ID             : 7c3415ed370f1777
    Name           : [redacted]
    Kind           : SPAN_KIND_SERVER
    Start time     : 2200-11-16 22:32:41.14035456 +0000 UTC
    End time       : 2200-11-16 22:33:02.68735456 +0000 UTC
```

The year is almost 100 years in the future.

Before we send a span to the gateway, it goes through an OpenTelemetry collector sidecar. We use Zipkin V1 endpoint to send the spans to the sidecar.

In the same pod, we're also using Zipkin V2 which did not have any issues.

The problem itself: zipkin uses microseconds. This has to be multipled with 1e3 to get nanoseconds, not with 1e6.

[1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15720