### PR TITLE
[docs] [chore] Update Development stability links in the Readme headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This is a repository for OpenTelemetry Collector components that are not suitabl
 
 The official distributions, core and contrib, are available as part of the [opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) repository. Some of the components in this repository are part of the "core" distribution, such as the Jaeger and Prometheus components, but most of the components here are only available as part of the "contrib" distribution. Users of the OpenTelemetry Collector are also encouraged to build their own custom distributions with the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder), using the components they need from the core repository, the contrib repository, and possibly third-party or internal repositories.
 
-Each component has its own support levels, as defined in the following sections. For each signal that a component supports, there's a stability level, setting the right expectations. It is possible then that a component will be **Stable** for traces but **Alpha** for metrics and **In Development** for logs.
+Each component has its own support levels, as defined in the following sections. For each signal that a component supports, there's a stability level, setting the right expectations. It is possible then that a component will be **Stable** for traces but **Alpha** for metrics and **Development** for logs.
 
 ## Stability levels
 

--- a/cmd/telemetrygen/README.md
+++ b/cmd/telemetrygen/README.md
@@ -1,10 +1,9 @@
 # Telemetry generator for OpenTelemetry
 
-| Status                   |                       |
-| ------------------------ | --------------------- |
-| Stability                | traces [WIP]          |
-|                          | metrics [WIP]         |
-| Supported signal types   | traces, metrics       |
+| Status                   |                 |
+| ------------------------ |-----------------|
+| Stability                | [development]   |
+| Supported signal types   | traces, metrics |
 
 This utility simulates a client generating **traces** and **metrics**, useful for testing and demonstration purposes.
 
@@ -28,3 +27,5 @@ telemetrygen traces
 ```
 telemetrygen metrics
 ```
+
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development

--- a/exporter/parquetexporter/README.md
+++ b/exporter/parquetexporter/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |                       |
 | ------------------------ |-----------------------|
-| Stability                | [in-development]      |
+| Stability                | [development]         |
 | Supported pipeline types | traces, logs, metrics |
 | Distributions            | none                  |
 
@@ -29,4 +29,4 @@ exporters:
 The full list of settings exposed for this exporter is going to be documented later
 with detailed sample configurations [here](testdata/config.yaml).
 
-[in-development]:https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development

--- a/processor/deltatorateprocessor/README.md
+++ b/processor/deltatorateprocessor/README.md
@@ -1,10 +1,10 @@
 # Delta to Rate Processor
 
-| Status                   |                  |
-|--------------------------|------------------|
-| Stability                | [in development] |
-| Supported pipeline types | metrics          |
-| Distributions            | [contrib]        |
+| Status                   |               |
+|--------------------------|---------------|
+| Stability                | [development] |
+| Supported pipeline types | metrics       |
+| Distributions            | [contrib]     |
 
 **Status: under development; Not recommended for production usage.**
 
@@ -32,5 +32,5 @@ processors:
             - <metric_n_name>
 ```
 
-[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/processor/logstransformprocessor/README.md
+++ b/processor/logstransformprocessor/README.md
@@ -1,10 +1,10 @@
 # Logs Transform Processor
 
-| Status                   |                  |
-|--------------------------|------------------|
-| Stability                | [in development] |
-| Supported pipeline types | logs             |
-| Distributions            | none             |
+| Status                   |               |
+|--------------------------|---------------|
+| Stability                | [development] |
+| Supported pipeline types | logs          |
+| Distributions            | none          |
 
 NOTE - This processor is experimental, with the intention that its functionality will be reimplemented in the [transform processor](../transformprocessor/README.md) in the future.
 
@@ -29,4 +29,4 @@ processors:
 Refer to [config.yaml](./testdata/config.yaml) for detailed
 examples on using the processor.
 
-[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development

--- a/processor/metricsgenerationprocessor/README.md
+++ b/processor/metricsgenerationprocessor/README.md
@@ -1,10 +1,10 @@
 # Metrics Generation Processor
 
-| Status                   |                  |
-|--------------------------|------------------|
-| Stability                | [in development] |
-| Supported pipeline types | metrics          |
-| Distributions            | [contrib]        |
+| Status                   |               |
+|--------------------------|---------------|
+| Stability                | [development] |
+| Supported pipeline types | metrics       |
+| Distributions            | [contrib]     |
 
 **Status: under development; Not recommended for production usage.**
 
@@ -72,5 +72,5 @@ rules:
       scale_by: 1048576
 ```
 
