### PR TITLE
[Docker Stats Receiver] Add @jamesmoessis as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -159,7 +159,7 @@ receiver/chronyreceiver/                             @open-telemetry/collector-c
 receiver/cloudfoundryreceiver/                       @open-telemetry/collector-contrib-approvers @agoallikmaa @pellared @crobert-1
 receiver/collectdreceiver/                           @open-telemetry/collector-contrib-approvers @owais
 receiver/couchdbreceiver/                            @open-telemetry/collector-contrib-approvers @djaglowski
-receiver/dockerstatsreceiver/                        @open-telemetry/collector-contrib-approvers @rmfitzpatrick
+receiver/dockerstatsreceiver/                        @open-telemetry/collector-contrib-approvers @rmfitzpatrick @jamesmoessis
 receiver/elasticsearchreceiver/                      @open-telemetry/collector-contrib-approvers @djaglowski @binaryfissiongames
 receiver/expvarreceiver/                             @open-telemetry/collector-contrib-approvers @jamesmoessis @MovieStoreGuy
 receiver/filelogreceiver/                            @open-telemetry/collector-contrib-approvers @djaglowski


### PR DESCRIPTION
**Description:** 

@jamesmoessis has contributed heavily to improve the usability of the `Docker Stats Receiver` with the following PRs:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14968
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14558
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14184
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14093
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13655
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13445
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12743

All of these features have been contributing improvements to the component and deserves recognition of their efforts.