### PR TITLE
[Azure Monitor Exporter] Add  support to SpanEvents of type Exception

### DIFF
--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -60,6 +60,7 @@ The exporter follows the semantic conventions to fill the Application Insights s
 The exact mapping can be found [here](trace_to_envelope.go).
 
 All attributes are also mapped to custom properties if they are booleans or strings and to custom measurements if they are ints or doubles.
+[SpanEvents with name `exception`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md) are mapped to Application Insights Exception type.
 
 ### Logs
 This exporter saves log records to Application Insights `traces` table.

--- a/exporter/azuremonitorexporter/conventions.go
+++ b/exporter/azuremonitorexporter/conventions.go
@@ -37,7 +37,7 @@ const (
 	exceptionDetailsMessageMaxLength  int    = 32768
 	exceptionDetailsTypeMaxLength     int    = 1024
 	exceptionDetailsStackMaxLength    int    = 32768
-	exceptionDataProblemIdMaxLength   int    = 1024
+	exceptionDataProblemIDMaxLength   int    = 1024
 )
 
 // NetworkAttributes is the set of known network attributes

--- a/exporter/azuremonitorexporter/conventions.go
+++ b/exporter/azuremonitorexporter/conventions.go
@@ -27,9 +27,18 @@ import (
 
 const (
 	// TODO replace with convention.* values once/if available
-	attributeRPCGRPCStatusCode     string = "rpc.grpc.status_code"
-	attributeOtelStatusCode        string = "otel.status_code"
-	attributeOtelStatusDescription string = "otel.status_description"
+	attributeRPCGRPCStatusCode        string = "rpc.grpc.status_code"
+	attributeOtelStatusCode           string = "otel.status_code"
+	attributeOtelStatusDescription    string = "otel.status_description"
+	attributeExceptionEventName       string = "exception"
+	attributeExceptionEventType       string = "exception.type"
+	attributeExceptionEventMessage    string = "exception.message"
+	attributeExceptionEventStackTrace string = "exception.stacktrace"
+	exceptionDetailsMessageMaxLength  int    = 32768
+	exceptionDetailsTypeMaxLength     int    = 1024
+	exceptionDetailsStackMaxLength    int    = 32768
+	exceptionDetailsStackMaxFrames    int    = 32768
+	exceptionDataProblemIdMaxLength   int    = 1024
 )
 
 // NetworkAttributes is the set of known network attributes

--- a/exporter/azuremonitorexporter/conventions.go
+++ b/exporter/azuremonitorexporter/conventions.go
@@ -37,7 +37,6 @@ const (
 	exceptionDetailsMessageMaxLength  int    = 32768
 	exceptionDetailsTypeMaxLength     int    = 1024
 	exceptionDetailsStackMaxLength    int    = 32768
-	exceptionDetailsStackMaxFrames    int    = 32768
 	exceptionDataProblemIdMaxLength   int    = 1024
 )
 

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -60,10 +60,7 @@ func spanToEnvelopes(
 	span ptrace.Span,
 	logger *zap.Logger) ([]contracts.Envelope, error) {
 
-	envelopes, err := spanEventExceptionsToEnvelopes(resource, instrumentationScope, span, logger)
-	if err != nil {
-		return nil, err
-	}
+	envelopes := spanEventExceptionsToEnvelopes(resource, instrumentationScope, span, logger)
 
 	spanEnvelop, err := spanToEnvelope(resource, instrumentationScope, span, logger)
 	if err != nil {
@@ -77,7 +74,7 @@ func spanEventExceptionsToEnvelopes(
 	resource pcommon.Resource,
 	instrumentationScope pcommon.InstrumentationScope,
 	span ptrace.Span,
-	logger *zap.Logger) ([]contracts.Envelope, error) {
+	logger *zap.Logger) []contracts.Envelope {
 
 	envelopes := []contracts.Envelope{}
 	events := span.Events()
@@ -287,7 +284,7 @@ func eventToException(event ptrace.SpanEvent) *contracts.ExceptionData {
 	}
 
 	data.Exceptions = []*contracts.ExceptionDetails{details}
-	data.ProblemId = truncateString(fmt.Sprintf("%s%s", details.TypeName, details.Stack), exceptionDataProblemIdMaxLength)
+	data.ProblemId = truncateString(fmt.Sprintf("%s%s", details.TypeName, details.Stack), exceptionDataProblemIDMaxLength)
 	data.SeverityLevel = contracts.Error
 	return data
 }

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -136,9 +136,9 @@ func TestHTTPServerSpanToRequestDataAttributeSet1(t *testing.T) {
 	spanAttributes.PutBool("somebool", false)
 	spanAttributes.PutDouble("somedouble", 0.1)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRequestDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 
 	// set verification
 	commonRequestDataValidations(t, span, data)
@@ -167,9 +167,9 @@ func TestHTTPServerSpanToRequestDataAttributeSet2(t *testing.T) {
 
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRequestDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 
 	defaultHTTPRequestDataValidations(t, span, data)
 	assert.Equal(t, "127.0.0.1", data.Source)
@@ -193,9 +193,9 @@ func TestHTTPServerSpanToRequestDataAttributeSet3(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeHTTPClientIP, "127.0.0.2")
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRequestDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultHTTPRequestDataValidations(t, span, data)
 	assert.Equal(t, "127.0.0.2", data.Source)
 	assert.Equal(t, "https://foo:81/bar?biz=baz", data.Url)
@@ -210,9 +210,9 @@ func TestHTTPServerSpanToRequestDataAttributeSet4(t *testing.T) {
 	spanAttributes.PutInt(conventions.AttributeHTTPStatusCode, defaultHTTPStatusCode)
 	spanAttributes.PutStr(conventions.AttributeHTTPURL, "https://foo:81/bar?biz=baz")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRequestDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultHTTPRequestDataValidations(t, span, data)
 	assert.Equal(t, "https://foo:81/bar?biz=baz", data.Url)
 }
@@ -237,9 +237,9 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet1(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeHTTPURL, "https://foo:81/bar?biz=baz")
 	spanAttributes.PutInt(conventions.AttributeHTTPStatusCode, 400)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRemoteDependencyDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	commonRemoteDependencyDataValidations(t, span, data)
 
 	assert.Equal(t, "400", data.ResultCode)
@@ -266,9 +266,9 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet2(t *testing.T) {
 	// A specific http.route
 	spanAttributes.PutStr(conventions.AttributeHTTPRoute, "/bar/:baz_id")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRemoteDependencyDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	commonRemoteDependencyDataValidations(t, span, data)
 
 	assert.Equal(t, "200", data.ResultCode)
@@ -290,9 +290,9 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet3(t *testing.T) {
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 	spanAttributes.PutStr(conventions.AttributeHTTPTarget, "/bar?biz=baz")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRemoteDependencyDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultHTTPRemoteDependencyDataValidations(t, span, data)
 	assert.Equal(t, "https://foo:81/bar?biz=baz", data.Data)
 }
@@ -309,9 +309,9 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet4(t *testing.T) {
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 	spanAttributes.PutStr(conventions.AttributeHTTPTarget, "/bar?biz=baz")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRemoteDependencyDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultHTTPRemoteDependencyDataValidations(t, span, data)
 	assert.Equal(t, "https://127.0.0.1:81/bar?biz=baz", data.Data)
 }
@@ -325,17 +325,17 @@ func TestRPCServerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRequestDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultRPCRequestDataValidations(t, span, data, "foo:81")
 
 	// test fallback to peerip
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "")
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	data = envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultRPCRequestDataValidations(t, span, data, "127.0.0.1:81")
 }
 
@@ -348,17 +348,17 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRemoteDependencyDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultRPCRemoteDependencyDataValidations(t, span, data, "foo:81")
 
 	// test fallback to peerip
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "")
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	data = envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultRPCRemoteDependencyDataValidations(t, span, data, "127.0.0.1:81")
 
 	// test RPC error using the new rpc.grpc.status_code attribute
@@ -366,8 +366,8 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	span.Status().SetMessage("Resource exhausted")
 	spanAttributes.PutInt(attributeRPCGRPCStatusCode, 8)
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	data = envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
 	assert.Equal(t, "8", data.ResultCode)
 	assert.Equal(t, traceutil.StatusCodeStr(span.Status().Code()), data.Properties[attributeOtelStatusCode])
@@ -383,9 +383,9 @@ func TestDatabaseClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "foo")
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRemoteDependencyDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultDatabaseRemoteDependencyDataValidations(t, span, data)
 
 	assert.Equal(t, "foo:81", data.Target)
@@ -395,8 +395,8 @@ func TestDatabaseClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeDBStatement, "")
 	spanAttributes.PutStr(conventions.AttributeDBOperation, defaultDBOperation)
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	data = envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	assert.Equal(t, defaultDBOperation, data.Data)
 }
 
