### PR TITLE
[pkg/ottl] Add support for lists as Getter values

### DIFF
--- a/.chloggen/ottl-list-getter.yaml
+++ b/.chloggen/ottl-list-getter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for lists to be used as Getter values
+
+# One or more tracking issues related to the change
+issues: [16320]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/contexts/internal/ottlcommon/map.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/map.go
@@ -29,7 +29,7 @@ func GetMapValue(attrs pcommon.Map, mapKey string) interface{} {
 func SetMapValue(attrs pcommon.Map, mapKey string, val interface{}) {
 	var value pcommon.Value
 	switch val.(type) {
-	case []string, []bool, []int64, []float64, [][]byte:
+	case []string, []bool, []int64, []float64, [][]byte, []any:
 		value = pcommon.NewValueSlice()
 	default:
 		value = pcommon.NewValueEmpty()

--- a/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
@@ -131,6 +131,23 @@ func TestResourcePathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes array empty",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("arr_empty"),
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refResource.Attributes().Get("arr_empty")
+				return val.Slice()
+			}(),
+			newVal: []any{},
+			modified: func(resource pcommon.Resource) {
+				// no-op
+			},
+		},
+		{
 			name: "attributes array string",
 			path: []ottl.Field{
 				{
@@ -258,6 +275,8 @@ func createResource() pcommon.Resource {
 	resource.Attributes().PutInt("int", 10)
 	resource.Attributes().PutDouble("double", 1.2)
 	resource.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+
+	resource.Attributes().PutEmptySlice("arr_empty")
 
 	arrStr := resource.Attributes().PutEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStr("one")

--- a/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
@@ -169,6 +169,23 @@ func TestScopePathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes array empty",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("arr_empty"),
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refIS.Attributes().Get("arr_empty")
+				return val.Slice()
+			}(),
+			newVal: []any{},
+			modified: func(is pcommon.InstrumentationScope) {
+				// no-op
+			},
+		},
+		{
 			name: "attributes array string",
 			path: []ottl.Field{
 				{
@@ -292,6 +309,8 @@ func createInstrumentationScope() pcommon.InstrumentationScope {
 	is.Attributes().PutInt("int", 10)
 	is.Attributes().PutDouble("double", 1.2)
 	is.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+
+	is.Attributes().PutEmptySlice("arr_empty")
 
 	arrStr := is.Attributes().PutEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStr("one")

--- a/pkg/ottl/contexts/internal/ottlcommon/span_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/span_test.go
@@ -307,6 +307,23 @@ func TestSpanPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes array empty",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("arr_empty"),
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refSpan.Attributes().Get("arr_empty")
+				return val.Slice()
+			}(),
+			newVal: []any{},
+			modified: func(span ptrace.Span) {
+				// no-op
+			},
+		},
+		{
 			name: "attributes array string",
 			path: []ottl.Field{
 				{
@@ -545,6 +562,8 @@ func createSpan() ptrace.Span {
 	span.Attributes().PutInt("int", 10)
 	span.Attributes().PutDouble("double", 1.2)
 	span.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+
+	span.Attributes().PutEmptySlice("arr_empty")
 
 	arrStr := span.Attributes().PutEmptySlice("arr_str")
 	arrStr.AppendEmpty().SetStr("one")

--- a/pkg/ottl/contexts/internal/ottlcommon/value.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/value.go
@@ -51,39 +51,35 @@ func SetValue(value pcommon.Value, val interface{}) {
 	case []byte:
 		value.SetEmptyBytes().FromRaw(v)
 	case []string:
-		value.Slice().RemoveIf(func(_ pcommon.Value) bool {
-			return true
-		})
+		value.SetEmptySlice().EnsureCapacity(len(v))
 		for _, str := range v {
 			value.Slice().AppendEmpty().SetStr(str)
 		}
 	case []bool:
-		value.Slice().RemoveIf(func(_ pcommon.Value) bool {
-			return true
-		})
+		value.SetEmptySlice().EnsureCapacity(len(v))
 		for _, b := range v {
 			value.Slice().AppendEmpty().SetBool(b)
 		}
 	case []int64:
-		value.Slice().RemoveIf(func(_ pcommon.Value) bool {
-			return true
-		})
+		value.SetEmptySlice().EnsureCapacity(len(v))
 		for _, i := range v {
 			value.Slice().AppendEmpty().SetInt(i)
 		}
 	case []float64:
-		value.Slice().RemoveIf(func(_ pcommon.Value) bool {
-			return true
-		})
+		value.SetEmptySlice().EnsureCapacity(len(v))
 		for _, f := range v {
 			value.Slice().AppendEmpty().SetDouble(f)
 		}
 	case [][]byte:
-		value.Slice().RemoveIf(func(_ pcommon.Value) bool {
-			return true
-		})
+		value.SetEmptySlice().EnsureCapacity(len(v))
 		for _, b := range v {
 			value.Slice().AppendEmpty().SetEmptyBytes().FromRaw(b)
+		}
+	case []any:
+		value.SetEmptySlice().EnsureCapacity(len(v))
+		for _, a := range v {
+			pval := value.Slice().AppendEmpty()
+			SetValue(pval, a)
 		}
 	case pcommon.Map:
 		v.CopyTo(value.SetEmptyMap())

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -34,6 +34,7 @@ func Test_newGetter(t *testing.T) {
 	tests := []struct {
 		name string
 		val  value
+		ctx  interface{}
 		want interface{}
 	}{
 		{
@@ -83,7 +84,7 @@ func Test_newGetter(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "path mathExpression",
+			name: "path expression",
 			val: value{
 				Literal: &mathExprLiteral{
 					Path: &Path{
@@ -115,6 +116,176 @@ func Test_newGetter(t *testing.T) {
 			},
 			want: int64(1),
 		},
+		{
+			name: "empty list",
+			val: value{
+				List: &list{
+					Values: []value{},
+				},
+			},
+			want: []any{},
+		},
+		{
+			name: "string list",
+			val: value{
+				List: &list{
+					Values: []value{
+						{
+							String: ottltest.Strp("test0"),
+						},
+						{
+							String: ottltest.Strp("test1"),
+						},
+					},
+				},
+			},
+			want: []any{"test0", "test1"},
+		},
+		{
+			name: "int list",
+			val: value{
+				List: &list{
+					Values: []value{
+						{
+							Literal: &mathExprLiteral{
+								Int: ottltest.Intp(1),
+							},
+						},
+						{
+							Literal: &mathExprLiteral{
+								Int: ottltest.Intp(2),
+							},
+						},
+					},
+				},
+			},
+			want: []any{int64(1), int64(2)},
+		},
+		{
+			name: "float list",
+			val: value{
+				List: &list{
+					Values: []value{
+						{
+							Literal: &mathExprLiteral{
+								Float: ottltest.Floatp(1.2),
+							},
+						},
+						{
+							Literal: &mathExprLiteral{
+								Float: ottltest.Floatp(2.4),
+							},
+						},
+					},
+				},
+			},
+			want: []any{1.2, 2.4},
+		},
+		{
+			name: "bool list",
+			val: value{
+				List: &list{
+					Values: []value{
+						{
+							Bool: (*boolean)(ottltest.Boolp(true)),
+						},
+						{
+							Bool: (*boolean)(ottltest.Boolp(false)),
+						},
+					},
+				},
+			},
+			want: []any{true, false},
+		},
+		{
+			name: "byte slice list",
+			val: value{
+				List: &list{
+					Values: []value{
+						{
+							Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+						},
+						{
+							Bytes: (*byteSlice)(&[]byte{9, 8, 7, 6, 5, 4, 3, 2}),
+						},
+					},
+				},
+			},
+			want: []any{[]byte{1, 2, 3, 4, 5, 6, 7, 8}, []byte{9, 8, 7, 6, 5, 4, 3, 2}},
+		},
+		{
+			name: "path expression",
+			val: value{
+				List: &list{
+					Values: []value{
+						{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ctx:  "bear",
+			want: []any{"bear"},
+		},
+		{
+			name: "function call",
+			val: value{
+				List: &list{
+					Values: []value{
+						{
+							Literal: &mathExprLiteral{
+								Invocation: &invocation{
+									Function: "hello",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []any{"world"},
+		},
+		{
+			name: "nil slice",
+			val: value{
+				List: &list{
+					Values: []value{
+						{
+							IsNil: (*isNil)(ottltest.Boolp(true)),
+						},
+						{
+							IsNil: (*isNil)(ottltest.Boolp(true)),
+						},
+					},
+				},
+			},
+			want: []any{nil, nil},
+		},
+		{
+			name: "heterogeneous slice",
+			val: value{
+				List: &list{
+					Values: []value{
+						{
+							String: ottltest.Strp("test0"),
+						},
+						{
+							Literal: &mathExprLiteral{
+								Int: ottltest.Intp(1),
+							},
+						},
+					},
+				},
+			},
+			want: []any{"test0", int64(1)},
+		},
 	}
 
 	functions := map[string]interface{}{"hello": hello[interface{}]}
@@ -130,7 +301,14 @@ func Test_newGetter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			reader, err := p.newGetter(tt.val)
 			assert.NoError(t, err)
-			val, _ := reader.Get(context.Background(), tt.want)
+
+			tCtx := tt.want
+
+			if tt.ctx != nil {
+				tCtx = tt.ctx
+			}
+
+			val, _ := reader.Get(context.Background(), tCtx)
 			assert.Equal(t, tt.want, val)
 		})
 	}

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -418,6 +418,48 @@ func Test_NewFunctionCall(t *testing.T) {
 									Enum: (*EnumSymbol)(ottltest.Strp("TEST_ENUM")),
 								},
 								{
+									List: &list{
+										Values: []value{
+											{
+												String: ottltest.Strp("test"),
+											},
+											{
+												String: ottltest.Strp("test"),
+											},
+										},
+									},
+								},
+								{
+									List: &list{
+										Values: []value{
+											{
+												String: ottltest.Strp("test"),
+											},
+											{
+												List: &list{
+													Values: []value{
+														{
+															String: ottltest.Strp("test"),
+														},
+														{
+															List: &list{
+																Values: []value{
+																	{
+																		String: ottltest.Strp("test"),
+																	},
+																	{
+																		String: ottltest.Strp("test"),
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
 									Literal: &mathExprLiteral{
 										Invocation: &invocation{
 											Function: "testing_getter",
@@ -442,8 +484,9 @@ func Test_NewFunctionCall(t *testing.T) {
 					},
 				},
 			},
-			want: 7,
-		}, {
+			want: 9,
+		},
+		{
 			name: "setter arg",
 			inv: invocation{
 				Function: "testing_setter",
@@ -510,6 +553,71 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []value{
 					{
 						IsNil: (*isNil)(ottltest.Boolp(true)),
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "getter arg with list",
+			inv: invocation{
+				Function: "testing_getter",
+				Arguments: []value{
+					{
+						List: &list{
+							Values: []value{
+								{
+									String: ottltest.Strp("test"),
+								},
+								{
+									Literal: &mathExprLiteral{
+										Int: ottltest.Intp(1),
+									},
+								},
+								{
+									Literal: &mathExprLiteral{
+										Float: ottltest.Floatp(1.1),
+									},
+								},
+								{
+									Bool: (*boolean)(ottltest.Boolp(true)),
+								},
+								{
+									Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+								},
+								{
+									Literal: &mathExprLiteral{
+										Path: &Path{
+											Fields: []Field{
+												{
+													Name: "name",
+												},
+											},
+										},
+									},
+								},
+								{
+									Literal: &mathExprLiteral{
+										Invocation: &invocation{
+											Function: "testing_getter",
+											Arguments: []value{
+												{
+													Literal: &mathExprLiteral{
+														Path: &Path{
+															Fields: []Field{
+																{
+																	Name: "name",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -266,6 +266,15 @@ func Test_ProcessLogs_LogContext(t *testing.T) {
 			want:      func(td plog.Logs) {},
 		},
 		{
+			statement: `set(attributes["test"], ["A", "B", "C"]) where body == "operationA"`,
+			want: func(td plog.Logs) {
+				v1 := td.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().PutEmptySlice("test")
+				v1.AppendEmpty().SetStr("A")
+				v1.AppendEmpty().SetStr("B")
+				v1.AppendEmpty().SetStr("C")
+			},
+		},
+		{
 			statement: `set(attributes["test"], ConvertCase(body, "lower")) where body == "operationA"`,
 			want: func(td plog.Logs) {
 				td.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().PutStr("test", "operationa")

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -456,6 +456,19 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().PutStr("test_camel", "OperationA")
 			},
 		},
+		{
+			statements: []string{`set(attributes["test"], ["A", "B", "C"]) where metric.name == "operationA"`},
+			want: func(td pmetric.Metrics) {
+				v00 := td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().PutEmptySlice("test")
+				v00.AppendEmpty().SetStr("A")
+				v00.AppendEmpty().SetStr("B")
+				v00.AppendEmpty().SetStr("C")
+				v01 := td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().PutEmptySlice("test")
+				v01.AppendEmpty().SetStr("A")
+				v01.AppendEmpty().SetStr("B")
+				v01.AppendEmpty().SetStr("C")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -307,6 +307,15 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 			want:      func(td ptrace.Traces) {},
 		},
 		{
+			statement: `set(attributes["test"], ["A", "B", "C"]) where name == "operationA"`,
+			want: func(td ptrace.Traces) {
+				v1 := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().PutEmptySlice("test")
+				v1.AppendEmpty().SetStr("A")
+				v1.AppendEmpty().SetStr("B")
+				v1.AppendEmpty().SetStr("C")
+			},
+		},
+		{
 			statement: `set(attributes["entrypoint"], name) where parent_span_id == SpanID(0x0000000000000000)`,
 			want: func(td ptrace.Traces) {
 				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Attributes().PutStr("entrypoint", "operationB")


### PR DESCRIPTION
**Description:**

Allow using lists as a Getter value. This implementation implements a `listGetter` struct that allows recursively evaluating list elements, which allows putting paths and invocations in lists.

**Link to tracking Issue:**

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16320

**Testing:**

Added unit tests to check for this functionality at multiple levels.

**Documentation:**

The existing docs should cover this functionality.