### PR TITLE
[exporter/splunkhecexporter] Do not log a warning on mapping empty metrics

### DIFF
--- a/.chloggen/remove-warning-on-empty-metric.yaml
+++ b/.chloggen/remove-warning-on-empty-metric.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not log a warning on mapping empty metrics.
+
+# One or more tracking issues related to the change
+issues: [3549]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/metricdata_to_splunk.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk.go
@@ -213,7 +213,7 @@ func mapMetricToSplunkEvent(res pcommon.Resource, m pmetric.Metric, config *Conf
 		}
 		return splunkMetrics
 	case pmetric.MetricTypeEmpty:
-		fallthrough
+		return nil
 	default:
 		logger.Warn(
 			"Point with unsupported type",


### PR DESCRIPTION
**Description:**
Do not log a warning on mapping empty metrics.

**Link to tracking Issue:**
#3549

**Testing:**
No changes.

**Documentation:**
N/A