### PR TITLE
[processor/filter] Don't use SpanKind.String() in config enums

### DIFF
--- a/internal/coreinternal/processor/filterconfig/config.go
+++ b/internal/coreinternal/processor/filterconfig/config.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
 )
 
 // MatchConfig has two optional MatchProperties one to define what is processed
@@ -141,11 +142,11 @@ var (
 	ErrMissingRequiredLogField = errors.New(`at least one of "attributes", "libraries", "span_kinds", "resources", "log_bodies", "log_severity_texts" or "log_severity_number" field must be specified`)
 
 	spanKinds = map[string]bool{
-		ptrace.SpanKindInternal.String(): true,
-		ptrace.SpanKindClient.String():   true,
-		ptrace.SpanKindServer.String():   true,
-		ptrace.SpanKindConsumer.String(): true,
-		ptrace.SpanKindProducer.String(): true,
+		traceutil.SpanKindStr(ptrace.SpanKindInternal): true,
+		traceutil.SpanKindStr(ptrace.SpanKindClient):   true,
+		traceutil.SpanKindStr(ptrace.SpanKindServer):   true,
+		traceutil.SpanKindStr(ptrace.SpanKindConsumer): true,
+		traceutil.SpanKindStr(ptrace.SpanKindProducer): true,
 	}
 )
 

--- a/internal/coreinternal/processor/filterspan/filterspan_test.go
+++ b/internal/coreinternal/processor/filterspan/filterspan_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
 )
 
 func createConfig(matchType filterset.MatchType) *filterset.Config {
@@ -160,7 +161,7 @@ func TestSpan_Matching_False(t *testing.T) {
 			properties: &filterconfig.MatchProperties{
 				Config:     *createConfig(filterset.Regexp),
 				Attributes: []filterconfig.Attribute{},
-				SpanKinds:  []string{ptrace.SpanKindProducer.String()},
+				SpanKinds:  []string{traceutil.SpanKindStr(ptrace.SpanKindProducer)},
 			},
 		},
 		{
@@ -168,7 +169,7 @@ func TestSpan_Matching_False(t *testing.T) {
 			properties: &filterconfig.MatchProperties{
 				Config:     *createConfig(filterset.Strict),
 				Attributes: []filterconfig.Attribute{},
-				SpanKinds:  []string{ptrace.SpanKindProducer.String()},
+				SpanKinds:  []string{traceutil.SpanKindStr(ptrace.SpanKindProducer)},
 			},
 		},
 	}
@@ -250,7 +251,7 @@ func TestSpan_Matching_True(t *testing.T) {
 			properties: &filterconfig.MatchProperties{
 				Config: *createConfig(filterset.Strict),
 				SpanKinds: []string{
-					ptrace.SpanKindClient.String(),
+					traceutil.SpanKindStr(ptrace.SpanKindClient),
 				},
 				Attributes: []filterconfig.Attribute{},
 			},


### PR DESCRIPTION
ptrace.SpanKind.String() changed returned value in the recent update. We don't want to break the filter interface right away, so we stick with the old values for now. Later we'll do a graceful transition

Unblocks https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16085