### PR TITLE
[pkg/ottl] Add support for setting maps in Values

### DIFF
--- a/.chloggen/ottl-handle-maps.yaml
+++ b/.chloggen/ottl-handle-maps.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for setting Maps in Values.  This enables Contexts to set map values for attributes.
+
+# One or more tracking issues related to the change
+issues: [16352]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/contexts/internal/ottlcommon/value.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/value.go
@@ -85,7 +85,12 @@ func SetValue(value pcommon.Value, val interface{}) {
 		for _, b := range v {
 			value.Slice().AppendEmpty().SetEmptyBytes().FromRaw(b)
 		}
-	default:
-		// TODO(anuraaga): Support set of map type.
+	case pcommon.Map:
+		v.CopyTo(value.SetEmptyMap())
+	case map[string]interface{}:
+		value.SetEmptyMap()
+		for mk, mv := range v {
+			SetMapValue(value.Map(), mk, mv)
+		}
 	}
 }

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -32,6 +32,17 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 
 	newExemplars, newAttrs := createNewTelemetry()
 
+	newPMap := pcommon.NewMap()
+	newPMap.PutStr("k1", "string")
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]interface{})
+	newMap2 := make(map[string]interface{})
+	newMap2["k1"] = "string"
+	newMap["k1"] = "string"
+	newMap["k2"] = newMap2
+
 	tests := []struct {
 		name      string
 		path      []ottl.Field
@@ -287,6 +298,46 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 				datapoint.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
 		},
+		{
+			name: "attributes pcommon.Map",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("pMap"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refNumberDataPoint.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(datapoint pmetric.NumberDataPoint) {
+				m := datapoint.Attributes().PutEmptyMap("pMap")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes map[string]interface{}",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("map"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refNumberDataPoint.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(datapoint pmetric.NumberDataPoint) {
+				m := datapoint.Attributes().PutEmptyMap("map")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -334,6 +385,17 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 	refHistogramDataPoint := createHistogramDataPointTelemetry()
 
 	newExemplars, newAttrs := createNewTelemetry()
+
+	newPMap := pcommon.NewMap()
+	newPMap.PutStr("k1", "string")
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]interface{})
+	newMap2 := make(map[string]interface{})
+	newMap2["k1"] = "string"
+	newMap["k1"] = "string"
+	newMap["k2"] = newMap2
 
 	tests := []struct {
 		name     string
@@ -614,6 +676,46 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 				datapoint.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
 		},
+		{
+			name: "attributes pcommon.Map",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("pMap"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refHistogramDataPoint.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(datapoint pmetric.HistogramDataPoint) {
+				m := datapoint.Attributes().PutEmptyMap("pMap")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes map[string]interface{}",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("map"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refHistogramDataPoint.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(datapoint pmetric.HistogramDataPoint) {
+				m := datapoint.Attributes().PutEmptyMap("map")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -667,6 +769,17 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 	newNegative := pmetric.NewExponentialHistogramDataPointBuckets()
 	newNegative.SetOffset(10)
 	newNegative.BucketCounts().FromRaw([]uint64{4, 5})
+
+	newPMap := pcommon.NewMap()
+	newPMap.PutStr("k1", "string")
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]interface{})
+	newMap2 := make(map[string]interface{})
+	newMap2["k1"] = "string"
+	newMap["k1"] = "string"
+	newMap["k2"] = newMap2
 
 	tests := []struct {
 		name     string
@@ -1037,6 +1150,46 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 				datapoint.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
 		},
+		{
+			name: "attributes pcommon.Map",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("pMap"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refExpoHistogramDataPoint.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
+				m := datapoint.Attributes().PutEmptyMap("pMap")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes map[string]interface{}",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("map"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refExpoHistogramDataPoint.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
+				m := datapoint.Attributes().PutEmptyMap("map")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1085,12 +1238,23 @@ func createExpoHistogramDataPointTelemetry() pmetric.ExponentialHistogramDataPoi
 }
 
 func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
-	refExpoHistogramDataPoint := createSummaryDataPointTelemetry()
+	refSummaryDataPoint := createSummaryDataPointTelemetry()
 
 	_, newAttrs := createNewTelemetry()
 
 	newQuartileValues := pmetric.NewSummaryDataPointValueAtQuantileSlice()
 	newQuartileValues.AppendEmpty().SetValue(100)
+
+	newPMap := pcommon.NewMap()
+	newPMap.PutStr("k1", "string")
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]interface{})
+	newMap2 := make(map[string]interface{})
+	newMap2["k1"] = "string"
+	newMap["k1"] = "string"
+	newMap["k2"] = newMap2
 
 	tests := []struct {
 		name     string
@@ -1171,7 +1335,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 					Name: "quantile_values",
 				},
 			},
