### PR TITLE
[chore] replace statement for otlp receiver no longer needed

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -1031,5 +1031,3 @@ exclude github.com/docker/distribution v2.8.0+incompatible
 // some dependencies attempt to bring something like v1.8.2-0.20220303173753-edfe657b5405, which is older than v0.38.0
 // at the time of this inclusion, v0.38.0 was the latest version available (also tagged as v2.38.0)
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.38.0
-
-replace go.opentelemetry.io/collector/receiver/otlpreceiver => go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -2138,8 +2138,8 @@ go.opentelemetry.io/collector/processor/batchprocessor v0.64.0 h1:QHLmr0Mw3j9Ewb
 go.opentelemetry.io/collector/processor/batchprocessor v0.64.0/go.mod h1:ZZtDQ1M9szgmwa0aT/R8JteB2zadwogylE9p3Sr64qU=
 go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.64.0 h1:1BvrtJiYcaupu2I10LDQhjbi+X3F9WAF/Ai7GvDLNG4=
 go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.64.0/go.mod h1:q90okpYJ2dBLtfHPRIijwGFknhaZPDqcHtmi1UHiE08=
-go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426 h1:6cosCaS91068I8El0q8TJkv3V5lRzAfH2Wuja/5ydIo=
-go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426/go.mod h1:+sGF2/LgOFWN1QClgdzg2NYCY9dYyPO4W4NAfxdODto=
+go.opentelemetry.io/collector/receiver/otlpreceiver v0.64.0 h1:z4kTdkSCzsbi9iH2jZ0twJrRkmfYqC8PfZ2vAIUclQk=
+go.opentelemetry.io/collector/receiver/otlpreceiver v0.64.0/go.mod h1:CoDUStGu6pmcRGwqsjm9/4HHXvDcSToWt5HMQuIvsrM=
 go.opentelemetry.io/collector/semconv v0.56.0/go.mod h1:EH1wbDvTyqKpKBBpoMIe0KQk2plCcFS66Mo17WtR7CQ=
 go.opentelemetry.io/collector/semconv v0.57.2/go.mod h1:84YnUjmm+nhGu4YTDLnHCbxnL74ooWpismPG79tFD7w=
 go.opentelemetry.io/collector/semconv v0.63.0/go.mod h1:5o9yhOa+ABt7g2E5JABDxGZ1PQPbtfxrKNbYn+LOTXU=

