### PR TITLE
[receiver/hostmetrics] docs: correct deprecation notice

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -166,9 +166,9 @@ the following process will be followed to phase out the old metrics:
 
 - Until and including `v0.63.0`, only the old metrics `process.memory.physical_usage` and `process.memory.virtual_usage` are emitted.
   You can use the [Metrics Transform processor][metricstransformprocessor_docs] to rename them.
-- Between `v0.64.0` and `v0.66.0`, the new metrics are introduced and the old metrics are marked as deprecated.
-  Both the new and the old metrics are emitted by default.
-- Between `v0.67.0` and `v0.69.0`, the old metrics are disabled by default.
+- Between `v0.64.0` and `v0.66.0`, the new metrics are introduced as optional (disabled by default) and the old metrics are marked as deprecated.
+  Only the old metrics are emitted by default.
+- Between `v0.67.0` and `v0.69.0`, the new metrics are enabled and the old metrics are disabled by default.
 - In `v0.70.0` and up, the old metrics are removed.
 
 To change the enabled state for the specific metrics, use the standard configuration options that are available for all metrics.


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14927

Fixing incorrect information in the deprecation notice about the process memory metrics: between v0.64.0 and v0.66.0, the new metrics are not enabled by default.

This must have crept in during a rebase, or I just missed the docs update when changing this.