### PR TITLE
[processor/filter] fixed vm usage in filterexpr

### DIFF
--- a/.chloggen/filterexpr-parallel-fix.yaml
+++ b/.chloggen/filterexpr-parallel-fix.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: filterexpr
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fixed filterexpr Matcher.MatchMetric to be gorutine-safe
+note: Fixed filterexpr Matcher.MatchMetric to be thread-safe
 
 # One or more tracking issues related to the change
 issues: [13573]

--- a/.chloggen/filterexpr-parallel-fix.yaml
+++ b/.chloggen/filterexpr-parallel-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filterexpr
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed filterexpr Matcher.MatchMetric to be gorutine-safe
+
+# One or more tracking issues related to the change
+issues: [13573]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/filter/filterexpr/matcher_test.go
+++ b/internal/filter/filterexpr/matcher_test.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/antonmedv/expr/vm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -31,7 +32,7 @@ func TestCompileExprError(t *testing.T) {
 func TestRunExprError(t *testing.T) {
 	matcher, err := NewMatcher("foo")
 	require.NoError(t, err)
-	matched, _ := matcher.match(env{})
+	matched, _ := matcher.match(env{}, &vm.VM{})
 	require.False(t, matched)
 }
 


### PR DESCRIPTION
* Added test to filterexpr package to highlight issue with
parallel usage of expression filter.
* Instead of reusing the same vm for all execution of
Matcher.MatchMetric in filterexpr (which is not gorutine-safe), use
a sync.Pool for managing vms.

see: #13573