### PR TITLE
[exporter/azuremonitor] Support span and exception events

### DIFF
--- a/.chloggen/exporter-azuremonitor-support-span-events.yaml
+++ b/.chloggen/exporter-azuremonitor-support-span-events.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support span and exception events
+
+# One or more tracking issues related to the change
+issues: [16260]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -19,7 +19,7 @@ The following settings can be optionally configured:
 - `endpoint` (default = `https://dc.services.visualstudio.com/v2/track`): The endpoint URL where data will be submitted.
 - `maxbatchsize` (default = 1024): The maximum number of telemetry items that can be submitted in each request. If this many items are buffered, the buffer will be flushed before `maxbatchinterval` expires.
 - `maxbatchinterval` (default = 10s): The maximum time to wait before sending a batch of telemetry.
-- `spaneventsenabled` (default = true): Enables export of span events.
+- `spaneventsenabled` (default = false): Enables export of span events.
 
 Example:
 
@@ -72,5 +72,5 @@ This exporter saves log records to Application Insights `traces` table.
 
 ### Span Events
 
-This exporter saves span events to Application Insights `traces` table.
-Exception events are saved tot he Application Insights `exception` table.
+Span events are optionally saved to the Application Insights `traces` table.
+Exception events are saved to the Application Insights `exception` table.

--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -19,6 +19,7 @@ The following settings can be optionally configured:
 - `endpoint` (default = `https://dc.services.visualstudio.com/v2/track`): The endpoint URL where data will be submitted.
 - `maxbatchsize` (default = 1024): The maximum number of telemetry items that can be submitted in each request. If this many items are buffered, the buffer will be flushed before `maxbatchinterval` expires.
 - `maxbatchinterval` (default = 10s): The maximum time to wait before sending a batch of telemetry.
+- `spaneventsenabled` (default = true): Enables export of span events.
 
 Example:
 
@@ -62,8 +63,14 @@ The exact mapping can be found [here](trace_to_envelope.go).
 All attributes are also mapped to custom properties if they are booleans or strings and to custom measurements if they are ints or doubles.
 
 ### Logs
+
 This exporter saves log records to Application Insights `traces` table.
 [TraceId](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-traceid) is mapped to `operation_id` column and [SpanId](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-spanid) is mapped to `operation_parentId` column.
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
+
+### Span Events
+
+This exporter saves span events to Application Insights `traces` table.
+Exception events are saved tot he Application Insights `exception` table.

--- a/exporter/azuremonitorexporter/config.go
+++ b/exporter/azuremonitorexporter/config.go
@@ -27,4 +27,5 @@ type Config struct {
 	InstrumentationKey      string        `mapstructure:"instrumentation_key"`
 	MaxBatchSize            int           `mapstructure:"maxbatchsize"`
 	MaxBatchInterval        time.Duration `mapstructure:"maxbatchinterval"`
+	SpanEventsEnabled       bool          `mapstructure:"spaneventsenabled"`
 }

--- a/exporter/azuremonitorexporter/config_test.go
+++ b/exporter/azuremonitorexporter/config_test.go
@@ -49,6 +49,7 @@ func TestLoadConfig(t *testing.T) {
 				InstrumentationKey: "abcdefg",
 				MaxBatchSize:       100,
 				MaxBatchInterval:   10 * time.Second,
+				SpanEventsEnabled:  true,
 			},
 		},
 	}

--- a/exporter/azuremonitorexporter/config_test.go
+++ b/exporter/azuremonitorexporter/config_test.go
@@ -49,7 +49,7 @@ func TestLoadConfig(t *testing.T) {
 				InstrumentationKey: "abcdefg",
 				MaxBatchSize:       100,
 				MaxBatchInterval:   10 * time.Second,
-				SpanEventsEnabled:  true,
+				SpanEventsEnabled:  false,
 			},
 		},
 	}

