### PR TITLE
[processor/resourcedetectionprocessor] support openshift

### DIFF
--- a/.chloggen/resourcedetectionprocessor_support_openshift.yaml
+++ b/.chloggen/resourcedetectionprocessor_support_openshift.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add openshift support
+
+# One or more tracking issues related to the change
+issues: [15694]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -141,6 +141,7 @@ processor/resourcedetectionprocessor/                    @open-telemetry/collect
 processor/resourceprocessor/                             @open-telemetry/collector-contrib-approvers @dmitryax
 processor/resourcedetectionprocessor/internal/azure/     @open-telemetry/collector-contrib-approvers @mx-psi
 processor/resourcedetectionprocessor/internal/heroku/    @open-telemetry/collector-contrib-approvers @atoulme
+processor/resourcedetectionprocessor/internal/openshift/ @open-telemetry/collector-contrib-approvers @frzifus
 processor/routingprocessor/                              @open-telemetry/collector-contrib-approvers @jpkrohling @kovrus
 processor/schemaprocessor/                               @open-telemetry/collector-contrib-approvers @MovieStoreGuy
 processor/servicegraphprocessor/                         @open-telemetry/collector-contrib-approvers @jpkrohling @mapno

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -131,6 +131,7 @@ body:
       - processor/resourcedetection
       - processor/resourcedetection/internal/azure
       - processor/resourcedetection/internal/heroku
+      - processor/resourcedetection/internal/openshift
       - processor/routing
       - processor/schema
       - processor/servicegraph

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -125,6 +125,7 @@ body:
       - processor/resourcedetection
       - processor/resourcedetection/internal/azure
       - processor/resourcedetection/internal/heroku
+      - processor/resourcedetection/internal/openshift
       - processor/routing
       - processor/schema
       - processor/servicegraph

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -125,6 +125,7 @@ body:
       - processor/resourcedetection
       - processor/resourcedetection/internal/azure
       - processor/resourcedetection/internal/heroku
+      - processor/resourcedetection/internal/openshift
       - processor/routing
       - processor/schema
       - processor/servicegraph

--- a/internal/metadataproviders/openshift/metadata.go
+++ b/internal/metadataproviders/openshift/metadata.go
@@ -1,0 +1,200 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshift // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/openshift"
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	conventions "go.opentelemetry.io/collector/semconv/v1.16.0"
+)
+
+// Provider gets cluster metadata from Openshift.
+type Provider interface {
+	K8SClusterVersion(context.Context) (string, error)
+	OpenShiftClusterVersion(context.Context) (string, error)
+	Infrastructure(context.Context) (*InfrastructureMetadata, error)
+}
+
+// NewProvider creates a new metadata provider.
+func NewProvider(address, token string) Provider {
+	return &openshiftProvider{
+		address: address,
+		token:   token,
+		client:  &http.Client{},
+	}
+}
+
+type openshiftProvider struct {
+	client  *http.Client
+	address string
+	token   string
+}
+
+func (o *openshiftProvider) makeOCPRequest(ctx context.Context, endpoint, target string) (*http.Request, error) {
+	addr := fmt.Sprintf("%s/apis/config.openshift.io/v1/%s/%s/status", o.address, endpoint, target)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", o.token))
+	return req, nil
+}
+
+// OpenShiftClusterVersion requests the ClusterVersion from the openshift api.
+func (o *openshiftProvider) OpenShiftClusterVersion(ctx context.Context) (string, error) {
+	req, err := o.makeOCPRequest(ctx, "clusterversions", "version")
+	if err != nil {
+		return "", err
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	res := ocpClusterVersionAPIResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return "", err
+	}
+	return res.Status.Desired.Version, nil
+}
+
+// ClusterVersion requests Infrastructure details from the openshift api.
+func (o *openshiftProvider) Infrastructure(ctx context.Context) (*InfrastructureMetadata, error) {
+	req, err := o.makeOCPRequest(ctx, "infrastructures", "cluster")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	res := infrastructureAPIResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, err
+	}
+
+	var (
+		region   string
+		platform string
+		provider string
+	)
+
+	switch strings.ToLower(res.Status.PlatformStatus.Type) {
+	case "aws":
+		provider = conventions.AttributeCloudProviderAWS
+		platform = conventions.AttributeCloudPlatformAWSOpenshift
+		region = strings.ToLower(res.Status.PlatformStatus.Aws.Region)
+	case "azure":
+		provider = conventions.AttributeCloudProviderAzure
+		platform = conventions.AttributeCloudPlatformAzureOpenshift
+		region = strings.ToLower(res.Status.PlatformStatus.Azure.CloudName)
+	case "gcp":
+		provider = conventions.AttributeCloudProviderGCP
+		platform = conventions.AttributeCloudPlatformGoogleCloudOpenshift
+		region = strings.ToLower(res.Status.PlatformStatus.GCP.Region)
+	case "ibmcloud":
+		provider = conventions.AttributeCloudProviderIbmCloud
+		platform = conventions.AttributeCloudPlatformIbmCloudOpenshift
+		region = strings.ToLower(res.Status.PlatformStatus.IBMCloud.Location)
+	case "openstack":
+		region = strings.ToLower(res.Status.PlatformStatus.OpenStack.CloudName)
+	}
+
+	return &InfrastructureMetadata{
+		Name:     res.Status.InfrastructureName,
+		Topology: res.Status.ControlPlaneTopology,
+		Provider: provider,
+		Platform: platform,
+		Region:   region,
+	}, nil
+}
+
+// K8SClusterVersion requests the ClusterVersion from the kubernetes api.
+func (o *openshiftProvider) K8SClusterVersion(ctx context.Context) (string, error) {
+	addr := fmt.Sprintf("%s/version", o.address)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", o.token))
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	res := k8sClusterVersionAPIResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return "", err
+	}
+	version := res.GitVersion
+	if strings.Contains(version, "+") {
+		version = strings.Split(version, "+")[0]
+	}
+	return version, nil
+}
+
+// InfrastructureMetadata bundles the most important Infrastructure details.
+type InfrastructureMetadata struct {
+	Name     string `json:"name"`
+	Region   string `json:"region"`
+	Platform string `json:"platform"`
+	Provider string `json:"provider"`
+	Topology string `json:"topology"`
+}
+
+type ocpClusterVersionAPIResponse struct {
+	Status struct {
+		Desired struct {
+			Version string `json:"version"`
+		} `json:"desired"`
+	} `json:"status"`
+}
+
+type infrastructureAPIResponse struct {
+	Status struct {
+		ControlPlaneTopology   string `json:"controlPlaneTopology"`
+		InfrastructureName     string `json:"infrastructureName"`
+		InfrastructureTopology string `json:"infrastructureTopology"`
+		Platform               string `json:"platform"`
+		PlatformStatus         struct {
+			Aws struct {
+				Region string `json:"region"`
+			} `json:"aws"`
+			Azure struct {
+				CloudName string `json:"cloudName"`
+			} `json:"azure"`
+			Baremetal struct{} `json:"baremetal"`
+			GCP       struct {
+				Region string `json:"region"`
+			} `json:"gcp"`
+			IBMCloud struct {
+				Location string `json:"location"`
+			} `json:"ibmcloud"`
+			OpenStack struct {
+				CloudName string `json:"cloudName"`
+			} `json:"openstack"`
+			OVirt   struct{} `json:"ovirt"`
+			VSphere struct{} `json:"vsphere"`
+			Type    string   `json:"type"`
+		} `json:"platformStatus"`
+	} `json:"status"`
+}
+
+type k8sClusterVersionAPIResponse struct {
+	GitVersion string `json:"gitVersion"`
+}

