### PR TITLE
[receiver/prometheus] ensure safe shutdown

### DIFF
--- a/.chloggen/msg_ensure-safe-shutdown.yaml
+++ b/.chloggen/msg_ensure-safe-shutdown.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensures on component shutdown that it can not panic
+
+# One or more tracking issues related to the change
+issues: [6507]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: -|
+  The referenced issue comes from https://github.com/open-telemetry/opentelemetry-collector/issues/6507

--- a/.chloggen/msg_ensure-safe-shutdown.yaml
+++ b/.chloggen/msg_ensure-safe-shutdown.yaml
@@ -8,10 +8,10 @@ component: prometheusreceiver
 note: Ensures on component shutdown that it can not panic
 
 # One or more tracking issues related to the change
-issues: [6507]
+issues: [16211]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: -|
-  The referenced issue comes from https://github.com/open-telemetry/opentelemetry-collector/issues/6507
+  - Resolves issue https://github.com/open-telemetry/opentelemetry-collector/issues/6507 for prometheusreceiver

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -314,7 +314,7 @@ func gcInterval(cfg *config.Config) time.Duration {
 func (r *pReceiver) Shutdown(context.Context) error {
 	select {
 	case <-r.configLoaded:
-		// recevier has been correctly started
+		// receiver has been correctly started
 		// so it is safe to continue shutdown.
 	default:
 		return nil

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -312,6 +312,13 @@ func gcInterval(cfg *config.Config) time.Duration {
 
 // Shutdown stops and cancels the underlying Prometheus scrapers.
 func (r *pReceiver) Shutdown(context.Context) error {
+	select {
+	case <-r.configLoaded:
+		// recevier has been correctly started
+		// so it is safe to continue shutdown.
+	default:
+		return nil
+	}
 	r.cancelFunc()
 	r.scrapeManager.Stop()
 	close(r.targetAllocatorStop)

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -15,12 +15,15 @@
 package prometheusreceiver
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/prometheus/common/model"
 	promConfig "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -1535,4 +1538,16 @@ func TestGCInterval(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSafeShutdown(t *testing.T) {
+	p := newPrometheusReceiver(
+		componenttest.NewNopReceiverCreateSettings(),
+		&Config{},
+		consumertest.NewNop(),
+		featuregate.GetRegistry(),
+	)
+	assert.NotPanics(t, func() {
+		assert.NoError(t, p.Shutdown(context.Background()))
+	}, "Must not panic when shutting down")
 }


### PR DESCRIPTION
**Description:**
In a failure scenario of the service starting up, it is possible that `Shutdown` can be called without an associated `Start`. 
This ensure that if that case were to happen, that it checks itself before continue stopping internal processes.

**Link to tracking Issue:**
Not strictly related to but https://github.com/open-telemetry/opentelemetry-collector/issues/6507

**Testing:**

Added check to ensure shutdown is safe locally but worth considering making it part of the lifecycle tests.

**Documentation:** <Describe the documentation added.>