-			orig:   refExpoHistogramDataPoint.QuantileValues(),
+			orig:   refSummaryDataPoint.QuantileValues(),
 			newVal: newQuartileValues,
 			modified: func(datapoint pmetric.SummaryDataPoint) {
 				newQuartileValues.CopyTo(datapoint.QuantileValues())
@@ -1184,7 +1348,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 					Name: "attributes",
 				},
 			},
-			orig:   refExpoHistogramDataPoint.Attributes(),
+			orig:   refSummaryDataPoint.Attributes(),
 			newVal: newAttrs,
 			modified: func(datapoint pmetric.SummaryDataPoint) {
 				newAttrs.CopyTo(datapoint.Attributes())
@@ -1269,7 +1433,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 				},
 			},
 			orig: func() pcommon.Slice {
-				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_str")
+				val, _ := refSummaryDataPoint.Attributes().Get("arr_str")
 				return val.Slice()
 			}(),
 			newVal: []string{"new"},
@@ -1286,7 +1450,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 				},
 			},
 			orig: func() pcommon.Slice {
-				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_bool")
+				val, _ := refSummaryDataPoint.Attributes().Get("arr_bool")
 				return val.Slice()
 			}(),
 			newVal: []bool{false},
@@ -1303,7 +1467,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 				},
 			},
 			orig: func() pcommon.Slice {
-				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_int")
+				val, _ := refSummaryDataPoint.Attributes().Get("arr_int")
 				return val.Slice()
 			}(),
 			newVal: []int64{20},
@@ -1320,7 +1484,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 				},
 			},
 			orig: func() pcommon.Slice {
-				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_float")
+				val, _ := refSummaryDataPoint.Attributes().Get("arr_float")
 				return val.Slice()
 			}(),
 			newVal: []float64{2.0},
@@ -1337,12 +1501,52 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 				},
 			},
 			orig: func() pcommon.Slice {
-				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_bytes")
+				val, _ := refSummaryDataPoint.Attributes().Get("arr_bytes")
 				return val.Slice()
 			}(),
 			newVal: [][]byte{{9, 6, 4}},
 			modified: func(datapoint pmetric.SummaryDataPoint) {
 				datapoint.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
+			},
+		},
+		{
+			name: "attributes pcommon.Map",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("pMap"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refSummaryDataPoint.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(datapoint pmetric.SummaryDataPoint) {
+				m := datapoint.Attributes().PutEmptyMap("pMap")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes map[string]interface{}",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("map"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refSummaryDataPoint.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(datapoint pmetric.SummaryDataPoint) {
+				m := datapoint.Attributes().PutEmptyMap("map")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
 			},
 		},
 	}