--- a/exporter/f5cloudexporter/go.mod
+++ b/exporter/f5cloudexporter/go.mod
@@ -58,5 +58,3 @@ require (
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
-
-replace go.opentelemetry.io/collector/receiver/otlpreceiver => go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426

--- a/exporter/f5cloudexporter/go.sum
+++ b/exporter/f5cloudexporter/go.sum
@@ -305,7 +305,7 @@ go.opentelemetry.io/collector/exporter/otlphttpexporter v0.64.0 h1:FlBNipMdi3Ygy
 go.opentelemetry.io/collector/exporter/otlphttpexporter v0.64.0/go.mod h1:H4FkbD4NkkrPLoi9t4O3KFhJ4zfUDS6fIgwjVXsOIc0=
 go.opentelemetry.io/collector/pdata v0.64.0 h1:Mx0ZawbR5F0WyUPCGB1EYsCJYsEj0iJBqX+hm3CFH40=
 go.opentelemetry.io/collector/pdata v0.64.0/go.mod h1:IzvXUGQml2mrnvdb8zIlEW3qQs9oFLdD2hLwJdZ+pek=
-go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426 h1:6cosCaS91068I8El0q8TJkv3V5lRzAfH2Wuja/5ydIo=
+go.opentelemetry.io/collector/receiver/otlpreceiver v0.64.0 h1:z4kTdkSCzsbi9iH2jZ0twJrRkmfYqC8PfZ2vAIUclQk=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.4 h1:PRXhsszxTt5bbPriTjmaweWUsAnJYeWBhUMLRetUgBU=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.4 h1:aUEBEdCa6iamGzg6fuYxDA8ThxvOG240mAvWDU+XLio=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.4/go.mod h1:l2MdsbKTocpPS5nQZscqTR9jd8u96VYZdcpF8Sye7mA=

--- a/go.mod
+++ b/go.mod
@@ -1039,5 +1039,3 @@ exclude github.com/docker/distribution v2.8.0+incompatible
 // some dependencies attempt to bring something like v1.8.2-0.20220303173753-edfe657b5405, which is older than v0.38.0
 // at the time of this inclusion, v0.38.0 was the latest version available (also tagged as v2.38.0)
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.38.0
-
-replace go.opentelemetry.io/collector/receiver/otlpreceiver => go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426

--- a/go.sum
+++ b/go.sum
@@ -2135,8 +2135,8 @@ go.opentelemetry.io/collector/processor/batchprocessor v0.64.0 h1:QHLmr0Mw3j9Ewb
 go.opentelemetry.io/collector/processor/batchprocessor v0.64.0/go.mod h1:ZZtDQ1M9szgmwa0aT/R8JteB2zadwogylE9p3Sr64qU=
 go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.64.0 h1:1BvrtJiYcaupu2I10LDQhjbi+X3F9WAF/Ai7GvDLNG4=
 go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.64.0/go.mod h1:q90okpYJ2dBLtfHPRIijwGFknhaZPDqcHtmi1UHiE08=
-go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426 h1:6cosCaS91068I8El0q8TJkv3V5lRzAfH2Wuja/5ydIo=
-go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426/go.mod h1:+sGF2/LgOFWN1QClgdzg2NYCY9dYyPO4W4NAfxdODto=
+go.opentelemetry.io/collector/receiver/otlpreceiver v0.64.0 h1:z4kTdkSCzsbi9iH2jZ0twJrRkmfYqC8PfZ2vAIUclQk=
+go.opentelemetry.io/collector/receiver/otlpreceiver v0.64.0/go.mod h1:CoDUStGu6pmcRGwqsjm9/4HHXvDcSToWt5HMQuIvsrM=
 go.opentelemetry.io/collector/semconv v0.56.0/go.mod h1:EH1wbDvTyqKpKBBpoMIe0KQk2plCcFS66Mo17WtR7CQ=
 go.opentelemetry.io/collector/semconv v0.57.2/go.mod h1:84YnUjmm+nhGu4YTDLnHCbxnL74ooWpismPG79tFD7w=
 go.opentelemetry.io/collector/semconv v0.63.0/go.mod h1:5o9yhOa+ABt7g2E5JABDxGZ1PQPbtfxrKNbYn+LOTXU=

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -303,5 +303,3 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../internal/coreinternal
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry => ../pkg/resourcetotelemetry
-
-replace go.opentelemetry.io/collector/receiver/otlpreceiver => go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -1441,8 +1441,8 @@ go.opentelemetry.io/collector/processor/batchprocessor v0.64.0 h1:QHLmr0Mw3j9Ewb
 go.opentelemetry.io/collector/processor/batchprocessor v0.64.0/go.mod h1:ZZtDQ1M9szgmwa0aT/R8JteB2zadwogylE9p3Sr64qU=
 go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.64.0 h1:1BvrtJiYcaupu2I10LDQhjbi+X3F9WAF/Ai7GvDLNG4=
 go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.64.0/go.mod h1:q90okpYJ2dBLtfHPRIijwGFknhaZPDqcHtmi1UHiE08=
-go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426 h1:6cosCaS91068I8El0q8TJkv3V5lRzAfH2Wuja/5ydIo=
-go.opentelemetry.io/collector/receiver/otlpreceiver v0.0.0-20221108014805-0b08d5316426/go.mod h1:+sGF2/LgOFWN1QClgdzg2NYCY9dYyPO4W4NAfxdODto=
+go.opentelemetry.io/collector/receiver/otlpreceiver v0.64.0 h1:z4kTdkSCzsbi9iH2jZ0twJrRkmfYqC8PfZ2vAIUclQk=
+go.opentelemetry.io/collector/receiver/otlpreceiver v0.64.0/go.mod h1:CoDUStGu6pmcRGwqsjm9/4HHXvDcSToWt5HMQuIvsrM=
 go.opentelemetry.io/collector/semconv v0.56.0/go.mod h1:EH1wbDvTyqKpKBBpoMIe0KQk2plCcFS66Mo17WtR7CQ=
 go.opentelemetry.io/collector/semconv v0.57.2/go.mod h1:84YnUjmm+nhGu4YTDLnHCbxnL74ooWpismPG79tFD7w=
 go.opentelemetry.io/collector/semconv v0.63.0/go.mod h1:5o9yhOa+ABt7g2E5JABDxGZ1PQPbtfxrKNbYn+LOTXU=


### PR DESCRIPTION
This was only needed before the module was released.
