### PR TITLE
[pkg/ottl] Add new accessors for span time precision

### DIFF
--- a/.chloggen/ottl-more-times.yaml
+++ b/.chloggen/ottl-more-times.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds new accessors so Span and SpanEvent contexts to allow getting and setting start and end time with different precision.
+
+# One or more tracking issues related to the change
+issues: [16359]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Impacts the following components:
+  - `transformprocessor`
+  - `routingprocessor`

--- a/pkg/ottl/contexts/internal/ottlcommon/span.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/span.go
@@ -84,8 +84,20 @@ func SpanPathGetSetter[K SpanContext](path []ottl.Field) (ottl.GetSetter[K], err
 		return accessKind[K](), nil
 	case "start_time_unix_nano":
 		return accessStartTimeUnixNano[K](), nil
+	case "start_time_unix_milli":
+		return accessStartTimeUnixMilli[K](), nil
+	case "start_time_unix_micro":
+		return accessStartTimeUnixMicro[K](), nil
+	case "start_time_unix_sec":
+		return accessStartTimeUnixSec[K](), nil
 	case "end_time_unix_nano":
 		return accessEndTimeUnixNano[K](), nil
+	case "end_time_unix_milli":
+		return accessEndTimeUnixMilli[K](), nil
+	case "end_time_unix_micro":
+		return accessEndTimeUnixMicro[K](), nil
+	case "end_time_unix_sec":
+		return accessEndTimeUnixSec[K](), nil
 	case "attributes":
 		mapKey := path[0].MapKey
 		if mapKey == nil {
@@ -298,6 +310,48 @@ func accessStartTimeUnixNano[K SpanContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
+func accessStartTimeUnixMicro[K SpanContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
+			return tCtx.GetSpan().StartTimestamp().AsTime().UnixMicro(), nil
+		},
+		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
+			if i, ok := val.(int64); ok {
+				tCtx.GetSpan().SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMicro(i)))
+			}
+			return nil
+		},
+	}
+}
+
+func accessStartTimeUnixMilli[K SpanContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
+			return tCtx.GetSpan().StartTimestamp().AsTime().UnixMilli(), nil
+		},
+		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
+			if i, ok := val.(int64); ok {
+				tCtx.GetSpan().SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(i)))
+			}
+			return nil
+		},
+	}
+}
+
+func accessStartTimeUnixSec[K SpanContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
+			return tCtx.GetSpan().StartTimestamp().AsTime().Unix(), nil
+		},
+		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
+			if i, ok := val.(int64); ok {
+				tCtx.GetSpan().SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(i, 0)))
+			}
+			return nil
+		},
+	}
+}
+
 func accessEndTimeUnixNano[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
@@ -306,6 +360,48 @@ func accessEndTimeUnixNano[K SpanContext]() ottl.StandardGetSetter[K] {
 		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetSpan().SetEndTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, i)))
+			}
+			return nil
+		},
+	}
+}
+
+func accessEndTimeUnixMicro[K SpanContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
+			return tCtx.GetSpan().EndTimestamp().AsTime().UnixMicro(), nil
+		},
+		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
+			if i, ok := val.(int64); ok {
+				tCtx.GetSpan().SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMicro(i)))
+			}
+			return nil
+		},
+	}
+}
+
+func accessEndTimeUnixMilli[K SpanContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
+			return tCtx.GetSpan().EndTimestamp().AsTime().UnixMilli(), nil
+		},
+		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
+			if i, ok := val.(int64); ok {
+				tCtx.GetSpan().SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(i)))
+			}
+			return nil
+		},
+	}
+}
+
+func accessEndTimeUnixSec[K SpanContext]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
+			return tCtx.GetSpan().EndTimestamp().AsTime().Unix(), nil
+		},
+		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
+			if i, ok := val.(int64); ok {
+				tCtx.GetSpan().SetEndTimestamp(pcommon.NewTimestampFromTime(time.Unix(i, 0)))
 			}
 			return nil
 		},

--- a/pkg/ottl/contexts/internal/ottlcommon/span_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/span_test.go
@@ -204,10 +204,49 @@ func TestSpanPathGetSetter(t *testing.T) {
 					Name: "start_time_unix_nano",
 				},
 			},
