### PR TITLE
Polish up awscontainerinsightreceiver README to fix incorrect format in sample configuration

### DIFF
--- a/.chloggen/polish-awscontainerinsightreceiver-readme.yaml
+++ b/.chloggen/polish-awscontainerinsightreceiver-readme.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/awscontainerinsightreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Polish up awscontainerinsightreceiver README"
+
+# One or more tracking issues related to the change
+issues: [16378]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -273,8 +273,8 @@ spec:
               mountPath: /var/lib/docker
               readOnly: true
             - name: containerdsock
-               mountPath: /run/containerd/containerd.sock
-               readOnly: true
+              mountPath: /run/containerd/containerd.sock
+              readOnly: true
             - name: sys
               mountPath: /sys
               readOnly: true
@@ -307,8 +307,8 @@ spec:
           hostPath:
             path: /var/lib/docker
         - name: containerdsock
-           hostPath:
-             path: /run/containerd/containerd.sock
+          hostPath:
+            path: /run/containerd/containerd.sock
         - name: sys
           hostPath:
             path: /sys


### PR DESCRIPTION
The YAML format of sample configuration in awscontainerinsightreceiver README.md is wrong.

Signed-off-by: pg.yang <pg.yang@hotmail.com>

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>