### PR TITLE
[processor/filter] Add ottl to filter processor

### DIFF
--- a/.chloggen/fp-add-ottl.yaml
+++ b/.chloggen/fp-add-ottl.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filterprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ability to filter spans, span events, metrics, datapoints, and logs via OTTL conditions
+
+# One or more tracking issues related to the change
+issues: [16369]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -316,24 +316,24 @@ If all datapoints for a metric are dropped, the metric will also be dropped.
 
 ```yaml
 processors:
-  filter/spans-and-spanevents:
+  filter:
     traces:
-      span_conditions:
+      span:
         - 'attributes["container.name"] == "app_container_1"'
         - 'resource.attributes["host.name"] == "localhost"'
         - 'name == "app_3"'
-      spanevent_conditions:
+      spanevent:
         - 'attributes["grpc"] == true'
         - 'IsMatch(name, ".*grpc.*") == true'
     metrics:
-      metric_conditions:
+      metric:
           - 'name == "my.metric" and attributes["my_label"] == "abc123"'
           - 'type == METRIC_DATA_TYPE_HISTOGRAM'
-      datapoint_conditions:
+      datapoint:
           - 'metric.type == METRIC_DATA_TYPE_SUMMARY'
           - 'resource.attributes["service.name"] == "my_service_name"'
     logs:
-      log_conditions:
+      log_record:
         - 'IsMatch(body, ".*password.*") == true'
         - 'severity_number < SEVERITY_NUMBER_WARN'
 ```

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -8,11 +8,15 @@
 
 The filter processor can be configured to include or exclude:
 
-- logs, based on resource attributes using the `strict` or `regexp` match types
-- metrics based on metric name in the case of the `strict` or `regexp` match types,
+- Logs, based on OTTL conditions or resource attributes using the `strict` or `regexp` match types
+- Metrics based on OTTL Conditions or metric name in the case of the `strict` or `regexp` match types,
   or based on other metric attributes in the case of the `expr` match type.
   Please refer to [config.go](./config.go) for the config spec.
