### PR TITLE
[chore] Assign reviewers through API in ping code owners workflow

### DIFF
--- a/.github/workflows/ping-codeowners-prs.yml
+++ b/.github/workflows/ping-codeowners-prs.yml
@@ -1,6 +1,6 @@
 name: 'Ping code owners on PRs'
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 jobs:
@@ -13,7 +13,8 @@ jobs:
       - name: Run ping-codeowners-prs.sh
         run: ./.github/workflows/scripts/ping-codeowners-prs.sh
         env:
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.number }}
           COMPONENT: ${{ github.event.label.name }}
-          SENDER: ${{ github.event.sender.login }}

--- a/.github/workflows/scripts/ping-codeowners-prs.sh
+++ b/.github/workflows/scripts/ping-codeowners-prs.sh
@@ -14,23 +14,51 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-#
 
 set -euo pipefail
 
-if [[ -z "${COMPONENT:-}" || -z "${PR:-}" ]]; then
-    echo "At least one of COMPONENT or PR has not been set, please ensure each is set."
+if [[  -z "${REPO:-}" || -z "${AUTHOR:-}" || -z "${COMPONENT:-}" || -z "${PR:-}" ]]; then
+    echo "At least one of REPO, AUTHOR, COMPONENT, or PR has not been set, please ensure each is set."
     exit 0
 fi
 
 CUR_DIRECTORY=$(dirname "$0")
 
-OWNERS=$(COMPONENT="${COMPONENT}" bash "${CUR_DIRECTORY}/get-codeowners.sh")
+main() {
+    OWNERS=$(COMPONENT="${COMPONENT}" bash "${CUR_DIRECTORY}/get-codeowners.sh")
+    REVIEWERS=""
 
-if [[ -z "${OWNERS}" ]]; then
-    exit 0
-fi
+    if [[ -z "${OWNERS}" ]]; then
+        exit 0
+    fi
 
-REVIEWERS=$(echo "${OWNERS}" | sed 's/@//g' | sed 's/ /,/g')
+    for OWNER in ${OWNERS}; do
+        if [[ "${OWNER}" = "@${AUTHOR}" ]]; then
+            continue
+        fi
+    
+        if [[ -n "${REVIEWERS}" ]]; then
+            REVIEWERS+=","
+        fi
+        REVIEWERS+=$(echo "${OWNER}" | sed -E 's/@(.+)/"\1"/')
+    done
 
-gh pr edit "${PR}" --add-reviewer "${REVIEWERS}"
+    # We have to use the GitHub API directly due to an issue with how the CLI
+    # handles PR updates that causes it require access to organization teams,
+    # and the GitHub token doesn't provide that permission.
+    # For more: https://github.com/cli/cli/issues/4844
+    #
+    # The GitHub API validates that authors are not requested to review, but
+    # accepts duplicate logins and logins that are already reviewers.
+    curl \
+        --fail \
+        -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "https://api.github.com/repos/${REPO}/pulls/${PR}/requested_reviewers" \
+        -d "{\"reviewers\":[${REVIEWERS}]}" \
+        | jq ".message" \
+        || echo "Request failed to request review from code owners on #${PR}"
+}
+
+main || echo "Failed to request review from code owners on PR #${PR}"


### PR DESCRIPTION
**Description:**

Assigns reviewers through the GitHub API in the "ping codeowners on PRs" workflow and ensure the workflow should never fail under ordinary circumstances. Also uses a loop for more comprehensible construction of the reviewers JSON list, the previous pipe had an issue in the situation where the PR author was also the last code owner in the list.