### PR TITLE
[receiver/elasticsearch] add jvm heap percentage usage metric

### DIFF
--- a/.chloggen/elastic-jvm-heap-percent.yaml
+++ b/.chloggen/elastic-jvm-heap-percent.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add jvm heap percentage usage metric
+
+# One or more tracking issues related to the change
+issues: [14635]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -55,6 +55,5 @@ The following metric are available with versions:
 - `elasticsearch.cluster.state_update.time` >= [7.16.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.0.html)
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
-
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -82,7 +82,7 @@ These are the metrics available for this scraper.
 | **jvm.memory.heap.committed** | The amount of memory that is guaranteed to be available for the heap | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.heap.max** | The maximum amount of memory can be used for the heap | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.heap.used** | The current heap memory usage | By | Gauge(Int) | <ul> </ul> |
-| jvm.memory.heap.utilization | Percentage of heap memory usage | % | Gauge(Int) | <ul> </ul> |
+| jvm.memory.heap.utilization | Fraction of heap memory usage | 1 | Gauge(Double) | <ul> </ul> |
 | **jvm.memory.nonheap.committed** | The amount of memory that is guaranteed to be available for non-heap purposes | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.nonheap.used** | The current non-heap memory usage | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.pool.max** | The maximum amount of memory can be used for the memory pool | By | Gauge(Int) | <ul> <li>memory_pool_name</li> </ul> |

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -81,6 +81,7 @@ These are the metrics available for this scraper.
 | **jvm.gc.collections.elapsed** | The approximate accumulated collection elapsed time | ms | Sum(Int) | <ul> <li>collector_name</li> </ul> |
 | **jvm.memory.heap.committed** | The amount of memory that is guaranteed to be available for the heap | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.heap.max** | The maximum amount of memory can be used for the heap | By | Gauge(Int) | <ul> </ul> |
+| jvm.memory.heap.percentage | Percentage of heap memory usage | % | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.heap.used** | The current heap memory usage | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.nonheap.committed** | The amount of memory that is guaranteed to be available for non-heap purposes | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.nonheap.used** | The current non-heap memory usage | By | Gauge(Int) | <ul> </ul> |

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -81,8 +81,8 @@ These are the metrics available for this scraper.
 | **jvm.gc.collections.elapsed** | The approximate accumulated collection elapsed time | ms | Sum(Int) | <ul> <li>collector_name</li> </ul> |
 | **jvm.memory.heap.committed** | The amount of memory that is guaranteed to be available for the heap | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.heap.max** | The maximum amount of memory can be used for the heap | By | Gauge(Int) | <ul> </ul> |
