### PR TITLE
[chore] Refactor CI scripts that ping code owners

### DIFF
--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -27,16 +27,17 @@ fi
 
 # grep exits with status code 1 if there are no matches,
 # so we manually set RESULT to 0 if nothing is found.
-RESULT=`grep -c "${COMPONENT}" .github/CODEOWNERS || true`
+RESULT=$(grep -c "${COMPONENT}" .github/CODEOWNERS || true)
 
 # there may be more than 1 component matching a label
 # if so, try to narrow things down by appending the component
 # type to the label
 if [[ ${RESULT} != 1 ]]; then
-    COMPONENT_TYPE=`echo "${COMPONENT}" | cut -f 1 -d '/'`
+    COMPONENT_TYPE=$(echo "${COMPONENT}" | cut -f 1 -d '/')
     COMPONENT="${COMPONENT}${COMPONENT_TYPE}"
 fi
 
-OWNERS=`(grep -m 1 "${COMPONENT}" .github/CODEOWNERS || true) | sed 's/   */ /g' | cut -f3- -d ' '`
+OWNERS=$( (grep -m 1 "${COMPONENT}" .github/CODEOWNERS || true) | sed 's/   */ /g' | cut -f3- -d ' ' )
 
 echo "${OWNERS}"
+

--- a/.github/workflows/scripts/mark-issues-as-stale.sh
+++ b/.github/workflows/scripts/mark-issues-as-stale.sh
@@ -28,67 +28,54 @@
 
 set -euo pipefail
 
-if [[ -z ${DAYS_BEFORE_STALE} || -z ${DAYS_BEFORE_CLOSE} || -z ${STALE_LABEL} || -z ${EXEMPT_LABEL} ]]; then
+if [[ -z ${DAYS_BEFORE_STALE:-} || -z ${DAYS_BEFORE_CLOSE:-} || -z ${STALE_LABEL:-} || -z ${EXEMPT_LABEL:-} ]]; then
     echo "At least one of DAYS_BEFORE_STALE, DAYS_BEFORE_CLOSE, STALE_LABEL, or EXEMPT_LABEL has not been set, please ensure each is set."
     exit 0
 fi
 
+CUR_DIRECTORY=$(dirname "$0")
 STALE_MESSAGE="This issue has been inactive for ${DAYS_BEFORE_STALE} days. It will be closed in ${DAYS_BEFORE_CLOSE} days if there is no activity. To ping code owners by adding a component label, see [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments), or if you are unsure of which component this issue relates to, please ping \`@open-telemetry/collector-contrib-triagers\`. If this issue is still relevant, please ping the code owners or leave a comment explaining why it is still relevant. Otherwise, please close it."
 
 # Check for the least recently-updated issues that aren't currently stale.
 # If no issues in this list are stale, the repo has no stale issues.
-ISSUES=(`gh issue list --limit 100 --search "is:issue is:open -label:${STALE_LABEL} -label:\"${EXEMPT_LABEL}\" sort:updated-asc" --json number --jq '.[].number'`)
+ISSUES=$(gh issue list --limit 100 --search "is:issue is:open -label:\"${STALE_LABEL}\" -label:\"${EXEMPT_LABEL}\" sort:updated-asc" --json number --jq '.[].number')
 
-for ISSUE in "${ISSUES[@]}"; do
-    OWNER_PINGS=''
+for ISSUE in ${ISSUES}; do
+    OWNER_MENTIONS=''
 
-    UPDATED_AT=`gh issue view ${ISSUE} --json updatedAt --jq '.updatedAt'`
-    UPDATED_UNIX=`date +%s --date="${UPDATED_AT}"`
-    NOW=`date +%s`
-    DIFF_DAYS=$(($((${NOW}-${UPDATED_UNIX}))/(3600*24)))    
+    UPDATED_AT=$(gh issue view "${ISSUE}" --json updatedAt --jq '.updatedAt')
+    UPDATED_UNIX=$(date +%s --date="${UPDATED_AT}")
+    NOW=$(date +%s)
+    DIFF_DAYS=$(((NOW-UPDATED_UNIX)/(3600*24)))
 
