### PR TITLE
[processor/tailsampling] Honor final decision for late arriving spans

### DIFF
--- a/.chloggen/tailsampling-honor-final-decision.yaml
+++ b/.chloggen/tailsampling-honor-final-decision.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix`1`
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: When dealing with traces that have already been evaluated, use the final decision instead of trying using the individual decisions by the policies.
+
+# One or more tracking issues related to the change
+issues: [14760]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/tailsampling-honor-final-decision.yaml
+++ b/.chloggen/tailsampling-honor-final-decision.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix`1`
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: tailsamplingprocessor

--- a/processor/tailsamplingprocessor/internal/sampling/policy.go
+++ b/processor/tailsamplingprocessor/internal/sampling/policy.go
@@ -36,6 +36,8 @@ type TraceData struct {
 	SpanCount *atomic.Int64
 	// ReceivedBatches stores all the batches received for the trace.
 	ReceivedBatches ptrace.Traces
+	// FinalDecision.
+	FinalDecision Decision
 }
 
 // Decision gives the status of sampling decision.

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -185,6 +185,7 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() {
 		// Sampled or not, remove the batches
 		trace.Lock()
 		allSpans := ptrace.NewTraces()
+		trace.FinalDecision = decision
 		trace.ReceivedBatches.MoveTo(allSpans)
 		trace.Unlock()
 
@@ -356,43 +357,30 @@ func (tsp *tailSamplingSpanProcessor) processTraces(resourceSpans ptrace.Resourc
 			}
 		}
 
-		for i, p := range tsp.policies {
-			actualData.Lock()
-			actualDecision := actualData.Decisions[i]
-			// If decision is pending, we want to add the new spans still under the lock, so the decision doesn't happen
-			// in between the transition from pending.
-			if actualDecision == sampling.Pending {
-				// Add the spans to the trace, but only once for all policy, otherwise same spans will
-				// be duplicated in the final trace.
-				appendToTraces(actualData.ReceivedBatches, resourceSpans, spans)
-				actualData.Unlock()
-				break
-			}
-			actualData.Unlock()
+		// The only thing we really care about here is the final decision.
+		actualData.Lock()
+		finalDecision := actualData.FinalDecision
 
-			switch actualDecision {
-			case sampling.Sampled:
+		if finalDecision == sampling.Unspecified {
+			// If the final decision hasn't been made, add the new spans under the lock.
+			appendToTraces(actualData.ReceivedBatches, resourceSpans, spans)
+			actualData.Unlock()
+		} else {
+			actualData.Unlock()
+			if finalDecision == sampling.Sampled {
 				// Forward the spans to the policy destinations
 				traceTd := ptrace.NewTraces()
 				appendToTraces(traceTd, resourceSpans, spans)
-				if err := tsp.nextConsumer.ConsumeTraces(p.ctx, traceTd); err != nil {
-					tsp.logger.Warn("Error sending late arrived spans to destination",
-						zap.String("policy", p.name),
+				if err := tsp.nextConsumer.ConsumeTraces(tsp.ctx, traceTd); err != nil {
+					tsp.logger.Warn(
+						"Error sending late arrived spans to destination",
 						zap.Error(err))
 				}
-			case sampling.NotSampled:
+			} else if finalDecision == sampling.NotSampled {
 				stats.Record(tsp.ctx, statLateSpanArrivalAfterDecision.M(int64(time.Since(actualData.DecisionTime)/time.Second)))
-
-			default:
+			} else {
 				tsp.logger.Warn("Encountered unexpected sampling decision",
-					zap.String("policy", p.name),
-					zap.Int("decision", int(actualDecision)))
-			}
-
-			// At this point the late arrival has been passed to nextConsumer. Need to break out of the policy loop
-			// so that it isn't sent to nextConsumer more than once when multiple policies chose to sample
-			if actualDecision == sampling.Sampled {
-				break
+					zap.Int("decision", int(finalDecision)))
 			}
 		}
 	}

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -367,7 +367,9 @@ func (tsp *tailSamplingSpanProcessor) processTraces(resourceSpans ptrace.Resourc
 			actualData.Unlock()
 		} else {
 			actualData.Unlock()
-			if finalDecision == sampling.Sampled {
+
+			switch finalDecision {
+			case sampling.Sampled:
 				// Forward the spans to the policy destinations
 				traceTd := ptrace.NewTraces()
 				appendToTraces(traceTd, resourceSpans, spans)
@@ -376,9 +378,9 @@ func (tsp *tailSamplingSpanProcessor) processTraces(resourceSpans ptrace.Resourc
 						"Error sending late arrived spans to destination",
 						zap.Error(err))
 				}
-			} else if finalDecision == sampling.NotSampled {
+			case sampling.NotSampled:
 				stats.Record(tsp.ctx, statLateSpanArrivalAfterDecision.M(int64(time.Since(actualData.DecisionTime)/time.Second)))
-			} else {
+			default:
 				tsp.logger.Warn("Encountered unexpected sampling decision",
 					zap.Int("decision", int(finalDecision)))
 			}


### PR DESCRIPTION
**Description:**
When dealing with traces that have already been evaluated, use the final decision instead of trying using the individual decisions by the policies.

**Link to tracking Issue:**
Close https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14760

**Testing:**
A new test was added that matches the bug repro

**Documentation:**
None