### PR TITLE
[receiver/mongodb] Drop support for versions prior to 4.0

### DIFF
--- a/.chloggen/mongodb-update-supported-versions.yaml
+++ b/.chloggen/mongodb-update-supported-versions.yaml
@@ -2,7 +2,7 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: receiver/mongodb
+component: mongodbreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Drop support for versions of MongoDB prior to 4.0

--- a/.chloggen/mongodb-update-supported-versions.yaml
+++ b/.chloggen/mongodb-update-supported-versions.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mongodb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Drop support for versions of MongoDB prior to 4.0
+
+# One or more tracking issues related to the change
+issues: [16182]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -18,13 +18,10 @@ The purpose of this receiver is to allow users to monitor metrics from standalon
 
 This receiver supports MongoDB versions:
 
-- 2.6
-- 3.0+
 - 4.0+
 - 5.0
 
 Mongodb recommends to set up a least privilege user (LPU) with a [`clusterMonitor` role](https://www.mongodb.com/docs/v5.0/reference/built-in-roles/#mongodb-authrole-clusterMonitor) in order to collect metrics. Please refer to [lpu.sh](./testdata/integration/scripts/lpu.sh) for an example of how to configure these permissions.
-
 
 ## Configuration
 
@@ -61,6 +58,7 @@ The full list of settings exposed for this receiver are documented [here](./conf
 ## Metrics
 
 The following metric are available with versions:
+
 - `mongodb.extent.count` < 4.4 with mmapv1 storage engine
 - `mongodb.session.count` >= 3.0 with wiredTiger storage engine
 - `mongodb.cache.operations` >= 3.0 with wiredTiger storage engine

--- a/receiver/mongodbreceiver/integration_test.go
+++ b/receiver/mongodbreceiver/integration_test.go
@@ -38,22 +38,6 @@ import (
 var (
 	LPUSetupScript      = []string{"/lpu.sh"}
 	setupScript         = []string{"/setup.sh"}
-	containerRequest2_6 = testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context:    filepath.Join("testdata", "integration"),
-			Dockerfile: "Dockerfile.mongodb.2_6",
-		},
-		ExposedPorts: []string{"27017:27017"},
-		WaitingFor:   wait.ForListeningPort("27017").WithStartupTimeout(2 * time.Minute),
-	}
-	containerRequest3_0 = testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context:    filepath.Join("testdata", "integration"),
-			Dockerfile: "Dockerfile.mongodb.3_0",
-		},
-		ExposedPorts: []string{"27117:27017"},
-		WaitingFor:   wait.ForListeningPort("27017").WithStartupTimeout(2 * time.Minute),
-	}
 	containerRequest4_0 = testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
 			Context:    filepath.Join("testdata", "integration"),
