### PR TITLE
[receiver/azureeventhub] Mark Azure event hub receiver as alpha

### DIFF
--- a/.chloggen/mark-azure-eventhub-alpha.yaml
+++ b/.chloggen/mark-azure-eventhub-alpha.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azureeventhubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark the Azure Event Hub receiver as alpha.
+
+# One or more tracking issues related to the change
+issues: [12786]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/azureeventhubreceiver/README.md
+++ b/receiver/azureeventhubreceiver/README.md
@@ -1,10 +1,10 @@
 # Azure Event Hub Receiver
 
-| Status                   |                  |
-| ------------------------ |------------------|
-| Stability                | [in development] |
-| Supported pipeline types | logs             |
-| Distributions            | [contrib]        |
+| Status                   |           |
+| ------------------------ |-----------|
+| Stability                | [alpha]   |
+| Supported pipeline types | logs      |
+| Distributions            | [contrib] |
 
 ## Overview
 The Azure Event Hub receiver listens to logs emitted by Azure Event hubs.
@@ -36,6 +36,6 @@ receivers:
 
 This component can persist its state using the [storage extension].
 
-[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [storage extension]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage


### PR DESCRIPTION
**Description:** 
Mark the azure event hub receiver as alpha.

**Link to tracking Issue:**
#12786

**Testing:**
N/A

**Documentation:**
N/A