### PR TITLE
[receiver/hostmetrics] Remove deprecated label from network metrics

### DIFF
--- a/.chloggen/hostmetrics-remove-deprecated-label.yaml
+++ b/.chloggen/hostmetrics-remove-deprecated-label.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: receiver/hostmetrics
+note: Remove "Deprecated" label from network metrics
+issues: [16227]
+subtext: |
+  Replacement of the metrics was rejected some time ago, but the labels were not updated.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
@@ -11,10 +11,10 @@ These are the metrics available for this scraper.
 | **system.network.connections** | The number of connections. | {connections} | Sum(Int) | <ul> <li>protocol</li> <li>state</li> </ul> |
 | system.network.conntrack.count | The count of entries in conntrack table. | {entries} | Sum(Int) | <ul> </ul> |
 | system.network.conntrack.max | The limit for entries in the conntrack table. | {entries} | Sum(Int) | <ul> </ul> |
-| **system.network.dropped** | The number of packets dropped. (Deprecated) | {packets} | Sum(Int) | <ul> <li>device</li> <li>direction</li> </ul> |
-| **system.network.errors** | The number of errors encountered. (Deprecated) | {errors} | Sum(Int) | <ul> <li>device</li> <li>direction</li> </ul> |
-| **system.network.io** | The number of bytes transmitted and received. (Deprecated) | By | Sum(Int) | <ul> <li>device</li> <li>direction</li> </ul> |
-| **system.network.packets** | The number of packets transferred. (Deprecated) | {packets} | Sum(Int) | <ul> <li>device</li> <li>direction</li> </ul> |
+| **system.network.dropped** | The number of packets dropped. | {packets} | Sum(Int) | <ul> <li>device</li> <li>direction</li> </ul> |
+| **system.network.errors** | The number of errors encountered. | {errors} | Sum(Int) | <ul> <li>device</li> <li>direction</li> </ul> |
+| **system.network.io** | The number of bytes transmitted and received. | By | Sum(Int) | <ul> <li>device</li> <li>direction</li> </ul> |
+| **system.network.packets** | The number of packets transferred. | {packets} | Sum(Int) | <ul> <li>device</li> <li>direction</li> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
 Any metric can be enabled or disabled with the following scraper configuration:

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -286,7 +286,7 @@ type metricSystemNetworkDropped struct {
 // init fills system.network.dropped metric with initial data.
 func (m *metricSystemNetworkDropped) init() {
 	m.data.SetName("system.network.dropped")
-	m.data.SetDescription("The number of packets dropped. (Deprecated)")
+	m.data.SetDescription("The number of packets dropped.")
 	m.data.SetUnit("{packets}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
@@ -340,7 +340,7 @@ type metricSystemNetworkErrors struct {
 // init fills system.network.errors metric with initial data.
 func (m *metricSystemNetworkErrors) init() {
 	m.data.SetName("system.network.errors")
-	m.data.SetDescription("The number of errors encountered. (Deprecated)")
+	m.data.SetDescription("The number of errors encountered.")
 	m.data.SetUnit("{errors}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
@@ -394,7 +394,7 @@ type metricSystemNetworkIo struct {
 // init fills system.network.io metric with initial data.
 func (m *metricSystemNetworkIo) init() {
 	m.data.SetName("system.network.io")
-	m.data.SetDescription("The number of bytes transmitted and received. (Deprecated)")
+	m.data.SetDescription("The number of bytes transmitted and received.")
 	m.data.SetUnit("By")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
@@ -448,7 +448,7 @@ type metricSystemNetworkPackets struct {
 // init fills system.network.packets metric with initial data.
 func (m *metricSystemNetworkPackets) init() {
 	m.data.SetName("system.network.packets")
-	m.data.SetDescription("The number of packets transferred. (Deprecated)")
+	m.data.SetDescription("The number of packets transferred.")
 	m.data.SetUnit("{packets}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -17,7 +17,7 @@ attributes:
 metrics:
   system.network.packets:
     enabled: true
-    description: The number of packets transferred. (Deprecated)
+    description: The number of packets transferred.
     unit: "{packets}"
     sum:
       value_type: int
@@ -26,7 +26,7 @@ metrics:
     attributes: [device, direction]
   system.network.dropped:
     enabled: true
-    description: The number of packets dropped. (Deprecated)
+    description: The number of packets dropped.
     unit: "{packets}"
     sum:
       value_type: int
@@ -35,7 +35,7 @@ metrics:
     attributes: [device, direction]
   system.network.errors:
     enabled: true
-    description: The number of errors encountered. (Deprecated)
+    description: The number of errors encountered.
     unit: "{errors}"
     sum:
       value_type: int
@@ -44,7 +44,7 @@ metrics:
     attributes: [device, direction]
   system.network.io:
     enabled: true
-    description: The number of bytes transmitted and received. (Deprecated)
+    description: The number of bytes transmitted and received.
     unit: "By"
     sum:
       value_type: int


### PR DESCRIPTION
The label was missed to be removed once the metrics splitting was rolled back
