### PR TITLE
Update the usage of set-output command in GH actions

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Get changed files
         id: changes
         run: |
-          echo "::set-output name=md::$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main ${{ github.event.pull_request.head.sha }}) ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
+          echo "md=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main ${{ github.event.pull_request.head.sha }}) ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)" >> $GITHUB_OUTPUT
   check-links:
     runs-on: ubuntu-latest
     needs: changedfiles

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -108,7 +108,7 @@ jobs:
           TEST_ARGS: "-test.run=${{ matrix.test }}"
       - name: Set results filename
         id: filename
-        run: echo "::set-output name=name::$(echo '${{ matrix.test }}' | sed -e 's/|/_/g')"
+        run: echo "name=$(echo '${{ matrix.test }}' | sed -e 's/|/_/g')" >> $GITHUB_OUTPUT
       - name: Create Test Result Archive
         if: ${{ failure() || success() }}
         continue-on-error: true

--- a/.github/workflows/scripts/set_release_tag.sh
+++ b/.github/workflows/scripts/set_release_tag.sh
@@ -1,5 +1,5 @@
 TAG="${GITHUB_REF##*/}"
 if [[ $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+.* ]]
 then
-    echo "::set-output name=tag::$TAG"
+    echo "tag=$TAG" >> $GITHUB_OUTPUT
 fi

--- a/.github/workflows/scripts/setup_e2e_tests.sh
+++ b/.github/workflows/scripts/setup_e2e_tests.sh
@@ -15,4 +15,4 @@ else
 fi
 done
 MATRIX+=",{\"test\":\"$curr\"}]}"
-echo "::set-output name=loadtest_matrix::$MATRIX"
+echo "loadtest_matrix=$MATRIX" >> $GITHUB_OUTPUT

--- a/.github/workflows/scripts/setup_stability_tests.sh
+++ b/.github/workflows/scripts/setup_stability_tests.sh
@@ -8,4 +8,4 @@ for i in "${!TESTS[@]}"; do
     MATRIX+="{\"test\":\"$curr\"},"
 done
 MATRIX+="]}"
-echo "::set-output name=stabilitytest_matrix::$MATRIX"
+echo "stabilitytest_matrix=$MATRIX" >> $GITHUB_OUTPUT

--- a/.github/workflows/scripts/verify-dist-files-exist.sh
+++ b/.github/workflows/scripts/verify-dist-files-exist.sh
@@ -19,8 +19,8 @@ do
     if [[ ! -f $f ]]
     then
         echo "$f does not exist."
-        echo "::set-output name=passed::false"
+        echo "passed=false" >> $GITHUB_OUTPUT
         exit 0
     fi
 done
-echo "::set-output name=passed::true"
+echo "passed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Description:**

This PR updates the usage of set-output command in GH actions.

Reference : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


ChangeLog entry is not required.