@@ -409,9 +409,9 @@ func TestMessagingConsumerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "foo")
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRequestDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultMessagingRequestDataValidations(t, span, data)
 
 	assert.Equal(t, defaultMessagingURL, data.Source)
@@ -419,8 +419,8 @@ func TestMessagingConsumerSpanToRequestData(t *testing.T) {
 	// test fallback from MessagingURL to net.* properties
 	spanAttributes.PutStr(conventions.AttributeMessagingURL, "")
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	data = envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 
 	assert.Equal(t, "foo:81", data.Source)
 }
@@ -434,9 +434,9 @@ func TestMessagingProducerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "foo")
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRemoteDependencyDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultMessagingRemoteDependencyDataValidations(t, span, data)
 
 	assert.Equal(t, defaultMessagingURL, data.Target)
@@ -444,8 +444,8 @@ func TestMessagingProducerSpanToRequestData(t *testing.T) {
 	// test fallback from MessagingURL to net.* properties
 	spanAttributes.PutStr(conventions.AttributeMessagingURL, "")
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	data = envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
 	assert.Equal(t, "foo:81", data.Target)
 }
@@ -457,9 +457,9 @@ func TestUnknownInternalSpanToRemoteDependencyData(t *testing.T) {
 
 	spanAttributes.PutStr("foo", "bar")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRemoteDependencyDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultInternalRemoteDependencyDataValidations(t, span, data)
 }
 
