### PR TITLE
(httpcheck): fix receiver name in the example config

### DIFF
--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -33,7 +33,7 @@ The following configuration settings are optional:
 
 ```yaml
 receivers:
-  http_check:
+  httpcheck:
     endpoint: http://endpoint:80
     method: GET
     collection_interval: 10s


### PR DESCRIPTION
I believe the example has a typo https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/httpcheckreceiver/factory.go#L32