### PR TITLE
[pkg/stanza/fileconsumer] Require rotation tests to produce all lines every time

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -3,7 +3,7 @@ SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
-GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
+GOTEST_OPT?= -race -v -timeout 300m --tags=$(GO_BUILD_TAGS)
 GOTEST_INTEGRATION_OPT?= -race -timeout 360s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic


### PR DESCRIPTION
Temporarily, extend max duration of tests and run rotation tests 100 times to test stability,