### PR TITLE
[chore] Disable unnecessary automations on forks

### DIFF
--- a/.github/workflows/add-codeowners-to-pr.yml
+++ b/.github/workflows/add-codeowners-to-pr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-owners-to-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   add-labels:
-    if: ${{ !github.event.issue.pull_request && startsWith(github.event.comment.body, '/label') }}
+    if: ${{ !github.event.issue.pull_request && startsWith(github.event.comment.body, '/label') && github.repository_owner == "open-telemetry" }}
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/generate-component-labels.yml
+++ b/.github/workflows/generate-component-labels.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   generate-component-labels:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/mark-issues-as-stale.yml
+++ b/.github/workflows/mark-issues-as-stale.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   mark-issues-as-stale:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ping-codeowners-issues.yml
+++ b/.github/workflows/ping-codeowners-issues.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   ping-owners:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v3
     

--- a/.github/workflows/ping-codeowners-on-new-issue.yml
+++ b/.github/workflows/ping-codeowners-on-new-issue.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   ping-owners-on-new-issue:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v3
     

--- a/.github/workflows/ping-codeowners-prs.yml
+++ b/.github/workflows/ping-codeowners-prs.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   ping-owners:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v3
     


### PR DESCRIPTION
**Description:**

Skip workflows on forks that aren't useful or might fail in the fork.

**Link to tracking Issue:**

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16235

**Testing:**

I tested that the job condition fails on my fork.