-- Spans based on span names, and resource attributes, all with full regex support
+- Data points based on OTTL conditions
+- Spans based on OTTL conditions or span names and resource attributes, all with full regex support
+- Span Events based on OTTL conditions.
+
+For OTTL conditions configuration see [OTTL](#ottl).  For all other options, continue reading.
 
 It takes a pipeline type, of which `logs` `metrics`, and `traces` are supported, followed
 by an action:
@@ -281,6 +285,56 @@ processors:
         resources:
           - Key: container.host
             Value: (localhost|127.0.0.1)
+```
+
+## OTTL
+The [OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md) is a language for interacting with telemetry within the collector in generic ways.
+The filterprocessor can be configured to use OTTL conditions to determine when to drop telemetry.
+Each configuration option corresponds with a different type of telemetry and OTTL Context.
+See the table below for details on each context and the fields it exposes.
+
+| Config              | OTTL Context                                                                                                                       |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `spans.span`        | [Span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md)           |
+| `spans.spanevent`   | [SpanEvent](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspanevent/README.md) |
+| `metrics.metric`    | [Metric](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlmetric/README.md)       |
+| `metrics.datapoint` | [DataPoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottldatapoint/README.md) |
+| `logs.log`          | [Log](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottllog/README.md)             |
+
+The OTTL allows the use of `and`, `or`, and `()` in conditions.
+See [OTTL Boolean Expressions](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md#boolean-expressions) for more details.
+
+For conditions that apply to the same signal, such as spans and span events, if the "higher" level telemetry matches a condition and is dropped, the "lower" level condition will not be checked.
+This means that if a span is dropped but a span event condition was defined, the span event condition will not be checked.
+The same relationship applies to metrics and datapoints.
+
+If all span events for a span are dropped, the span will be left intact.
+If all datapoints for a metric are dropped, the metric will also be dropped.
+
+### OTTL Examples
+
+```yaml
+processors:
+  filter/spans-and-spanevents:
+    spans:
+      span: '
+      attributes["container.name"] == "app_container_1" or
+      resource.attributes["host.name"] == "localhost" or
+      name == "app_3'
+      spanevent: '
+      attributes["grpc"] == true or
+      IsMatch(name, ".*grpc.*") == true'
+    metrics:
+      metric: '
+      (name == "my.metric" and attributes["my_label"] == "abc123") or
+      (type == METRIC_DATA_TYPE_HISTOGRAM)'
+      datapoint: '
+      metric.type == METRIC_DATA_TYPE_SUMMARY and
+      resource.attributes["service.name"] == "my_service_name"'
+    logs:
+      log: '
+      IsMatch(body, ".*password.*") == true or
+      severity_number < SEVERITY_NUMBER_WARN'
 ```
 
 [alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -317,7 +317,7 @@ If all datapoints for a metric are dropped, the metric will also be dropped.
 ```yaml
 processors:
   filter/spans-and-spanevents:
-    spans:
+    traces:
       span_conditions:
         - 'attributes["container.name"] == "app_container_1"'
         - 'resource.attributes["host.name"] == "localhost"'

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -290,6 +290,7 @@ processors:
 ## OTTL
 The [OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md) is a language for interacting with telemetry within the collector in generic ways.
 The filterprocessor can be configured to use OTTL conditions to determine when to drop telemetry.
+If any condition is met, the telemetry is dropped.
 Each configuration option corresponds with a different type of telemetry and OTTL Context.
 See the table below for details on each context and the fields it exposes.
 
@@ -317,24 +318,24 @@ If all datapoints for a metric are dropped, the metric will also be dropped.
 processors:
   filter/spans-and-spanevents:
     spans:
-      span: '
-      attributes["container.name"] == "app_container_1" or
-      resource.attributes["host.name"] == "localhost" or
-      name == "app_3'
-      spanevent: '
-      attributes["grpc"] == true or
-      IsMatch(name, ".*grpc.*") == true'
+      span_conditions:
+        - 'attributes["container.name"] == "app_container_1"'
+        - 'resource.attributes["host.name"] == "localhost"'
+        - 'name == "app_3"'
+      spanevent_conditions:
+        - 'attributes["grpc"] == true'
+        - 'IsMatch(name, ".*grpc.*") == true'
     metrics:
-      metric: '
-      (name == "my.metric" and attributes["my_label"] == "abc123") or
-      (type == METRIC_DATA_TYPE_HISTOGRAM)'
-      datapoint: '
-      metric.type == METRIC_DATA_TYPE_SUMMARY and
-      resource.attributes["service.name"] == "my_service_name"'
+      metric_conditions:
+          - 'name == "my.metric" and attributes["my_label"] == "abc123"'
+          - 'type == METRIC_DATA_TYPE_HISTOGRAM'
+      datapoint_conditions:
+          - 'metric.type == METRIC_DATA_TYPE_SUMMARY'
+          - 'resource.attributes["service.name"] == "my_service_name"'
     logs:
-      log: '
-      IsMatch(body, ".*password.*") == true or
-      severity_number < SEVERITY_NUMBER_WARN'
+      log_conditions:
+        - 'IsMatch(body, ".*password.*") == true'
+        - 'severity_number < SEVERITY_NUMBER_WARN'
 ```
 
 [alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -68,12 +68,12 @@ type MetricFilters struct {
 	// MetricConditions is a list of OTTL conditions for an ottlmetric context.
 	// If any condition resolves to true, the metric will be dropped.
 	// Supports `and`, `or`, and `()`
-	MetricConditions []string `mapstructure:"metric_conditions"`
+	MetricConditions []string `mapstructure:"metric"`
 
 	// DataPointConditions is a list of OTTL conditions for an ottldatapoint context.
 	// If any condition resolves to true, the datapoint will be dropped.
 	// Supports `and`, `or`, and `()`
-	DataPointConditions []string `mapstructure:"datapoint_conditions"`
+	DataPointConditions []string `mapstructure:"datapoint"`
 }
 
 // SpanFilters filters by Span attributes and various other fields, Regexp config is per matcher
@@ -94,12 +94,12 @@ type TraceFilters struct {
 	// SpanConditions is a list of OTTL conditions for an ottlspan context.
 	// If any condition resolves to true, the span will be dropped.
 	// Supports `and`, `or`, and `()`
-	SpanConditions []string `mapstructure:"span_conditions"`
+	SpanConditions []string `mapstructure:"span"`
 
 	// SpanEventConditions is a list of OTTL conditions for an ottlspanevent context.
 	// If any condition resolves to true, the span event will be dropped.
 	// Supports `and`, `or`, and `()`
-	SpanEventConditions []string `mapstructure:"spanevent_conditions"`
+	SpanEventConditions []string `mapstructure:"spanevent"`
 }
 
 // LogFilters filters by Log properties.
@@ -116,7 +116,7 @@ type LogFilters struct {
 	// LogConditions is a list of OTTL conditions for an ottllog context.
 	// If any condition resolves to true, the log event will be dropped.
 	// Supports `and`, `or`, and `()`
-	LogConditions []string `mapstructure:"log_conditions"`
+	LogConditions []string `mapstructure:"log_record"`
 }
 
 // LogMatchType specifies the strategy for matching against `plog.Log`s.

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -856,7 +856,7 @@ func TestLoadingConfigOTTL(t *testing.T) {
 			id: component.NewIDWithName("filter", "ottl"),
 			expected: &Config{
 				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
-				Spans: SpanFilters{
+				Traces: TraceFilters{
 					SpanConditions: []string{
 						`attributes["test"] == "pass"`,
 					},
@@ -883,7 +883,7 @@ func TestLoadingConfigOTTL(t *testing.T) {
 			id: component.NewIDWithName("filter", "multiline"),
 			expected: &Config{
 				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
-				Spans: SpanFilters{
+				Traces: TraceFilters{
 					SpanConditions: []string{
 						`attributes["test"] == "pass"`,
 						`attributes["test"] == "also pass"`,

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -874,7 +874,7 @@ func TestLoadingConfigOTTL(t *testing.T) {
 			expected: &Config{
 				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
 				Spans: SpanFilters{
-					Span: `attributes["test"] == "pass" or attributes["test"] == "also pass"`,
+					Span: ` attributes["test"] == "pass" or attributes["test"] == "also pass"`,
 				},
 			},
 		},

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -857,15 +857,25 @@ func TestLoadingConfigOTTL(t *testing.T) {
 			expected: &Config{
 				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
 				Spans: SpanFilters{
-					Span:      `attributes["test"] == "pass"`,
-					SpanEvent: `attributes["test"] == "pass"`,
+					SpanConditions: []string{
+						`attributes["test"] == "pass"`,
+					},
+					SpanEventConditions: []string{
+						`attributes["test"] == "pass"`,
+					},
 				},
 				Metrics: MetricFilters{
-					Metric:    `name == "pass"`,
-					DataPoint: `attributes["test"] == "pass"`,
+					MetricConditions: []string{
+						`name == "pass"`,
+					},
+					DataPointConditions: []string{
+						`attributes["test"] == "pass"`,
+					},
 				},
 				Logs: LogFilters{
-					Log: `attributes["test"] == "pass"`,
+					LogConditions: []string{
+						`attributes["test"] == "pass"`,
+					},
 				},
 			},
 		},
@@ -874,7 +884,10 @@ func TestLoadingConfigOTTL(t *testing.T) {
 			expected: &Config{
 				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
 				Spans: SpanFilters{
-					Span: ` attributes["test"] == "pass" or attributes["test"] == "also pass"`,
+					SpanConditions: []string{
+						`attributes["test"] == "pass"`,
+						`attributes["test"] == "also pass"`,
+					},
 				},
 			},
 		},

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -841,3 +841,92 @@ func TestLogSeverity_severityValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadingConfigOTTL(t *testing.T) {
+
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config_ottl.yaml"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		id           component.ID
+		expected     *Config
+		errorMessage string
+	}{
+		{
+			id: component.NewIDWithName("filter", "ottl"),
+			expected: &Config{
+				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
+				Spans: SpanFilters{
+					Span:      `attributes["test"] == "pass"`,
+					SpanEvent: `attributes["test"] == "pass"`,
+				},
+				Metrics: MetricFilters{
+					Metric:    `name == "pass"`,
+					DataPoint: `attributes["test"] == "pass"`,
+				},
+				Logs: LogFilters{
+					Log: `attributes["test"] == "pass"`,
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName("filter", "multiline"),
+			expected: &Config{
+				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
+				Spans: SpanFilters{
+					Span: `attributes["test"] == "pass" or attributes["test"] == "also pass"`,
+				},
+			},
+		},
+		{
+			id:           component.NewIDWithName(typeStr, "spans_mix_config"),
+			errorMessage: "cannot use ottl conditions and include/exclude for spans at the same time",
+		},
+		{
+			id:           component.NewIDWithName(typeStr, "metrics_mix_config"),
+			errorMessage: "cannot use ottl conditions and include/exclude for metrics at the same time",
+		},
+		{
+			id:           component.NewIDWithName(typeStr, "logs_mix_config"),
+			errorMessage: "cannot use ottl conditions and include/exclude for logs at the same time",
+		},
+		{
+			id:           component.NewIDWithName(typeStr, "bad_syntax_span"),
+			errorMessage: "1:24: unexpected token \"[\" (expected <opcomparison> Value)",
+		},
+		{
+			id:           component.NewIDWithName(typeStr, "bad_syntax_spanevent"),
+			errorMessage: "1:24: unexpected token \"[\" (expected <opcomparison> Value)",
+		},
+		{
+			id:           component.NewIDWithName(typeStr, "bad_syntax_metric"),
+			errorMessage: "1:33: unexpected token \"[\" (expected <opcomparison> Value)",
+		},
+		{
+			id:           component.NewIDWithName(typeStr, "bad_syntax_datapoint"),
+			errorMessage: "1:24: unexpected token \"[\" (expected <opcomparison> Value)",
+		},
+		{
+			id:           component.NewIDWithName(typeStr, "bad_syntax_log"),
+			errorMessage: "1:24: unexpected token \"[\" (expected <opcomparison> Value)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
+
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, component.UnmarshalProcessorConfig(sub, cfg))
+
+			if tt.expected == nil {
+				assert.EqualError(t, component.ValidateConfig(cfg), tt.errorMessage)
+			} else {
+				assert.NoError(t, component.ValidateConfig(cfg))
+				assert.Equal(t, tt.expected, cfg)
+			}
+		})
+	}
+}

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -83,7 +83,7 @@ func createLogsProcessor(
 		set,
 		cfg,
 		nextConsumer,
-		fp.ProcessLogs,
+		fp.processLogs,
 		processorhelper.WithCapabilities(processorCapabilities))
 }
 

--- a/processor/filterprocessor/go.mod
+++ b/processor/filterprocessor/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.64.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.64.0
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.64.2-0.20221119033128-e3509cd9f772
 	go.opentelemetry.io/collector/component v0.0.0-20221119033128-e3509cd9f772
@@ -14,21 +15,22 @@ require (
 )
 
 require (
+	github.com/alecthomas/participle/v2 v2.0.0-beta.5 // indirect
 	github.com/antonmedv/expr v1.9.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.4.4 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/featuregate v0.0.0-20221119033128-e3509cd9f772 // indirect
 	go.opentelemetry.io/collector/semconv v0.64.2-0.20221119033128-e3509cd9f772 // indirect
@@ -36,6 +38,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.33.0 // indirect
 	go.opentelemetry.io/otel/trace v1.11.1 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
@@ -46,3 +49,5 @@ require (
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl => ../../pkg/ottl

--- a/processor/filterprocessor/go.mod
+++ b/processor/filterprocessor/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/featuregate v0.0.0-20221119033128-e3509cd9f772 // indirect
 	go.opentelemetry.io/collector/semconv v0.64.2-0.20221119033128-e3509cd9f772 // indirect

--- a/processor/filterprocessor/go.sum
+++ b/processor/filterprocessor/go.sum
@@ -2,6 +2,10 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/alecthomas/assert/v2 v2.0.3 h1:WKqJODfOiQG0nEJKFKzDIG3E29CN2/4zR9XGJzKIkbg=
+github.com/alecthomas/participle/v2 v2.0.0-beta.5 h1:y6dsSYVb1G5eK6mgmy+BgI3Mw35a3WghArZ/Hbebrjo=
+github.com/alecthomas/participle/v2 v2.0.0-beta.5/go.mod h1:RC764t6n4L8D8ITAJv0qdokritYSNR3wV5cVwmIEaMM=
+github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -36,7 +40,6 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -64,6 +67,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -139,8 +144,11 @@ github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoI
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -166,7 +174,6 @@ github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -243,7 +250,6 @@ github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShE
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
-github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
@@ -310,6 +316,8 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -446,10 +454,8 @@ google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/processor/filterprocessor/go.sum
+++ b/processor/filterprocessor/go.sum
@@ -172,8 +172,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -249,7 +249,8 @@ github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8d
 github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShEf0EaOCaTQYyB7d5nSbb181KtjlS+84=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
-github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=

--- a/processor/filterprocessor/internal/common/functions.go
+++ b/processor/filterprocessor/internal/common/functions.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor/internal/common"
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+)
+
+func Functions[K any]() map[string]interface{} {
+	return map[string]interface{}{
+		"TraceID":     ottlfuncs.TraceID[K],
+		"SpanID":      ottlfuncs.SpanID[K],
+		"IsMatch":     ottlfuncs.IsMatch[K],
+		"Concat":      ottlfuncs.Concat[K],
+		"Split":       ottlfuncs.Split[K],
+		"Int":         ottlfuncs.Int[K],
+		"ConvertCase": ottlfuncs.ConvertCase[K],
+		"drop": func() (ottl.ExprFunc[K], error) {
+			return func(context.Context, K) (interface{}, error) {
+				return true, nil
+			}, nil
+		},
+	}
+}

--- a/processor/filterprocessor/internal/common/matcher.go
+++ b/processor/filterprocessor/internal/common/matcher.go
@@ -14,14 +14,21 @@
 
 package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor/internal/common"
 
-import "fmt"
+import (
+	"context"
 
-const functionWithCondition = "drop() where %v"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
 
-func PrepareConditionForParsing(conditions []string) []string {
-	validStatements := make([]string, len(conditions))
-	for i, condition := range conditions {
-		validStatements[i] = fmt.Sprintf(functionWithCondition, condition)
+func CheckConditions[K any](ctx context.Context, tCtx K, statements []*ottl.Statement[K]) (bool, error) {
+	for _, statement := range statements {
+		_, metCondition, err := statement.Execute(ctx, tCtx)
+		if err != nil {
+			return false, err
+		}
+		if metCondition {
+			return true, nil
+		}
 	}
-	return validStatements
+	return false, nil
 }

--- a/processor/filterprocessor/internal/common/parser.go
+++ b/processor/filterprocessor/internal/common/parser.go
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor/internal/common"
+
+import "fmt"
+
+const functionWithCondition = "drop() where %v"
+
+func PrepareConditionForParsing(condition string) []string {
+	return []string{
+		fmt.Sprintf(functionWithCondition, condition),
+	}
+}

--- a/processor/filterprocessor/logs.go
+++ b/processor/filterprocessor/logs.go
@@ -18,11 +18,16 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterlog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor/internal/common"
 )
 
 type filterLogProcessor struct {
@@ -30,9 +35,24 @@ type filterLogProcessor struct {
 	excludeMatcher filterlog.Matcher
 	includeMatcher filterlog.Matcher
 	logger         *zap.Logger
+	logCondition   *ottl.Statement[ottllog.TransformContext]
 }
 
 func newFilterLogsProcessor(logger *zap.Logger, cfg *Config) (*filterLogProcessor, error) {
+	if cfg.Logs.Log != "" {
+		logp := ottllog.NewParser(common.Functions[ottllog.TransformContext](), component.TelemetrySettings{Logger: zap.NewNop()})
+		statements, err := logp.ParseStatements(common.PrepareConditionForParsing(cfg.Logs.Log))
+		if err != nil {
+			return nil, err
+		}
+
+		return &filterLogProcessor{
+			cfg:          cfg,
+			logger:       logger,
+			logCondition: statements[0],
+		}, nil
+	}
+
 	var includeMatcher filterlog.Matcher
 	var excludeMatcher filterlog.Matcher
 
@@ -60,7 +80,35 @@ func newFilterLogsProcessor(logger *zap.Logger, cfg *Config) (*filterLogProcesso
 	}, nil
 }
 
-func (flp *filterLogProcessor) ProcessLogs(_ context.Context, logs plog.Logs) (plog.Logs, error) {
+func (flp *filterLogProcessor) processLogs(ctx context.Context, logs plog.Logs) (plog.Logs, error) {
+	filteringLogs := flp.logCondition != nil
+
+	if filteringLogs {
+		var errors error
+		logs.ResourceLogs().RemoveIf(func(rlogs plog.ResourceLogs) bool {
+			rlogs.ScopeLogs().RemoveIf(func(slogs plog.ScopeLogs) bool {
+				slogs.LogRecords().RemoveIf(func(log plog.LogRecord) bool {
+					tCtx := ottllog.NewTransformContext(log, slogs.Scope(), rlogs.Resource())
+					_, conditionMet, err := flp.logCondition.Execute(ctx, tCtx)
+					if err != nil {
+						errors = multierr.Append(errors, err)
+					}
+					return conditionMet
+				})
+				return slogs.LogRecords().Len() == 0
+			})
+			return rlogs.ScopeLogs().Len() == 0
+		})
+
+		if errors != nil {
+			return logs, errors
+		}
+		if logs.ResourceLogs().Len() == 0 {
+			return logs, processorhelper.ErrSkipProcessingData
+		}
+		return logs, nil
+	}
+
 	rLogs := logs.ResourceLogs()
 
 	// Filter out logs

--- a/processor/filterprocessor/logs_test.go
+++ b/processor/filterprocessor/logs_test.go
@@ -17,6 +17,7 @@ package filterprocessor
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,10 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
 )
@@ -693,4 +697,100 @@ func requireNotPanicsLogs(t *testing.T, logs plog.Logs) {
 	require.NotPanics(t, func() {
 		_ = proc.ConsumeLogs(ctx, logs)
 	})
+}
+
+var (
+	TestLogTime      = time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC)
+	TestLogTimestamp = pcommon.NewTimestampFromTime(TestLogTime)
+
+	TestObservedTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestObservedTimestamp = pcommon.NewTimestampFromTime(TestObservedTime)
+
+	logTraceID = [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	logSpanID  = [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+)
+
+func TestFilterLogProcessorWithOTTL(t *testing.T) {
+	tests := []struct {
+		name             string
+		conditions       string
+		filterEverything bool
+		want             func(ld plog.Logs)
+	}{
+		{
+			name:       "drop logs",
+			conditions: `body == "operationA"`,
+			want: func(ld plog.Logs) {
+				ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().RemoveIf(func(log plog.LogRecord) bool {
+					return log.Body().AsString() == "operationA"
+				})
+				ld.ResourceLogs().At(0).ScopeLogs().At(1).LogRecords().RemoveIf(func(log plog.LogRecord) bool {
+					return log.Body().AsString() == "operationA"
+				})
+			},
+		},
+		{
+			name:             "drop everything by dropping all logs",
+			conditions:       `IsMatch(body, "operation.*") == true`,
+			filterEverything: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor, err := newFilterLogsProcessor(zap.NewNop(), &Config{Logs: LogFilters{Log: tt.conditions}})
+			assert.NoError(t, err)
+
+			got, err := processor.processLogs(context.Background(), constructLogs())
+
+			if tt.filterEverything {
+				assert.Equal(t, processorhelper.ErrSkipProcessingData, err)
+			} else {
+				exTd := constructLogs()
+				tt.want(exTd)
+				assert.Equal(t, exTd, got)
+			}
+		})
+	}
+}
+
+func constructLogs() plog.Logs {
+	td := plog.NewLogs()
+	rs0 := td.ResourceLogs().AppendEmpty()
+	rs0.Resource().Attributes().PutStr("host.name", "localhost")
+	rs0ils0 := rs0.ScopeLogs().AppendEmpty()
+	rs0ils0.Scope().SetName("scope1")
+	fillLogOne(rs0ils0.LogRecords().AppendEmpty())
+	fillLogTwo(rs0ils0.LogRecords().AppendEmpty())
+	rs0ils1 := rs0.ScopeLogs().AppendEmpty()
+	rs0ils1.Scope().SetName("scope2")
+	fillLogOne(rs0ils1.LogRecords().AppendEmpty())
+	fillLogTwo(rs0ils1.LogRecords().AppendEmpty())
+	return td
+}
+
+func fillLogOne(log plog.LogRecord) {
+	log.Body().SetStr("operationA")
+	log.SetTimestamp(TestLogTimestamp)
+	log.SetObservedTimestamp(TestObservedTimestamp)
+	log.SetDroppedAttributesCount(1)
+	log.SetFlags(plog.DefaultLogRecordFlags.WithIsSampled(true))
+	log.SetSeverityNumber(1)
+	log.SetTraceID(logTraceID)
+	log.SetSpanID(logSpanID)
+	log.Attributes().PutStr("http.method", "get")
+	log.Attributes().PutStr("http.path", "/health")
+	log.Attributes().PutStr("http.url", "http://localhost/health")
+	log.Attributes().PutStr("flags", "A|B|C")
+
+}
+
+func fillLogTwo(log plog.LogRecord) {
+	log.Body().SetStr("operationB")
+	log.SetTimestamp(TestLogTimestamp)
+	log.SetObservedTimestamp(TestObservedTimestamp)
+	log.Attributes().PutStr("http.method", "get")
+	log.Attributes().PutStr("http.path", "/health")
+	log.Attributes().PutStr("http.url", "http://localhost/health")
+	log.Attributes().PutStr("flags", "C|D")
+
 }

--- a/processor/filterprocessor/metrics.go
+++ b/processor/filterprocessor/metrics.go
@@ -17,29 +17,63 @@ package filterprocessor // import "github.com/open-telemetry/opentelemetry-colle
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filtermatcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filtermetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor/internal/common"
 )
 
 type filterMetricProcessor struct {
-	cfg              *Config
-	include          filtermetric.Matcher
-	includeAttribute filtermatcher.AttributesMatcher
-	exclude          filtermetric.Matcher
-	excludeAttribute filtermatcher.AttributesMatcher
-	logger           *zap.Logger
-	checksMetrics    bool
-	checksResouces   bool
+	cfg                *Config
+	include            filtermetric.Matcher
+	includeAttribute   filtermatcher.AttributesMatcher
+	exclude            filtermetric.Matcher
+	excludeAttribute   filtermatcher.AttributesMatcher
+	logger             *zap.Logger
+	checksMetrics      bool
+	checksResouces     bool
+	metricCondition    *ottl.Statement[ottlmetric.TransformContext]
+	dataPointCondition *ottl.Statement[ottldatapoint.TransformContext]
 }
 
 func newFilterMetricProcessor(logger *zap.Logger, cfg *Config) (*filterMetricProcessor, error) {
+	if cfg.Metrics.Metric != "" || cfg.Metrics.DataPoint != "" {
+		fsp := &filterMetricProcessor{
+			cfg:    cfg,
+			logger: logger,
+		}
+
+		if cfg.Metrics.Metric != "" {
+			metricp := ottlmetric.NewParser(common.Functions[ottlmetric.TransformContext](), component.TelemetrySettings{Logger: zap.NewNop()})
+			statements, err := metricp.ParseStatements(common.PrepareConditionForParsing(cfg.Metrics.Metric))
+			if err != nil {
+				return nil, err
+			}
+			fsp.metricCondition = statements[0]
+		}
+
+		if cfg.Metrics.DataPoint != "" {
+			datapointp := ottldatapoint.NewParser(common.Functions[ottldatapoint.TransformContext](), component.TelemetrySettings{Logger: zap.NewNop()})
+			statements, err := datapointp.ParseStatements(common.PrepareConditionForParsing(cfg.Metrics.DataPoint))
+			if err != nil {
+				return nil, err
+			}
+			fsp.dataPointCondition = statements[0]
+		}
+
+		return fsp, nil
+	}
 
 	inc, includeAttr, err := createMatcher(cfg.Metrics.Include)
 	if err != nil {
@@ -124,7 +158,77 @@ func createMatcher(mp *filtermetric.MatchProperties) (filtermetric.Matcher, filt
 }
 
 // processMetrics filters the given metrics based off the filterMetricProcessor's filters.
-func (fmp *filterMetricProcessor) processMetrics(_ context.Context, pdm pmetric.Metrics) (pmetric.Metrics, error) {
+func (fmp *filterMetricProcessor) processMetrics(ctx context.Context, pdm pmetric.Metrics) (pmetric.Metrics, error) {
+	filteringMetrics := fmp.metricCondition != nil
+	filteringDataPoints := fmp.dataPointCondition != nil
+
+	if filteringMetrics || filteringDataPoints {
+		var errors error
+		pdm.ResourceMetrics().RemoveIf(func(rmetrics pmetric.ResourceMetrics) bool {
+			rmetrics.ScopeMetrics().RemoveIf(func(smetrics pmetric.ScopeMetrics) bool {
+				smetrics.Metrics().RemoveIf(func(metric pmetric.Metric) bool {
+					if filteringMetrics {
+						tCtx := ottlmetric.NewTransformContext(metric, smetrics.Scope(), rmetrics.Resource())
+						_, conditionMet, err := fmp.metricCondition.Execute(ctx, tCtx)
+						if err != nil {
+							errors = multierr.Append(errors, err)
+						}
+						if conditionMet {
+							return true
+						}
+					}
+					if filteringDataPoints {
+						switch metric.Type() {
+						case pmetric.MetricTypeSum:
+							err := fmp.handleNumberDataPoints(ctx, metric.Sum().DataPoints(), metric, smetrics.Metrics(), smetrics.Scope(), rmetrics.Resource())
+							if err != nil {
+								errors = multierr.Append(errors, err)
+							}
+							return metric.Sum().DataPoints().Len() == 0
+						case pmetric.MetricTypeGauge:
+							err := fmp.handleNumberDataPoints(ctx, metric.Gauge().DataPoints(), metric, smetrics.Metrics(), smetrics.Scope(), rmetrics.Resource())
+							if err != nil {
+								errors = multierr.Append(errors, err)
+							}
+							return metric.Gauge().DataPoints().Len() == 0
+						case pmetric.MetricTypeHistogram:
+							err := fmp.handleHistogramDataPoints(ctx, metric.Histogram().DataPoints(), metric, smetrics.Metrics(), smetrics.Scope(), rmetrics.Resource())
+							if err != nil {
+								errors = multierr.Append(errors, err)
+							}
+							return metric.Histogram().DataPoints().Len() == 0
+						case pmetric.MetricTypeExponentialHistogram:
+							err := fmp.handleExponetialHistogramDataPoints(ctx, metric.ExponentialHistogram().DataPoints(), metric, smetrics.Metrics(), smetrics.Scope(), rmetrics.Resource())
+							if err != nil {
+								errors = multierr.Append(errors, err)
+							}
+							return metric.ExponentialHistogram().DataPoints().Len() == 0
+						case pmetric.MetricTypeSummary:
+							err := fmp.handleSummaryDataPoints(ctx, metric.Summary().DataPoints(), metric, smetrics.Metrics(), smetrics.Scope(), rmetrics.Resource())
+							if err != nil {
+								errors = multierr.Append(errors, err)
+							}
+							return metric.Summary().DataPoints().Len() == 0
+						default:
+							return false
+						}
+					}
+					return false
+				})
+				return smetrics.Metrics().Len() == 0
+			})
+			return rmetrics.ScopeMetrics().Len() == 0
+		})
+
+		if errors != nil {
+			return pdm, errors
+		}
+		if pdm.ResourceMetrics().Len() == 0 {
+			return pdm, processorhelper.ErrSkipProcessingData
+		}
+		return pdm, nil
+	}
+
 	pdm.ResourceMetrics().RemoveIf(func(rm pmetric.ResourceMetrics) bool {
 		keepMetricsForResource := fmp.shouldKeepMetricsForResource(rm.Resource())
 		if !keepMetricsForResource {
@@ -199,4 +303,60 @@ func (fmp *filterMetricProcessor) shouldKeepMetricsForResource(resource pcommon.
 	}
 
 	return true
+}
+
+func (fmp *filterMetricProcessor) handleNumberDataPoints(ctx context.Context, dps pmetric.NumberDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
+	var errors error
+	dps.RemoveIf(func(datapoint pmetric.NumberDataPoint) bool {
+		tCtx := ottldatapoint.NewTransformContext(datapoint, metric, metrics, is, resource)
+		_, conditionMet, err := fmp.dataPointCondition.Execute(ctx, tCtx)
+		if err != nil {
+			errors = multierr.Append(errors, err)
+			return false
+		}
+		return conditionMet
+	})
+	return errors
+}
+
+func (fmp *filterMetricProcessor) handleHistogramDataPoints(ctx context.Context, dps pmetric.HistogramDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
+	var errors error
+	dps.RemoveIf(func(datapoint pmetric.HistogramDataPoint) bool {
+		tCtx := ottldatapoint.NewTransformContext(datapoint, metric, metrics, is, resource)
+		_, conditionMet, err := fmp.dataPointCondition.Execute(ctx, tCtx)
+		if err != nil {
+			errors = multierr.Append(errors, err)
+			return false
+		}
+		return conditionMet
+	})
+	return errors
+}
+
+func (fmp *filterMetricProcessor) handleExponetialHistogramDataPoints(ctx context.Context, dps pmetric.ExponentialHistogramDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
+	var errors error
+	dps.RemoveIf(func(datapoint pmetric.ExponentialHistogramDataPoint) bool {
+		tCtx := ottldatapoint.NewTransformContext(datapoint, metric, metrics, is, resource)
+		_, conditionMet, err := fmp.dataPointCondition.Execute(ctx, tCtx)
+		if err != nil {
+			errors = multierr.Append(errors, err)
+			return false
+		}
+		return conditionMet
+	})
+	return errors
+}
+
+func (fmp *filterMetricProcessor) handleSummaryDataPoints(ctx context.Context, dps pmetric.SummaryDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
+	var errors error
+	dps.RemoveIf(func(datapoint pmetric.SummaryDataPoint) bool {
+		tCtx := ottldatapoint.NewTransformContext(datapoint, metric, metrics, is, resource)
+		_, conditionMet, err := fmp.dataPointCondition.Execute(ctx, tCtx)
+		if err != nil {
+			errors = multierr.Append(errors, err)
+			return false
+		}
+		return conditionMet
+	})
+	return errors
 }

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -538,7 +538,9 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop metrics",
 			conditions: MetricFilters{
-				Metric: `name == "operationA"`,
+				MetricConditions: []string{
+					`name == "operationA"`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
@@ -549,14 +551,18 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop everything by dropping all metrics",
 			conditions: MetricFilters{
-				Metric: `IsMatch(name, "operation.*") == true`,
+				MetricConditions: []string{
+					`IsMatch(name, "operation.*") == true`,
+				},
 			},
 			filterEverything: true,
 		},
 		{
 			name: "drop sum data point",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_SUM and value_double == 1.0`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_SUM and value_double == 1.0`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().RemoveIf(func(point pmetric.NumberDataPoint) bool {
@@ -567,7 +573,9 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop all sum data points",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_SUM`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_SUM`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
@@ -578,7 +586,9 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop gauge data point",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_GAUGE and value_double == 1.0`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_GAUGE and value_double == 1.0`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(4).Gauge().DataPoints().RemoveIf(func(point pmetric.NumberDataPoint) bool {
@@ -589,7 +599,9 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop all gauge data points",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_GAUGE`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_GAUGE`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
@@ -600,7 +612,9 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop histogram data point",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_HISTOGRAM and count == 1`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_HISTOGRAM and count == 1`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1).Histogram().DataPoints().RemoveIf(func(point pmetric.HistogramDataPoint) bool {
@@ -611,7 +625,9 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop all histogram data points",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_HISTOGRAM`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_HISTOGRAM`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
@@ -622,7 +638,9 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop exponential histogram data point",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM and count == 1`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM and count == 1`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(2).ExponentialHistogram().DataPoints().RemoveIf(func(point pmetric.ExponentialHistogramDataPoint) bool {
@@ -633,7 +651,9 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop all exponential histogram data points",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
@@ -644,7 +664,9 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop summary data point",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_SUMMARY and sum == 43.21`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_SUMMARY and sum == 43.21`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(3).Summary().DataPoints().RemoveIf(func(point pmetric.SummaryDataPoint) bool {
@@ -655,13 +677,25 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop all summary data points",
 			conditions: MetricFilters{
-				DataPoint: `metric.type == METRIC_DATA_TYPE_SUMMARY`,
+				DataPointConditions: []string{
+					`metric.type == METRIC_DATA_TYPE_SUMMARY`,
+				},
 			},
 			want: func(md pmetric.Metrics) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
 					return metric.Type() == pmetric.MetricTypeSummary
 				})
 			},
+		},
+		{
+			name: "multiple conditions",
+			conditions: MetricFilters{
+				MetricConditions: []string{
+					`resource.attributes["not real"] == "unknown"`,
+					`type != nil`,
+				},
+			},
+			filterEverything: true,
 		},
 	}
 	for _, tt := range tests {

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -28,6 +28,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/goldendataset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
@@ -519,4 +521,290 @@ func requireNotPanics(t *testing.T, metrics pmetric.Metrics) {
 	require.NotPanics(t, func() {
 		_ = proc.ConsumeMetrics(ctx, metrics)
 	})
+}
+
+var (
+	dataPointStartTimestamp = pcommon.NewTimestampFromTime(time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC))
+	dataPointTestTimeStamp  = pcommon.NewTimestampFromTime(time.Date(2021, 3, 12, 21, 27, 13, 322, time.UTC))
+)
+
+func TestFilterMetricProcessorWithOTTL(t *testing.T) {
+	tests := []struct {
+		name             string
+		conditions       MetricFilters
+		filterEverything bool
+		want             func(md pmetric.Metrics)
+	}{
+		{
+			name: "drop metrics",
+			conditions: MetricFilters{
+				Metric: `name == "operationA"`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
+					return metric.Name() == "operationA"
+				})
+			},
+		},
+		{
+			name: "drop everything by dropping all metrics",
+			conditions: MetricFilters{
+				Metric: `IsMatch(name, "operation.*") == true`,
+			},
+			filterEverything: true,
+		},
+		{
+			name: "drop sum data point",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_SUM and value_double == 1.0`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().RemoveIf(func(point pmetric.NumberDataPoint) bool {
+					return point.DoubleValue() == 1.0
+				})
+			},
+		},
+		{
+			name: "drop all sum data points",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_SUM`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
+					return metric.Type() == pmetric.MetricTypeSum
+				})
+			},
+		},
+		{
+			name: "drop gauge data point",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_GAUGE and value_double == 1.0`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(4).Gauge().DataPoints().RemoveIf(func(point pmetric.NumberDataPoint) bool {
+					return point.DoubleValue() == 1.0
+				})
+			},
+		},
+		{
+			name: "drop all gauge data points",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_GAUGE`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
+					return metric.Type() == pmetric.MetricTypeGauge
+				})
+			},
+		},
+		{
+			name: "drop histogram data point",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_HISTOGRAM and count == 1`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1).Histogram().DataPoints().RemoveIf(func(point pmetric.HistogramDataPoint) bool {
+					return point.Count() == 1
+				})
+			},
+		},
+		{
+			name: "drop all histogram data points",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_HISTOGRAM`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
+					return metric.Type() == pmetric.MetricTypeHistogram
+				})
+			},
+		},
+		{
+			name: "drop exponential histogram data point",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM and count == 1`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(2).ExponentialHistogram().DataPoints().RemoveIf(func(point pmetric.ExponentialHistogramDataPoint) bool {
+					return point.Count() == 1
+				})
+			},
+		},
+		{
+			name: "drop all exponential histogram data points",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
+					return metric.Type() == pmetric.MetricTypeExponentialHistogram
+				})
+			},
+		},
+		{
+			name: "drop summary data point",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_SUMMARY and sum == 43.21`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(3).Summary().DataPoints().RemoveIf(func(point pmetric.SummaryDataPoint) bool {
+					return point.Sum() == 43.21
+				})
+			},
+		},
+		{
+			name: "drop all summary data points",
+			conditions: MetricFilters{
+				DataPoint: `metric.type == METRIC_DATA_TYPE_SUMMARY`,
+			},
+			want: func(md pmetric.Metrics) {
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(metric pmetric.Metric) bool {
+					return metric.Type() == pmetric.MetricTypeSummary
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor, err := newFilterMetricProcessor(zap.NewNop(), &Config{Metrics: tt.conditions})
+			assert.NoError(t, err)
+
+			got, err := processor.processMetrics(context.Background(), constructMetrics())
+
+			if tt.filterEverything {
+				assert.Equal(t, processorhelper.ErrSkipProcessingData, err)
+			} else {
+
+				exTd := constructMetrics()
+				tt.want(exTd)
+				assert.Equal(t, exTd, got)
+			}
+		})
+	}
+}
+
+func constructMetrics() pmetric.Metrics {
+	td := pmetric.NewMetrics()
+	rm0 := td.ResourceMetrics().AppendEmpty()
+	rm0.Resource().Attributes().PutStr("host.name", "myhost")
+	rm0ils0 := rm0.ScopeMetrics().AppendEmpty()
+	rm0ils0.Scope().SetName("scope")
+	fillMetricOne(rm0ils0.Metrics().AppendEmpty())
+	fillMetricTwo(rm0ils0.Metrics().AppendEmpty())
+	fillMetricThree(rm0ils0.Metrics().AppendEmpty())
+	fillMetricFour(rm0ils0.Metrics().AppendEmpty())
+	fillMetricFive(rm0ils0.Metrics().AppendEmpty())
+	return td
+}
+
+func fillMetricOne(m pmetric.Metric) {
+	m.SetName("operationA")
+	m.SetDescription("operationA description")
+	m.SetUnit("operationA unit")
+
+	dataPoint0 := m.SetEmptySum().DataPoints().AppendEmpty()
+	dataPoint0.SetStartTimestamp(dataPointStartTimestamp)
+	dataPoint0.SetDoubleValue(1.0)
+	dataPoint0.Attributes().PutStr("attr1", "test1")
+	dataPoint0.Attributes().PutStr("attr2", "test2")
+	dataPoint0.Attributes().PutStr("attr3", "test3")
+	dataPoint0.Attributes().PutStr("flags", "A|B|C")
+
+	dataPoint1 := m.Sum().DataPoints().AppendEmpty()
+	dataPoint1.SetStartTimestamp(dataPointStartTimestamp)
+	dataPoint1.SetDoubleValue(3.7)
+	dataPoint1.Attributes().PutStr("attr1", "test1")
+	dataPoint1.Attributes().PutStr("attr2", "test2")
+	dataPoint1.Attributes().PutStr("attr3", "test3")
+	dataPoint1.Attributes().PutStr("flags", "A|B|C")
+}
+
+func fillMetricTwo(m pmetric.Metric) {
+	m.SetName("operationB")
+	m.SetDescription("operationB description")
+	m.SetUnit("operationB unit")
+
+	dataPoint0 := m.SetEmptyHistogram().DataPoints().AppendEmpty()
+	dataPoint0.SetStartTimestamp(dataPointStartTimestamp)
+	dataPoint0.Attributes().PutStr("attr1", "test1")
+	dataPoint0.Attributes().PutStr("attr2", "test2")
+	dataPoint0.Attributes().PutStr("attr3", "test3")
+	dataPoint0.Attributes().PutStr("flags", "C|D")
+	dataPoint0.SetCount(1)
+
+	dataPoint1 := m.Histogram().DataPoints().AppendEmpty()
+	dataPoint1.SetStartTimestamp(dataPointStartTimestamp)
+	dataPoint1.Attributes().PutStr("attr1", "test1")
+	dataPoint1.Attributes().PutStr("attr2", "test2")
+	dataPoint1.Attributes().PutStr("attr3", "test3")
+	dataPoint1.Attributes().PutStr("flags", "C|D")
+}
+
+func fillMetricThree(m pmetric.Metric) {
+	m.SetName("operationC")
+	m.SetDescription("operationC description")
+	m.SetUnit("operationC unit")
+
+	dataPoint0 := m.SetEmptyExponentialHistogram().DataPoints().AppendEmpty()
+	dataPoint0.SetStartTimestamp(dataPointStartTimestamp)
+	dataPoint0.Attributes().PutStr("attr1", "test1")
+	dataPoint0.Attributes().PutStr("attr2", "test2")
+	dataPoint0.Attributes().PutStr("attr3", "test3")
+	dataPoint0.SetCount(1)
+	dataPoint0.SetScale(1)
+	dataPoint0.SetZeroCount(1)
+	dataPoint0.Positive().SetOffset(1)
+	dataPoint0.Negative().SetOffset(1)
+
+	dataPoint1 := m.ExponentialHistogram().DataPoints().AppendEmpty()
+	dataPoint1.SetStartTimestamp(dataPointStartTimestamp)
+	dataPoint1.Attributes().PutStr("attr1", "test1")
+	dataPoint1.Attributes().PutStr("attr2", "test2")
+	dataPoint1.Attributes().PutStr("attr3", "test3")
+}
+
+func fillMetricFour(m pmetric.Metric) {
+	m.SetName("operationD")
+	m.SetDescription("operationD description")
+	m.SetUnit("operationD unit")
+
+	dataPoint0 := m.SetEmptySummary().DataPoints().AppendEmpty()
+	dataPoint0.SetStartTimestamp(dataPointStartTimestamp)
+	dataPoint0.SetTimestamp(dataPointTestTimeStamp)
+	dataPoint0.Attributes().PutStr("attr1", "test1")
+	dataPoint0.Attributes().PutStr("attr2", "test2")
+	dataPoint0.Attributes().PutStr("attr3", "test3")
+	dataPoint0.SetCount(1234)
+	dataPoint0.SetSum(12.34)
+
+	quantileDataPoint0 := dataPoint0.QuantileValues().AppendEmpty()
+	quantileDataPoint0.SetQuantile(.99)
+	quantileDataPoint0.SetValue(123)
+
+	quantileDataPoint1 := dataPoint0.QuantileValues().AppendEmpty()
+	quantileDataPoint1.SetQuantile(.95)
+	quantileDataPoint1.SetValue(321)
+
+	dataPoint1 := m.Summary().DataPoints().AppendEmpty()
+	dataPoint1.SetSum(43.21)
+}
+
+func fillMetricFive(m pmetric.Metric) {
+	m.SetName("operationE")
+	m.SetDescription("operationE description")
+	m.SetUnit("operationE unit")
+
+	dataPoint0 := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dataPoint0.SetStartTimestamp(dataPointStartTimestamp)
+	dataPoint0.SetDoubleValue(1.0)
+	dataPoint0.Attributes().PutStr("attr1", "test1")
+	dataPoint0.Attributes().PutStr("attr2", "test2")
+	dataPoint0.Attributes().PutStr("attr3", "test3")
+
+	dataPoint1 := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dataPoint1.SetStartTimestamp(dataPointStartTimestamp)
+	dataPoint1.SetDoubleValue(2.0)
+	dataPoint1.Attributes().PutStr("attr1", "test1")
+	dataPoint1.Attributes().PutStr("attr2", "test2")
+	dataPoint1.Attributes().PutStr("attr3", "test3")
 }

--- a/processor/filterprocessor/testdata/config_ottl.yaml
+++ b/processor/filterprocessor/testdata/config_ottl.yaml
@@ -1,20 +1,20 @@
 filter/ottl:
   traces:
-    span_conditions:
+    span:
       - 'attributes["test"] == "pass"'
-    spanevent_conditions:
+    spanevent:
       - 'attributes["test"] == "pass"'
   metrics:
-    metric_conditions:
+    metric:
       - 'name == "pass"'
-    datapoint_conditions:
+    datapoint:
       - 'attributes["test"] == "pass"'
   logs:
-    log_conditions:
+    log_record:
       - 'attributes["test"] == "pass"'
 filter/multiline:
   traces:
-    span_conditions:
+    span:
       - 'attributes["test"] == "pass"'
       - 'attributes["test"] == "also pass"'
 filter/spans_mix_config:
@@ -28,7 +28,7 @@ filter/spans_mix_config:
         - key: should_include
           value: "(true|probably_true)"
   traces:
-    span_conditions:
+    span:
       - 'attributes["test"] == "pass"'
 filter/metrics_mix_config:
   metrics:
@@ -37,7 +37,7 @@ filter/metrics_mix_config:
       expressions:
         - Label("foo") == "bar"
         - HasLabel("baz")
-    metric_conditions:
+    metric:
       - 'attributes["test"] == "pass"'
 filter/logs_mix_config:
   logs:
@@ -46,25 +46,25 @@ filter/logs_mix_config:
       resource_attributes:
         - key: should_include
           value: "true"
-    log_conditions:
+    log_record:
       - 'attributes["test"] == "pass"'
 filter/bad_syntax_span:
   traces:
-    span_conditions:
+    span:
       - 'attributes[test] == "pass"'
 filter/bad_syntax_spanevent:
   traces:
-    spanevent_conditions:
+    spanevent:
       - 'attributes[test] == "pass"'
 filter/bad_syntax_metric:
   metrics:
-    metric_conditions:
+    metric:
       - 'resource.attributes[test] == "pass"'
 filter/bad_syntax_datapoint:
   metrics:
-    datapoint_conditions:
+    datapoint:
       - 'attributes[test] == "pass"'
 filter/bad_syntax_log:
   logs:
-    log_conditions:
+    log_record:
       - 'attributes[test] == "pass"'

--- a/processor/filterprocessor/testdata/config_ottl.yaml
+++ b/processor/filterprocessor/testdata/config_ottl.yaml
@@ -1,5 +1,5 @@
 filter/ottl:
-  spans:
+  traces:
     span_conditions:
       - 'attributes["test"] == "pass"'
     spanevent_conditions:
@@ -13,7 +13,7 @@ filter/ottl:
     log_conditions:
       - 'attributes["test"] == "pass"'
 filter/multiline:
-  spans:
+  traces:
     span_conditions:
       - 'attributes["test"] == "pass"'
       - 'attributes["test"] == "also pass"'
@@ -27,6 +27,7 @@ filter/spans_mix_config:
       attributes:
         - key: should_include
           value: "(true|probably_true)"
+  traces:
     span_conditions:
       - 'attributes["test"] == "pass"'
 filter/metrics_mix_config:
@@ -48,11 +49,11 @@ filter/logs_mix_config:
     log_conditions:
       - 'attributes["test"] == "pass"'
 filter/bad_syntax_span:
-  spans:
+  traces:
     span_conditions:
       - 'attributes[test] == "pass"'
 filter/bad_syntax_spanevent:
-  spans:
+  traces:
     spanevent_conditions:
       - 'attributes[test] == "pass"'
 filter/bad_syntax_metric:

--- a/processor/filterprocessor/testdata/config_ottl.yaml
+++ b/processor/filterprocessor/testdata/config_ottl.yaml
@@ -1,17 +1,22 @@
 filter/ottl:
   spans:
-    span: 'attributes["test"] == "pass"'
-    spanevent: 'attributes["test"] == "pass"'
+    span_conditions:
+      - 'attributes["test"] == "pass"'
+    spanevent_conditions:
+      - 'attributes["test"] == "pass"'
   metrics:
-    metric: 'name == "pass"'
-    datapoint: 'attributes["test"] == "pass"'
+    metric_conditions:
+      - 'name == "pass"'
+    datapoint_conditions:
+      - 'attributes["test"] == "pass"'
   logs:
-    log: 'attributes["test"] == "pass"'
+    log_conditions:
+      - 'attributes["test"] == "pass"'
 filter/multiline:
   spans:
-    span: '
-    attributes["test"] == "pass" or
-    attributes["test"] == "also pass"'
+    span_conditions:
+      - 'attributes["test"] == "pass"'
+      - 'attributes["test"] == "also pass"'
 filter/spans_mix_config:
   spans:
     include:
@@ -22,7 +27,8 @@ filter/spans_mix_config:
       attributes:
         - key: should_include
           value: "(true|probably_true)"
-    span: 'attributes["test"] == "pass"'
+    span_conditions:
+      - 'attributes["test"] == "pass"'
 filter/metrics_mix_config:
   metrics:
     include:
@@ -30,7 +36,8 @@ filter/metrics_mix_config:
       expressions:
         - Label("foo") == "bar"
         - HasLabel("baz")
-    metric: 'attributes["test"] == "pass"'
+    metric_conditions:
+      - 'attributes["test"] == "pass"'
 filter/logs_mix_config:
   logs:
     include:
@@ -38,19 +45,25 @@ filter/logs_mix_config:
       resource_attributes:
         - key: should_include
           value: "true"
-    log: 'attributes["test"] == "pass"'
+    log_conditions:
+      - 'attributes["test"] == "pass"'
 filter/bad_syntax_span:
   spans:
-    span: 'attributes[test] == "pass"'
+    span_conditions:
+      - 'attributes[test] == "pass"'
 filter/bad_syntax_spanevent:
   spans:
-    spanevent: 'attributes[test] == "pass"'
+    spanevent_conditions:
+      - 'attributes[test] == "pass"'
 filter/bad_syntax_metric:
   metrics:
-    metric: 'resource.attributes[test] == "pass"'
+    metric_conditions:
+      - 'resource.attributes[test] == "pass"'
 filter/bad_syntax_datapoint:
   metrics:
-    datapoint: 'attributes[test] == "pass"'
+    datapoint_conditions:
+      - 'attributes[test] == "pass"'
 filter/bad_syntax_log:
   logs:
-    log: 'attributes[test] == "pass"'
+    log_conditions:
+      - 'attributes[test] == "pass"'

--- a/processor/filterprocessor/testdata/config_ottl.yaml
+++ b/processor/filterprocessor/testdata/config_ottl.yaml
@@ -1,0 +1,55 @@
+filter/ottl:
+  spans:
+    span: 'attributes["test"] == "pass"'
+    spanevent: 'attributes["test"] == "pass"'
+  metrics:
+    metric: 'name == "pass"'
+    datapoint: 'attributes["test"] == "pass"'
+  logs:
+    log: 'attributes["test"] == "pass"'
+filter/multiline:
+  spans:
+    span: 'attributes["test"] == "pass" or 
+    attributes["test"] == "also pass"'
+filter/spans_mix_config:
+  spans:
+    include:
+      match_type: strict
+      services:
+        - test
+        - test2
+      attributes:
+        - key: should_include
+          value: "(true|probably_true)"
+    span: 'attributes["test"] == "pass"'
+filter/metrics_mix_config:
+  metrics:
+    include:
+      match_type: expr
+      expressions:
+        - Label("foo") == "bar"
+        - HasLabel("baz")
+    metric: 'attributes["test"] == "pass"'
+filter/logs_mix_config:
+  logs:
+    include:
+      match_type: strict
+      resource_attributes:
+        - key: should_include
+          value: "true"
+    log: 'attributes["test"] == "pass"'
+filter/bad_syntax_span:
+  spans:
+    span: 'attributes[test] == "pass"'
+filter/bad_syntax_spanevent:
+  spans:
+    spanevent: 'attributes[test] == "pass"'
+filter/bad_syntax_metric:
+  metrics:
+    metric: 'resource.attributes[test] == "pass"'
+filter/bad_syntax_datapoint:
+  metrics:
+    datapoint: 'attributes[test] == "pass"'
+filter/bad_syntax_log:
+  logs:
+    log: 'attributes[test] == "pass"'

--- a/processor/filterprocessor/testdata/config_ottl.yaml
+++ b/processor/filterprocessor/testdata/config_ottl.yaml
@@ -9,7 +9,8 @@ filter/ottl:
     log: 'attributes["test"] == "pass"'
 filter/multiline:
   spans:
-    span: 'attributes["test"] == "pass" or 
+    span: '
+    attributes["test"] == "pass" or
     attributes["test"] == "also pass"'
 filter/spans_mix_config:
   spans:

--- a/processor/filterprocessor/traces.go
+++ b/processor/filterprocessor/traces.go
@@ -40,24 +40,24 @@ type filterSpanProcessor struct {
 }
 
 func newFilterSpansProcessor(logger *zap.Logger, cfg *Config) (*filterSpanProcessor, error) {
-	if cfg.Spans.SpanConditions != nil || cfg.Spans.SpanEventConditions != nil {
+	if cfg.Traces.SpanConditions != nil || cfg.Traces.SpanEventConditions != nil {
 		fsp := &filterSpanProcessor{
 			cfg:    cfg,
 			logger: logger,
 		}
 
-		if cfg.Spans.SpanConditions != nil {
+		if cfg.Traces.SpanConditions != nil {
 			spanp := ottlspan.NewParser(common.Functions[ottlspan.TransformContext](), component.TelemetrySettings{Logger: zap.NewNop()})
-			statements, err := spanp.ParseStatements(common.PrepareConditionForParsing(cfg.Spans.SpanConditions))
+			statements, err := spanp.ParseStatements(common.PrepareConditionForParsing(cfg.Traces.SpanConditions))
 			if err != nil {
 				return nil, err
 			}
 			fsp.spanConditions = statements
 		}
 
-		if cfg.Spans.SpanEventConditions != nil {
+		if cfg.Traces.SpanEventConditions != nil {
 			spaneventp := ottlspanevent.NewParser(common.Functions[ottlspanevent.TransformContext](), component.TelemetrySettings{Logger: zap.NewNop()})
-			statements, err := spaneventp.ParseStatements(common.PrepareConditionForParsing(cfg.Spans.SpanEventConditions))
+			statements, err := spaneventp.ParseStatements(common.PrepareConditionForParsing(cfg.Traces.SpanEventConditions))
 			if err != nil {
 				return nil, err
 			}

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -17,13 +17,18 @@ package filterprocessor
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
@@ -165,6 +170,7 @@ func TestFilterTraceProcessor(t *testing.T) {
 		})
 	}
 }
+
 func generateTraces(traces []testTrace) ptrace.Traces {
 	td := ptrace.NewTraces()
 
@@ -181,4 +187,134 @@ func generateTraces(traces []testTrace) ptrace.Traces {
 		span.SetName(trace.spanName)
 	}
 	return td
+}
+
+var (
+	TestSpanStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC)
+	TestSpanStartTimestamp = pcommon.NewTimestampFromTime(TestSpanStartTime)
+
+	TestSpanEndTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestSpanEndTimestamp = pcommon.NewTimestampFromTime(TestSpanEndTime)
+
+	traceID = [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID  = [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	spanID2 = [8]byte{8, 7, 6, 5, 4, 3, 2, 1}
+)
+
+func TestFilterTraceProcessorWithOTTL(t *testing.T) {
+	tests := []struct {
+		name             string
+		conditions       SpanFilters
+		filterEverything bool
+		want             func(td ptrace.Traces)
+	}{
+		{
+			name: "drop spans",
+			conditions: SpanFilters{
+				Span: `name == "operationA"`,
+			},
+			want: func(td ptrace.Traces) {
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().RemoveIf(func(span ptrace.Span) bool {
+					return span.Name() == "operationA"
+				})
+				td.ResourceSpans().At(0).ScopeSpans().At(1).Spans().RemoveIf(func(span ptrace.Span) bool {
+					return span.Name() == "operationA"
+				})
+			},
+		},
+		{
+			name: "drop everything by dropping all spans",
+			conditions: SpanFilters{
+				Span: `IsMatch(name, "operation.*") == true`,
+			},
+			filterEverything: true,
+		},
+		{
+			name: "drop span events",
+			conditions: SpanFilters{
+				SpanEvent: `name == "spanEventA"`,
+			},
+			want: func(td ptrace.Traces) {
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Events().RemoveIf(func(event ptrace.SpanEvent) bool {
+					return event.Name() == "spanEventA"
+				})
+				td.ResourceSpans().At(0).ScopeSpans().At(1).Spans().At(1).Events().RemoveIf(func(event ptrace.SpanEvent) bool {
+					return event.Name() == "spanEventA"
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor, err := newFilterSpansProcessor(zap.NewNop(), &Config{Spans: tt.conditions})
+			assert.NoError(t, err)
+
+			got, err := processor.processTraces(context.Background(), constructTraces())
+
+			if tt.filterEverything {
+				assert.Equal(t, processorhelper.ErrSkipProcessingData, err)
+			} else {
+
+				exTd := constructTraces()
+				tt.want(exTd)
+				assert.Equal(t, exTd, got)
+			}
+		})
+	}
+}
+
+func constructTraces() ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs0 := td.ResourceSpans().AppendEmpty()
+	rs0.Resource().Attributes().PutStr("host.name", "localhost")
+	rs0ils0 := rs0.ScopeSpans().AppendEmpty()
+	rs0ils0.Scope().SetName("scope1")
+	fillSpanOne(rs0ils0.Spans().AppendEmpty())
+	fillSpanTwo(rs0ils0.Spans().AppendEmpty())
+	rs0ils1 := rs0.ScopeSpans().AppendEmpty()
+	rs0ils1.Scope().SetName("scope2")
+	fillSpanOne(rs0ils1.Spans().AppendEmpty())
+	fillSpanTwo(rs0ils1.Spans().AppendEmpty())
+	return td
+}
+
+func fillSpanOne(span ptrace.Span) {
+	span.SetName("operationA")
+	span.SetSpanID(spanID)
+	span.SetParentSpanID(spanID2)
+	span.SetTraceID(traceID)
+	span.SetStartTimestamp(TestSpanStartTimestamp)
+	span.SetEndTimestamp(TestSpanEndTimestamp)
+	span.SetDroppedAttributesCount(1)
+	span.SetDroppedLinksCount(1)
+	span.SetDroppedEventsCount(1)
+	span.SetKind(1)
+	span.TraceState().FromRaw("new")
+	span.Attributes().PutStr("http.method", "get")
+	span.Attributes().PutStr("http.path", "/health")
+	span.Attributes().PutStr("http.url", "http://localhost/health")
+	span.Attributes().PutStr("flags", "A|B|C")
+	status := span.Status()
+	status.SetCode(ptrace.StatusCodeError)
+	status.SetMessage("status-cancelled")
+}
+
+func fillSpanTwo(span ptrace.Span) {
+	span.SetName("operationB")
+	span.SetStartTimestamp(TestSpanStartTimestamp)
+	span.SetEndTimestamp(TestSpanEndTimestamp)
+	span.Attributes().PutStr("http.method", "get")
+	span.Attributes().PutStr("http.path", "/health")
+	span.Attributes().PutStr("http.url", "http://localhost/health")
+	span.Attributes().PutStr("flags", "C|D")
+	link0 := span.Links().AppendEmpty()
+	link0.SetDroppedAttributesCount(4)
+	link1 := span.Links().AppendEmpty()
+	link1.SetDroppedAttributesCount(4)
+	span.SetDroppedLinksCount(3)
+	status := span.Status()
+	status.SetCode(ptrace.StatusCodeError)
+	status.SetMessage("status-cancelled")
+	spanEvent := span.Events().AppendEmpty()
+	spanEvent.SetName("spanEventA")
 }

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -204,13 +204,13 @@ var (
 func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 	tests := []struct {
 		name             string
-		conditions       SpanFilters
+		conditions       TraceFilters
 		filterEverything bool
 		want             func(td ptrace.Traces)
 	}{
 		{
 			name: "drop spans",
-			conditions: SpanFilters{
+			conditions: TraceFilters{
 				SpanConditions: []string{
 					`name == "operationA"`,
 				},
@@ -226,7 +226,7 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 		},
 		{
 			name: "drop everything by dropping all spans",
-			conditions: SpanFilters{
+			conditions: TraceFilters{
 				SpanConditions: []string{
 					`IsMatch(name, "operation.*") == true`,
 				},
@@ -235,7 +235,7 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 		},
 		{
 			name: "drop span events",
-			conditions: SpanFilters{
+			conditions: TraceFilters{
 				SpanEventConditions: []string{
 					`name == "spanEventA"`,
 				},
@@ -251,7 +251,7 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 		},
 		{
 			name: "multiple conditions",
-			conditions: SpanFilters{
+			conditions: TraceFilters{
 				SpanConditions: []string{
 					`name == "operationZ"`,
 					`span_id != nil`,
@@ -262,7 +262,7 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			processor, err := newFilterSpansProcessor(zap.NewNop(), &Config{Spans: tt.conditions})
+			processor, err := newFilterSpansProcessor(zap.NewNop(), &Config{Traces: tt.conditions})
 			assert.NoError(t, err)
 
 			got, err := processor.processTraces(context.Background(), constructTraces())

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -211,7 +211,9 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop spans",
 			conditions: SpanFilters{
-				Span: `name == "operationA"`,
+				SpanConditions: []string{
+					`name == "operationA"`,
+				},
 			},
 			want: func(td ptrace.Traces) {
 				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().RemoveIf(func(span ptrace.Span) bool {
@@ -225,14 +227,18 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 		{
 			name: "drop everything by dropping all spans",
 			conditions: SpanFilters{
-				Span: `IsMatch(name, "operation.*") == true`,
+				SpanConditions: []string{
+					`IsMatch(name, "operation.*") == true`,
+				},
 			},
 			filterEverything: true,
 		},
 		{
 			name: "drop span events",
 			conditions: SpanFilters{
-				SpanEvent: `name == "spanEventA"`,
+				SpanEventConditions: []string{
+					`name == "spanEventA"`,
+				},
 			},
 			want: func(td ptrace.Traces) {
 				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Events().RemoveIf(func(event ptrace.SpanEvent) bool {
@@ -242,6 +248,16 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 					return event.Name() == "spanEventA"
 				})
 			},
+		},
+		{
+			name: "multiple conditions",
+			conditions: SpanFilters{
+				SpanConditions: []string{
+					`name == "operationZ"`,
+					`span_id != nil`,
+				},
+			},
+			filterEverything: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:**
Adds a new configuration options to the filterprocessor that allow filtering spans, spanevents, metrics, datapoints, and logs using OTTL conditions.

**Link to tracking Issue:**
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7151
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13578
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13579
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13580
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13581
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5679

**Testing:** 
Unit tests

**Documentation:**
Updated README

