### PR TITLE
[receiver/elasticsearch]: Add additional node metrics around request cache and process stats

### DIFF
--- a/.chloggen/elasticsearch-add-request-cache-process-stats.yaml
+++ b/.chloggen/elasticsearch-add-request-cache-process-stats.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add additional node metrics around request cache and process stats
+
+# One or more tracking issues related to the change
+issues: [16095]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -947,6 +947,28 @@ Size of the transaction log for an index.
 | ---- | ----------- | ------ |
 | aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
 
+### elasticsearch.node.cache.size
+
+Total amount of memory used for the query cache across all shards assigned to the node.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| By | Sum | Int | Cumulative | false |
+
+### elasticsearch.node.operations.current
+
+Number of query operations currently running.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {operations} | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| operation | The type of operation. | Str: ``index``, ``delete``, ``get``, ``query``, ``fetch``, ``scroll``, ``suggest``, ``merge``, ``refresh``, ``flush``, ``warmer`` |
+
 ### elasticsearch.node.operations.get.completed
 
 The number of hits and misses resulting from GET operations.
@@ -988,6 +1010,30 @@ Size of memory for segment object of a node.
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | object | Type of object in segment | Str: ``term``, ``doc_value``, ``index_writer``, ``fixed_bit_set`` |
+
+### elasticsearch.process.cpu.time
+
+CPU time used by the process on which the Java virtual machine is running.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| ms | Sum | Int | Cumulative | true |
+
+### elasticsearch.process.cpu.usage
+
+CPU usage in percent.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| 1 | Gauge | Double |
+
+### elasticsearch.process.memory.virtual
+
+Size of virtual memory that is guaranteed to be available to the running process.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| By | Sum | Int | Cumulative | false |
 
 ### jvm.memory.heap.utilization
 

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_test.go
@@ -116,6 +116,8 @@ func TestDefaultMetrics(t *testing.T) {
 	enabledMetrics["elasticsearch.node.cache.memory.usage"] = true
 	mb.RecordElasticsearchNodeCacheMemoryUsageDataPoint(ts, 1, AttributeCacheName(1))
 
+	mb.RecordElasticsearchNodeCacheSizeDataPoint(ts, 1)
+
 	enabledMetrics["elasticsearch.node.cluster.connections"] = true
 	mb.RecordElasticsearchNodeClusterConnectionsDataPoint(ts, 1)
 
@@ -157,6 +159,8 @@ func TestDefaultMetrics(t *testing.T) {
 
 	enabledMetrics["elasticsearch.node.operations.completed"] = true
 	mb.RecordElasticsearchNodeOperationsCompletedDataPoint(ts, 1, AttributeOperation(1))
+
+	mb.RecordElasticsearchNodeOperationsCurrentDataPoint(ts, 1, AttributeOperation(1))
 
 	mb.RecordElasticsearchNodeOperationsGetCompletedDataPoint(ts, 1, AttributeGetResult(1))
 
@@ -226,6 +230,12 @@ func TestDefaultMetrics(t *testing.T) {
 
 	enabledMetrics["elasticsearch.os.memory"] = true
 	mb.RecordElasticsearchOsMemoryDataPoint(ts, 1, AttributeMemoryState(1))
+
+	mb.RecordElasticsearchProcessCPUTimeDataPoint(ts, 1)
+
+	mb.RecordElasticsearchProcessCPUUsageDataPoint(ts, 1)
+
+	mb.RecordElasticsearchProcessMemoryVirtualDataPoint(ts, 1)
 
 	enabledMetrics["jvm.classes.loaded"] = true
 	mb.RecordJvmClassesLoadedDataPoint(ts, 1)
@@ -317,6 +327,7 @@ func TestAllMetrics(t *testing.T) {
 		ElasticsearchNodeCacheCount:                               MetricSettings{Enabled: true},
 		ElasticsearchNodeCacheEvictions:                           MetricSettings{Enabled: true},
 		ElasticsearchNodeCacheMemoryUsage:                         MetricSettings{Enabled: true},
+		ElasticsearchNodeCacheSize:                                MetricSettings{Enabled: true},
 		ElasticsearchNodeClusterConnections:                       MetricSettings{Enabled: true},
 		ElasticsearchNodeClusterIo:                                MetricSettings{Enabled: true},
 		ElasticsearchNodeDiskIoRead:                               MetricSettings{Enabled: true},
@@ -331,6 +342,7 @@ func TestAllMetrics(t *testing.T) {
 		ElasticsearchNodeIngestOperationsFailed:                   MetricSettings{Enabled: true},
 		ElasticsearchNodeOpenFiles:                                MetricSettings{Enabled: true},
 		ElasticsearchNodeOperationsCompleted:                      MetricSettings{Enabled: true},
+		ElasticsearchNodeOperationsCurrent:                        MetricSettings{Enabled: true},
 		ElasticsearchNodeOperationsGetCompleted:                   MetricSettings{Enabled: true},
 		ElasticsearchNodeOperationsGetTime:                        MetricSettings{Enabled: true},
 		ElasticsearchNodeOperationsTime:                           MetricSettings{Enabled: true},
@@ -355,6 +367,9 @@ func TestAllMetrics(t *testing.T) {
 		ElasticsearchOsCPULoadAvg5m:                               MetricSettings{Enabled: true},
 		ElasticsearchOsCPUUsage:                                   MetricSettings{Enabled: true},
 		ElasticsearchOsMemory:                                     MetricSettings{Enabled: true},
+		ElasticsearchProcessCPUTime:                               MetricSettings{Enabled: true},
+		ElasticsearchProcessCPUUsage:                              MetricSettings{Enabled: true},
+		ElasticsearchProcessMemoryVirtual:                         MetricSettings{Enabled: true},
 		JvmClassesLoaded:                                          MetricSettings{Enabled: true},
 		JvmGcCollectionsCount:                                     MetricSettings{Enabled: true},
 		JvmGcCollectionsElapsed:                                   MetricSettings{Enabled: true},
@@ -411,6 +426,7 @@ func TestAllMetrics(t *testing.T) {
 	mb.RecordElasticsearchNodeCacheCountDataPoint(ts, 1, AttributeQueryCacheCountType(1))
 	mb.RecordElasticsearchNodeCacheEvictionsDataPoint(ts, 1, AttributeCacheName(1))
 	mb.RecordElasticsearchNodeCacheMemoryUsageDataPoint(ts, 1, AttributeCacheName(1))
+	mb.RecordElasticsearchNodeCacheSizeDataPoint(ts, 1)
 	mb.RecordElasticsearchNodeClusterConnectionsDataPoint(ts, 1)
 	mb.RecordElasticsearchNodeClusterIoDataPoint(ts, 1, AttributeDirection(1))
 	mb.RecordElasticsearchNodeDiskIoReadDataPoint(ts, 1)
@@ -425,6 +441,7 @@ func TestAllMetrics(t *testing.T) {
 	mb.RecordElasticsearchNodeIngestOperationsFailedDataPoint(ts, 1)
 	mb.RecordElasticsearchNodeOpenFilesDataPoint(ts, 1)
 	mb.RecordElasticsearchNodeOperationsCompletedDataPoint(ts, 1, AttributeOperation(1))
+	mb.RecordElasticsearchNodeOperationsCurrentDataPoint(ts, 1, AttributeOperation(1))
 	mb.RecordElasticsearchNodeOperationsGetCompletedDataPoint(ts, 1, AttributeGetResult(1))
 	mb.RecordElasticsearchNodeOperationsGetTimeDataPoint(ts, 1, AttributeGetResult(1))
 	mb.RecordElasticsearchNodeOperationsTimeDataPoint(ts, 1, AttributeOperation(1))
@@ -449,6 +466,9 @@ func TestAllMetrics(t *testing.T) {
 	mb.RecordElasticsearchOsCPULoadAvg5mDataPoint(ts, 1)
 	mb.RecordElasticsearchOsCPUUsageDataPoint(ts, 1)
 	mb.RecordElasticsearchOsMemoryDataPoint(ts, 1, AttributeMemoryState(1))
+	mb.RecordElasticsearchProcessCPUTimeDataPoint(ts, 1)
+	mb.RecordElasticsearchProcessCPUUsageDataPoint(ts, 1)
+	mb.RecordElasticsearchProcessMemoryVirtualDataPoint(ts, 1)
 	mb.RecordJvmClassesLoadedDataPoint(ts, 1)
 	mb.RecordJvmGcCollectionsCountDataPoint(ts, 1, "attr-val")
 	mb.RecordJvmGcCollectionsElapsedDataPoint(ts, 1, "attr-val")
@@ -1057,6 +1077,19 @@ func TestAllMetrics(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, "fielddata", attrVal.Str())
 			validatedMetrics["elasticsearch.node.cache.memory.usage"] = struct{}{}
+		case "elasticsearch.node.cache.size":
+			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+			assert.Equal(t, "Total amount of memory used for the query cache across all shards assigned to the node.", ms.At(i).Description())
+			assert.Equal(t, "By", ms.At(i).Unit())
+			assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
+			assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+			dp := ms.At(i).Sum().DataPoints().At(0)
+			assert.Equal(t, start, dp.StartTimestamp())
+			assert.Equal(t, ts, dp.Timestamp())
+			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+			assert.Equal(t, int64(1), dp.IntValue())
+			validatedMetrics["elasticsearch.node.cache.size"] = struct{}{}
 		case "elasticsearch.node.cluster.connections":
 			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
@@ -1248,6 +1281,20 @@ func TestAllMetrics(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, "index", attrVal.Str())
 			validatedMetrics["elasticsearch.node.operations.completed"] = struct{}{}
+		case "elasticsearch.node.operations.current":
+			assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+			assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+			assert.Equal(t, "Number of query operations currently running.", ms.At(i).Description())
+			assert.Equal(t, "{operations}", ms.At(i).Unit())
+			dp := ms.At(i).Gauge().DataPoints().At(0)
+			assert.Equal(t, start, dp.StartTimestamp())
+			assert.Equal(t, ts, dp.Timestamp())
+			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+			assert.Equal(t, int64(1), dp.IntValue())
+			attrVal, ok := dp.Attributes().Get("operation")
+			assert.True(t, ok)
+			assert.Equal(t, "index", attrVal.Str())
+			validatedMetrics["elasticsearch.node.operations.current"] = struct{}{}
 		case "elasticsearch.node.operations.get.completed":
 			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
@@ -1589,6 +1636,43 @@ func TestAllMetrics(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, "free", attrVal.Str())
 			validatedMetrics["elasticsearch.os.memory"] = struct{}{}
+		case "elasticsearch.process.cpu.time":
+			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+			assert.Equal(t, "CPU time used by the process on which the Java virtual machine is running.", ms.At(i).Description())
+			assert.Equal(t, "ms", ms.At(i).Unit())
+			assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
+			assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+			dp := ms.At(i).Sum().DataPoints().At(0)
+			assert.Equal(t, start, dp.StartTimestamp())
+			assert.Equal(t, ts, dp.Timestamp())
+			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+			assert.Equal(t, int64(1), dp.IntValue())
+			validatedMetrics["elasticsearch.process.cpu.time"] = struct{}{}
+		case "elasticsearch.process.cpu.usage":
+			assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+			assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+			assert.Equal(t, "CPU usage in percent.", ms.At(i).Description())
+			assert.Equal(t, "1", ms.At(i).Unit())
+			dp := ms.At(i).Gauge().DataPoints().At(0)
+			assert.Equal(t, start, dp.StartTimestamp())
+			assert.Equal(t, ts, dp.Timestamp())
+			assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+			assert.Equal(t, float64(1), dp.DoubleValue())
+			validatedMetrics["elasticsearch.process.cpu.usage"] = struct{}{}
+		case "elasticsearch.process.memory.virtual":
+			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+			assert.Equal(t, "Size of virtual memory that is guaranteed to be available to the running process.", ms.At(i).Description())
+			assert.Equal(t, "By", ms.At(i).Unit())
+			assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
+			assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+			dp := ms.At(i).Sum().DataPoints().At(0)
+			assert.Equal(t, start, dp.StartTimestamp())
+			assert.Equal(t, ts, dp.Timestamp())
+			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+			assert.Equal(t, int64(1), dp.IntValue())
+			validatedMetrics["elasticsearch.process.memory.virtual"] = struct{}{}
 		case "jvm.classes.loaded":
 			assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 			assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
@@ -1782,6 +1866,7 @@ func TestNoMetrics(t *testing.T) {
 		ElasticsearchNodeCacheCount:                               MetricSettings{Enabled: false},
 		ElasticsearchNodeCacheEvictions:                           MetricSettings{Enabled: false},
 		ElasticsearchNodeCacheMemoryUsage:                         MetricSettings{Enabled: false},
+		ElasticsearchNodeCacheSize:                                MetricSettings{Enabled: false},
 		ElasticsearchNodeClusterConnections:                       MetricSettings{Enabled: false},
 		ElasticsearchNodeClusterIo:                                MetricSettings{Enabled: false},
 		ElasticsearchNodeDiskIoRead:                               MetricSettings{Enabled: false},
@@ -1796,6 +1881,7 @@ func TestNoMetrics(t *testing.T) {
 		ElasticsearchNodeIngestOperationsFailed:                   MetricSettings{Enabled: false},
 		ElasticsearchNodeOpenFiles:                                MetricSettings{Enabled: false},
 		ElasticsearchNodeOperationsCompleted:                      MetricSettings{Enabled: false},
+		ElasticsearchNodeOperationsCurrent:                        MetricSettings{Enabled: false},
 		ElasticsearchNodeOperationsGetCompleted:                   MetricSettings{Enabled: false},
 		ElasticsearchNodeOperationsGetTime:                        MetricSettings{Enabled: false},
 		ElasticsearchNodeOperationsTime:                           MetricSettings{Enabled: false},
@@ -1820,6 +1906,9 @@ func TestNoMetrics(t *testing.T) {
 		ElasticsearchOsCPULoadAvg5m:                               MetricSettings{Enabled: false},
 		ElasticsearchOsCPUUsage:                                   MetricSettings{Enabled: false},
 		ElasticsearchOsMemory:                                     MetricSettings{Enabled: false},
+		ElasticsearchProcessCPUTime:                               MetricSettings{Enabled: false},
+		ElasticsearchProcessCPUUsage:                              MetricSettings{Enabled: false},
+		ElasticsearchProcessMemoryVirtual:                         MetricSettings{Enabled: false},
 		JvmClassesLoaded:                                          MetricSettings{Enabled: false},
 		JvmGcCollectionsCount:                                     MetricSettings{Enabled: false},
 		JvmGcCollectionsElapsed:                                   MetricSettings{Enabled: false},
@@ -1875,6 +1964,7 @@ func TestNoMetrics(t *testing.T) {
 	mb.RecordElasticsearchNodeCacheCountDataPoint(ts, 1, AttributeQueryCacheCountType(1))
 	mb.RecordElasticsearchNodeCacheEvictionsDataPoint(ts, 1, AttributeCacheName(1))
 	mb.RecordElasticsearchNodeCacheMemoryUsageDataPoint(ts, 1, AttributeCacheName(1))
+	mb.RecordElasticsearchNodeCacheSizeDataPoint(ts, 1)
 	mb.RecordElasticsearchNodeClusterConnectionsDataPoint(ts, 1)
 	mb.RecordElasticsearchNodeClusterIoDataPoint(ts, 1, AttributeDirection(1))
 	mb.RecordElasticsearchNodeDiskIoReadDataPoint(ts, 1)
@@ -1889,6 +1979,7 @@ func TestNoMetrics(t *testing.T) {
 	mb.RecordElasticsearchNodeIngestOperationsFailedDataPoint(ts, 1)
 	mb.RecordElasticsearchNodeOpenFilesDataPoint(ts, 1)
 	mb.RecordElasticsearchNodeOperationsCompletedDataPoint(ts, 1, AttributeOperation(1))
+	mb.RecordElasticsearchNodeOperationsCurrentDataPoint(ts, 1, AttributeOperation(1))
 	mb.RecordElasticsearchNodeOperationsGetCompletedDataPoint(ts, 1, AttributeGetResult(1))
 	mb.RecordElasticsearchNodeOperationsGetTimeDataPoint(ts, 1, AttributeGetResult(1))
 	mb.RecordElasticsearchNodeOperationsTimeDataPoint(ts, 1, AttributeOperation(1))
@@ -1913,6 +2004,9 @@ func TestNoMetrics(t *testing.T) {
 	mb.RecordElasticsearchOsCPULoadAvg5mDataPoint(ts, 1)
 	mb.RecordElasticsearchOsCPUUsageDataPoint(ts, 1)
 	mb.RecordElasticsearchOsMemoryDataPoint(ts, 1, AttributeMemoryState(1))
+	mb.RecordElasticsearchProcessCPUTimeDataPoint(ts, 1)
+	mb.RecordElasticsearchProcessCPUUsageDataPoint(ts, 1)
+	mb.RecordElasticsearchProcessMemoryVirtualDataPoint(ts, 1)
 	mb.RecordJvmClassesLoadedDataPoint(ts, 1)
 	mb.RecordJvmGcCollectionsCountDataPoint(ts, 1, "attr-val")
 	mb.RecordJvmGcCollectionsElapsedDataPoint(ts, 1, "attr-val")

--- a/receiver/elasticsearchreceiver/internal/model/nodestats.go
+++ b/receiver/elasticsearchreceiver/internal/model/nodestats.go
@@ -176,7 +176,10 @@ type NodeStatsNodesInfoIndices struct {
 	QueryCache         BasicCacheInfo      `json:"query_cache"`
 	FieldDataCache     BasicCacheInfo      `json:"fielddata"`
 	TranslogStats      TranslogStats       `json:"translog"`
+	RequestCacheStats  RequestCacheStats   `json:"request_cache"`
 	SegmentsStats      SegmentsStats       `json:"segments"`
+	SharedStats        SharedStats         `json:"shard_stats"`
+	Mappings           MappingsStats       `json:"mappings"`
 }
 
 type SegmentsStats struct {
@@ -188,10 +191,26 @@ type SegmentsStats struct {
 	FixedBitSetMemoryInBy    int64 `json:"fixed_bit_set_memory_in_bytes"`
 }
 
+type SharedStats struct {
+	TotalCount int64 `json:"total_count"`
+}
+
+type MappingsStats struct {
+	TotalCount                 int64 `json:"total_count"`
+	TotalEstimatedOverheadInBy int64 `json:"total_estimated_overhead_in_bytes"`
+}
+
 type TranslogStats struct {
 	Operations                int64 `json:"operations"`
 	SizeInBy                  int64 `json:"size_in_bytes"`
 	UncommittedOperationsInBy int64 `json:"uncommitted_size_in_bytes"`
+}
+
+type RequestCacheStats struct {
+	MemorySizeInBy int64 `json:"memory_size_in_bytes"`
+	Evictions      int64 `json:"evictions"`
+	HitCount       int64 `json:"hit_count"`
+	MissCount      int64 `json:"miss_count"`
 }
 
 type StoreInfo struct {
@@ -228,6 +247,7 @@ type GetOperation struct {
 }
 
 type SearchOperations struct {
+	QueryCurrent    int64 `json:"query_current"`
 	QueryTotal      int64 `json:"query_total"`
 	QueryTimeInMs   int64 `json:"query_time_in_millis"`
 	FetchTotal      int64 `json:"fetch_total"`
@@ -315,7 +335,20 @@ type ThreadPoolStats struct {
 }
 
 type ProcessStats struct {
-	OpenFileDescriptorsCount int64 `json:"open_file_descriptors"`
+	OpenFileDescriptorsCount int64              `json:"open_file_descriptors"`
+	MaxFileDescriptorsCount  int64              `json:"max_file_descriptors_count"`
+	CPU                      ProcessCPUStats    `json:"cpu"`
+	Memory                   ProcessMemoryStats `json:"mem"`
+}
+
+type ProcessCPUStats struct {
+	Percent   int64 `json:"percent"`
+	TotalInMs int64 `json:"total_in_millis"`
+}
+
+type ProcessMemoryStats struct {
+	TotalVirtual     int64 `json:"total_virtual"`
+	TotalVirtualInBy int64 `json:"total_virtual_in_bytes"`
 }
 
 type TransportStats struct {

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -228,6 +228,15 @@ metrics:
       value_type: int
     attributes: [ query_cache_count_type ]
     enabled: true
+  elasticsearch.node.cache.size:
+    description: Total amount of memory used for the query cache across all shards assigned to the node.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: false
   elasticsearch.node.fs.disk.available:
     description: The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise.
     unit: By
@@ -310,6 +319,13 @@ metrics:
       value_type: int
     attributes: []
     enabled: true
+  elasticsearch.node.operations.current:
+    description: Number of query operations currently running.
+    unit: "{operations}"
+    gauge:
+      value_type: int
+    attributes: [ operation ]
+    enabled: false
   elasticsearch.node.operations.completed:
     description: The number of operations completed by a node.
     unit: "{operations}"
@@ -935,4 +951,29 @@ metrics:
       aggregation: cumulative
       value_type: int
     attributes: [document_state, index_aggregation_type]
+    enabled: false
+  elasticsearch.process.cpu.usage:
+    description: CPU usage in percent.
+    unit: 1.0
+    gauge:
+      value_type: double
+    attributes: [ ]
+    enabled: false
+  elasticsearch.process.cpu.time:
+    description: CPU time used by the process on which the Java virtual machine is running.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: false
+  elasticsearch.process.memory.virtual:
+    description: Size of virtual memory that is guaranteed to be available to the running process.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation: cumulative
+      value_type: int
+    attributes: [ ]
     enabled: false

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -165,6 +165,8 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordElasticsearchNodeCacheCountDataPoint(now, info.Indices.QueryCache.HitCount, metadata.AttributeQueryCacheCountTypeHit)
 		r.mb.RecordElasticsearchNodeCacheCountDataPoint(now, info.Indices.QueryCache.MissCount, metadata.AttributeQueryCacheCountTypeMiss)
 
+		r.mb.RecordElasticsearchNodeCacheSizeDataPoint(now, info.Indices.QueryCache.MemorySizeInBy)
+
 		r.mb.RecordElasticsearchNodeFsDiskAvailableDataPoint(now, info.FS.Total.AvailableBytes)
 		r.mb.RecordElasticsearchNodeFsDiskFreeDataPoint(now, info.FS.Total.FreeBytes)
 		r.mb.RecordElasticsearchNodeFsDiskTotalDataPoint(now, info.FS.Total.TotalBytes)
@@ -178,6 +180,8 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordElasticsearchNodeClusterConnectionsDataPoint(now, info.TransportStats.OpenConnections)
 
 		r.mb.RecordElasticsearchNodeHTTPConnectionsDataPoint(now, info.HTTPStats.OpenConnections)
+
+		r.mb.RecordElasticsearchNodeOperationsCurrentDataPoint(now, info.Indices.SearchOperations.QueryCurrent, metadata.AttributeOperationQuery)
 
 		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.IndexingOperations.IndexTotal, metadata.AttributeOperationIndex)
 		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.IndexingOperations.DeleteTotal, metadata.AttributeOperationDelete)
@@ -248,6 +252,17 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordElasticsearchOsCPULoadAvg1mDataPoint(now, info.OS.CPU.LoadAvg.OneMinute)
 		r.mb.RecordElasticsearchOsCPULoadAvg5mDataPoint(now, info.OS.CPU.LoadAvg.FiveMinutes)
 		r.mb.RecordElasticsearchOsCPULoadAvg15mDataPoint(now, info.OS.CPU.LoadAvg.FifteenMinutes)
+
+		// Elasticsearch sends this data in percent, but we want to represent it as a number between 0 and 1, so we need to divide.
+		// Additionally, if the usage is not known, ES will send '-1'. We do not want to report the metric in this case.
+		if info.ProcessStats.CPU.Percent != -1 {
+			r.mb.RecordElasticsearchProcessCPUUsageDataPoint(now, float64(info.ProcessStats.CPU.Percent)/100)
+		}
+		if info.ProcessStats.CPU.TotalInMs != -1 {
+			r.mb.RecordElasticsearchProcessCPUTimeDataPoint(now, info.ProcessStats.CPU.TotalInMs)
+		}
+
+		r.mb.RecordElasticsearchProcessMemoryVirtualDataPoint(now, info.ProcessStats.Memory.TotalVirtualInBy)
 
 		r.mb.RecordElasticsearchOsMemoryDataPoint(now, info.OS.Memory.UsedInBy, metadata.AttributeMemoryStateUsed)
 		r.mb.RecordElasticsearchOsMemoryDataPoint(now, info.OS.Memory.FreeInBy, metadata.AttributeMemoryStateFree)

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -61,6 +61,8 @@ func TestScraper(t *testing.T) {
 
 	config.Metrics.JvmMemoryHeapUtilization.Enabled = true
 
+	config.Metrics.ElasticsearchNodeOperationsCurrent.Enabled = true
+
 	config.Metrics.ElasticsearchIndexOperationsMergeSize.Enabled = true
 	config.Metrics.ElasticsearchIndexOperationsMergeDocsCount.Enabled = true
 	config.Metrics.ElasticsearchIndexSegmentsCount.Enabled = true
@@ -74,6 +76,11 @@ func TestScraper(t *testing.T) {
 	config.Metrics.ElasticsearchIndexDocuments.Enabled = true
 
 	config.Metrics.ElasticsearchClusterIndicesCacheEvictions.Enabled = true
+
+	config.Metrics.ElasticsearchNodeCacheSize.Enabled = true
+	config.Metrics.ElasticsearchProcessCPUUsage.Enabled = true
+	config.Metrics.ElasticsearchProcessCPUTime.Enabled = true
+	config.Metrics.ElasticsearchProcessMemoryVirtual.Enabled = true
 
 	sc := newElasticSearchScraper(receivertest.NewNopCreateSettings(), config)
 

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -794,6 +794,21 @@
                      "unit": "By"
                   },
                   {
+                     "description": "Total amount of memory used for the query cache across all shards assigned to the node.",
+                     "name": "elasticsearch.node.cache.size",
+                     "sum": {
+                        "aggregationTemporality": 2,
+                        "dataPoints": [
+                           {
+                              "asInt": "394",
+                              "startTimeUnixNano": "1670395732182417000",
+                              "timeUnixNano": "1670395732187524000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
                      "description": "Total count of query cache misses across all shards assigned to selected nodes.",
                      "name": "elasticsearch.node.cache.count",
                      "sum": {
@@ -1294,6 +1309,28 @@
                         ],
                         "isMonotonic": true
                      },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "Number of query operations currently running.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "6723",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "query"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1670396411069414000",
+                              "timeUnixNano": "1670396411072189000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.node.operations.current",
                      "unit": "{operations}"
                   },
                   {
@@ -1980,6 +2017,51 @@
                         ]
                      },
                      "name": "elasticsearch.os.memory",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "CPU time used by the process on which the Java virtual machine is running.",
+                     "name": "elasticsearch.process.cpu.time",
+                     "sum": {
+                        "aggregationTemporality": 2,
+                        "dataPoints": [
+                           {
+                              "asInt": "42970",
+                              "startTimeUnixNano": "1670400055325086000",
+                              "timeUnixNano": "1670400055330564000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "CPU usage in percent.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 0,
+                              "startTimeUnixNano": "1670556275657741000",
+                              "timeUnixNano": "1670556275662037000"
+                           }
+                        ]
+                     },
+                     "name": "elasticsearch.process.cpu.usage",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Size of virtual memory that is guaranteed to be available to the running process.",
+                     "name": "elasticsearch.process.memory.virtual",
+                     "sum": {
+                        "aggregationTemporality": 2,
+                        "dataPoints": [
+                           {
+                              "asInt": "4961767424",
+                              "startTimeUnixNano": "1670400872688367000",
+                              "timeUnixNano": "1670400872693424000"
+                           }
+                        ]
+                     },
                      "unit": "By"
                   },
                   {


### PR DESCRIPTION
#16095

----

Metrics to add:

- [x] elasticsearch_indices_active_queries
- [x] elasticsearch_indices_request_cache_memory_size_bytes
- [x] elasticsearch_process_cpu_percent
- [x] elasticsearch_process_cpu_seconds_total
- [x] elasticsearch_process_mem_virtual_size_bytes