--- a/internal/metadataproviders/openshift/metadata_test.go
+++ b/internal/metadataproviders/openshift/metadata_test.go
@@ -152,12 +152,18 @@ func TestQueryEndpointCorrectInfrastructureAWS(t *testing.T) {
 
 	got, err := provider.Infrastructure(context.Background())
 	require.NoError(t, err)
-	expect := InfrastructureMetadata{
-		Name:     "test-d-bm4rt",
-		Region:   "us-east-1",
-		Provider: "aws",
-		Platform: "aws_openshift",
-		Topology: "HighlyAvailable",
+	expect := InfrastructureAPIResponse{
+		Status: InfrastructureStatus{
+			InfrastructureName:     "test-d-bm4rt",
+			ControlPlaneTopology:   "HighlyAvailable",
+			InfrastructureTopology: "HighlyAvailable",
+			PlatformStatus: InfrastructurePlatformStatus{
+				Type: "AWS",
+				Aws: InfrastructureStatusAWS{
+					Region: "us-east-1",
+				},
+			},
+		},
 	}
 	assert.Equal(t, expect, *got)
 }
@@ -191,12 +197,18 @@ func TestQueryEndpointCorrectInfrastructureAzure(t *testing.T) {
 
 	got, err := provider.Infrastructure(context.Background())
 	require.NoError(t, err)
-	expect := InfrastructureMetadata{
-		Name:     "test-d-bm4rt",
-		Region:   "us-east-1",
-		Provider: "azure",
-		Platform: "azure_openshift",
-		Topology: "HighlyAvailable",
+	expect := InfrastructureAPIResponse{
+		Status: InfrastructureStatus{
+			InfrastructureName:     "test-d-bm4rt",
+			ControlPlaneTopology:   "HighlyAvailable",
+			InfrastructureTopology: "HighlyAvailable",
+			PlatformStatus: InfrastructurePlatformStatus{
+				Type: "AZURE",
+				Azure: InfrastructureStatusAzure{
+					CloudName: "us-east-1",
+				},
+			},
+		},
 	}
 	assert.Equal(t, expect, *got)
 }
@@ -228,12 +240,18 @@ func TestQueryEndpointCorrectInfrastructureGCP(t *testing.T) {
 
 	got, err := provider.Infrastructure(context.Background())
 	require.NoError(t, err)
-	expect := InfrastructureMetadata{
-		Name:     "test-d-bm4rt",
-		Region:   "us-east-1",
-		Provider: "gcp",
-		Platform: "google_cloud_openshift",
-		Topology: "HighlyAvailable",
+	expect := InfrastructureAPIResponse{
+		Status: InfrastructureStatus{
+			InfrastructureName:     "test-d-bm4rt",
+			ControlPlaneTopology:   "HighlyAvailable",
+			InfrastructureTopology: "HighlyAvailable",
+			PlatformStatus: InfrastructurePlatformStatus{
+				Type: "GCP",
+				GCP: InfrastructureStatusGCP{
+					Region: "us-east-1",
+				},
+			},
+		},
 	}
 	assert.Equal(t, expect, *got)
 }
@@ -265,12 +283,18 @@ func TestQueryEndpointCorrectInfrastructureIBMCloud(t *testing.T) {
 
 	got, err := provider.Infrastructure(context.Background())
 	require.NoError(t, err)
-	expect := InfrastructureMetadata{
-		Name:     "test-d-bm4rt",
-		Region:   "us-east-1",
-		Provider: "ibm_cloud",
-		Platform: "ibm_cloud_openshift",
-		Topology: "HighlyAvailable",
+	expect := InfrastructureAPIResponse{
+		Status: InfrastructureStatus{
+			InfrastructureName:     "test-d-bm4rt",
+			ControlPlaneTopology:   "HighlyAvailable",
+			InfrastructureTopology: "HighlyAvailable",
+			PlatformStatus: InfrastructurePlatformStatus{
+				Type: "ibmcloud",
+				IBMCloud: InfrastructureStatusIBMCloud{
+					Location: "us-east-1",
+				},
+			},
+		},
 	}
 	assert.Equal(t, expect, *got)
 }
@@ -302,10 +326,18 @@ func TestQueryEndpointCorrectInfrastructureOpenstack(t *testing.T) {
 
 	got, err := provider.Infrastructure(context.Background())
 	require.NoError(t, err)
-	expect := InfrastructureMetadata{
-		Name:     "test-d-bm4rt",
-		Region:   "us-east-1",
-		Topology: "HighlyAvailable",
+	expect := InfrastructureAPIResponse{
+		Status: InfrastructureStatus{
+			InfrastructureName:     "test-d-bm4rt",
+			ControlPlaneTopology:   "HighlyAvailable",
+			InfrastructureTopology: "HighlyAvailable",
+			PlatformStatus: InfrastructurePlatformStatus{
+				Type: "openstack",
+				OpenStack: InfrastructureStatusOpenStack{
+					CloudName: "us-east-1",
+				},
+			},
+		},
 	}
 	assert.Equal(t, expect, *got)
 }

--- a/internal/metadataproviders/openshift/metadata_test.go
+++ b/internal/metadataproviders/openshift/metadata_test.go
@@ -1,0 +1,311 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshift
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProvider(t *testing.T) {
+	provider1 := NewProvider("127.0.0.1:4444", "abc")
+	assert.NotNil(t, provider1)
+	provider2 := NewProvider("", "")
+	assert.NotNil(t, provider2)
+}
+
+func TestQueryEndpointFailed(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	provider := &openshiftProvider{
+		address: ts.URL,
+		token:   "test",
+		client:  &http.Client{},
+	}
+
+	_, err := provider.OpenShiftClusterVersion(context.Background())
+	assert.Error(t, err)
+
+	_, err = provider.K8SClusterVersion(context.Background())
+	assert.Error(t, err)
+
+	_, err = provider.Infrastructure(context.Background())
+	assert.Error(t, err)
+}
+
+func TestQueryEndpointMalformed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintln(w, "{")
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	provider := &openshiftProvider{
+		address: ts.URL,
+		token:   "",
+		client:  &http.Client{},
+	}
+
+	_, err := provider.Infrastructure(context.Background())
+	assert.Error(t, err)
+}
+
+func TestQueryEndpointCorrectK8SClusterVersion(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintf(w, `{
+  "major": "1",
+  "minor": "21",
+  "gitVersion": "v1.21.11+5cc9227",
+  "gitCommit": "047f86f8e2212f25394de1c8bad35d9426ae0f4c",
+  "gitTreeState": "clean",
+  "buildDate": "2022-09-20T16:39:45Z",
+  "goVersion": "go1.16.12",
+  "compiler": "gc",
+  "platform": "linux/amd64"
+}`)
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	provider := &openshiftProvider{
+		address: ts.URL,
+		token:   "test",
+		client:  &http.Client{},
+	}
+
+	got, err := provider.K8SClusterVersion(context.Background())
+	require.NoError(t, err)
+	expect := "v1.21.11"
+	assert.Equal(t, expect, got)
+}
+
+func TestQueryEndpointCorrectOpenShiftClusterVersion(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintf(w, `{
+"apiVersion": "config.openshift.io/v1",
+"kind": "ClusterVersion",
+"status": {
+  "desired": {"version": "4.8.51"}
+  }
+}`)
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	provider := &openshiftProvider{
+		address: ts.URL,
+		token:   "test",
+		client:  &http.Client{},
+	}
+
+	got, err := provider.OpenShiftClusterVersion(context.Background())
+	require.NoError(t, err)
+	expect := "4.8.51"
+	assert.Equal(t, expect, got)
+}
+
+func TestQueryEndpointCorrectInfrastructureAWS(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintf(w, `{
+"apiVersion": "config.openshift.io/v1",
+"kind": "Infrastructure",
+"status": {
+  "apiServerInternalURI": "https://api.myopenshift.com:4443",
+  "apiServerURL": "https://api.myopenshift.com:4443",
+  "controlPlaneTopology": "HighlyAvailable",
+  "etcdDiscoveryDomain": "",
+  "infrastructureName": "test-d-bm4rt",
+  "infrastructureTopology": "HighlyAvailable",
+  "platform": "AWS",
+  "platformStatus": {
+	"type": "AWS",
+	"aws": {"region": "us-east-1"}
+}}}`)
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	provider := &openshiftProvider{
+		address: ts.URL,
+		token:   "test",
+		client:  &http.Client{},
+	}
+
+	got, err := provider.Infrastructure(context.Background())
+	require.NoError(t, err)
+	expect := InfrastructureMetadata{
+		Name:     "test-d-bm4rt",
+		Region:   "us-east-1",
+		Provider: "aws",
+		Platform: "aws_openshift",
+		Topology: "HighlyAvailable",
+	}
+	assert.Equal(t, expect, *got)
+}
+
+func TestQueryEndpointCorrectInfrastructureAzure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintf(w, `{
+"apiVersion": "config.openshift.io/v1",
+"kind": "Infrastructure",
+"status": {
+  "apiServerInternalURI": "https://api.myopenshift.com:4443",
+  "apiServerURL": "https://api.myopenshift.com:4443",
+  "controlPlaneTopology": "HighlyAvailable",
+  "etcdDiscoveryDomain": "",
+  "infrastructureName": "test-d-bm4rt",
+  "infrastructureTopology": "HighlyAvailable",
+  "platform": "AZURE",
+  "platformStatus": {
+	"type": "AZURE",
+	"azure": {"cloudName": "us-east-1"}
+}}}`)
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	provider := &openshiftProvider{
+		address: ts.URL,
+		token:   "test",
+		client:  &http.Client{},
+	}
+
+	got, err := provider.Infrastructure(context.Background())
+	require.NoError(t, err)
+	expect := InfrastructureMetadata{
+		Name:     "test-d-bm4rt",
+		Region:   "us-east-1",
+		Provider: "azure",
+		Platform: "azure_openshift",
+		Topology: "HighlyAvailable",
+	}
+	assert.Equal(t, expect, *got)
+}
+
+func TestQueryEndpointCorrectInfrastructureGCP(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintf(w, `{
+"apiVersion": "config.openshift.io/v1",
+"kind": "Infrastructure",
+"status": {
+  "controlPlaneTopology": "HighlyAvailable",
+  "etcdDiscoveryDomain": "",
+  "infrastructureName": "test-d-bm4rt",
+  "infrastructureTopology": "HighlyAvailable",
+  "platform": "GCP",
+  "platformStatus": {
+	"type": "GCP",
+	"gcp": {"region": "us-east-1"}
+}}}`)
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	provider := &openshiftProvider{
+		address: ts.URL,
+		token:   "test",
+		client:  &http.Client{},
+	}
+
+	got, err := provider.Infrastructure(context.Background())
+	require.NoError(t, err)
+	expect := InfrastructureMetadata{
+		Name:     "test-d-bm4rt",
+		Region:   "us-east-1",
+		Provider: "gcp",
+		Platform: "google_cloud_openshift",
+		Topology: "HighlyAvailable",
+	}
+	assert.Equal(t, expect, *got)
+}
+
+func TestQueryEndpointCorrectInfrastructureIBMCloud(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintf(w, `{
+"apiVersion": "config.openshift.io/v1",
+"kind": "Infrastructure",
+"status": {
+  "controlPlaneTopology": "HighlyAvailable",
+  "etcdDiscoveryDomain": "",
+  "infrastructureName": "test-d-bm4rt",
+  "infrastructureTopology": "HighlyAvailable",
+  "platform": "IBMCloud",
+  "platformStatus": {
+	"type": "ibmcloud",
+	"ibmcloud": {"location": "us-east-1"}
+}}}`)
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	provider := &openshiftProvider{
+		address: ts.URL,
+		token:   "test",
+		client:  &http.Client{},
+	}
+
+	got, err := provider.Infrastructure(context.Background())
+	require.NoError(t, err)
+	expect := InfrastructureMetadata{
+		Name:     "test-d-bm4rt",
+		Region:   "us-east-1",
+		Provider: "ibm_cloud",
+		Platform: "ibm_cloud_openshift",
+		Topology: "HighlyAvailable",
+	}
+	assert.Equal(t, expect, *got)
+}
+
+func TestQueryEndpointCorrectInfrastructureOpenstack(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintf(w, `{
+"apiVersion": "config.openshift.io/v1",
+"kind": "Infrastructure",
+"status": {
+  "controlPlaneTopology": "HighlyAvailable",
+  "etcdDiscoveryDomain": "",
+  "infrastructureName": "test-d-bm4rt",
+  "infrastructureTopology": "HighlyAvailable",
+  "platform": "openstack",
+  "platformStatus": {
+	"type": "openstack",
+	"openstack": {"cloudName": "us-east-1"}
+}}}`)
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	provider := &openshiftProvider{
+		address: ts.URL,
+		token:   "test",
+		client:  &http.Client{},
+	}
+
+	got, err := provider.Infrastructure(context.Background())
+	require.NoError(t, err)
+	expect := InfrastructureMetadata{
+		Name:     "test-d-bm4rt",
+		Region:   "us-east-1",
+		Topology: "HighlyAvailable",
+	}
+	assert.Equal(t, expect, *got)
+}

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -314,12 +314,39 @@ processors:
     detectors: [env, heroku]
     timeout: 2s
     override: false
+
+### Openshift
+
+Queries the OpenShift and Kubernetes API to retrieve the following resource attributes:
+
+    * cloud.provider
+    * cloud.platform
+    * cloud.region
+    * k8s.cluster.name
+    * k8s.cluster.version
+    * openshift.cluster.version
+
+Your service account needs `read` access to the API endpoints `/apis/config.openshift.io/v1/clusterversions/version/status`, `/apis/config.openshift.io/v1/infrastructures/cluster/status` and `/version`.
+By default, the API address is determined from the environment variables `KUBERNETES_SERVICE_HOST`, `KUBERNETES_SERVICE_PORT` and the service token is read from `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+The determination of the API address and the service token is skipped if they are set in the configuration.
+
+Example:
+
+```yaml
+processors:
+  resourcedetection/openshift:
+    detectors: [openshift]
+    timeout: 2s
+    override: false
+    openshift: # optional
+      address: "https://api.example.com"
+      token: "token"
 ```
 
 ## Configuration
 
 ```yaml
-# a list of resource detectors to run, valid options are: "env", "system", "gce", "gke", "ec2", "ecs", "elastic_beanstalk", "eks", "azure", "heroku"
+# a list of resource detectors to run, valid options are: "env", "system", "gce", "gke", "ec2", "ecs", "elastic_beanstalk", "eks", "azure", "heroku", "openshift"
 detectors: [ <string> ]
 # determines if existing resource attributes should be overridden or preserved, defaults to true
 override: <bool>

--- a/processor/resourcedetectionprocessor/config.go
+++ b/processor/resourcedetectionprocessor/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/consul"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openshift"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/system"
 )
 
@@ -52,6 +53,9 @@ type DetectorConfig struct {
 
 	// SystemConfig contains user-specified configurations for the System detector
 	SystemConfig system.Config `mapstructure:"system"`
+
+	// OpenShift contains user-specified configurations for the Openshift detector
+	OpenShiftConfig openshift.Config `mapstructure:"openshift"`
 }
 
 func (d *DetectorConfig) GetConfigFromType(detectorType internal.DetectorType) internal.DetectorConfig {
@@ -62,6 +66,8 @@ func (d *DetectorConfig) GetConfigFromType(detectorType internal.DetectorType) i
 		return d.ConsulConfig
 	case system.TypeStr:
 		return d.SystemConfig
+	case openshift.TypeStr:
+		return d.OpenShiftConfig
 	default:
 		return nil
 	}

--- a/processor/resourcedetectionprocessor/config_test.go
+++ b/processor/resourcedetectionprocessor/config_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/heroku"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openshift"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/system"
 )
 
@@ -42,6 +43,20 @@ func TestLoadConfig(t *testing.T) {
 		expected     component.Config
 		errorMessage string
 	}{
+		{
+			id: component.NewIDWithName(typeStr, "openshift"),
+			expected: &Config{
+				Detectors: []string{"openshift"},
+				DetectorConfig: DetectorConfig{
+					OpenShiftConfig: openshift.Config{
+						Address: "127.0.0.1:4444",
+						Token:   "some_token",
+					},
+				},
+				HTTPClientSettings: cfg,
+				Override:           false,
+			},
+		},
 		{
 			id: component.NewIDWithName(typeStr, "gcp"),
 			expected: &Config{

--- a/processor/resourcedetectionprocessor/factory.go
+++ b/processor/resourcedetectionprocessor/factory.go
@@ -38,6 +38,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/env"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/gcp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/heroku"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openshift"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/system"
 )
 
@@ -74,6 +75,7 @@ func NewFactory() processor.Factory {
 		gcp.TypeStr:              gcp.NewDetector,
 		heroku.TypeStr:           heroku.NewDetector,
 		system.TypeStr:           system.NewDetector,
+		openshift.TypeStr:        openshift.NewDetector,
 	})
 
 	f := &factory{
@@ -101,7 +103,7 @@ func createDefaultConfig() component.Config {
 		Override:           true,
 		Attributes:         nil,
 		// TODO: Once issue(https://github.com/open-telemetry/opentelemetry-collector/issues/4001) gets resolved,
-		// 		 Set the default value of 'hostname_source' here instead of 'system' detector
+		//		 Set the default value of 'hostname_source' here instead of 'system' detector
 	}
 }
 

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Showmax/go-fqdn v1.0.0 // indirect
 	github.com/armon/go-metrics v0.3.10 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.22+incompatible // indirect

--- a/processor/resourcedetectionprocessor/go.sum
+++ b/processor/resourcedetectionprocessor/go.sum
@@ -39,6 +39,7 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+
 github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21TfrhJ8AEMzVybRNSb/b4g=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/processor/resourcedetectionprocessor/internal/openshift/config.go
+++ b/processor/resourcedetectionprocessor/internal/openshift/config.go
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshift // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openshift"
+
+import (
+	"fmt"
+	"os"
+)
+
+const defaultServiceTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" //#nosec
+
+func readK8STokenFromFile() (string, error) {
+	token, err := os.ReadFile(defaultServiceTokenPath)
+	if err != nil {
+		return "", err
+	}
+	return string(token), nil
+}
+
+func readSVCAddressFromENV() (string, error) {
+	host := os.Getenv("KUBERNETES_SERVICE_HOST")
+	if host == "" {
+		return "", fmt.Errorf("could not extract openshift api host")
+	}
+	port := os.Getenv("KUBERNETES_SERVICE_PORT")
+	if port == "" {
+		return "", fmt.Errorf("could not extract openshift api port")
+	}
+	return fmt.Sprintf("https://%s:%s", host, port), nil
+}
+
+// Config can contain user-specified inputs to overwrite default values.
+// See `openshift.go#NewDetector` for more information.
+type Config struct {
+	// Address is the address of the openshift api server
+	Address string `mapstructure:"address"`
+
+	// Token is used to identify against the openshift api server
+	Token string `mapstructure:"token"`
+}
+
+// MergeWithDefaults fills unset fields with default values.
+func (c *Config) MergeWithDefaults() error {
+	if c.Token == "" {
+		token, err := readK8STokenFromFile()
+		if err != nil {
+			return err
+		}
+		c.Token = token
+	}
+
+	if c.Address == "" {
+		addr, err := readSVCAddressFromENV()
+		if err != nil {
+			return err
+		}
+		c.Address = addr
+	}
+	return nil
+}

--- a/processor/resourcedetectionprocessor/internal/openshift/openshift.go
+++ b/processor/resourcedetectionprocessor/internal/openshift/openshift.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshift // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openshift"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/processor"
+	conventions "go.opentelemetry.io/collector/semconv/v1.16.0"
+	"go.uber.org/zap"
+
+	ocp "github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/openshift"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+)
+
+const (
+	// TypeStr is type of detector.
+	TypeStr = "openshift"
+)
+
+// NewDetector returns a detector which can detect resource attributes on OpenShift 4.
+func NewDetector(set processor.CreateSettings, dcfg internal.DetectorConfig) (internal.Detector, error) {
+	userCfg := dcfg.(Config)
+
+	if err := userCfg.MergeWithDefaults(); err != nil {
+		return nil, err
+	}
+
+	return &detector{
+		logger:   set.Logger,
+		provider: ocp.NewProvider(userCfg.Address, userCfg.Token),
+	}, nil
+}
+
+type detector struct {
+	logger   *zap.Logger
+	provider ocp.Provider
+}
+
+func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schemaURL string, err error) {
+	res := pcommon.NewResource()
+	attrs := res.Attributes()
+
+	infra, err := d.provider.Infrastructure(ctx)
+	if err != nil {
+		d.logger.Debug("OpenShift detector metadata retrieval failed", zap.Error(err))
+		// return an empty Resource and no error
+		return res, "", nil
+	}
+
+	if infra.Provider != "" {
+		attrs.PutStr(conventions.AttributeCloudProvider, infra.Provider)
+	}
+	if infra.Platform != "" {
+		attrs.PutStr(conventions.AttributeCloudPlatform, infra.Platform)
+	}
+	if infra.Name != "" {
+		attrs.PutStr(conventions.AttributeK8SClusterName, infra.Name)
+	}
+	if infra.Region != "" {
+		attrs.PutStr(conventions.AttributeCloudRegion, infra.Region)
+	}
+
+	// TODO(frzifus): support conventions openshift and kubernetes cluster version.
+	// SEE: https://github.com/open-telemetry/opentelemetry-specification/issues/2913
+
+	return res, conventions.SchemaURL, nil
+}

