### PR TITLE
enable lint exhaustive and exclude all components not passed

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,6 +132,7 @@ linters:
     - tenv
     - unconvert
     - unparam
+    - exhaustive
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/cmd/configschema/fields.go
+++ b/cmd/configschema/fields.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package configschema // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema"
 
 import (

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package main
 
 import (

--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package main
 
 import (

--- a/exporter/alibabacloudlogserviceexporter/metricsdata_to_logservice.go
+++ b/exporter/alibabacloudlogserviceexporter/metricsdata_to_logservice.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package alibabacloudlogserviceexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter"
 
 import (

--- a/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice.go
+++ b/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package alibabacloudlogserviceexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter"
 
 import (

--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package awscloudwatchlogsexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter"
 
 import (

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package awsemfexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
 
 import (

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package awsemfexporter
 
 import (

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter/internal/translator"
 
 import (

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package azuredataexplorerexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter"
 
 import (

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package azuredataexplorerexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter"
 
 import (

--- a/exporter/azuremonitorexporter/conventions.go
+++ b/exporter/azuremonitorexporter/conventions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package azuremonitorexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter"
 
 import (

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package azuremonitorexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter"
 
 // Contains code common to both trace and metrics exporters

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package azuremonitorexporter
 
 import (

--- a/exporter/carbonexporter/metricdata_to_plaintext.go
+++ b/exporter/carbonexporter/metricdata_to_plaintext.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive,varcheck,deadcode
 package carbonexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter"
 
 import (

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package coralogixexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter"
 
 import (

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package datadogexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
 
 import (

--- a/exporter/dynatraceexporter/internal/serialization/serialization.go
+++ b/exporter/dynatraceexporter/internal/serialization/serialization.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package serialization // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter/internal/serialization"
 
 import (

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -40,6 +40,7 @@
 // Ingest Node is used. But either way, we try to present only well formed
 // document to Elasticsearch.
 
+// nolint:exhaustive
 package objmodel // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/objmodel"
 
 import (

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:deadcode,varcheck
 package fileexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
 
 import (

--- a/exporter/googlecloudpubsubexporter/watermark.go
+++ b/exporter/googlecloudpubsubexporter/watermark.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package googlecloudpubsubexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter"
 
 import (

--- a/exporter/humioexporter/traces_exporter.go
+++ b/exporter/humioexporter/traces_exporter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package humioexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/humioexporter"
 
 import (

--- a/exporter/instanaexporter/internal/converter/model/util.go
+++ b/exporter/instanaexporter/internal/converter/model/util.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package model // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/instanaexporter/internal/converter/model"
 
 import (

--- a/exporter/jaegerthrifthttpexporter/exporter.go
+++ b/exporter/jaegerthrifthttpexporter/exporter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package jaegerthrifthttpexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerthrifthttpexporter"
 
 import (

--- a/exporter/logzioexporter/jsonlog.go
+++ b/exporter/logzioexporter/jsonlog.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package logzioexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter"
 
 import (

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package prometheusexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
 
 import (

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package prometheusexporter
 
 import (

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package prometheusexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
 
 import (

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package prometheusexporter
 
 import (

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package prometheusremotewriteexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
 
 import (

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package sentryexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter"
 
 import (

--- a/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
+++ b/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package translation // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/translation"
 
 import (

--- a/exporter/skywalkingexporter/metricrecord_to_metricdata.go
+++ b/exporter/skywalkingexporter/metricrecord_to_metricdata.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package skywalkingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/skywalkingexporter"
 
 import (

--- a/exporter/splunkhecexporter/logdata_to_splunk.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
 
 import (

--- a/exporter/splunkhecexporter/metricdata_to_splunk.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
 
 import (

--- a/exporter/sumologicexporter/carbon_formatter.go
+++ b/exporter/sumologicexporter/carbon_formatter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package sumologicexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter"
 
 import (

--- a/exporter/sumologicexporter/graphite_formatter.go
+++ b/exporter/sumologicexporter/graphite_formatter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package sumologicexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter"
 
 import (

--- a/exporter/sumologicexporter/prometheus_formatter.go
+++ b/exporter/sumologicexporter/prometheus_formatter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package sumologicexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter"
 
 import (

--- a/exporter/tanzuobservabilityexporter/metrics.go
+++ b/exporter/tanzuobservabilityexporter/metrics.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package tanzuobservabilityexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tanzuobservabilityexporter"
 
 import (

--- a/exporter/tanzuobservabilityexporter/metrics_test.go
+++ b/exporter/tanzuobservabilityexporter/metrics_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package tanzuobservabilityexporter
 
 import (

--- a/extension/observer/k8sobserver/pod_endpoint.go
+++ b/extension/observer/k8sobserver/pod_endpoint.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package k8sobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"
 
 import (

--- a/internal/aws/containerinsight/utils_test.go
+++ b/internal/aws/containerinsight/utils_test.go
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// nolint:exhaustive
 package containerinsight
 
 import (

--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package attraction // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/attraction"
 
 import (

--- a/internal/coreinternal/attraction/hasher.go
+++ b/internal/coreinternal/attraction/hasher.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package attraction // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/attraction"
 
 import (

--- a/internal/coreinternal/attraction/type_converter.go
+++ b/internal/coreinternal/attraction/type_converter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package attraction // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/attraction"
 
 import (

--- a/internal/coreinternal/goldendataset/metrics_gen.go
+++ b/internal/coreinternal/goldendataset/metrics_gen.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package goldendataset // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/goldendataset"
 
 import (

--- a/internal/coreinternal/metricstestutil/metric_diff.go
+++ b/internal/coreinternal/metricstestutil/metric_diff.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricstestutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
 
 import (

--- a/internal/coreinternal/processor/filterexpr/matcher.go
+++ b/internal/coreinternal/processor/filterexpr/matcher.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package filterexpr // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterexpr"
 
 import (

--- a/internal/coreinternal/processor/filterexpr/matcher_test.go
+++ b/internal/coreinternal/processor/filterexpr/matcher_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package filterexpr
 
 import (

--- a/internal/coreinternal/processor/filtermatcher/attributematcher.go
+++ b/internal/coreinternal/processor/filtermatcher/attributematcher.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package filtermatcher // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filtermatcher"
 
 import (

--- a/internal/k8sconfig/config.go
+++ b/internal/k8sconfig/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package k8sconfig // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 
 import (

--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package kubelet // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet"
 
 import (

--- a/internal/scrapertest/compare.go
+++ b/internal/scrapertest/compare.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package scrapertest // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
 
 import (

--- a/internal/scrapertest/mask.go
+++ b/internal/scrapertest/mask.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package scrapertest // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
 
 import (

--- a/internal/scrapertest/sort/attributes.go
+++ b/internal/scrapertest/sort/attributes.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package sort // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest/sort"
 
 import (

--- a/internal/scrapertest/util.go
+++ b/internal/scrapertest/util.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package scrapertest // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
 
 import (

--- a/pkg/ottl/boolean_value.go
+++ b/pkg/ottl/boolean_value.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:revive
 package ottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 
 import (

--- a/pkg/ottl/compare.go
+++ b/pkg/ottl/compare.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package ottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 
 import (

--- a/pkg/ottl/compare_test.go
+++ b/pkg/ottl/compare_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package ottl
 
 import (

--- a/pkg/ottl/contexts/internal/ottlcommon/metric.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/metric.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
 
 import (

--- a/pkg/ottl/contexts/internal/ottlcommon/value.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/value.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
 
 import (

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:deadcode,varcheck
 package ottlspanevent
 
 import (

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:revive
 package ottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 
 import (

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:revive
 package ottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 
 import (

--- a/pkg/resourcetotelemetry/resource_to_telemetry.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package resourcetotelemetry // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry"
 
 import (

--- a/pkg/stanza/entry/field.go
+++ b/pkg/stanza/entry/field.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package entry // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 
 import (

--- a/pkg/stanza/operator/input/windows/security.go
+++ b/pkg/stanza/operator/input/windows/security.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 
 import (

--- a/pkg/translator/jaeger/jaegerproto_to_traces.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package jaeger // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 
 import (

--- a/pkg/translator/jaeger/traces_to_jaegerproto.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package jaeger // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 
 import (

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package loki // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki"
 
 import (

--- a/pkg/translator/loki/encode.go
+++ b/pkg/translator/loki/encode.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package loki // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki"
 
 import (

--- a/pkg/translator/opencensus/metrics_to_oc.go
+++ b/pkg/translator/opencensus/metrics_to_oc.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package opencensus // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 
 import (

--- a/pkg/translator/opencensus/oc_to_metrics.go
+++ b/pkg/translator/opencensus/oc_to_metrics.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package opencensus // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 
 import (

--- a/pkg/translator/opencensus/oc_to_traces.go
+++ b/pkg/translator/opencensus/oc_to_traces.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package opencensus // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 
 import (

--- a/pkg/translator/opencensus/resource_to_oc.go
+++ b/pkg/translator/opencensus/resource_to_oc.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package opencensus // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 
 import (

--- a/pkg/translator/opencensus/resource_to_oc_test.go
+++ b/pkg/translator/opencensus/resource_to_oc_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package opencensus
 
 import (

--- a/pkg/translator/opencensus/traces_to_oc.go
+++ b/pkg/translator/opencensus/traces_to_oc.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package opencensus // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 
 import (

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
 
 import (

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
 
 import (

--- a/pkg/translator/signalfx/from_metrics.go
+++ b/pkg/translator/signalfx/from_metrics.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package signalfx // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx"
 
 import (

--- a/pkg/translator/signalfx/to_metrics.go
+++ b/pkg/translator/signalfx/to_metrics.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package signalfx // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx"
 
 import (

--- a/pkg/translator/signalfx/to_metrics_test.go
+++ b/pkg/translator/signalfx/to_metrics_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package signalfx
 
 import (

--- a/pkg/translator/zipkin/zipkinv1/json.go
+++ b/pkg/translator/zipkin/zipkinv1/json.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package zipkinv1 // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv1"
 
 import (

--- a/pkg/translator/zipkin/zipkinv1/status_code.go
+++ b/pkg/translator/zipkin/zipkinv1/status_code.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package zipkinv1 // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv1"
 
 import (

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package zipkinv2 // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv2"
 
 import (

--- a/pkg/translator/zipkin/zipkinv2/from_translator_test.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package zipkinv2
 
 import (

--- a/pkg/translator/zipkin/zipkinv2/to_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/to_translator.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package zipkinv2 // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv2"
 
 import (

--- a/processor/attributesprocessor/attributes_metric.go
+++ b/processor/attributesprocessor/attributes_metric.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package attributesprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 
 import (

--- a/processor/attributesprocessor/attributes_metric_test.go
+++ b/processor/attributesprocessor/attributes_metric_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package attributesprocessor
 
 import (

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package tracking // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor/internal/tracking"
 
 import (

--- a/processor/cumulativetodeltaprocessor/processor.go
+++ b/processor/cumulativetodeltaprocessor/processor.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package cumulativetodeltaprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
 
 import (

--- a/processor/deltatorateprocessor/processor.go
+++ b/processor/deltatorateprocessor/processor.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package deltatorateprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor"
 
 import (

--- a/processor/filterprocessor/expr_test.go
+++ b/processor/filterprocessor/expr_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package filterprocessor
 
 import (

--- a/processor/groupbyattrsprocessor/processor.go
+++ b/processor/groupbyattrsprocessor/processor.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package groupbyattrsprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor"
 
 import (

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package kube // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/kube"
 
 import (

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package k8sattributesprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
 
 import (

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricsgenerationprocessor
 
 import (

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricsgenerationprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor"
 
 import (

--- a/processor/metricstransformprocessor/metrics_testcase_builder_test.go
+++ b/processor/metricstransformprocessor/metrics_testcase_builder_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricstransformprocessor
 
 import (

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 
 import (

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricstransformprocessor
 
 import (

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 
 import (

--- a/processor/metricstransformprocessor/operation_delete_label_value.go
+++ b/processor/metricstransformprocessor/operation_delete_label_value.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 
 import (

--- a/processor/metricstransformprocessor/operation_scale_value.go
+++ b/processor/metricstransformprocessor/operation_scale_value.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 
 import (

--- a/processor/metricstransformprocessor/operation_toggle_scalar_datatype.go
+++ b/processor/metricstransformprocessor/operation_toggle_scalar_datatype.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 
 import (

--- a/processor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package probabilisticsamplerprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
 
 import (

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package gcp // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/gcp"
 
 import (

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -14,6 +14,7 @@
 
 // Package internal contains an interface for detecting resource information,
 // and a provider to merge the resources returned by a slice of custom detectors.
+// nolint:exhaustive
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 
 import (

--- a/processor/servicegraphprocessor/processor.go
+++ b/processor/servicegraphprocessor/processor.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package servicegraphprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/servicegraphprocessor"
 
 import (

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package spanprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor"
 
 import (

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (

--- a/processor/transformprocessor/internal/common/logs.go
+++ b/processor/transformprocessor/internal/common/logs.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 
 import (

--- a/processor/transformprocessor/internal/common/metrics.go
+++ b/processor/transformprocessor/internal/common/metrics.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 
 import (

--- a/processor/transformprocessor/internal/common/processor.go
+++ b/processor/transformprocessor/internal/common/processor.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 
 import (

--- a/processor/transformprocessor/internal/common/traces.go
+++ b/processor/transformprocessor/internal/common/traces.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 
 import (

--- a/processor/transformprocessor/internal/metrics/processor.go
+++ b/processor/transformprocessor/internal/metrics/processor.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package k8sapiserver
 
 import (

--- a/receiver/dockerstatsreceiver/metrics.go
+++ b/receiver/dockerstatsreceiver/metrics.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package dockerstatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
 
 import (

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package fluentforwardreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver"
 
 import (

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package fluentforwardreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver"
 
 import (

--- a/receiver/googlecloudpubsubreceiver/receiver.go
+++ b/receiver/googlecloudpubsubreceiver/receiver.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package googlecloudpubsubreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver"
 
 import (

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metadata // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
 
 import (

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metadata // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
 
 import (

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metadata // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
 
 import (

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package metadataparser // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadataparser"
 
 import (

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package kubelet
 
 import (

--- a/receiver/nsxtreceiver/client.go
+++ b/receiver/nsxtreceiver/client.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package nsxtreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver"
 import (
 	"context"

--- a/receiver/nsxtreceiver/scraper_test.go
+++ b/receiver/nsxtreceiver/scraper_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package nsxtreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver"
 
 import (

--- a/receiver/podmanreceiver/metrics_test.go
+++ b/receiver/podmanreceiver/metrics_test.go
@@ -15,6 +15,7 @@
 //go:build !windows
 // +build !windows
 
+// nolint:exhaustive
 package podmanreceiver
 
 import (

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
 
 import (

--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
 
 import (

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package internal_test
 
 import (

--- a/receiver/prometheusreceiver/internal/starttimemetricadjuster.go
+++ b/receiver/prometheusreceiver/internal/starttimemetricadjuster.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
 
 import (

--- a/receiver/prometheusreceiver/internal/starttimemetricadjuster_test.go
+++ b/receiver/prometheusreceiver/internal/starttimemetricadjuster_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package internal
 
 import (

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package internal
 
 import (

--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
 
 import (

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package prometheusreceiver
 
 import (

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package prometheusreceiver
 
 import (

--- a/receiver/snmpreceiver/client.go
+++ b/receiver/snmpreceiver/client.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package snmpreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver"
 
 import (

--- a/receiver/snmpreceiver/otel_metric_helper.go
+++ b/receiver/snmpreceiver/otel_metric_helper.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package snmpreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver"
 
 import (

--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package statsdreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver"
 
 import (

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package protocol // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 
 import (

--- a/testbed/datasenders/fluent.go
+++ b/testbed/datasenders/fluent.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package datasenders // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
 
 import (

--- a/testbed/datasenders/fluentbit.go
+++ b/testbed/datasenders/fluentbit.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package datasenders // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
 
 import (

--- a/testbed/datasenders/k8s.go
+++ b/testbed/datasenders/k8s.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package datasenders // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
 
 import (

--- a/testbed/datasenders/stanza.go
+++ b/testbed/datasenders/stanza.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package datasenders // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
 
 import (

--- a/testbed/testbed/in_process_collector.go
+++ b/testbed/testbed/in_process_collector.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package testbed // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 
 import (

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:exhaustive
 package testbed // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 
 import (


### PR DESCRIPTION
Description:

Fix #7532 as @mx-psi suggested, first enable `exhaustive` and exclude all components that are not passing right now.

Link to tracking Issue:
#7532 #9109

Signed-off-by: Ziqi Zhao [zhaoziqi9146@gmail.com](mailto:zhaoziqi9146@gmail.com)