-			orig:   int64(100_000_000),
-			newVal: int64(200_000_000),
+			orig:   int64(1_000_000_000),
+			newVal: int64(2_000_000_000),
 			modified: func(span ptrace.Span) {
-				span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
+				span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 2_000_000_000)))
+			},
+		},
+		{
+			name: "start_time_unix_micro",
+			path: []ottl.Field{
+				{
+					Name: "start_time_unix_micro",
+				},
+			},
+			orig:   int64(1_000_000),
+			newVal: int64(2_000_000),
+			modified: func(span ptrace.Span) {
+				span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMicro(2_000_000)))
+			},
+		},
+		{
+			name: "start_time_unix_milli",
+			path: []ottl.Field{
+				{
+					Name: "start_time_unix_milli",
+				},
+			},
+			orig:   int64(1_000),
+			newVal: int64(2_000),
+			modified: func(span ptrace.Span) {
+				span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(2_000)))
+			},
+		},
+		{
+			name: "start_time_unix_sec",
+			path: []ottl.Field{
+				{
+					Name: "start_time_unix_sec",
+				},
+			},
+			orig:   int64(1),
+			newVal: int64(2),
+			modified: func(span ptrace.Span) {
+				span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(2, 0)))
 			},
 		},
 		{
@@ -217,10 +256,49 @@ func TestSpanPathGetSetter(t *testing.T) {
 					Name: "end_time_unix_nano",
 				},
 			},
-			orig:   int64(500_000_000),
-			newVal: int64(200_000_000),
+			orig:   int64(5_000_000_000),
+			newVal: int64(2_000_000_000),
 			modified: func(span ptrace.Span) {
-				span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
+				span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 2_000_000_000)))
+			},
+		},
+		{
+			name: "end_time_unix_micro",
+			path: []ottl.Field{
+				{
+					Name: "end_time_unix_micro",
+				},
+			},
+			orig:   int64(5_000_000),
+			newVal: int64(2_000_000),
+			modified: func(span ptrace.Span) {
+				span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMicro(2_000_000)))
+			},
+		},
+		{
+			name: "end_time_unix_milli",
+			path: []ottl.Field{
+				{
+					Name: "end_time_unix_milli",
+				},
+			},
+			orig:   int64(5_000),
+			newVal: int64(2_000),
+			modified: func(span ptrace.Span) {
+				span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(2_000)))
+			},
+		},
+		{
+			name: "end_time_unix_sec",
+			path: []ottl.Field{
+				{
+					Name: "end_time_unix_sec",
+				},
+			},
+			orig:   int64(5),
+			newVal: int64(2),
+			modified: func(span ptrace.Span) {
+				span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Unix(2, 0)))
 			},
 		},
 		{
@@ -538,8 +616,8 @@ func createSpan() ptrace.Span {
 	span.SetParentSpanID(spanID2)
 	span.SetName("bear")
 	span.SetKind(ptrace.SpanKindServer)
-	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(100)))
-	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(500)))
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1_000_000_000)))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 5_000_000_000)))
 	span.Attributes().PutStr("str", "val")
 	span.Attributes().PutBool("bool", true)
 	span.Attributes().PutInt("int", 10)

--- a/pkg/ottl/contexts/ottlspan/README.md
+++ b/pkg/ottl/contexts/ottlspan/README.md
@@ -32,6 +32,13 @@ The following fields are the exception.
 | trace_state\[""\]                              | an individual entry in the trace state                                                | string                                                                  |
 | status.code                                    | the status code of the span being processed                                           | int64                                                                   |
 | status.message                                 | the status message of the span being processed                                        | string                                                                  |
+| start_time_unix_micro                          | start_time_unix_nano, but converted to/from microseconds                              | int64                                                                   |
+| start_time_unix_milli                          | start_time_unix_nano, but converted to/from milliseconds                              | int64                                                                   |
+| start_time_unix_sec                            | start_time_unix_nano, but converted to/from seconds                                   | int64                                                                   |
+| end_time_unix_micro                            | end_time_unix_nano, but converted to/from microseconds                                | int64                                                                   |
+| end_time_unix_milli                            | end_time_unix_nano, but converted to/from milliseconds                                | int64                                                                   |
+| end_time_unix_sec                              | end_time_unix_nano, but converted to/from seconds                                     | int64                                                                   |
+
 
 ## Enums
 


### PR DESCRIPTION
**Description:** 
Adds new accessors to the Span (and SpanEvent) context to allows getting and setting the start time and end time with `micro`, `milli`, and `sec` precision.  This makes using start and end time in conditions easier. 

Other functions like scaling/rounding may still be needed, but without a setter for each precision I think setting gets really messy.

If we like the accessor solution I will continue it with the other time fields in OTTL contexts.

**Link to tracking Issue:**
Works towards #16067

**Testing:** 
Updated unit tests

**Documentation:** 
Added new accessor paths to README.