### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,7 +166,7 @@ receiver/filelogreceiver/                            @open-telemetry/collector-c
 receiver/flinkmetricsreceiver/                       @open-telemetry/collector-contrib-approvers @jonathanwamsley @djaglowski
 receiver/fluentforwardreceiver/                      @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/googlecloudpubsubreceiver/                  @open-telemetry/collector-contrib-approvers @alexvanboxel
-receiver/googlecloudspannerreceiver/                 @open-telemetry/collector-contrib-approvers @ydrozhdzhal @asukhyy @khospodarysko @architjugran
+receiver/googlecloudspannerreceiver/                 @open-telemetry/collector-contrib-approvers @architjugran @varunraiko @kiranmayib
 receiver/hostmetricsreceiver/                        @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/httpcheckreceiver/                          @open-telemetry/collector-contrib-approvers @codeboten
 receiver/influxdbreceiver/                           @open-telemetry/collector-contrib-approvers @jacobmarble


### PR DESCRIPTION
Update codeowners for googlecloudspannerreceiver

The codeowners being removed no longer work on this component. Hence I am adding my team members from Google as codeowners

