### PR TITLE
[chore] Use `pull_request_target` event to trigger "add codeowners" workflow

### DIFF
--- a/.github/workflows/add-codeowners-to-pr.yml
+++ b/.github/workflows/add-codeowners-to-pr.yml
@@ -1,6 +1,6 @@
 name: 'Add code owners to a PR'
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
**Description:**

This updates the workflow to use the `pull_request_target` event instead of the `pull_request` event. The former event generates an access token with write permissions on the target repo, as where the latter only creates one with read permissions.

I had only tested this on pull requests within my fork, which is why `pull_request` worked in that case. The "auto assign" workflow uses `pull_request_target`, so this should fix the issue.