### PR TITLE
[chore] Clean up documented parameters for stateful pkg/stanza receivers

### DIFF
--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -29,7 +29,7 @@ Tails and parses logs from files.
 | `attributes`                 | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
 | `resource`                   | {}               | A map of `key: value` pairs to add to the entry's resource                                                    |
 | `operators`                  | []               | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
-| `storage`                    |                  | The ID of a storage extension. The extension will be used to store file checkpoints, which allow the receiver to pick up where it left off in the case of a collector restart. |
+| `storage`                    | none             | The ID of a storage extension to be used to store file checkpoints. File checkpoints allow the receiver to pick up where it left off in the case of a collector restart. If no storage extension is used, the receiver will manage checkpoints in memory only. |
 
 Note that _by default_, no logs will be read from a file that is not actively being written to because `start_at` defaults to `end`.
 

--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -29,12 +29,7 @@ Tails and parses logs from files.
 | `attributes`                 | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
 | `resource`                   | {}               | A map of `key: value` pairs to add to the entry's resource                                                    |
 | `operators`                  | []               | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
-| `converter`                  | <pre lang="jsonp">{<br>  max_flush_count: 100,<br>  flush_interval: 100ms,<br>  worker_count: max(1,runtime.NumCPU()/4)<br>}</pre> | A map of `key: value` pairs to configure the [`entry.Entry`][entry_link] to [`plog.LogRecord`][pdata_logrecord_link] converter, more info can be found [here][converter_link] |
-| `storage`                   |                  | The ID of a storage extension. The extension will be used to store file checkpoints, which allows the receiver to pick up where it left off in the case of a collector restart. |
-
-[entry_link]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/entry/entry.go
-[pdata_logrecord_link]: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.40.0/model/pdata/generated_log.go#L553-L564
-[converter_link]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.40.0/internal/stanza/converter.go#L41-L82
+| `storage`                    |                  | The ID of a storage extension. The extension will be used to store file checkpoints, which allow the receiver to pick up where it left off in the case of a collector restart. |
 
 Note that _by default_, no logs will be read from a file that is not actively being written to because `start_at` defaults to `end`.
 

--- a/receiver/journaldreceiver/README.md
+++ b/receiver/journaldreceiver/README.md
@@ -18,7 +18,7 @@ Journald receiver is dependent on `journalctl` binary to be present and must be 
 | `start_at`  | `end`                                | At startup, where to start reading logs from the file. Options are beginning or end |
 | `units`     | `[ssh, kubelet, docker, containerd]` | A list of units to read entries from |
 | `priority`  | `info`                               | Filter output by message priorities or priority ranges |
-| `storage`   |                                      | The ID of a storage extension. The extension will be used to store cursors, which allow the receiver to pick up where it left off in the case of a collector restart. |
+| `storage`   | none                                 | The ID of a storage extension to be used to store cursors. Cursors allow the receiver to pick up where it left off in the case of a collector restart. If no storage extension is used, the receiver will manage cursors in memory only. |
 
 ### Example Configurations
 

--- a/receiver/journaldreceiver/README.md
+++ b/receiver/journaldreceiver/README.md
@@ -11,15 +11,17 @@ Journald receiver is dependent on `journalctl` binary to be present and must be 
 
 ## Configuration
 
-| Field                  | Default          | Description                                                                                                        |
-| ---                    | ---              | ---                                                                                                                |
-| `directory`            | /run/log/journal or /run/journal | A directory containing journal files to read entries from.     |
-| `files`                |                  | A list of journal files to read entries from                  |
-| `start_at`              | `end`              | At startup, where to start reading logs from the file. Options are beginning or end          |
-| `units`        | `[ssh, kubelet, docker, containerd]` | A list of units to read entries from          |
-| `prioriry`             | `info`           | Filter output by message priorities or priority ranges        |
+| Field       | Default                              | Description |
+| ---         | ---                                  | --- |
+| `directory` | `/run/log/journal` or `/run/journal` | A directory containing journal files to read entries from |
+| `files`     |                                      | A list of journal files to read entries from |
+| `start_at`  | `end`                                | At startup, where to start reading logs from the file. Options are beginning or end |
+| `units`     | `[ssh, kubelet, docker, containerd]` | A list of units to read entries from |
+| `priority`  | `info`                               | Filter output by message priorities or priority ranges |
+| `storage`   |                                      | The ID of a storage extension. The extension will be used to store cursors, which allow the receiver to pick up where it left off in the case of a collector restart. |
 
 ### Example Configurations
+
 ```yaml
 receivers:
   journald:

--- a/receiver/windowseventlogreceiver/README.md
+++ b/receiver/windowseventlogreceiver/README.md
@@ -19,7 +19,7 @@ Tails and parses logs from windows event log API using the [opentelemetry-log-co
 | `attributes`    | {}                       | A map of `key: value` pairs to add to the entry's attributes. |
 | `resource`      | {}                       | A map of `key: value` pairs to add to the entry's resource. |
 | `operators`            | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
-| `storage`                   |                  | The ID of a storage extension. The extension will be used to store bookmarks, which allow the receiver to pick up where it left off in the case of a collector restart. |
+| `storage`       | none             | The ID of a storage extension to be used to store bookmarks. Bookmarks allow the receiver to pick up where it left off in the case of a collector restart. If no storage extension is used, the receiver will manage bookmarks in memory only. |
 
 ### Operators
 

--- a/receiver/windowseventlogreceiver/README.md
+++ b/receiver/windowseventlogreceiver/README.md
@@ -19,7 +19,7 @@ Tails and parses logs from windows event log API using the [opentelemetry-log-co
 | `attributes`    | {}                       | A map of `key: value` pairs to add to the entry's attributes. |
 | `resource`      | {}                       | A map of `key: value` pairs to add to the entry's resource. |
 | `operators`            | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
-| `converter`            | <pre lang="jsonp">{<br>  max_flush_count: 100,<br>  flush_interval: 100ms,<br>  worker_count: max(1,runtime.NumCPU()/4)<br>}</pre> | A map of `key: value` pairs to configure the [`entry.Entry`][entry_link] to [`pdata.LogRecord`][pdata_logrecord_link] converter, more info can be found [here][converter_link] |
+| `storage`                   |                  | The ID of a storage extension. The extension will be used to store bookmarks, which allow the receiver to pick up where it left off in the case of a collector restart. |
 
 ### Operators
 


### PR DESCRIPTION
- Remove references to `converter`
- Add references to `storage`
- Improve formatting on tables