@@ -1409,6 +1613,12 @@ func createAttributeTelemetry(attributes pcommon.Map) {
 	arrBytes := attributes.PutEmptySlice("arr_bytes")
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2, 3})
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{2, 3, 4})
+
+	pMap := attributes.PutEmptyMap("pMap")
+	pMap.PutStr("original", "map")
+
+	m := attributes.PutEmptyMap("map")
+	m.PutStr("original", "map")
 }
 
 func Test_newPathGetSetter_Metric(t *testing.T) {

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -33,14 +33,12 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 	newExemplars, newAttrs := createNewTelemetry()
 
 	newPMap := pcommon.NewMap()
-	newPMap.PutStr("k1", "string")
 	pMap2 := newPMap.PutEmptyMap("k2")
 	pMap2.PutStr("k1", "string")
 
 	newMap := make(map[string]interface{})
 	newMap2 := make(map[string]interface{})
 	newMap2["k1"] = "string"
-	newMap["k1"] = "string"
 	newMap["k2"] = newMap2
 
 	tests := []struct {
@@ -313,7 +311,6 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			newVal: newPMap,
 			modified: func(datapoint pmetric.NumberDataPoint) {
 				m := datapoint.Attributes().PutEmptyMap("pMap")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -333,7 +330,6 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			newVal: newMap,
 			modified: func(datapoint pmetric.NumberDataPoint) {
 				m := datapoint.Attributes().PutEmptyMap("map")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -387,14 +383,12 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 	newExemplars, newAttrs := createNewTelemetry()
 
 	newPMap := pcommon.NewMap()
-	newPMap.PutStr("k1", "string")
 	pMap2 := newPMap.PutEmptyMap("k2")
 	pMap2.PutStr("k1", "string")
 
 	newMap := make(map[string]interface{})
 	newMap2 := make(map[string]interface{})
 	newMap2["k1"] = "string"
-	newMap["k1"] = "string"
 	newMap["k2"] = newMap2
 
 	tests := []struct {
@@ -691,7 +685,6 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			newVal: newPMap,
 			modified: func(datapoint pmetric.HistogramDataPoint) {
 				m := datapoint.Attributes().PutEmptyMap("pMap")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -711,7 +704,6 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			newVal: newMap,
 			modified: func(datapoint pmetric.HistogramDataPoint) {
 				m := datapoint.Attributes().PutEmptyMap("map")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -771,14 +763,12 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 	newNegative.BucketCounts().FromRaw([]uint64{4, 5})
 
 	newPMap := pcommon.NewMap()
-	newPMap.PutStr("k1", "string")
 	pMap2 := newPMap.PutEmptyMap("k2")
 	pMap2.PutStr("k1", "string")
 
 	newMap := make(map[string]interface{})
 	newMap2 := make(map[string]interface{})
 	newMap2["k1"] = "string"
-	newMap["k1"] = "string"
 	newMap["k2"] = newMap2
 
 	tests := []struct {
@@ -1165,7 +1155,6 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			newVal: newPMap,
 			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
 				m := datapoint.Attributes().PutEmptyMap("pMap")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -1185,7 +1174,6 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			newVal: newMap,
 			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
 				m := datapoint.Attributes().PutEmptyMap("map")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -1246,14 +1234,12 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 	newQuartileValues.AppendEmpty().SetValue(100)
 
 	newPMap := pcommon.NewMap()
-	newPMap.PutStr("k1", "string")
 	pMap2 := newPMap.PutEmptyMap("k2")
 	pMap2.PutStr("k1", "string")
 
 	newMap := make(map[string]interface{})
 	newMap2 := make(map[string]interface{})
 	newMap2["k1"] = "string"
-	newMap["k1"] = "string"
 	newMap["k2"] = newMap2
 
 	tests := []struct {
@@ -1524,7 +1510,6 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			newVal: newPMap,
 			modified: func(datapoint pmetric.SummaryDataPoint) {
 				m := datapoint.Attributes().PutEmptyMap("pMap")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -1544,7 +1529,6 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			newVal: newMap,
 			modified: func(datapoint pmetric.SummaryDataPoint) {
 				m := datapoint.Attributes().PutEmptyMap("map")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -41,6 +41,17 @@ func Test_newPathGetSetter(t *testing.T) {
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
 
+	newPMap := pcommon.NewMap()
+	newPMap.PutStr("k1", "string")
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]interface{})
+	newMap2 := make(map[string]interface{})
+	newMap2["k1"] = "string"
+	newMap["k1"] = "string"
+	newMap["k2"] = newMap2
+
 	tests := []struct {
 		name     string
 		path     []ottl.Field
@@ -353,6 +364,46 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes pcommon.Map",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("pMap"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refLog.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				m := log.Attributes().PutEmptyMap("pMap")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes map[string]interface{}",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("map"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refLog.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				m := log.Attributes().PutEmptyMap("map")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
 			name: "dropped_attributes_count",
 			path: []ottl.Field{
 				{
@@ -448,6 +499,12 @@ func createTelemetry() (plog.LogRecord, pcommon.InstrumentationScope, pcommon.Re
 	arrBytes := log.Attributes().PutEmptySlice("arr_bytes")
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2, 3})
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{2, 3, 4})
+
+	pMap := log.Attributes().PutEmptyMap("pMap")
+	pMap.PutStr("original", "map")
+
+	m := log.Attributes().PutEmptyMap("map")
+	m.PutStr("original", "map")
 
 	log.SetDroppedAttributesCount(10)
 

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -42,14 +42,12 @@ func Test_newPathGetSetter(t *testing.T) {
 	newAttrs.PutStr("hello", "world")
 
 	newPMap := pcommon.NewMap()
-	newPMap.PutStr("k1", "string")
 	pMap2 := newPMap.PutEmptyMap("k2")
 	pMap2.PutStr("k1", "string")
 
 	newMap := make(map[string]interface{})
 	newMap2 := make(map[string]interface{})
 	newMap2["k1"] = "string"
-	newMap["k1"] = "string"
 	newMap["k2"] = newMap2
 
 	tests := []struct {
@@ -378,7 +376,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newPMap,
 			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource) {
 				m := log.Attributes().PutEmptyMap("pMap")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -398,7 +395,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newMap,
 			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource) {
 				m := log.Attributes().PutEmptyMap("map")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -31,6 +31,17 @@ func Test_newPathGetSetter(t *testing.T) {
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
 
+	newPMap := pcommon.NewMap()
+	newPMap.PutStr("k1", "string")
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]interface{})
+	newMap2 := make(map[string]interface{})
+	newMap2["k1"] = "string"
+	newMap["k1"] = "string"
+	newMap["k2"] = newMap2
+
 	tests := []struct {
 		name     string
 		path     []ottl.Field
@@ -207,6 +218,46 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes pcommon.Map",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("pMap"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refResource.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(resource pcommon.Resource) {
+				m := resource.Attributes().PutEmptyMap("pMap")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes mpa[string]interface",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("map"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refResource.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(resource pcommon.Resource) {
+				m := resource.Attributes().PutEmptyMap("map")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
 			name: "dropped_attributes_count",
 			path: []ottl.Field{
 				{
@@ -270,6 +321,12 @@ func createTelemetry() pcommon.Resource {
 	arrBytes := resource.Attributes().PutEmptySlice("arr_bytes")
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2, 3})
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{2, 3, 4})
+
+	pMap := resource.Attributes().PutEmptyMap("pMap")
+	pMap.PutStr("original", "map")
+
+	m := resource.Attributes().PutEmptyMap("map")
+	m.PutStr("original", "map")
 
 	resource.SetDroppedAttributesCount(10)
 

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -32,14 +32,12 @@ func Test_newPathGetSetter(t *testing.T) {
 	newAttrs.PutStr("hello", "world")
 
 	newPMap := pcommon.NewMap()
-	newPMap.PutStr("k1", "string")
 	pMap2 := newPMap.PutEmptyMap("k2")
 	pMap2.PutStr("k1", "string")
 
 	newMap := make(map[string]interface{})
 	newMap2 := make(map[string]interface{})
 	newMap2["k1"] = "string"
-	newMap["k1"] = "string"
 	newMap["k2"] = newMap2
 
 	tests := []struct {
@@ -232,7 +230,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newPMap,
 			modified: func(resource pcommon.Resource) {
 				m := resource.Attributes().PutEmptyMap("pMap")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -252,7 +249,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newMap,
 			modified: func(resource pcommon.Resource) {
 				m := resource.Attributes().PutEmptyMap("map")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -32,14 +32,12 @@ func Test_newPathGetSetter(t *testing.T) {
 	newAttrs.PutStr("hello", "world")
 
 	newPMap := pcommon.NewMap()
-	newPMap.PutStr("k1", "string")
 	pMap2 := newPMap.PutEmptyMap("k2")
 	pMap2.PutStr("k1", "string")
 
 	newMap := make(map[string]interface{})
 	newMap2 := make(map[string]interface{})
 	newMap2["k1"] = "string"
-	newMap["k1"] = "string"
 	newMap["k2"] = newMap2
 
 	tests := []struct {
@@ -232,7 +230,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newPMap,
 			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource) {
 				m := il.Attributes().PutEmptyMap("pMap")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -252,7 +249,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newMap,
 			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource) {
 				m := il.Attributes().PutEmptyMap("map")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -31,6 +31,17 @@ func Test_newPathGetSetter(t *testing.T) {
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
 
+	newPMap := pcommon.NewMap()
+	newPMap.PutStr("k1", "string")
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]interface{})
+	newMap2 := make(map[string]interface{})
+	newMap2["k1"] = "string"
+	newMap["k1"] = "string"
+	newMap["k2"] = newMap2
+
 	tests := []struct {
 		name     string
 		path     []ottl.Field
@@ -207,6 +218,46 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes pcommon.Map",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("pMap"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refIS.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				m := il.Attributes().PutEmptyMap("pMap")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes map[string]interface{}",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("map"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refIS.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				m := il.Attributes().PutEmptyMap("map")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
 			name: "dropped_attributes_count",
 			path: []ottl.Field{
 				{
@@ -313,6 +364,12 @@ func createTelemetry() (pcommon.InstrumentationScope, pcommon.Resource) {
 	arrBytes := is.Attributes().PutEmptySlice("arr_bytes")
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2, 3})
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{2, 3, 4})
+
+	pMap := is.Attributes().PutEmptyMap("pMap")
+	pMap.PutStr("original", "map")
+
+	m := is.Attributes().PutEmptyMap("map")
+	m.PutStr("original", "map")
 
 	resource := pcommon.NewResource()
 	is.Attributes().CopyTo(resource.Attributes())

--- a/pkg/ottl/contexts/ottlspan/span_test.go
+++ b/pkg/ottl/contexts/ottlspan/span_test.go
@@ -51,14 +51,12 @@ func Test_newPathGetSetter(t *testing.T) {
 	newStatus.SetMessage("new status")
 
 	newPMap := pcommon.NewMap()
-	newPMap.PutStr("k1", "string")
 	pMap2 := newPMap.PutEmptyMap("k2")
 	pMap2.PutStr("k1", "string")
 
 	newMap := make(map[string]interface{})
 	newMap2 := make(map[string]interface{})
 	newMap2["k1"] = "string"
-	newMap["k1"] = "string"
 	newMap["k2"] = newMap2
 
 	tests := []struct {
@@ -401,7 +399,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newPMap,
 			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
 				m := span.Attributes().PutEmptyMap("pMap")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -421,7 +418,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newMap,
 			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
 				m := span.Attributes().PutEmptyMap("map")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},

--- a/pkg/ottl/contexts/ottlspan/span_test.go
+++ b/pkg/ottl/contexts/ottlspan/span_test.go
@@ -50,6 +50,17 @@ func Test_newPathGetSetter(t *testing.T) {
 	newStatus := ptrace.NewStatus()
 	newStatus.SetMessage("new status")
 
+	newPMap := pcommon.NewMap()
+	newPMap.PutStr("k1", "string")
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]interface{})
+	newMap2 := make(map[string]interface{})
+	newMap2["k1"] = "string"
+	newMap["k1"] = "string"
+	newMap["k2"] = newMap2
+
 	tests := []struct {
 		name     string
 		path     []ottl.Field
@@ -376,6 +387,46 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes pcommon.Map",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("pMap"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refSpan.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				m := span.Attributes().PutEmptyMap("pMap")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes map[string]interface{}",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("map"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refSpan.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				m := span.Attributes().PutEmptyMap("map")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
 			name: "dropped_attributes_count",
 			path: []ottl.Field{
 				{
@@ -577,6 +628,12 @@ func createTelemetry() (ptrace.Span, pcommon.InstrumentationScope, pcommon.Resou
 	arrBytes := span.Attributes().PutEmptySlice("arr_bytes")
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2, 3})
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{2, 3, 4})
+
+	pMap := span.Attributes().PutEmptyMap("pMap")
+	pMap.PutStr("original", "map")
+
+	m := span.Attributes().PutEmptyMap("map")
+	m.PutStr("original", "map")
 
 	span.SetDroppedAttributesCount(10)
 

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -49,6 +49,17 @@ func Test_newPathGetSetter(t *testing.T) {
 	newStatus := ptrace.NewStatus()
 	newStatus.SetMessage("new status")
 
+	newPMap := pcommon.NewMap()
+	newPMap.PutStr("k1", "string")
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]interface{})
+	newMap2 := make(map[string]interface{})
+	newMap2["k1"] = "string"
+	newMap["k1"] = "string"
+	newMap["k2"] = newMap2
+
 	tests := []struct {
 		name     string
 		path     []ottl.Field
@@ -251,6 +262,46 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes pcommon.Map",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("pMap"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refSpanEvent.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				m := spanEvent.Attributes().PutEmptyMap("pMap")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes map[string]interface{}",
+			path: []ottl.Field{
+				{
+					Name:   "attributes",
+					MapKey: ottltest.Strp("map"),
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refSpanEvent.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				m := spanEvent.Attributes().PutEmptyMap("map")
+				m.PutStr("k1", "string")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
 			name: "dropped_attributes_count",
 			path: []ottl.Field{
 				{
@@ -359,6 +410,12 @@ func createTelemetry() (ptrace.SpanEvent, ptrace.Span, pcommon.InstrumentationSc
 	arrBytes := spanEvent.Attributes().PutEmptySlice("arr_bytes")
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2, 3})
 	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{2, 3, 4})
+
+	pMap := spanEvent.Attributes().PutEmptyMap("pMap")
+	pMap.PutStr("original", "map")
+
+	m := spanEvent.Attributes().PutEmptyMap("map")
+	m.PutStr("original", "map")
 
 	span := ptrace.NewSpan()
 	span.SetName("test")

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -50,14 +50,12 @@ func Test_newPathGetSetter(t *testing.T) {
 	newStatus.SetMessage("new status")
 
 	newPMap := pcommon.NewMap()
-	newPMap.PutStr("k1", "string")
 	pMap2 := newPMap.PutEmptyMap("k2")
 	pMap2.PutStr("k1", "string")
 
 	newMap := make(map[string]interface{})
 	newMap2 := make(map[string]interface{})
 	newMap2["k1"] = "string"
-	newMap["k1"] = "string"
 	newMap["k2"] = newMap2
 
 	tests := []struct {
@@ -276,7 +274,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newPMap,
 			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
 				m := spanEvent.Attributes().PutEmptyMap("pMap")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},
@@ -296,7 +293,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: newMap,
 			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
 				m := spanEvent.Attributes().PutEmptyMap("map")
-				m.PutStr("k1", "string")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
 			},


### PR DESCRIPTION
**Description:** 
Adds support for setting maps in Values.  The primary impact is the ability for contexts to set maps as attribute values.

**Link to tracking Issue:**
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16337

**Testing:**
Added unit tests