### PR TITLE
Add CODEOWNER for pkg/experimentalmetricmetadata

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -27,6 +27,3 @@ extension/fluentbitextension
 ## UNMANTAINED components
 extension/httpforwarder
 receiver/dotnetdiagnosticsreceiver
-
-# OTHER; Looking for an owner
-pkg/experimentalmetricmetadata

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,6 +118,7 @@ pkg/translator/signalfx/                             @open-telemetry/collector-c
 pkg/translator/zipkin/                               @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 pkg/winperfcounters/                                 @open-telemetry/collector-contrib-approvers @dashpole @mrod1598 @binaryfissiongames
 pkg/batchperresourceattr/                            @open-telemetry/collector-contrib-approvers @atoulme @dmitryax
+pkg/experimentalmetricmetadata/                      @open-telemetry/collector-contrib-approvers @rmfitzpatrick
 
 processor/attributesprocessor/                       @open-telemetry/collector-contrib-approvers @boostchicken
 processor/cumulativetodeltaprocessor/                @open-telemetry/collector-contrib-approvers @TylerHelmuth

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -86,6 +86,7 @@ body:
       - extension/storage/filestorage
       - pkg/batchperresourceattr
       - pkg/batchpersignal
+      - pkg/experimentalmetricmetadata
       - pkg/ottl
       - pkg/resourcetotelemetry
       - pkg/stanza

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -80,6 +80,7 @@ body:
       - extension/storage/filestorage
       - pkg/batchperresourceattr
       - pkg/batchpersignal
+      - pkg/experimentalmetricmetadata
       - pkg/ottl
       - pkg/resourcetotelemetry
       - pkg/stanza

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -80,6 +80,7 @@ body:
       - extension/storage/filestorage
       - pkg/batchperresourceattr
       - pkg/batchpersignal
+      - pkg/experimentalmetricmetadata
       - pkg/ottl
       - pkg/resourcetotelemetry
       - pkg/stanza


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adds @rmfitzpatrick as a CODEOWNER for `pkg/experimentalmetadata`, this module was added on #2367 without a CODEOWNER.

**Link to tracking Issue:** Fixes #3870
