### PR TITLE
[chore] Update autoassign.yaml with new approvers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -13,14 +13,16 @@ assigneeGroups:
     # Approvers
     - Aneurysm9
     - dashpole
-    - djaglowski
-    - dmitryax
-    - mx-psi
+    - evan-bradley
+    - MovieStoreGuy
     - TylerHelmuth
     # Maintainers
     - bogdandrutu
     - codeboten
+    - djaglowski
+    - dmitryax
     - jpkrohling
+    - mx-psi
 
 # A number of assignees added to the pull request
 # Set 0 to add all the assignees (default: 0)


### PR DESCRIPTION
Adds @evan-bradley  and @MovieStoreGuy to the autoassign workflow.  @evan-bradley I can't remember if we're still using this so let me know if it isn't needed.