### PR TITLE
[exporter/prometheus] settings were not set in prometheus exporter

### DIFF
--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -63,6 +63,7 @@ func newPrometheusExporter(config *Config, set component.ExporterCreateSettings)
 				EnableOpenMetrics: config.EnableOpenMetrics,
 			},
 		),
+		settings: set.TelemetrySettings,
 	}, nil
 }
 


### PR DESCRIPTION
Not passing in the settings correctly will cause a panic if the logger is used anywhere, which may happen after this change: https://github.com/open-telemetry/opentelemetry-collector/pull/6421

This was discovered in this PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16060