### PR TITLE
[exporter/tanzuobservability] Don't encode/decode TraceID as string

### DIFF
--- a/exporter/tanzuobservabilityexporter/transformer.go
+++ b/exporter/tanzuobservabilityexporter/transformer.go
@@ -288,7 +288,7 @@ func errorTagsFromStatus(status ptrace.Status) map[string]string {
 }
 
 func traceIDtoUUID(id pcommon.TraceID) (uuid.UUID, error) {
-	formatted, err := uuid.Parse(id.HexString())
+	formatted, err := uuid.FromBytes(id[:])
 	if err != nil || id.IsEmpty() {
 		return uuid.Nil, errInvalidTraceID
 	}

--- a/exporter/tanzuobservabilityexporter/transformer_test.go
+++ b/exporter/tanzuobservabilityexporter/transformer_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -445,4 +446,48 @@ func TestPointAndResAttrsToTagsAndFixSource(t *testing.T) {
 	attrMap = newMap(map[string]string{"application": "test_app", "service.name": "test_service.name", "source": "test_source", "service": "test_service", "other_source": "test_other_source"})
 	tags = pointAndResAttrsToTagsAndFixSource("other_source", attrMap)
 	assert.Equal(t, map[string]string{"application": "test_app", "service": "test_service", "service.name": "test_service.name", "_source": "test_source"}, tags)
+}
+
+func TestTraceIDtoUUID(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    pcommon.TraceID
+		out   uuid.UUID
+		error bool
+	}{
+		{
+			name:  "empty",
+			in:    pcommon.NewTraceIDEmpty(),
+			out:   uuid.UUID{},
+			error: true,
+		},
+		{
+			name: "one",
+			in:   pcommon.TraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			out:  uuid.UUID{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		},
+		{
+			name: "all_bytes",
+			in:   pcommon.TraceID([16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}),
+			out:  uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := traceIDtoUUID(tt.in)
+			if tt.error {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.out, got)
+		})
+	}
+}
+
+func BenchmarkTraceIDtoUUID(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, err := traceIDtoUUID([16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15})
+		assert.NoError(b, err)
+	}
 }


### PR DESCRIPTION
Avoid unnecessary string encoding and decoding of trace ID. Create UUID from bytes directly

Benchmarks on Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz:

Before:
```
BenchmarkTraceIDtoUUID-16    	 5456070	       224.3 ns/op
PASS
```

After
```
BenchmarkTraceIDtoUUID-16    	23599876	        52.67 ns/op
PASS
```