### PR TITLE
[exporter/datadog] Do not read response if nil on logs error

### DIFF
--- a/.chloggen/mx-psi_logs-exporter-crash.yaml
+++ b/.chloggen/mx-psi_logs-exporter-crash.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes crash when logging error on logs exporter
+
+# One or more tracking issues related to the change
+issues: [16077]


### PR DESCRIPTION
**Description:** 

Do not try to read the response body if nil. The `SubmitLogs` method returns an error when failing to submit (e.g. 4xx or 5xx) but also in other cases where there is no response. The latter are classified as permanent errors to avoid unnecessary retries.

**Link to tracking Issue:** Fixes #16077
