### PR TITLE
[exporter/awsxray] Favour semconv attributes for QueueURL and TableName

### DIFF
--- a/.chloggen/exporter-awsxray-semconv.yaml
+++ b/.chloggen/exporter-awsxray-semconv.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Favour semantic convention attributes for DynamoDB table name and messaging url when translating OTel data into X-Ray AWS data.
+
+# One or more tracking issues related to the change
+issues: [16075]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -162,6 +162,14 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource) (ma
 		return filtered, nil // not AWS so return nil
 	}
 
+	// Favour Semantic Conventions for specific SQS and DynamoDB attributes.
+	if value, ok := attributes[conventions.AttributeMessagingURL]; ok {
+		queueURL = value.Str()
+	}
+	if value, ok := attributes[conventions.AttributeAWSDynamoDBTableNames]; ok {
+		tableName = value.Str()
+	}
+
 	// EC2 - add ec2 metadata to xray request if
 	//       1. cloud.platfrom is set to "aws_ec2" or
 	//       2. there is an non-blank host/instance id found

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -162,7 +162,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource) (ma
 		return filtered, nil // not AWS so return nil
 	}
 
-	// Favour Semantic Conventions for specific SQS and DynamoDB attributes.
+	// Favor Semantic Conventions for specific SQS and DynamoDB attributes.
 	if value, ok := attributes[conventions.AttributeMessagingURL]; ok {
 		queueURL = value.Str()
 	}

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -182,7 +182,25 @@ func TestAwsFromEksResource(t *testing.T) {
 }
 
 func TestAwsWithAwsSqsResources(t *testing.T) {
+	instanceID := "i-00f7c0bcb26da2a99"
+	containerName := "signup_aggregator-x82ufje83"
+	containerID := "0123456789A"
 	resource := pcommon.NewResource()
+	attrs := pcommon.NewMap()
+	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
+	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
+	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-east-1c")
+	attrs.PutStr(conventions.AttributeContainerName, containerName)
+	attrs.PutStr(conventions.AttributeContainerImageName, "otel/signupaggregator")
+	attrs.PutStr(conventions.AttributeContainerImageTag, "v1")
+	attrs.PutStr(conventions.AttributeK8SClusterName, "production")
+	attrs.PutStr(conventions.AttributeK8SNamespaceName, "default")
+	attrs.PutStr(conventions.AttributeK8SDeploymentName, "signup_aggregator")
+	attrs.PutStr(conventions.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
+	attrs.PutStr(conventions.AttributeContainerName, containerName)
+	attrs.PutStr(conventions.AttributeContainerID, containerID)
+	attrs.PutStr(conventions.AttributeHostID, instanceID)
+	attrs.PutStr(conventions.AttributeHostType, "m5.xlarge")
 
 	queueURL := "https://sqs.use1.amazonaws.com/Meltdown-Alerts"
 	attributes := make(map[string]pcommon.Value)

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -182,25 +182,7 @@ func TestAwsFromEksResource(t *testing.T) {
 }
 
 func TestAwsWithAwsSqsResources(t *testing.T) {
-	instanceID := "i-00f7c0bcb26da2a99"
-	containerName := "signup_aggregator-x82ufje83"
-	containerID := "0123456789A"
 	resource := pcommon.NewResource()
-	attrs := pcommon.NewMap()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-east-1c")
-	attrs.PutStr(conventions.AttributeContainerName, containerName)
-	attrs.PutStr(conventions.AttributeContainerImageName, "otel/signupaggregator")
-	attrs.PutStr(conventions.AttributeContainerImageTag, "v1")
-	attrs.PutStr(conventions.AttributeK8SClusterName, "production")
-	attrs.PutStr(conventions.AttributeK8SNamespaceName, "default")
-	attrs.PutStr(conventions.AttributeK8SDeploymentName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
-	attrs.PutStr(conventions.AttributeContainerName, containerName)
-	attrs.PutStr(conventions.AttributeContainerID, containerID)
-	attrs.PutStr(conventions.AttributeHostID, instanceID)
-	attrs.PutStr(conventions.AttributeHostType, "m5.xlarge")
 
 	queueURL := "https://sqs.use1.amazonaws.com/Meltdown-Alerts"
 	attributes := make(map[string]pcommon.Value)
@@ -233,6 +215,18 @@ func TestAwsWithSqsAlternateAttribute(t *testing.T) {
 	queueURL := "https://sqs.use1.amazonaws.com/Meltdown-Alerts"
 	attributes := make(map[string]pcommon.Value)
 	attributes[awsxray.AWSQueueURLAttribute2] = pcommon.NewValueStr(queueURL)
+
+	filtered, awsData := makeAws(attributes, pcommon.NewResource())
+
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, queueURL, *awsData.QueueURL)
+}
+
+func TestAwsWithAwsSqsSemConvAttributes(t *testing.T) {
+	queueURL := "https://sqs.use1.amazonaws.com/Meltdown-Alerts"
+	attributes := make(map[string]pcommon.Value)
+	attributes[conventions.AttributeMessagingURL] = pcommon.NewValueStr(queueURL)
 
 	filtered, awsData := makeAws(attributes, pcommon.NewResource())
 
@@ -282,6 +276,18 @@ func TestAwsWithDynamoDbAlternateAttribute(t *testing.T) {
 	tableName := "MyTable"
 	attributes := make(map[string]pcommon.Value)
 	attributes[awsxray.AWSTableNameAttribute2] = pcommon.NewValueStr(tableName)
+
+	filtered, awsData := makeAws(attributes, pcommon.NewResource())
+
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, tableName, *awsData.TableName)
+}
+
+func TestAwsWithDynamoDbSemConvAttributes(t *testing.T) {
+	tableName := "MyTable"
+	attributes := make(map[string]pcommon.Value)
+	attributes[conventions.AttributeAWSDynamoDBTableNames] = pcommon.NewValueStr(tableName)
 
 	filtered, awsData := makeAws(attributes, pcommon.NewResource())
 


### PR DESCRIPTION
**Description:** 

THe AWS X-Ray Exporter does not use semantic convention attributes when attempting to populate the `queueURL` and `tableName` attributes. Instead it only looks for the X-Ray custom attributes. This PR extends the behaviour to favour the semantic convention attributes (if set). This was motivated by the recent discussion on the PR that extended the AWS-SDK-Go-v2 instrumentation library `otelaws`. [See discussion.](https://github.com/open-telemetry/opentelemetry-go-contrib/pull/2879#discussion_r1010208022) (cc. @Aneurysm9)

**Link to tracking Issue:** #16075