### PR TITLE
[exporter/splunkhecexporter] close HTTP servers used during testing

### DIFF
--- a/.chloggen/splunk_hec-http-server-close.yaml
+++ b/.chloggen/splunk_hec-http-server-close.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Close the HTTP servers used in testing
+
+# One or more tracking issues related to the change
+issues: [16285]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -216,8 +216,11 @@ func runMetricsExport(cfg *Config, metrics pmetric.Metrics, expectedBatchesNum i
 	s := &http.Server{
 		Handler: &capture,
 	}
+	defer s.Close()
 	go func() {
-		panic(s.Serve(listener))
+		if e := s.Serve(listener); e != http.ErrServerClosed {
+			require.NoError(t, e)
+		}
 	}()
 
 	params := componenttest.NewNopExporterCreateSettings()
@@ -265,8 +268,11 @@ func runTraceExport(testConfig *Config, traces ptrace.Traces, expectedBatchesNum
 	s := &http.Server{
 		Handler: &capture,
 	}
+	defer s.Close()
 	go func() {
-		panic(s.Serve(listener))
+		if e := s.Serve(listener); e != http.ErrServerClosed {
+			require.NoError(t, e)
+		}
 	}()
 
 	params := componenttest.NewNopExporterCreateSettings()
@@ -321,8 +327,11 @@ func runLogExport(cfg *Config, ld plog.Logs, expectedBatchesNum int, t *testing.
 	s := &http.Server{
 		Handler: &capture,
 	}
+	defer s.Close()
 	go func() {
-		panic(s.Serve(listener))
+		if e := s.Serve(listener); e != http.ErrServerClosed {
+			require.NoError(t, e)
+		}
 	}()
 
 	params := componenttest.NewNopExporterCreateSettings()
@@ -826,8 +835,11 @@ func TestErrorReceived(t *testing.T) {
 	s := &http.Server{
 		Handler: &capture,
 	}
+	defer s.Close()
 	go func() {
-		panic(s.Serve(listener))
+		if e := s.Serve(listener); e != http.ErrServerClosed {
+			require.NoError(t, e)
+		}
 	}()
 
 	factory := NewFactory()


### PR DESCRIPTION
**Description:**
Address test flakiness by closing HTTP servers used during testing

**Link to tracking Issue:**
#16285

**Testing:**
N/A

**Documentation:**
N/A