@@ -81,82 +65,6 @@ var (
 )
 
 func TestMongodbIntegration(t *testing.T) {
-	t.Run("Running mongodb 2.6", func(t *testing.T) {
-		t.Parallel()
-		container := getContainer(t, containerRequest2_6, setupScript)
-		defer func() {
-			require.NoError(t, container.Terminate(context.Background()))
-		}()
-		hostname, err := container.Host(context.Background())
-		require.NoError(t, err)
-
-		f := NewFactory()
-		cfg := f.CreateDefaultConfig().(*Config)
-		cfg.Hosts = []confignet.NetAddr{
-			{
-				Endpoint: net.JoinHostPort(hostname, "27017"),
-			},
-		}
-		cfg.Insecure = true
-
-		consumer := new(consumertest.MetricsSink)
-		settings := componenttest.NewNopReceiverCreateSettings()
-		rcvr, err := f.CreateMetricsReceiver(context.Background(), settings, cfg, consumer)
-		require.NoError(t, err, "failed creating metrics receiver")
-
-		require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
-		require.Eventuallyf(t, func() bool {
-			return len(consumer.AllMetrics()) > 0
-		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
-		require.NoError(t, rcvr.Shutdown(context.Background()))
-
-		actualMetrics := consumer.AllMetrics()[0]
-
-		expectedFile := filepath.Join("testdata", "integration", "expected.2_6.json")
-		expectedMetrics, err := golden.ReadMetrics(expectedFile)
-		require.NoError(t, err)
-
-		err = scrapertest.CompareMetrics(expectedMetrics, actualMetrics, scrapertest.IgnoreMetricValues())
-		require.NoError(t, err)
-	})
-	t.Run("Running mongodb 3.0", func(t *testing.T) {
-		t.Parallel()
-		container := getContainer(t, containerRequest3_0, setupScript)
-		defer func() {
-			require.NoError(t, container.Terminate(context.Background()))
-		}()
-		hostname, err := container.Host(context.Background())
-		require.NoError(t, err)
-
-		f := NewFactory()
-		cfg := f.CreateDefaultConfig().(*Config)
-		cfg.Hosts = []confignet.NetAddr{
-			{
-				Endpoint: net.JoinHostPort(hostname, "27117"),
-			},
-		}
-		cfg.Insecure = true
-
-		consumer := new(consumertest.MetricsSink)
-		settings := componenttest.NewNopReceiverCreateSettings()
-		rcvr, err := f.CreateMetricsReceiver(context.Background(), settings, cfg, consumer)
-		require.NoError(t, err, "failed creating metrics receiver")
-
-		require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
-		require.Eventuallyf(t, func() bool {
-			return len(consumer.AllMetrics()) > 0
-		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
-		require.NoError(t, rcvr.Shutdown(context.Background()))
-
-		actualMetrics := consumer.AllMetrics()[0]
-
-		expectedFile := filepath.Join("testdata", "integration", "expected.3_0.json")
-		expectedMetrics, err := golden.ReadMetrics(expectedFile)
-		require.NoError(t, err)
-
-		err = scrapertest.CompareMetrics(expectedMetrics, actualMetrics, scrapertest.IgnoreMetricValues())
-		require.NoError(t, err)
-	})
 	t.Run("Running mongodb 4.0", func(t *testing.T) {
 		t.Parallel()
 		container := getContainer(t, containerRequest4_0, setupScript)

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -118,7 +118,7 @@ func (s *mongodbScraper) recordExtentCount(now pcommon.Timestamp, doc bson.M, db
 	// Mongo version 4.4+ no longer returns numExtents since it is part of the obsolete MMAPv1
 	// https://www.mongodb.com/docs/manual/release-notes/4.4-compatibility/#mmapv1-cleanup
 	mongo44, _ := version.NewVersion("4.4")
-	if s.mongoVersion.LessThan(mongo44) {
+	if s.mongoVersion != nil && s.mongoVersion.LessThan(mongo44) {
 		metricPath := []string{"numExtents"}
 		metricName := "mongodb.extent.count"
 		val, err := collectMetric(doc, metricPath)
@@ -132,13 +132,7 @@ func (s *mongodbScraper) recordExtentCount(now pcommon.Timestamp, doc bson.M, db
 
 // ServerStatus
 func (s *mongodbScraper) recordConnections(now pcommon.Timestamp, doc bson.M, dbName string, errs *scrapererror.ScrapeErrors) {
-	mongo40, _ := version.NewVersion("4.0")
 	for ctVal, ct := range metadata.MapAttributeConnectionType {
-		// Mongo version 4.0 added active
-		// reference: https://www.mongodb.com/docs/v4.0/reference/command/serverStatus/#serverstatus.connections.active
-		if s.mongoVersion.LessThan(mongo40) && ctVal == "active" {
-			continue
-		}
 		metricPath := []string{"connections", ctVal}
 		metricName := "mongodb.connection.count"
 		metricAttributes := fmt.Sprintf("%s, %s", ctVal, dbName)
@@ -182,13 +176,6 @@ func (s *mongodbScraper) recordDocumentOperations(now pcommon.Timestamp, doc bso
 }
 
 func (s *mongodbScraper) recordSessionCount(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
-	// Collect session count for version 3.0+
-	// https://www.mongodb.com/docs/v3.0/reference/command/serverStatus/#serverStatus.wiredTiger.session
-	mongo30, _ := version.NewVersion("3.0")
-	if s.mongoVersion.LessThan(mongo30) {
-		return
-	}
-
 	storageEngine, err := dig(doc, []string{"storageEngine", "name"})
 	if err != nil {
 		errs.AddPartial(1, errors.New("failed to find storage engine for session count"))
@@ -224,14 +211,6 @@ func (s *mongodbScraper) recordOperations(now pcommon.Timestamp, doc bson.M, err
 }
 
 func (s *mongodbScraper) recordCacheOperations(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
-	// Collect Cache Hits & Misses if wiredTiger storage engine is used
-	// WiredTiger.cache metrics are available in 3.0+
-	// https://www.mongodb.com/docs/v4.0/reference/command/serverStatus/#serverstatus.wiredTiger.cache
-	mongo30, _ := version.NewVersion("3.0")
-	if s.mongoVersion.LessThan(mongo30) {
-		return
-	}
-
 	storageEngine, err := dig(doc, []string{"storageEngine", "name"})
 	if err != nil {
 		errs.AddPartial(1, errors.New("failed to find storage engine for cache operations"))
@@ -316,29 +295,24 @@ func (s *mongodbScraper) recordNetworkCount(now pcommon.Timestamp, doc bson.M, e
 
 // Index Stats
 func (s *mongodbScraper) recordIndexAccess(now pcommon.Timestamp, documents []bson.M, dbName string, collectionName string, errs *scrapererror.ScrapeErrors) {
-	// Collect the index access given a collection and database if version is >= 3.2
-	// https://www.mongodb.com/docs/v3.2/reference/operator/aggregation/indexStats/
-	mongo32, _ := version.NewVersion("3.2")
-	if s.mongoVersion.GreaterThanOrEqual(mongo32) {
-		metricName := "mongodb.index.access.count"
-		var indexAccessTotal int64
-		for _, doc := range documents {
-			metricAttributes := fmt.Sprintf("%s, %s", dbName, collectionName)
-			indexAccess, ok := doc["accesses"].(bson.M)["ops"]
-			if !ok {
-				err := errors.New("could not find key for index access metric")
-				errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, metricAttributes, err))
-				return
-			}
-			indexAccessValue, err := parseInt(indexAccess)
-			if err != nil {
-				errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, metricAttributes, err))
-				return
-			}
-			indexAccessTotal += indexAccessValue
+	metricName := "mongodb.index.access.count"
+	var indexAccessTotal int64
+	for _, doc := range documents {
+		metricAttributes := fmt.Sprintf("%s, %s", dbName, collectionName)
+		indexAccess, ok := doc["accesses"].(bson.M)["ops"]
+		if !ok {
+			err := errors.New("could not find key for index access metric")
+			errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, metricAttributes, err))
+			return
 		}
-		s.mb.RecordMongodbIndexAccessCountDataPoint(now, indexAccessTotal, dbName, collectionName)
+		indexAccessValue, err := parseInt(indexAccess)
+		if err != nil {
+			errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, metricAttributes, err))
+			return
+		}
+		indexAccessTotal += indexAccessValue
 	}
+	s.mb.RecordMongodbIndexAccessCountDataPoint(now, indexAccessTotal, dbName, collectionName)
 }
 
 // Top Stats

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -136,21 +136,6 @@ func TestScraperScrape(t *testing.T) {
 			expectedErr: errors.New("no client was initialized before calling scrape"),
 		},
 		{
-			desc:       "Failed to get version",
-			partialErr: false,
-			setupMockClient: func(t *testing.T) client {
-				fc := &fakeClient{}
-				mongo40, err := version.NewVersion("4.0")
-				require.NoError(t, err)
-				fc.On("GetVersion", mock.Anything).Return(mongo40, errors.New("some version error"))
-				return fc
-			},
-			expectedMetricGen: func(t *testing.T) pmetric.Metrics {
-				return pmetric.NewMetrics()
-			},
-			expectedErr: errors.New("unable to determine version of mongo scraping against: some version error"),
-		},
-		{
 			desc:       "Failed to fetch database names",
 			partialErr: true,
 			setupMockClient: func(t *testing.T) client {

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.2_6
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.2_6
@@ -1,6 +1,0 @@
-FROM mongo:2.6
-
-COPY scripts/setup.sh /setup.sh
-RUN chmod +x /setup.sh
-
-EXPOSE 27017

--- a/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.3_0
+++ b/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.3_0
@@ -1,6 +1,0 @@
-FROM mongo:3.0
-
-COPY scripts/setup.sh /setup.sh
-RUN chmod +x /setup.sh
-
-EXPOSE 27017


### PR DESCRIPTION
Resolves #16182 

I'm not sure if there is a defined process for a breaking change in this circumstance.

Mongo's latest driver dropped support for anything prior to 3.6. Anything prior to 4.0 has been EOL for at least 1.5 years. Still this is technically a breaking change. I don't think it can be controlled by a feature gate, since it is a dependency issue. 