@@ -468,9 +468,9 @@ func TestUnspecifiedSpanToInProcRemoteDependencyData(t *testing.T) {
 	span := getDefaultInternalSpan()
 	span.SetKind(ptrace.SpanKindUnspecified)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
-	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, &envelopes[0], defaultRemoteDependencyDataEnvelopeName)
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultInternalRemoteDependencyDataValidations(t, span, data)
 }
 

--- a/exporter/azuremonitorexporter/utils.go
+++ b/exporter/azuremonitorexporter/utils.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuremonitorexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter"
+
+// truncateString Truncates the given string to a maximum length provided by max.
+func truncateString(s string, max int) string {
+	if len(s) < max {
+		return s
+	}
+
+	return s[:max]
+}


### PR DESCRIPTION
**Description:** 
Even the specification defines how to treat exceptions, the azure monitor exporter doesn't implement the mapping between SpanEvents with name `exception`. To be able to use this exporter in our applications (and I guess that we are not the only with this requirement), we need to properly map the exceptions to the expected application insights table.
This PR adds support to it, processing the SpanEvents and generate the proper envelopes for events with event name `exception`

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16260

**Testing:** Following the already existing tests, I created a test to check that we don't create new envelops in there is any event attached to the span without the proper name and another test checking that in case of having the proper information, the envelope is generated with the correct information. I have also tested this on my on infrastructure to check that it works, but I can't reflect that in the PR (I could attach a picture, but it doesn't make sense IMO)

**Documentation:** I only added a note explaining that exception events are mapped to Application Insights Exceptions