### PR TITLE
[chore] Fix "add codeowners to PR" workflow

### DIFF
--- a/.github/workflows/scripts/add-codeowners-to-pr.sh
+++ b/.github/workflows/scripts/add-codeowners-to-pr.sh
@@ -30,7 +30,7 @@ fi
 
 main () {
     CUR_DIRECTORY=$(dirname "$0")
-    JSON=$(gh pr view "${PR}" --repo evan-bradley/opentelemetry-collector-contrib --json "files,author")
+    JSON=$(gh pr view "${PR}" --json "files,author")
     AUTHOR=$(printf "${JSON}"| jq '.author.login')
     FILES=$(printf "${JSON}"| jq -r '.files[].path')
     COMPONENTS=$(grep -oE '^[a-z]+/[a-z/]+ ' < .github/CODEOWNERS)
@@ -81,7 +81,11 @@ main () {
         done
     done
 
-    gh pr edit "${PR}" --add-label "${LABELS}" || echo "Failed to add labels to #${PR}"
+    if [[ -n "${LABELS}" ]]; then
+        gh pr edit "${PR}" --add-label "${LABELS}" || echo "Failed to add labels to #${PR}"
+    else
+        echo "No labels found"
+    fi
 
     # Note that adding the labels above will not trigger any other workflows to
     # add code owners, so we have to do it here.
@@ -93,15 +97,19 @@ main () {
     #
     # The GitHub API validates that authors are not requested to review, but
     # accepts duplicate logins and logins that are already reviewers.
-    curl \
-        --fail \
-        -X POST \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-        "https://api.github.com/repos/${REPO}/pulls/${PR}/requested_reviewers" \
-        -d "{\"reviewers\":[${REVIEWERS}]}" \
-        | jq ".message" \
-        || echo "Failed to add reviewers to #${PR}"
+    if [[ -n "${REVIEWERS}" ]]; then
+        curl \
+            --fail \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/${REPO}/pulls/${PR}/requested_reviewers" \
+            -d "{\"reviewers\":[${REVIEWERS}]}" \
+            | jq ".message" \
+            || echo "Failed to add reviewers to #${PR}"
+    else
+        echo "No code owners found"
+    fi
 }
 
 main || echo "Failed to run $0"


### PR DESCRIPTION
**Description:**

Remove a stray testing config I lost track of while rebasing, and check whether we have anything to update on the PR before issuing the requests.