--- a/exporter/azuremonitorexporter/conventions.go
+++ b/exporter/azuremonitorexporter/conventions.go
@@ -27,7 +27,6 @@ import (
 
 const (
 	// TODO replace with convention.* values once/if available
-	attributeRPCGRPCStatusCode     string = "rpc.grpc.status_code"
 	attributeOtelStatusCode        string = "otel.status_code"
 	attributeOtelStatusDescription string = "otel.status_description"
 )
@@ -169,7 +168,7 @@ func (attrs *RPCAttributes) MapAttribute(k string, v pcommon.Value) bool {
 		attrs.RPCService = v.Str()
 	case conventions.AttributeRPCMethod:
 		attrs.RPCMethod = v.Str()
-	case attributeRPCGRPCStatusCode:
+	case conventions.AttributeRPCGRPCStatusCode:
 		attrs.RPCGRPCStatusCode = v.Int()
 
 	default:
@@ -278,6 +277,29 @@ func (attrs *MessagingAttributes) MapAttribute(k string, v pcommon.Value) bool {
 
 	default:
 		attrs.NetworkAttributes.MapAttribute(k, v)
+	}
+	return true
+}
+
+// ExceptionAttributes is the set of known attributes for Exception events
+type ExceptionAttributes struct {
+	ExceptionEscaped    string
+	ExceptionMessage    string
+	ExceptionStackTrace string
+	ExceptionType       string
+}
+
+// MapAttribute attempts to map a SpanEvent attribute to one of the known types
+func (attrs *ExceptionAttributes) MapAttribute(k string, v pcommon.Value) bool {
+	switch k {
+	case conventions.AttributeExceptionEscaped:
+		attrs.ExceptionEscaped = v.Str()
+	case conventions.AttributeExceptionMessage:
+		attrs.ExceptionMessage = v.Str()
+	case conventions.AttributeExceptionStacktrace:
+		attrs.ExceptionStackTrace = v.Str()
+	case conventions.AttributeExceptionType:
+		attrs.ExceptionType = v.Str()
 	}
 	return true
 }

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -54,10 +54,11 @@ type factory struct {
 
 func createDefaultConfig() component.ExporterConfig {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(component.NewID(typeStr)),
-		Endpoint:         defaultEndpoint,
-		MaxBatchSize:     1024,
-		MaxBatchInterval: 10 * time.Second,
+		ExporterSettings:  config.NewExporterSettings(component.NewID(typeStr)),
+		Endpoint:          defaultEndpoint,
+		MaxBatchSize:      1024,
+		MaxBatchInterval:  10 * time.Second,
+		SpanEventsEnabled: true,
 	}
 }
 

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -58,7 +58,7 @@ func createDefaultConfig() component.ExporterConfig {
 		Endpoint:          defaultEndpoint,
 		MaxBatchSize:      1024,
 		MaxBatchInterval:  10 * time.Second,
-		SpanEventsEnabled: true,
+		SpanEventsEnabled: false,
 	}
 }
 

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -33,6 +33,8 @@ import (
 const (
 	defaultRequestDataEnvelopeName          = "Microsoft.ApplicationInsights.Request"
 	defaultRemoteDependencyDataEnvelopeName = "Microsoft.ApplicationInsights.RemoteDependency"
+	defaultMessageDataEnvelopeName          = "Microsoft.ApplicationInsights.Message"
+	defaultExceptionDataEnvelopeName        = "Microsoft.ApplicationInsights.Exception"
 	defaultServiceName                      = "foo"
 	defaultServiceNamespace                 = "ns1"
 	defaultServiceInstance                  = "112345"
@@ -67,6 +69,7 @@ var (
 	defaultSpanStartTime          = pcommon.Timestamp(0)
 	defaultSpanEndTme             = pcommon.Timestamp(60000000000)
 	defaultSpanDuration           = formatDuration(toTime(defaultSpanEndTme).Sub(toTime(defaultSpanStartTime)))
+	defaultSpanEventTime          = pcommon.Timestamp(0)
 	defaultHTTPStatusCodeAsString = strconv.FormatInt(defaultHTTPStatusCode, 10)
 	defaultRPCStatusCodeAsString  = strconv.FormatInt(defaultRPCStatusCode, 10)
 
@@ -136,7 +139,8 @@ func TestHTTPServerSpanToRequestDataAttributeSet1(t *testing.T) {
 	spanAttributes.PutBool("somebool", false)
 	spanAttributes.PutDouble("somedouble", 0.1)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 
@@ -167,7 +171,8 @@ func TestHTTPServerSpanToRequestDataAttributeSet2(t *testing.T) {
 
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 
@@ -193,7 +198,8 @@ func TestHTTPServerSpanToRequestDataAttributeSet3(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeHTTPClientIP, "127.0.0.2")
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultHTTPRequestDataValidations(t, span, data)
@@ -210,7 +216,8 @@ func TestHTTPServerSpanToRequestDataAttributeSet4(t *testing.T) {
 	spanAttributes.PutInt(conventions.AttributeHTTPStatusCode, defaultHTTPStatusCode)
 	spanAttributes.PutStr(conventions.AttributeHTTPURL, "https://foo:81/bar?biz=baz")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultHTTPRequestDataValidations(t, span, data)
@@ -237,7 +244,8 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet1(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeHTTPURL, "https://foo:81/bar?biz=baz")
 	spanAttributes.PutInt(conventions.AttributeHTTPStatusCode, 400)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	commonRemoteDependencyDataValidations(t, span, data)
@@ -266,7 +274,8 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet2(t *testing.T) {
 	// A specific http.route
 	spanAttributes.PutStr(conventions.AttributeHTTPRoute, "/bar/:baz_id")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	commonRemoteDependencyDataValidations(t, span, data)
@@ -290,7 +299,8 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet3(t *testing.T) {
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 	spanAttributes.PutStr(conventions.AttributeHTTPTarget, "/bar?biz=baz")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultHTTPRemoteDependencyDataValidations(t, span, data)
@@ -309,7 +319,8 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet4(t *testing.T) {
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 	spanAttributes.PutStr(conventions.AttributeHTTPTarget, "/bar?biz=baz")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultHTTPRemoteDependencyDataValidations(t, span, data)
@@ -325,7 +336,8 @@ func TestRPCServerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultRPCRequestDataValidations(t, span, data, "foo:81")
@@ -334,7 +346,8 @@ func TestRPCServerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "")
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultRPCRequestDataValidations(t, span, data, "127.0.0.1:81")
 }
@@ -348,7 +361,8 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultRPCRemoteDependencyDataValidations(t, span, data, "foo:81")
@@ -357,16 +371,18 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "")
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultRPCRemoteDependencyDataValidations(t, span, data, "127.0.0.1:81")
 
 	// test RPC error using the new rpc.grpc.status_code attribute
 	span.Status().SetCode(ptrace.StatusCodeError)
 	span.Status().SetMessage("Resource exhausted")
-	spanAttributes.PutInt(attributeRPCGRPCStatusCode, 8)
+	spanAttributes.PutInt(conventions.AttributeRPCGRPCStatusCode, 8)
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
 	assert.Equal(t, "8", data.ResultCode)
@@ -383,8 +399,9 @@ func TestDatabaseClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "foo")
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
-	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
+	commonEnvelopeValidations(t, span, envelopes[0], defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultDatabaseRemoteDependencyDataValidations(t, span, data)
 
@@ -395,7 +412,8 @@ func TestDatabaseClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeDBStatement, "")
 	spanAttributes.PutStr(conventions.AttributeDBOperation, defaultDBOperation)
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	assert.Equal(t, defaultDBOperation, data.Data)
 }
@@ -409,7 +427,8 @@ func TestMessagingConsumerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "foo")
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultMessagingRequestDataValidations(t, span, data)
@@ -419,7 +438,8 @@ func TestMessagingConsumerSpanToRequestData(t *testing.T) {
 	// test fallback from MessagingURL to net.* properties
 	spanAttributes.PutStr(conventions.AttributeMessagingURL, "")
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 
 	assert.Equal(t, "foo:81", data.Source)
@@ -434,7 +454,8 @@ func TestMessagingProducerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerName, "foo")
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultMessagingRemoteDependencyDataValidations(t, span, data)
@@ -444,7 +465,8 @@ func TestMessagingProducerSpanToRequestData(t *testing.T) {
 	// test fallback from MessagingURL to net.* properties
 	spanAttributes.PutStr(conventions.AttributeMessagingURL, "")
 
-	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
 	assert.Equal(t, "foo:81", data.Target)
@@ -457,7 +479,8 @@ func TestUnknownInternalSpanToRemoteDependencyData(t *testing.T) {
 
 	spanAttributes.PutStr("foo", "bar")
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultInternalRemoteDependencyDataValidations(t, span, data)
@@ -468,10 +491,57 @@ func TestUnspecifiedSpanToInProcRemoteDependencyData(t *testing.T) {
 	span := getDefaultInternalSpan()
 	span.SetKind(ptrace.SpanKindUnspecified)
 
-	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultInternalRemoteDependencyDataValidations(t, span, data)
+}
+
+func TestSpanWithEventsToEnvelopes(t *testing.T) {
+	span := getDefaultRPCClientSpan()
+
+	spanEvent := getSpanEvent("foo", map[string]interface{}{"bar": "baz"})
+	spanEvent.CopyTo(span.Events().AppendEmpty())
+
+	exceptionType := "foo"
+	exceptionMessage := "bar"
+	exceptionStackTrace := "baz"
+
+	exceptionEvent := getSpanEvent("exception", map[string]interface{}{
+		conventions.AttributeExceptionType:       exceptionType,
+		conventions.AttributeExceptionMessage:    exceptionMessage,
+		conventions.AttributeExceptionStacktrace: exceptionStackTrace,
+	})
+
+	exceptionEvent.CopyTo(span.Events().AppendEmpty())
+
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+
+	assert.NotNil(t, envelopes)
+	assert.Equal(t, 3, len(envelopes))
+
+	validateEnvelope := func(spanEvent ptrace.SpanEvent, envelope *contracts.Envelope, targetEnvelopeName string) {
+		assert.Equal(t, targetEnvelopeName, envelope.Name)
+		assert.Equal(t, toTime(spanEvent.Timestamp()).Format(time.RFC3339Nano), envelope.Time)
+		assert.Equal(t, defaultTraceIDAsHex, envelope.Tags[contracts.OperationId])
+		assert.Equal(t, defaultParentSpanIDAsHex, envelope.Tags[contracts.OperationParentId])
+		assert.Equal(t, defaultServiceNamespace+"."+defaultServiceName, envelope.Tags[contracts.CloudRole])
+		assert.Equal(t, defaultServiceInstance, envelope.Tags[contracts.CloudRoleInstance])
+		assert.NotNil(t, envelope.Data)
+	}
+
+	// We are ignoring the first envelope which is the span. Tested elsewhere
+	validateEnvelope(spanEvent, envelopes[1], defaultMessageDataEnvelopeName)
+	messageData := envelopes[1].Data.(*contracts.Data).BaseData.(*contracts.MessageData)
+	assert.Equal(t, "foo", messageData.Message)
+
+	validateEnvelope(exceptionEvent, envelopes[2], defaultExceptionDataEnvelopeName)
+	exceptionData := envelopes[2].Data.(*contracts.Data).BaseData.(*contracts.ExceptionData)
+	exceptionDetails := exceptionData.Exceptions[0]
+	assert.Equal(t, exceptionType, exceptionDetails.TypeName)
+	assert.Equal(t, exceptionMessage, exceptionDetails.Message)
+	assert.Equal(t, exceptionStackTrace, exceptionDetails.Stack)
 }
 
 func TestSanitize(t *testing.T) {
@@ -695,6 +765,15 @@ func getSpan(spanName string, spanKind ptrace.SpanKind, initialAttributes map[st
 	span.SetEndTimestamp(defaultSpanEndTme)
 	span.Attributes().FromRaw(initialAttributes)
 	return span
+}
+
+// Returns a default span event
+func getSpanEvent(name string, initialAttributes map[string]interface{}) ptrace.SpanEvent {
+	spanEvent := ptrace.NewSpanEvent()
+	spanEvent.SetName(name)
+	spanEvent.SetTimestamp(defaultSpanEventTime)
+	spanEvent.Attributes().FromRaw(initialAttributes)
+	return spanEvent
 }
 
 // Returns a default server span

--- a/exporter/azuremonitorexporter/traceexporter.go
+++ b/exporter/azuremonitorexporter/traceexporter.go
@@ -40,20 +40,23 @@ type traceVisitor struct {
 // Called for each tuple of Resource, InstrumentationScope, and Span
 func (v *traceVisitor) visit(
 	resource pcommon.Resource,
-	scope pcommon.InstrumentationScope, span ptrace.Span) (ok bool) {
+	scope pcommon.InstrumentationScope,
+	span ptrace.Span) (ok bool) {
 
-	envelope, err := spanToEnvelope(resource, scope, span, v.exporter.logger)
+	envelopes, err := spanToEnvelopes(resource, scope, span, v.exporter.config.SpanEventsEnabled, v.exporter.logger)
 	if err != nil {
 		// record the error and short-circuit
 		v.err = consumererror.NewPermanent(err)
 		return false
 	}
 
-	// apply the instrumentation key to the envelope
-	envelope.IKey = v.exporter.config.InstrumentationKey
+	for _, envelope := range envelopes {
+		envelope.IKey = v.exporter.config.InstrumentationKey
 
-	// This is a fire and forget operation
-	v.exporter.transportChannel.Send(envelope)
+		// This is a fire and forget operation
+		v.exporter.transportChannel.Send(envelope)
+	}
+
 	v.processed++
 
 	return true

--- a/exporter/azuremonitorexporter/traceexporter_test.go
+++ b/exporter/azuremonitorexporter/traceexporter_test.go
@@ -68,7 +68,9 @@ func TestExporterTraceDataCallbackSingleSpan(t *testing.T) {
 // Tests the export onTraceData callback with a single Span with SpanEvents
 func TestExporterTraceDataCallbackSingleSpanWithSpanEvents(t *testing.T) {
 	mockTransportChannel := getMockTransportChannel()
-	exporter := getExporter(defaultConfig, mockTransportChannel)
+	config := createDefaultConfig().(*Config)
+	config.SpanEventsEnabled = true
+	exporter := getExporter(config, mockTransportChannel)
 
 	// re-use some test generation method(s) from trace_to_envelope_test
 	resource := getResource()

--- a/exporter/azuremonitorexporter/traceexporter_test.go
+++ b/exporter/azuremonitorexporter/traceexporter_test.go
@@ -65,6 +65,36 @@ func TestExporterTraceDataCallbackSingleSpan(t *testing.T) {
 	mockTransportChannel.AssertNumberOfCalls(t, "Send", 1)
 }
 
+// Tests the export onTraceData callback with a single Span with SpanEvents
+func TestExporterTraceDataCallbackSingleSpanWithSpanEvents(t *testing.T) {
+	mockTransportChannel := getMockTransportChannel()
+	exporter := getExporter(defaultConfig, mockTransportChannel)
+
+	// re-use some test generation method(s) from trace_to_envelope_test
+	resource := getResource()
+	scope := getScope()
+	span := getDefaultHTTPServerSpan()
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	r := rs.Resource()
+	resource.CopyTo(r)
+	ilss := rs.ScopeSpans().AppendEmpty()
+	scope.CopyTo(ilss.Scope())
+
+	spanEvent1 := getSpanEvent("foo", map[string]interface{}{"foo": "bar"})
+	spanEvent1.CopyTo(span.Events().AppendEmpty())
+
+	spanEvent2 := getSpanEvent("bar", map[string]interface{}{"bar": "baz"})
+	spanEvent2.CopyTo(span.Events().AppendEmpty())
+
+	span.CopyTo(ilss.Spans().AppendEmpty())
+
+	assert.NoError(t, exporter.onTraceData(context.Background(), traces))
+
+	mockTransportChannel.AssertNumberOfCalls(t, "Send", 3)
+}
+
 // Tests the export onTraceData callback with a single Span that fails to produce an envelope
 func TestExporterTraceDataCallbackSingleSpanNoEnvelope(t *testing.T) {
 	mockTransportChannel := getMockTransportChannel()


### PR DESCRIPTION
**Description:**
Exception events flow to the AppInsights `exception` table.
Span events flow to the `traces` table, when enabled.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16260

**Testing:**
Unit tests added and e2e validation performed.

**Documentation:**
There is a new configuration element added called `spaneventsenabled` which can be used to turn off export of the span events. These can be incredibly verbose for gRPC calls.