-[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/processor/schemaprocessor/README.md
+++ b/processor/schemaprocessor/README.md
@@ -1,8 +1,8 @@
 # Schema Transformer Processor
 
 | Status                   |                       |
-| ------------------------ | --------------------- |
-| Stability                | [in development]      |
+| ------------------------ |-----------------------|
+| Stability                | [development]         |
 | Supported pipeline types | metrics, traces, logs |
 | Distributions            | none                  |
 
@@ -55,4 +55,4 @@ processors:
 
 For more complete examples, please refer to [config.yml](./testdata/config.yml).
 
-[in development]:https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -1,10 +1,10 @@
 # Span Metrics Processor
 
-| Status                   |                     |
-| ------------------------ |---------------------|
-| Stability                | [in development]    |
-| Supported pipeline types | traces              |
-| Distributions            | [contrib]           |
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [development] |
+| Supported pipeline types | traces        |
+| Distributions            | [contrib]     |
 
 **Note:** Currently experimental and subject to breaking changes (e.g. change from processor to exporter/translator component).
 See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/403.
@@ -138,5 +138,5 @@ service:
 
 For more example configuration covering various other use cases, please visit the [testdata directory](./testdata).
 
-[in development]:https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -1,10 +1,10 @@
 # Azure Blob Receiver
 
-| Status                   |             |
-| ------------------------ | ----------- |
-| Stability                |[development]|
-| Supported pipeline types | logs,traces |
-| Distributions            | [contrib]   |
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [development] |
+| Supported pipeline types | logs,traces   |
+| Distributions            | [contrib]     |
 
 
 This receiver reads logs and trace data from [Azure Blob Storage](https://azure.microsoft.com/services/storage/blobs/).
@@ -35,3 +35,5 @@ receivers:
 ```
 
 The receiver subscribes [on the events](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-event-overview) published by Azure Blob Storage and handled by Azure Event Hub. When it receives `Blob Create` event, it reads the logs or traces from a corresponding blob and deletes it after processing.
+
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -1,10 +1,10 @@
 # HTTP Check Receiver
 
-| Status                   |                  |
-| ------------------------ |------------------|
-| Stability                | [in development] |
-| Supported pipeline types | metrics          |
-| Distributions            | none             |
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [development] |
+| Supported pipeline types | metrics       |
+| Distributions            | none          |
 
 The HTTP Check Receiver can be used for synthethic checks against HTTP endpoints. This receiver will make a request to the specified `endpoint` using the
 configured `method`. This scraper generates a metric with a label for each HTTP response status class with a value of `1` if the status code matches the
@@ -43,5 +43,5 @@ receivers:
 
 Details about the metrics produced by this receiver can be found in [documentation.md](./documentation.md)
 
-[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/oracledbreceiver/README.md
+++ b/receiver/oracledbreceiver/README.md
@@ -1,11 +1,13 @@
 # Oracle DB receiver
 
-| Status                   |                            |
-| ------------------------ |----------------------------|
-| Stability                | [in-development]           |
-| Supported pipeline types | metrics                    |
-| Distributions            | [contrib]                  |
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [development] |
+| Supported pipeline types | metrics       |
+| Distributions            | [contrib]     |
 
 This receiver collects metrics from an Oracle Database.
 
 The receiver connects to a database host and performs periodically queries.
+
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development

--- a/receiver/podmanreceiver/README.md
+++ b/receiver/podmanreceiver/README.md
@@ -1,10 +1,10 @@
 # Podman Stats Receiver
 
-| Status                   |                   |
-| ------------------------ |-------------------|
-| Stability                | [in development]  |
-| Supported pipeline types | metrics           |
-| Distributions            | [contrib]         |
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [development] |
+| Supported pipeline types | metrics       |
+| Distributions            | [contrib]     |
 
 The Podman Stats receiver queries the Podman service API to fetch stats for all running containers 
 on a configured interval.  These stats are for container
@@ -89,5 +89,5 @@ Recommended build tags to use when including this receiver in your build:
 - `exclude_graphdriver_btrfs`
 - `exclude_graphdriver_devicemapper`
 
-[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/saphanareceiver/README.md
+++ b/receiver/saphanareceiver/README.md
@@ -1,10 +1,10 @@
 # SAP HANA Receiver
 
-| Status                   |                     |
-| ------------------------ |---------------------|
-| Stability                | [in-development]    |
-| Supported pipeline types | metrics             |
-| Distributions            |                     |
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [development] |
+| Supported pipeline types | metrics       |
+| Distributions            |               |
 
 This receiver can fetch stats from a SAP HANA instance. It leverages the [driver](https://github.com/SAP/go-hdb) written by SAP for connecting to SAP HANA with the golang sql module to execute several monitoring queries.
 
@@ -95,4 +95,4 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 > If all of the metrics collected by a given monitoring query are marked as `enabled: false` in the receiver configration, the monitoring query will not be executed.
 
-[in-development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development

--- a/receiver/snmpreceiver/README.md
+++ b/receiver/snmpreceiver/README.md
@@ -1,10 +1,10 @@
 # SNMP Receiver
 
-| Status                   |           |
-| ------------------------ |-----------|
-| Stability                | [in development] |
-| Supported pipeline types | metrics   |
-| Distributions            | [contrib] |
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [development] |
+| Supported pipeline types | metrics       |
+| Distributions            | [contrib]     |
 
 This receiver fetches stats from a SNMP enabled host using a [golang
 snmp client](https://github.com/gosnmp/gosnmp). Metrics are collected
@@ -241,5 +241,5 @@ receivers:
 
 The full list of settings exposed for this receiver are documented [here](./config.go) with detailed sample configurations [here](./testdata/config.yaml).
 
-[in development]:https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/snowflakereceiver/README.md
+++ b/receiver/snowflakereceiver/README.md
@@ -1,10 +1,12 @@
 # Snowflake Receiver
 
-| Status                   |                   |
-|--------------------------|-------------------|
-| Stability                | in development    |
-| Supported pipeline types | metrics           |
-| Distributions            | contrib           |
+| Status                   |               |
+|--------------------------|---------------|
+| Stability                | [development] |
+| Supported pipeline types | metrics       |
+| Distributions            | [contrib]     |
 
 This receiver collects metrics from a Snowflake account by connecting to an account and running queries at set intervals.
 
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/zookeeperreceiver/README.md
+++ b/receiver/zookeeperreceiver/README.md
@@ -1,10 +1,10 @@
 # Zookeeper Receiver
 
-| Status                   |                  |
-| ------------------------ | ---------------- |
-| Stability                | [in development] |
-| Supported pipeline types | traces           |
-| Distributions            | [contrib]        |
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [development] |
+| Supported pipeline types | traces        |
+| Distributions            | [contrib]     |
 
 The Zookeeper receiver collects metrics from a Zookeeper instance, using the `mntr` command. The `mntr` 4 letter word command needs
 to be enabled for the receiver to be able to collect metrics.
@@ -27,5 +27,5 @@ receivers:
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml) with further documentation in [documentation.md](./documentation.md)
 
-[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
The stability level was renamed in https://github.com/open-telemetry/opentelemetry-collector/pull/6561