### PR TITLE
[pkg/stanza] Fix serverity range unmarshaling

### DIFF
--- a/.chloggen/pkg-stanza-sev-range-fix.yaml
+++ b/.chloggen/pkg-stanza-sev-range-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix severity range unmarshaling
+
+# One or more tracking issues related to the change
+issues: [16339]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -658,7 +658,7 @@ func NewTestParserConfig() ParserConfig {
 	expect.TimeParser = &tp
 
 	sp := NewSeverityConfig()
-	sp.Mapping = map[interface{}]interface{}{
+	sp.Mapping = map[string]interface{}{
 		"info": "3xx",
 		"warn": "4xx",
 	}

--- a/pkg/stanza/operator/helper/severity_builder.go
+++ b/pkg/stanza/operator/helper/severity_builder.go
@@ -29,34 +29,7 @@ func getBuiltinMapping(name string) severityMap {
 	switch name {
 	case "none":
 		return map[string]entry.Severity{}
-	case "aliases":
-		return map[string]entry.Severity{
-			"trace":  entry.Trace,
-			"trace2": entry.Trace2,
-			"trace3": entry.Trace3,
-			"trace4": entry.Trace4,
-			"debug":  entry.Debug,
-			"debug2": entry.Debug2,
-			"debug3": entry.Debug3,
-			"debug4": entry.Debug4,
-			"info":   entry.Info,
-			"info2":  entry.Info2,
-			"info3":  entry.Info3,
-			"info4":  entry.Info4,
-			"warn":   entry.Warn,
-			"warn2":  entry.Warn2,
-			"warn3":  entry.Warn3,
-			"warn4":  entry.Warn4,
-			"error":  entry.Error,
-			"error2": entry.Error2,
-			"error3": entry.Error3,
-			"error4": entry.Error4,
-			"fatal":  entry.Fatal,
-			"fatal2": entry.Fatal2,
-			"fatal3": entry.Fatal3,
-			"fatal4": entry.Fatal4,
-		}
-	case "otel":
+	case "otel", "aliases":
 		return map[string]entry.Severity{
 			"trace":  entry.Trace,
 			"1":      entry.Trace,
@@ -149,9 +122,9 @@ func NewSeverityConfig() SeverityConfig {
 
 // SeverityConfig allows users to specify how to parse a severity from a field.
 type SeverityConfig struct {
-	ParseFrom *entry.Field                `mapstructure:"parse_from,omitempty"`
-	Preset    string                      `mapstructure:"preset,omitempty"`
-	Mapping   map[interface{}]interface{} `mapstructure:"mapping,omitempty"`
+	ParseFrom *entry.Field           `mapstructure:"parse_from,omitempty"`
+	Preset    string                 `mapstructure:"preset,omitempty"`
+	Mapping   map[string]interface{} `mapstructure:"mapping,omitempty"`
 }
 
 // Build builds a SeverityParser from a SeverityConfig
@@ -200,7 +173,7 @@ func validateSeverity(severity interface{}) (entry.Severity, error) {
 }
 
 func isRange(value interface{}) (int, int, bool) {
-	rawMap, ok := value.(map[interface{}]interface{})
+	rawMap, ok := value.(map[string]interface{})
 	if !ok {
 		return 0, 0, false
 	}

--- a/pkg/stanza/operator/helper/severity_test.go
+++ b/pkg/stanza/operator/helper/severity_test.go
@@ -31,7 +31,7 @@ type severityTestCase struct {
 	name       string
 	sample     interface{}
 	mappingSet string
-	mapping    map[interface{}]interface{}
+	mapping    map[string]interface{}
 	buildErr   bool
 	parseErr   bool
 	expected   entry.Severity
@@ -77,7 +77,7 @@ func validMappingKeyCases() []severityTestCase {
 			severityTestCase{
 				name:     k,
 				sample:   "my_custom_value",
-				mapping:  map[interface{}]interface{}{k: "my_custom_value"},
+				mapping:  map[string]interface{}{k: "my_custom_value"},
 				expected: v,
 			})
 	}
@@ -142,19 +142,19 @@ func otlpSevCases() []severityTestCase {
 	return cases
 }
 
-func TestSeverityParser(t *testing.T) {
-	allTheThingsMap := map[interface{}]interface{}{
-		"info":   "3xx",
-		"error3": "4xx",
-		"debug4": "5xx",
-		"trace2": []interface{}{
-			"ttttttracer",
-			[]byte{100, 100, 100},
-			map[interface{}]interface{}{"min": 1111, "max": 1234},
-		},
-		"fatal2": "",
-	}
+var allTheThingsMap = map[string]interface{}{
+	"info":   "3xx",
+	"error3": "4xx",
+	"debug4": "5xx",
+	"trace2": []interface{}{
+		"ttttttracer",
+		map[string]interface{}{"min": 1111, "max": 1234},
+	},
+	"12":     "infooo",
+	"fatal2": "",
+}
 
+func TestSeverityParser(t *testing.T) {
 	testCases := []severityTestCase{
 		{
 			name:     "unknown",
@@ -201,138 +201,132 @@ func TestSeverityParser(t *testing.T) {
 		{
 			name:     "custom-string",
 			sample:   "NOOOOOOO",
-			mapping:  map[interface{}]interface{}{"error": "NOOOOOOO"},
+			mapping:  map[string]interface{}{"error": "NOOOOOOO"},
 			expected: entry.Error,
 		},
 		{
 			name:     "custom-string-caps-key",
 			sample:   "NOOOOOOO",
-			mapping:  map[interface{}]interface{}{"ErRoR": "NOOOOOOO"},
+			mapping:  map[string]interface{}{"ErRoR": "NOOOOOOO"},
 			expected: entry.Error,
 		},
 		{
 			name:     "custom-int",
 			sample:   1234,
-			mapping:  map[interface{}]interface{}{"error": 1234},
+			mapping:  map[string]interface{}{"error": 1234},
 			expected: entry.Error,
 		},
 		{
 			name:     "mixed-list-string",
 			sample:   "ThiS Is BaD",
-			mapping:  map[interface{}]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},
+			mapping:  map[string]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},
 			expected: entry.Error,
 		},
 		{
 			name:     "custom-float64",
 			sample:   float64(6),
-			mapping:  map[interface{}]interface{}{"error": 6},
+			mapping:  map[string]interface{}{"error": 6},
 			expected: entry.Error,
 		},
 		{
 			name:     "mixed-list-int",
 			sample:   1234,
-			mapping:  map[interface{}]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},
+			mapping:  map[string]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},
 			expected: entry.Error,
 		},
 		{
 			name:     "numbered-level",
 			sample:   "critical",
-			mapping:  map[interface{}]interface{}{"error2": "critical"},
+			mapping:  map[string]interface{}{"error2": "critical"},
 			expected: entry.Error2,
 		},
 		{
 			name:     "override-standard",
 			sample:   "error",
-			mapping:  map[interface{}]interface{}{"error3": []interface{}{"error"}},
+			mapping:  map[string]interface{}{"error3": []interface{}{"error"}},
 			expected: entry.Error3,
 		},
 		{
 			name:     "level-unfound",
 			sample:   "not-in-the-list-but-thats-ok",
-			mapping:  map[interface{}]interface{}{"error4": []interface{}{"hey!", 1234}},
+			mapping:  map[string]interface{}{"error4": []interface{}{"hey!", 1234}},
 			expected: entry.Default,
 		},
 		{
 			name:     "in-range",
 			sample:   123,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Error,
 		},
 		{
 			name:     "in-range-min",
 			sample:   120,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Error,
 		},
 		{
 			name:     "in-range-max",
 			sample:   125,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Error,
 		},
 		{
 			name:     "out-of-range-min-minus",
 			sample:   119,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Default,
 		},
 		{
 			name:     "out-of-range-max-plus",
 			sample:   126,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Default,
 		},
 		{
 			name:     "range-out-of-order",
 			sample:   123,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 125, "max": 120}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 125, "max": 120}},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http2xx-hit",
 			sample:   201,
-			mapping:  map[interface{}]interface{}{"error": "2xx"},
+			mapping:  map[string]interface{}{"error": "2xx"},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http2xx-miss",
 			sample:   301,
-			mapping:  map[interface{}]interface{}{"error": "2xx"},
+			mapping:  map[string]interface{}{"error": "2xx"},
 			expected: entry.Default,
 		},
 		{
 			name:     "Http3xx-hit",
 			sample:   301,
-			mapping:  map[interface{}]interface{}{"error": "3xx"},
+			mapping:  map[string]interface{}{"error": "3xx"},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http4xx-hit",
 			sample:   "404",
-			mapping:  map[interface{}]interface{}{"error": "4xx"},
+			mapping:  map[string]interface{}{"error": "4xx"},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http5xx-hit",
 			sample:   555,
-			mapping:  map[interface{}]interface{}{"error": "5xx"},
+			mapping:  map[string]interface{}{"error": "5xx"},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http-All",
 			sample:   "301",
-			mapping:  map[interface{}]interface{}{"debug": "2xx", "info": "3xx", "error": "4xx", "warn": "5xx"},
+			mapping:  map[string]interface{}{"debug": "2xx", "info": "3xx", "error": "4xx", "warn": "5xx"},
 			expected: entry.Info,
 		},
 		{
 			name:     "all-the-things-midrange",
 			sample:   1234,
-			mapping:  allTheThingsMap,
-			expected: entry.Trace2,
-		},
-		{
-			name:     "all-the-things-bytes",
-			sample:   []byte{100, 100, 100},
 			mapping:  allTheThingsMap,
 			expected: entry.Trace2,
 		},
@@ -480,6 +474,45 @@ func (tc severityTestCase) run(parseFrom entry.Field) func(*testing.T) {
 	}
 }
 
+func TestBuildCustomMapping(t *testing.T) {
+	t.Parallel()
+
+	expected := severityMap{
+		"300":         entry.Info,
+		"301":         entry.Info,
+		"399":         entry.Info,
+		"400":         entry.Error3,
+		"410":         entry.Error3,
+		"499":         entry.Error3,
+		"500":         entry.Debug4,
+		"555":         entry.Debug4,
+		"599":         entry.Debug4,
+		"ttttttracer": entry.Trace2,
+		"1111":        entry.Trace2,
+		"1200":        entry.Trace2,
+		"1234":        entry.Trace2,
+		"infooo":      entry.Info4, // 12
+		"":            entry.Fatal2,
+	}
+
+	parseFrom := entry.NewBodyField()
+	cfg := &SeverityConfig{
+		ParseFrom: &parseFrom,
+		Mapping:   allTheThingsMap,
+	}
+
+	severityParser, err := cfg.Build(testutil.Logger(t))
+	require.NoError(t, err)
+
+	for k, v := range expected {
+		sev, _, err := severityParser.Mapping.find(k)
+		t.Run(k, func(t *testing.T) {
+			require.NoError(t, err)
+			require.Equal(t, v, sev)
+		})
+	}
+}
+
 func TestUnmarshalSeverityConfig(t *testing.T) {
 	operatortest.ConfigUnmarshalTests{
 		DefaultConfig: newHelpersConfig(),
@@ -490,12 +523,7 @@ func TestUnmarshalSeverityConfig(t *testing.T) {
 				Expect: func() *helpersConfig {
 					c := newHelpersConfig()
 					c.Severity = NewSeverityConfig()
-					c.Severity.Mapping = map[interface{}]interface{}{
-						"critical": "5xx",
-						"error":    "4xx",
-						"info":     "3xx",
-						"debug":    "2xx",
-					}
+					c.Severity.Mapping = allTheThingsMap
 					return c
 				}(),
 			},

--- a/pkg/stanza/operator/helper/testdata/severity.yaml
+++ b/pkg/stanza/operator/helper/testdata/severity.yaml
@@ -2,10 +2,15 @@ mapping:
   type: helpers_test
   severity:
     mapping:
-      critical: 5xx
-      error: 4xx
       info: 3xx
-      debug: 2xx
+      error3: 4xx
+      debug4: 5xx
+      trace2:
+        - "ttttttracer"
+        - min: 1111
+          max: 1234
+      fatal2: ""
+      12: infooo
 parse_from:
   type: helpers_test
   severity:

--- a/pkg/stanza/operator/parser/json/config_test.go
+++ b/pkg/stanza/operator/parser/json/config_test.go
@@ -76,7 +76,7 @@ func TestConfig(t *testing.T) {
 					parseField := entry.NewBodyField("severity_field")
 					severityParser := helper.NewSeverityConfig()
 					severityParser.ParseFrom = &parseField
-					mapping := map[interface{}]interface{}{
+					mapping := map[string]interface{}{
 						"critical": "5xx",
 						"error":    "4xx",
 						"info":     "3xx",

--- a/pkg/stanza/operator/parser/keyvalue/config_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/config_test.go
@@ -76,7 +76,7 @@ func TestConfig(t *testing.T) {
 					parseField := entry.NewBodyField("severity_field")
 					severityField := helper.NewSeverityConfig()
 					severityField.ParseFrom = &parseField
-					mapping := map[interface{}]interface{}{
+					mapping := map[string]interface{}{
 						"critical": "5xx",
 						"error":    "4xx",
 						"info":     "3xx",

--- a/pkg/stanza/operator/parser/regex/config_test.go
+++ b/pkg/stanza/operator/parser/regex/config_test.go
@@ -84,7 +84,7 @@ func TestParserGoldenConfig(t *testing.T) {
 					parseField := entry.NewBodyField("severity_field")
 					severityParser := helper.NewSeverityConfig()
 					severityParser.ParseFrom = &parseField
-					mapping := map[interface{}]interface{}{
+					mapping := map[string]interface{}{
 						"critical": "5xx",
 						"error":    "4xx",
 						"info":     "3xx",

--- a/pkg/stanza/operator/parser/severity/severity_test.go
+++ b/pkg/stanza/operator/parser/severity/severity_test.go
@@ -30,21 +30,21 @@ type severityTestCase struct {
 	name       string
 	sample     interface{}
 	mappingSet string
-	mapping    map[interface{}]interface{}
+	mapping    map[string]interface{}
 	buildErr   bool
 	parseErr   bool
 	expected   entry.Severity
 }
 
 func TestSeverityParser(t *testing.T) {
-	allTheThingsMap := map[interface{}]interface{}{
+	allTheThingsMap := map[string]interface{}{
 		"info":   "3xx",
 		"error3": "4xx",
 		"debug4": "5xx",
 		"trace2": []interface{}{
 			"ttttttracer",
 			[]byte{100, 100, 100},
-			map[interface{}]interface{}{"min": 1111, "max": 1234},
+			map[string]interface{}{"min": 1111, "max": 1234},
 		},
 		"fatal2": "",
 	}
@@ -77,103 +77,103 @@ func TestSeverityParser(t *testing.T) {
 		{
 			name:     "custom-string",
 			sample:   "NOOOOOOO",
-			mapping:  map[interface{}]interface{}{"error": "NOOOOOOO"},
+			mapping:  map[string]interface{}{"error": "NOOOOOOO"},
 			expected: entry.Error,
 		},
 		{
 			name:     "custom-string-caps-key",
 			sample:   "NOOOOOOO",
-			mapping:  map[interface{}]interface{}{"ErRoR": "NOOOOOOO"},
+			mapping:  map[string]interface{}{"ErRoR": "NOOOOOOO"},
 			expected: entry.Error,
 		},
 		{
 			name:     "custom-int",
 			sample:   1234,
-			mapping:  map[interface{}]interface{}{"error": 1234},
+			mapping:  map[string]interface{}{"error": 1234},
 			expected: entry.Error,
 		},
 		{
 			name:     "mixed-list-string",
 			sample:   "ThiS Is BaD",
-			mapping:  map[interface{}]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},
+			mapping:  map[string]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},
 			expected: entry.Error,
 		},
 		{
 			name:     "mixed-list-int",
 			sample:   1234,
-			mapping:  map[interface{}]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},
+			mapping:  map[string]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},
 			expected: entry.Error,
 		},
 		{
 			name:     "in-range",
 			sample:   123,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Error,
 		},
 		{
 			name:     "in-range-min",
 			sample:   120,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Error,
 		},
 		{
 			name:     "in-range-max",
 			sample:   125,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Error,
 		},
 		{
 			name:     "out-of-range-min-minus",
 			sample:   119,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Default,
 		},
 		{
 			name:     "out-of-range-max-plus",
 			sample:   126,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 120, "max": 125}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 120, "max": 125}},
 			expected: entry.Default,
 		},
 		{
 			name:     "range-out-of-order",
 			sample:   123,
-			mapping:  map[interface{}]interface{}{"error": map[interface{}]interface{}{"min": 125, "max": 120}},
+			mapping:  map[string]interface{}{"error": map[string]interface{}{"min": 125, "max": 120}},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http2xx-hit",
 			sample:   201,
-			mapping:  map[interface{}]interface{}{"error": "2xx"},
+			mapping:  map[string]interface{}{"error": "2xx"},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http2xx-miss",
 			sample:   301,
-			mapping:  map[interface{}]interface{}{"error": "2xx"},
+			mapping:  map[string]interface{}{"error": "2xx"},
 			expected: entry.Default,
 		},
 		{
 			name:     "Http3xx-hit",
 			sample:   301,
-			mapping:  map[interface{}]interface{}{"error": "3xx"},
+			mapping:  map[string]interface{}{"error": "3xx"},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http4xx-hit",
 			sample:   "404",
-			mapping:  map[interface{}]interface{}{"error": "4xx"},
+			mapping:  map[string]interface{}{"error": "4xx"},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http5xx-hit",
 			sample:   555,
-			mapping:  map[interface{}]interface{}{"error": "5xx"},
+			mapping:  map[string]interface{}{"error": "5xx"},
 			expected: entry.Error,
 		},
 		{
 			name:     "Http-All",
 			sample:   "301",
-			mapping:  map[interface{}]interface{}{"debug": "2xx", "info": "3xx", "error": "4xx", "warn": "5xx"},
+			mapping:  map[string]interface{}{"debug": "2xx", "info": "3xx", "error": "4xx", "warn": "5xx"},
 			expected: entry.Info,
 		},
 		{
@@ -260,7 +260,7 @@ func runSeverityParseTest(cfg *Config, ent *entry.Entry, buildErr bool, parseErr
 	}
 }
 
-func parseSeverityTestConfig(parseFrom entry.Field, preset string, mapping map[interface{}]interface{}) *Config {
+func parseSeverityTestConfig(parseFrom entry.Field, preset string, mapping map[string]interface{}) *Config {
 	cfg := NewConfigWithID("test_operator_id")
 	cfg.OutputIDs = []string{"output1"}
 	cfg.SeverityConfig = helper.SeverityConfig{

--- a/pkg/stanza/operator/parser/syslog/config_test.go
+++ b/pkg/stanza/operator/parser/syslog/config_test.go
@@ -110,7 +110,7 @@ func TestUnmarshal(t *testing.T) {
 					parseField := entry.NewBodyField("severity_field")
 					severityParser := helper.NewSeverityConfig()
 					severityParser.ParseFrom = &parseField
-					mapping := map[interface{}]interface{}{
+					mapping := map[string]interface{}{
 						"critical": "5xx",
 						"error":    "4xx",
 						"info":     "3xx",

--- a/pkg/stanza/operator/parser/uri/config_test.go
+++ b/pkg/stanza/operator/parser/uri/config_test.go
@@ -76,7 +76,7 @@ func TestParserGoldenConfig(t *testing.T) {
 					parseField := entry.NewBodyField("severity_field")
 					severityField := helper.NewSeverityConfig()
 					severityField.ParseFrom = &parseField
-					mapping := map[interface{}]interface{}{
+					mapping := map[string]interface{}{
 						"critical": "5xx",
 						"error":    "4xx",
 						"info":     "3xx",


### PR DESCRIPTION
This functionality was broken during refactoring of the unmarshaling logic.

Previously, various yaml types could be used to represent a severity level. This was designed to be as open as possible to future implementations. However, it is now clear that only some keys are valid anyways. Namely, string and ints that represent OTel's native severity levels. Both strings and ints are now treated as strings when unmarshaling, which is fully compatible with the sev map lookup code.

Resolves #16336 