### PR TITLE
[receiver/jaeger] Fix an error message in thrift HTTP message decoder

### DIFF
--- a/.chloggen/fix-jaeger-error.yaml
+++ b/.chloggen/fix-jaeger-error.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: receiver/jaeger
+note: Fix an error message in thrift HTTP message decoder
+issues: [16372]

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -328,7 +328,10 @@ func (jr *jReceiver) decodeThriftHTTPBody(r *http.Request) (*jaeger.Batch, *http
 	bodyBytes, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
-		return nil, &httpError{"Unable to process request body: %v", http.StatusInternalServerError}
+		return nil, &httpError{
+			fmt.Sprintf("Unable to process request body: %v", err),
+			http.StatusInternalServerError,
+		}
 	}
 
 	contentType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))


### PR DESCRIPTION
A small follow-up fix to keep https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16370 noop: 

Return full error instead of the format string "Unable to process request body: %v"