### PR TITLE
[chore] Interact with GitHub API directly to add reviewers to a PR

### DIFF
--- a/.github/workflows/add-codeowners-to-pr.yml
+++ b/.github/workflows/add-codeowners-to-pr.yml
@@ -16,4 +16,5 @@ jobs:
         run: ./.github/workflows/scripts/add-codeowners-to-pr.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           PR: ${{ github.event.number }}

--- a/.github/workflows/scripts/add-codeowners-to-pr.sh
+++ b/.github/workflows/scripts/add-codeowners-to-pr.sh
@@ -23,14 +23,16 @@
 
 set -euo pipefail
 
-if [[ -z "${PR:-}" ]]; then
-    echo "PR has not been set, please ensure it is set."
+if [[ -z "${REPO:-}" || -z "${PR:-}" ]]; then
+    echo "One or more of REPO and PR have not been set, please ensure each is set."
     exit 0
 fi
 
 main () {
     CUR_DIRECTORY=$(dirname "$0")
-    FILES=$(gh pr view "${PR}" --json files | jq -r '.files[].path')
+    JSON=$(gh pr view "${PR}" --repo evan-bradley/opentelemetry-collector-contrib --json "files,author")
+    AUTHOR=$(printf "${JSON}"| jq '.author.login')
+    FILES=$(printf "${JSON}"| jq -r '.files[].path')
     COMPONENTS=$(grep -oE '^[a-z]+/[a-z/]+ ' < .github/CODEOWNERS)
     REVIEWERS=""
     LABELS=""
@@ -64,7 +66,7 @@ main () {
                 if [[ -n "${REVIEWERS}" ]]; then
                     REVIEWERS+=","
                 fi
-                REVIEWERS+="$(echo "${OWNERS}" | sed 's/@//g' | sed 's/ /,/g')"
+                REVIEWERS+="$(echo "${OWNERS}" | sed -E 's/@([A-Za-z0-9_-]+)( |$)/"\1"\2/g' | sed -E "s/${AUTHOR} ?//g" | sed 's/ /,/g')"
             fi
 
             # Convert the CODEOWNERS entry to a label
@@ -83,7 +85,23 @@ main () {
 
     # Note that adding the labels above will not trigger any other workflows to
     # add code owners, so we have to do it here.
-    gh pr edit "${PR}" --add-reviewer "${REVIEWERS}" || echo "Failed to add reviewers to #${PR}"
+    #
+    # We have to use the GitHub API directly due to an issue with how the CLI
+    # handles PR updates that causes it require access to organization teams,
+    # and the GitHub token doesn't provide that permission.
+    # For more: https://github.com/cli/cli/issues/4844
+    #
+    # The GitHub API validates that authors are not requested to review, but
+    # accepts duplicate logins and logins that are already reviewers.
+    curl \
+        --fail \
+        -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "https://api.github.com/repos/${REPO}/pulls/${PR}/requested_reviewers" \
+        -d "{\"reviewers\":[${REVIEWERS}]}" \
+        | jq ".message" \
+        || echo "Failed to add reviewers to #${PR}"
 }
 
 main || echo "Failed to run $0"


### PR DESCRIPTION
**Description:**

The GitHub CLI has an issue where it will attempt to grab the current set of reviewers when adding new reviewers. Since the current set of reviewers will include the approvers team, it will need access to see that team, which it does not have. This causes the call to add reviewers to fail. Instead we manually call the API, bypassing the need for this permission.

From what I can tell, GitHub does not offer organization-level permissions on the GitHub Actions token.

**Testing:**

I tested this as much as I could on my personal fork.