-| jvm.memory.heap.percentage | Percentage of heap memory usage | % | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.heap.used** | The current heap memory usage | By | Gauge(Int) | <ul> </ul> |
+| jvm.memory.heap.utilization | Percentage of heap memory usage | % | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.nonheap.committed** | The amount of memory that is guaranteed to be available for non-heap purposes | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.nonheap.used** | The current non-heap memory usage | By | Gauge(Int) | <ul> </ul> |
 | **jvm.memory.pool.max** | The maximum amount of memory can be used for the memory pool | By | Gauge(Int) | <ul> <li>memory_pool_name</li> </ul> |

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -110,8 +110,8 @@ type MetricsSettings struct {
 	JvmGcCollectionsElapsed                                   MetricSettings `mapstructure:"jvm.gc.collections.elapsed"`
 	JvmMemoryHeapCommitted                                    MetricSettings `mapstructure:"jvm.memory.heap.committed"`
 	JvmMemoryHeapMax                                          MetricSettings `mapstructure:"jvm.memory.heap.max"`
-	JvmMemoryHeapPercentage                                   MetricSettings `mapstructure:"jvm.memory.heap.percentage"`
 	JvmMemoryHeapUsed                                         MetricSettings `mapstructure:"jvm.memory.heap.used"`
+	JvmMemoryHeapUtilization                                  MetricSettings `mapstructure:"jvm.memory.heap.utilization"`
 	JvmMemoryNonheapCommitted                                 MetricSettings `mapstructure:"jvm.memory.nonheap.committed"`
 	JvmMemoryNonheapUsed                                      MetricSettings `mapstructure:"jvm.memory.nonheap.used"`
 	JvmMemoryPoolMax                                          MetricSettings `mapstructure:"jvm.memory.pool.max"`
@@ -340,11 +340,11 @@ func DefaultMetricsSettings() MetricsSettings {
 		JvmMemoryHeapMax: MetricSettings{
 			Enabled: true,
 		},
-		JvmMemoryHeapPercentage: MetricSettings{
-			Enabled: false,
-		},
 		JvmMemoryHeapUsed: MetricSettings{
 			Enabled: true,
+		},
+		JvmMemoryHeapUtilization: MetricSettings{
+			Enabled: false,
 		},
 		JvmMemoryNonheapCommitted: MetricSettings{
 			Enabled: true,
@@ -4719,55 +4719,6 @@ func newMetricJvmMemoryHeapMax(settings MetricSettings) metricJvmMemoryHeapMax {
 	return m
 }
 
-type metricJvmMemoryHeapPercentage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills jvm.memory.heap.percentage metric with initial data.
-func (m *metricJvmMemoryHeapPercentage) init() {
-	m.data.SetName("jvm.memory.heap.percentage")
-	m.data.SetDescription("Percentage of heap memory usage")
-	m.data.SetUnit("%")
-	m.data.SetEmptyGauge()
-}
-
-func (m *metricJvmMemoryHeapPercentage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricJvmMemoryHeapPercentage) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricJvmMemoryHeapPercentage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricJvmMemoryHeapPercentage(settings MetricSettings) metricJvmMemoryHeapPercentage {
-	m := metricJvmMemoryHeapPercentage{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricJvmMemoryHeapUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -4810,6 +4761,55 @@ func (m *metricJvmMemoryHeapUsed) emit(metrics pmetric.MetricSlice) {
 
 func newMetricJvmMemoryHeapUsed(settings MetricSettings) metricJvmMemoryHeapUsed {
 	m := metricJvmMemoryHeapUsed{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricJvmMemoryHeapUtilization struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills jvm.memory.heap.utilization metric with initial data.
+func (m *metricJvmMemoryHeapUtilization) init() {
+	m.data.SetName("jvm.memory.heap.utilization")
+	m.data.SetDescription("Percentage of heap memory usage")
+	m.data.SetUnit("%")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricJvmMemoryHeapUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricJvmMemoryHeapUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricJvmMemoryHeapUtilization) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricJvmMemoryHeapUtilization(settings MetricSettings) metricJvmMemoryHeapUtilization {
+	m := metricJvmMemoryHeapUtilization{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -5147,8 +5147,8 @@ type MetricsBuilder struct {
 	metricJvmGcCollectionsElapsed                                   metricJvmGcCollectionsElapsed
 	metricJvmMemoryHeapCommitted                                    metricJvmMemoryHeapCommitted
 	metricJvmMemoryHeapMax                                          metricJvmMemoryHeapMax
-	metricJvmMemoryHeapPercentage                                   metricJvmMemoryHeapPercentage
 	metricJvmMemoryHeapUsed                                         metricJvmMemoryHeapUsed
+	metricJvmMemoryHeapUtilization                                  metricJvmMemoryHeapUtilization
 	metricJvmMemoryNonheapCommitted                                 metricJvmMemoryNonheapCommitted
 	metricJvmMemoryNonheapUsed                                      metricJvmMemoryNonheapUsed
 	metricJvmMemoryPoolMax                                          metricJvmMemoryPoolMax
@@ -5244,8 +5244,8 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		metricJvmGcCollectionsElapsed:                                   newMetricJvmGcCollectionsElapsed(settings.JvmGcCollectionsElapsed),
 		metricJvmMemoryHeapCommitted:                                    newMetricJvmMemoryHeapCommitted(settings.JvmMemoryHeapCommitted),
 		metricJvmMemoryHeapMax:                                          newMetricJvmMemoryHeapMax(settings.JvmMemoryHeapMax),
-		metricJvmMemoryHeapPercentage:                                   newMetricJvmMemoryHeapPercentage(settings.JvmMemoryHeapPercentage),
 		metricJvmMemoryHeapUsed:                                         newMetricJvmMemoryHeapUsed(settings.JvmMemoryHeapUsed),
+		metricJvmMemoryHeapUtilization:                                  newMetricJvmMemoryHeapUtilization(settings.JvmMemoryHeapUtilization),
 		metricJvmMemoryNonheapCommitted:                                 newMetricJvmMemoryNonheapCommitted(settings.JvmMemoryNonheapCommitted),
 		metricJvmMemoryNonheapUsed:                                      newMetricJvmMemoryNonheapUsed(settings.JvmMemoryNonheapUsed),
 		metricJvmMemoryPoolMax:                                          newMetricJvmMemoryPoolMax(settings.JvmMemoryPoolMax),
@@ -5397,8 +5397,8 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricJvmGcCollectionsElapsed.emit(ils.Metrics())
 	mb.metricJvmMemoryHeapCommitted.emit(ils.Metrics())
 	mb.metricJvmMemoryHeapMax.emit(ils.Metrics())
-	mb.metricJvmMemoryHeapPercentage.emit(ils.Metrics())
 	mb.metricJvmMemoryHeapUsed.emit(ils.Metrics())
+	mb.metricJvmMemoryHeapUtilization.emit(ils.Metrics())
 	mb.metricJvmMemoryNonheapCommitted.emit(ils.Metrics())
 	mb.metricJvmMemoryNonheapUsed.emit(ils.Metrics())
 	mb.metricJvmMemoryPoolMax.emit(ils.Metrics())
@@ -5788,14 +5788,14 @@ func (mb *MetricsBuilder) RecordJvmMemoryHeapMaxDataPoint(ts pcommon.Timestamp, 
 	mb.metricJvmMemoryHeapMax.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordJvmMemoryHeapPercentageDataPoint adds a data point to jvm.memory.heap.percentage metric.
-func (mb *MetricsBuilder) RecordJvmMemoryHeapPercentageDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricJvmMemoryHeapPercentage.recordDataPoint(mb.startTime, ts, val)
-}
-
 // RecordJvmMemoryHeapUsedDataPoint adds a data point to jvm.memory.heap.used metric.
 func (mb *MetricsBuilder) RecordJvmMemoryHeapUsedDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricJvmMemoryHeapUsed.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordJvmMemoryHeapUtilizationDataPoint adds a data point to jvm.memory.heap.utilization metric.
+func (mb *MetricsBuilder) RecordJvmMemoryHeapUtilizationDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricJvmMemoryHeapUtilization.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordJvmMemoryNonheapCommittedDataPoint adds a data point to jvm.memory.nonheap.committed metric.

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -4777,19 +4777,19 @@ type metricJvmMemoryHeapUtilization struct {
 // init fills jvm.memory.heap.utilization metric with initial data.
 func (m *metricJvmMemoryHeapUtilization) init() {
 	m.data.SetName("jvm.memory.heap.utilization")
-	m.data.SetDescription("Percentage of heap memory usage")
-	m.data.SetUnit("%")
+	m.data.SetDescription("Fraction of heap memory usage")
+	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 }
 
-func (m *metricJvmMemoryHeapUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricJvmMemoryHeapUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
 	if !m.settings.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
+	dp.SetDoubleValue(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -5794,7 +5794,7 @@ func (mb *MetricsBuilder) RecordJvmMemoryHeapUsedDataPoint(ts pcommon.Timestamp,
 }
 
 // RecordJvmMemoryHeapUtilizationDataPoint adds a data point to jvm.memory.heap.utilization metric.
-func (mb *MetricsBuilder) RecordJvmMemoryHeapUtilizationDataPoint(ts pcommon.Timestamp, val int64) {
+func (mb *MetricsBuilder) RecordJvmMemoryHeapUtilizationDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricJvmMemoryHeapUtilization.recordDataPoint(mb.startTime, ts, val)
 }
 

--- a/receiver/elasticsearchreceiver/internal/model/nodestats.go
+++ b/receiver/elasticsearchreceiver/internal/model/nodestats.go
@@ -267,6 +267,7 @@ type JVMMemoryInfo struct {
 	NonHeapUsedInBy     int64          `json:"non_heap_used_in_bytes"`
 	MaxHeapInBy         int64          `json:"heap_max_in_bytes"`
 	HeapCommittedInBy   int64          `json:"heap_committed_in_bytes"`
+	HeapUsedPercent     int64          `json:"heap_used_percent"`
 	NonHeapComittedInBy int64          `json:"non_heap_committed_in_bytes"`
 	MemoryPools         JVMMemoryPools `json:"pools"`
 }

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -474,11 +474,11 @@ metrics:
     attributes: []
     enabled: true
   jvm.memory.heap.utilization:
-    description: Percentage of heap memory usage
-    unit: '%'
+    description: Fraction of heap memory usage
+    unit: 1
     gauge:
-      value_type: int
-    attributes:
+      value_type: double
+    attributes: []
     enabled: false
   jvm.memory.heap.committed:
     description: The amount of memory that is guaranteed to be available for the heap

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -473,6 +473,13 @@ metrics:
       value_type: int
     attributes: []
     enabled: true
+  jvm.memory.heap.utilization:
+    description: Percentage of heap memory usage
+    unit: '%'
+    gauge:
+      value_type: int
+    attributes:
+    enabled: false
   jvm.memory.heap.committed:
     description: The amount of memory that is guaranteed to be available for the heap
     unit: By
@@ -515,14 +522,6 @@ metrics:
       value_type: int
     attributes: []
     enabled: true
-  # other jvm metrics, disabled by default
-  jvm.memory.heap.percentage:
-    description: Percentage of heap memory usage
-    unit: '%'
-    gauge:
-      value_type: int
-    attributes:
-    enabled: false
   # these metrics are from /_cluster/pending_tasks, and are cluster level metrics
   elasticsearch.cluster.pending_tasks:
     description: The number of cluster-level changes that have not yet been executed.

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -515,6 +515,14 @@ metrics:
       value_type: int
     attributes: []
     enabled: true
+  # other jvm metrics, disabled by default
+  jvm.memory.heap.percentage:
+    description: Percentage of heap memory usage
+    unit: '%'
+    gauge:
+      value_type: int
+    attributes:
+    enabled: false
   # these metrics are from /_cluster/pending_tasks, and are cluster level metrics
   elasticsearch.cluster.pending_tasks:
     description: The number of cluster-level changes that have not yet been executed.

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -220,7 +220,8 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordJvmMemoryHeapMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MaxHeapInBy)
 		r.mb.RecordJvmMemoryHeapUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapUsedInBy)
 		r.mb.RecordJvmMemoryHeapCommittedDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapCommittedInBy)
-		r.mb.RecordJvmMemoryHeapUtilizationDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapUsedPercent)
+		// Elasticsearch sends this data in percent, but we want to represent it as a number between 0 and 1, so we need to divide.
+		r.mb.RecordJvmMemoryHeapUtilizationDataPoint(now, float64(info.JVMInfo.JVMMemoryInfo.HeapUsedPercent)/100)
 
 		r.mb.RecordJvmMemoryNonheapUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.NonHeapUsedInBy)
 		r.mb.RecordJvmMemoryNonheapCommittedDataPoint(now, info.JVMInfo.JVMMemoryInfo.NonHeapComittedInBy)

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -234,6 +234,8 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 
 		r.mb.RecordJvmThreadsCountDataPoint(now, info.JVMInfo.JVMThreadInfo.Count)
 
+		r.mb.RecordJvmMemoryHeapPercentageDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapUsedPercent)
+
 		// Elasticsearch version 7.10+ is required to collect `elasticsearch.indexing_pressure.memory.limit`.
 		// Reference: https://github.com/elastic/elasticsearch/pull/60342/files#diff-13864344bab3afc267797d67b2746e2939a3fd8af7611ac9fbda376323e2f5eaR37
 		if r.version != nil && r.version.GreaterThanOrEqual(es7_10) {

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -220,6 +220,7 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordJvmMemoryHeapMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MaxHeapInBy)
 		r.mb.RecordJvmMemoryHeapUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapUsedInBy)
 		r.mb.RecordJvmMemoryHeapCommittedDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapCommittedInBy)
+		r.mb.RecordJvmMemoryHeapUtilizationDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapUsedPercent)
 
 		r.mb.RecordJvmMemoryNonheapUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.NonHeapUsedInBy)
 		r.mb.RecordJvmMemoryNonheapCommittedDataPoint(now, info.JVMInfo.JVMMemoryInfo.NonHeapComittedInBy)
@@ -233,8 +234,6 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordJvmMemoryPoolMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Old.MemMaxBy, "old")
 
 		r.mb.RecordJvmThreadsCountDataPoint(now, info.JVMInfo.JVMThreadInfo.Count)
-
-		r.mb.RecordJvmMemoryHeapPercentageDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapUsedPercent)
 
 		// Elasticsearch version 7.10+ is required to collect `elasticsearch.indexing_pressure.memory.limit`.
 		// Reference: https://github.com/elastic/elasticsearch/pull/60342/files#diff-13864344bab3afc267797d67b2746e2939a3fd8af7611ac9fbda376323e2f5eaR37

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -46,7 +46,7 @@ func TestScraper(t *testing.T) {
 	config.Metrics.ElasticsearchNodeOperationsGetCompleted.Enabled = true
 	config.Metrics.ElasticsearchNodeOperationsGetTime.Enabled = true
 
-	config.Metrics.JvmMemoryHeapPercentage.Enabled = true
+	config.Metrics.JvmMemoryHeapUtilization.Enabled = true
 
 	config.Metrics.ElasticsearchIndexOperationsMergeSize.Enabled = true
 	config.Metrics.ElasticsearchIndexOperationsMergeDocsCount.Enabled = true

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -46,6 +46,8 @@ func TestScraper(t *testing.T) {
 	config.Metrics.ElasticsearchNodeOperationsGetCompleted.Enabled = true
 	config.Metrics.ElasticsearchNodeOperationsGetTime.Enabled = true
 
+	config.Metrics.JvmMemoryHeapPercentage.Enabled = true
+
 	config.Metrics.ElasticsearchIndexOperationsMergeSize.Enabled = true
 	config.Metrics.ElasticsearchIndexOperationsMergeDocsCount.Enabled = true
 	config.Metrics.ElasticsearchIndexSegmentsCount.Enabled = true

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -2249,6 +2249,20 @@
                      },
                      "name": "jvm.threads.count",
                      "unit": "1"
+                  },
+                  {
+                     "description": "Percentage of heap memory usage",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "56",
+                              "startTimeUnixNano": "1661811689941624000",
+                              "timeUnixNano": "1661811689943245000"
+                           }
+                        ]
+                     },
+                     "name": "jvm.memory.heap.percentage",
+                     "unit": "%"
                   }
                ],
                "scope": {

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -2251,18 +2251,18 @@
                      "unit": "1"
                   },
                   {
-                     "description": "Percentage of heap memory usage",
+                     "description": "Fraction of heap memory usage",
                      "gauge": {
                         "dataPoints": [
                            {
-                              "asInt": "56",
+                              "asDouble": "0.56",
                               "startTimeUnixNano": "1661811689941624000",
                               "timeUnixNano": "1661811689943245000"
                            }
                         ]
                      },
                      "name": "jvm.memory.heap.utilization",
-                     "unit": "%"
+                     "unit": "1"
                   }
                ],
                "scope": {

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.json
@@ -2261,7 +2261,7 @@
                            }
                         ]
                      },
-                     "name": "jvm.memory.heap.percentage",
+                     "name": "jvm.memory.heap.utilization",
                      "unit": "%"
                   }
                ],


### PR DESCRIPTION
**Description:** 
A metric responsible for jvm heap usage in percents has been added.
Related comment: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14635#issuecomment-1293521139

**Link to tracking Issue:** #14635

**Testing:** 
unit

**Documentation:** 
mdatagen