### PR TITLE
[receiver/awscloudwatch] docs update remove bad key from README config

### DIFF
--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -73,8 +73,7 @@ awscloudwatch:
     groups:
       named:
         /aws/eks/dev-0/cluster: 
-          streams:
-            names: [kube-apiserver-ea9c831555adca1815ae04b87661klasdj]
+          names: [kube-apiserver-ea9c831555adca1815ae04b87661klasdj]
 ```
 
 ## Sample Configs


### PR DESCRIPTION
**Description:** The `Named Example` config has an improper key `streams`. The content of this example should be like the one that is tested and validated found here https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/f58138420c9d03854a04437119f9cbfa981ddea9/receiver/awscloudwatchreceiver/testdata/sample-configs/named-prefix-streams.yaml#L1-L9

**Link to tracking Issue:**  Was not planning on making a changelog entry. Could a maintainer add the `skip-changelog` tag?

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>