--- a/processor/resourcedetectionprocessor/internal/openshift/openshift_test.go
+++ b/processor/resourcedetectionprocessor/internal/openshift/openshift_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 type providerResponse struct {
-	ocp.InfrastructureMetadata
+	ocp.InfrastructureAPIResponse
 
 	OpenShiftClusterVersion string
 	K8SClusterVersion       string
@@ -56,11 +56,11 @@ func (m *mockProvider) K8SClusterVersion(context.Context) (string, error) {
 	return m.res.K8SClusterVersion, nil
 }
 
-func (m *mockProvider) Infrastructure(context.Context) (*ocp.InfrastructureMetadata, error) {
+func (m *mockProvider) Infrastructure(context.Context) (*ocp.InfrastructureAPIResponse, error) {
 	if m.infraErr != nil {
 		return nil, m.infraErr
 	}
-	return &m.res.InfrastructureMetadata, nil
+	return &m.res.InfrastructureAPIResponse, nil
 }
 
 func newTestDetector(t *testing.T, res *providerResponse, ocpCVErr, k8sCVErr, infraErr error) internal.Detector {
@@ -107,11 +107,18 @@ func TestDetect(t *testing.T) {
 		{
 			name: "detect all details",
 			detector: newTestDetector(t, &providerResponse{
-				InfrastructureMetadata: ocp.InfrastructureMetadata{
-					Name:     "name",
-					Region:   "region",
-					Platform: "aws_openshift",
-					Provider: "aws",
+				InfrastructureAPIResponse: ocp.InfrastructureAPIResponse{
+					Status: ocp.InfrastructureStatus{
+						InfrastructureName:     "test-d-bm4rt",
+						ControlPlaneTopology:   "HighlyAvailable",
+						InfrastructureTopology: "HighlyAvailable",
+						PlatformStatus: ocp.InfrastructurePlatformStatus{
+							Type: "AWS",
+							Aws: ocp.InfrastructureStatusAWS{
+								Region: "us-east-1",
+							},
+						},
+					},
 				},
 				OpenShiftClusterVersion: "4.1.2",
 				K8SClusterVersion:       "1.23.4",
@@ -120,10 +127,10 @@ func TestDetect(t *testing.T) {
 			expectedResource: func() pcommon.Resource {
 				res := pcommon.NewResource()
 				attrs := res.Attributes()
+				attrs.PutStr(conventions.AttributeK8SClusterName, "test-d-bm4rt")
 				attrs.PutStr(conventions.AttributeCloudProvider, "aws")
 				attrs.PutStr(conventions.AttributeCloudPlatform, "aws_openshift")
-				attrs.PutStr(conventions.AttributeK8SClusterName, "name")
-				attrs.PutStr(conventions.AttributeCloudRegion, "region")
+				attrs.PutStr(conventions.AttributeCloudRegion, "us-east-1")
 				return res
 			}(),
 			expectedSchemaURL: conventions.SchemaURL,

--- a/processor/resourcedetectionprocessor/internal/openshift/openshift_test.go
+++ b/processor/resourcedetectionprocessor/internal/openshift/openshift_test.go
@@ -1,0 +1,145 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshift // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openshift"
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/collector/semconv/v1.16.0"
+	"go.uber.org/zap/zaptest"
+
+	ocp "github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/openshift"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+)
+
+type providerResponse struct {
+	ocp.InfrastructureMetadata
+
+	OpenShiftClusterVersion string
+	K8SClusterVersion       string
+}
+
+type mockProvider struct {
+	res      *providerResponse
+	ocpCVErr error
+	k8sCVErr error
+	infraErr error
+}
+
+func (m *mockProvider) OpenShiftClusterVersion(context.Context) (string, error) {
+	if m.ocpCVErr != nil {
+		return "", m.ocpCVErr
+	}
+	return m.res.OpenShiftClusterVersion, nil
+}
+
+func (m *mockProvider) K8SClusterVersion(context.Context) (string, error) {
+	if m.k8sCVErr != nil {
+		return "", m.k8sCVErr
+	}
+	return m.res.K8SClusterVersion, nil
+}
+
+func (m *mockProvider) Infrastructure(context.Context) (*ocp.InfrastructureMetadata, error) {
+	if m.infraErr != nil {
+		return nil, m.infraErr
+	}
+	return &m.res.InfrastructureMetadata, nil
+}
+
+func newTestDetector(t *testing.T, res *providerResponse, ocpCVErr, k8sCVErr, infraErr error) internal.Detector {
+	return &detector{
+		logger: zaptest.NewLogger(t),
+		provider: &mockProvider{
+			res:      res,
+			ocpCVErr: ocpCVErr,
+			k8sCVErr: k8sCVErr,
+			infraErr: infraErr,
+		},
+	}
+}
+
+func TestDetect(t *testing.T) {
+	someErr := errors.New("test")
+	tt := []struct {
+		name              string
+		detector          internal.Detector
+		expectedResource  pcommon.Resource
+		expectedSchemaURL string
+		expectedErr       error
+	}{
+		{
+			name:              "error getting openshift cluster version",
+			detector:          newTestDetector(t, &providerResponse{}, someErr, nil, nil),
+			expectedErr:       someErr,
+			expectedResource:  pcommon.NewResource(),
+			expectedSchemaURL: conventions.SchemaURL,
+		},
+		{
+			name:              "error getting k8s cluster version",
+			detector:          newTestDetector(t, &providerResponse{}, nil, someErr, nil),
+			expectedErr:       someErr,
+			expectedResource:  pcommon.NewResource(),
+			expectedSchemaURL: conventions.SchemaURL,
+		},
+		{
+			name:             "error getting infrastructure details",
+			detector:         newTestDetector(t, &providerResponse{}, nil, nil, someErr),
+			expectedErr:      someErr,
+			expectedResource: pcommon.NewResource(),
+		},
+		{
+			name: "detect all details",
+			detector: newTestDetector(t, &providerResponse{
+				InfrastructureMetadata: ocp.InfrastructureMetadata{
+					Name:     "name",
+					Region:   "region",
+					Platform: "aws_openshift",
+					Provider: "aws",
+				},
+				OpenShiftClusterVersion: "4.1.2",
+				K8SClusterVersion:       "1.23.4",
+			}, nil, nil, nil),
+			expectedErr: nil,
+			expectedResource: func() pcommon.Resource {
+				res := pcommon.NewResource()
+				attrs := res.Attributes()
+				attrs.PutStr(conventions.AttributeCloudProvider, "aws")
+				attrs.PutStr(conventions.AttributeCloudPlatform, "aws_openshift")
+				attrs.PutStr(conventions.AttributeK8SClusterName, "name")
+				attrs.PutStr(conventions.AttributeCloudRegion, "region")
+				return res
+			}(),
+			expectedSchemaURL: conventions.SchemaURL,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			resource, schemaURL, err := tc.detector.Detect(context.Background())
+			if err != nil && errors.Is(err, tc.expectedErr) {
+				return
+			} else if err != nil && !errors.Is(err, tc.expectedErr) {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.expectedResource, resource)
+			assert.Equal(t, tc.expectedSchemaURL, schemaURL)
+		})
+	}
+}

--- a/processor/resourcedetectionprocessor/testdata/config.yaml
+++ b/processor/resourcedetectionprocessor/testdata/config.yaml
@@ -1,4 +1,12 @@
 resourcedetection:
+resourcedetection/openshift:
+  detectors: [openshift]
+  timeout: 2s
+  override: false
+  openshift:
+    address: "127.0.0.1:4444"
+    token: "some_token"
+
 resourcedetection/gcp:
   detectors: [env, gcp]
   timeout: 2s


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This pr adds openshift support to the resourcedetectionprocessor.

**Link to tracking Issue:** <Issue number if applicable>
Closes #15694 

**Testing:** <Describe what testing was performed and which tests were added.>
A few tests have been added. 

The detector can be tested manually with the following configuration:
```yaml
receivers:
  otlp:
    protocols:
      grpc:
      http:

processors:
  resourcedetection/openshift:
    detectors: openshift
    timeout: 2s
    override: false
    openshift:
      address: https://api.openshift.com
      token: <your-serviceaccount-token>

exporters:
  logging:
    logLevel: debug

service:
  pipelines:
    traces:
      processors: [resourcedetection/openshift]
      receivers: [otlp]
      exporters: [logging]
```

If the collector is rolled out in an OpenShift cluster, there is no need for user configuration. Note that the used serviceaccount must be authorized to `read` the api endpoints [/apis/config.openshift.io/v1/infrastructures/{name}/status](https://docs.openshift.com/container-platform/4.11/rest_api/config_apis/infrastructure-config-openshift-io-v1.html#apisconfig-openshift-iov1infrastructuresnamestatus) and [/apis/config.openshift.io/v1/clusterversions/{name}/status](https://docs.openshift.com/container-platform/4.11/rest_api/config_apis/clusterversion-config-openshift-io-v1.html#apisconfig-openshift-iov1clusterversionsnamestatus).

Example:
```json
{
  "cloud.platform": "aws_openshift",
  "cloud.provider": "aws",
  "cloud.region": "us-east-1",
  "k8s.cluster.name": "observability-test",
  "k8s.cluster.version": "v1.21.11+5cc9227",
  "openshift.cluster.version": "4.8.51"
}
```

**Documentation:** <Describe the documentation added.>
Extended readme