-    if [[ ${DIFF_DAYS} < ${DAYS_BEFORE_STALE} ]]; then
-        # echo "Issue #${ISSUE} is not stale. Issues are sorted by updated date in ascending order, so all remaining issues must not be stale. Exiting."
+    if (( DIFF_DAYS < DAYS_BEFORE_STALE )); then
+        echo "Issue #${ISSUE} is not stale. Issues are sorted by updated date in ascending order, so all remaining issues must not be stale. Exiting."
         exit 0
     fi
 
-    LABELS=(`gh issue view ${ISSUE} --json labels --jq '.labels.[].name'`)
+    LABELS=$(gh issue view "${ISSUE}" --json labels --jq '.labels.[].name')
 
-    for LABEL in "${LABELS[@]}"; do
-        if ! [[ ${LABEL} =~ ^cmd/ || ${LABEL} =~ ^confmap/ || ${LABEL} =~ ^exporter/ || ${LABEL} =~ ^extension/ || ${LABEL} =~ ^internal/ || ${LABEL} =~ ^pkg/ || ${LABEL} =~ ^processor/ || ${LABEL} =~ ^receiver/ ]]; then
-            continue
-        fi
-
-        COMPONENT=${LABEL}
-        result=`grep -c ${LABEL} .github/CODEOWNERS || true`
-
-        # there may be more than 1 component matching a label
-        # if so, try to narrow things down by appending the component
-        # type to the label
-        if [[ $result != 1 ]]; then
-            COMPONENT_TYPE=`echo ${COMPONENT} | cut -f 1 -d '/'`
-            COMPONENT="${COMPONENT}${COMPONENT_TYPE}"
-        fi
-
-        OWNERS=$( (grep -m 1 ${COMPONENT} .github/CODEOWNERS || true) | sed 's/   */ /g' | cut -f3- -d ' ')
+    for LABEL in ${LABELS}; do
+        COMPONENT="${LABEL}"
+        OWNERS=$(COMPONENT=${LABEL} bash "${CUR_DIRECTORY}/get-codeowners.sh")
 
         if [[ -z "${OWNERS}" ]]; then
             continue
         fi
 
-        OWNER_PINGS+="- ${COMPONENT}: ${OWNERS}\n"
+        OWNER_MENTIONS+="- ${COMPONENT}: ${OWNERS}\n"
     done
 
-    if [[ -z "${OWNER_PINGS}" ]]; then
+    if [[ -z "${OWNER_MENTIONS}" ]]; then
         echo "No code owners found. Marking issue as stale without pinging code owners."
 
-        gh issue comment ${ISSUE} -b "${STALE_MESSAGE}"
+        gh issue comment "${ISSUE}" -b "${STALE_MESSAGE}"
     else
         echo "Pinging code owners for issue #${ISSUE}."
 
         # The GitHub CLI only offers multiline strings through file input.
-        printf "${STALE_MESSAGE}\nPinging code owners:\n${OWNER_PINGS}\nSee [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself." \
-          | gh issue comment ${ISSUE} -F -
+        printf "${STALE_MESSAGE}\n\nPinging code owners:\n${OWNER_MENTIONS}\nSee [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself." \
+          | gh issue comment "${ISSUE}" -F -
     fi
 
     # We want to add a label after making a comment for two reasons:
@@ -99,6 +86,6 @@ for ISSUE in "${ISSUES[@]}"; do
     #    was the last activity on the issue, or the stale bot will remove the stale
     #    label if our comment to ping code owners comes too long after the stale
     #    label is applied.
-    gh issue edit ${ISSUE} --add-label "${STALE_LABEL}"
+    gh issue edit "${ISSUE}" --add-label "${STALE_LABEL}"
 done
 


### PR DESCRIPTION
**Description:**

Refactor CI scripts that ping code owners to use the `get-codeowners.sh` script and to follow a few best practices according to [shellcheck](https://www.shellcheck.net/).

**Testing:**

I tested this on my personal fork.