### PR TITLE
[chore] Fix typo in "add labels" workflow definition

### DIFF
--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   add-labels:
-    if: ${{ !github.event.issue.pull_request && startsWith(github.event.comment.body, '/label') && github.repository_owner == "open-telemetry" }}
+    if: ${{ !github.event.issue.pull_request && startsWith(github.event.comment.body, '/label') && github.repository_owner == 'open-telemetry' }}
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Description:**

Fixes a typo in the definition for the "add labels" workflow where double quotes were used instead of single quotes.