### PR TITLE
[pkg/ottl] Print debug logs when unprintable values are passed to Concat

### DIFF
--- a/.chloggen/ottl-concat-log.yaml
+++ b/.chloggen/ottl-concat-log.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Print debug logs when unsupported values are passed to `Concat`
+
+# One or more tracking issues related to the change
+issues: [13390]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -27,7 +27,7 @@ Functions
 
 `Concat(values[], delimiter)`
 
-The `Concat` factory function takes a delimiter and a sequence of values and concatenates their string representation. Unsupported values, such as lists or maps that may substantially increase payload size, are not added to the resulting string.
+The `Concat` factory function takes a delimiter and a sequence of values and concatenates their string representation. Unsupported values, such as lists or maps that may substantially increase payload size, are not added to the resulting string. A debug log is printed when Concat is passed an unsupported value.
 
 `values` is a list of values passed as arguments. It supports paths, primitive values, and byte slices (such as trace IDs or span IDs).
 

--- a/pkg/ottl/ottlfuncs/func_concat.go
+++ b/pkg/ottl/ottlfuncs/func_concat.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"go.opentelemetry.io/collector/component"
 )
 
-func Concat[K any](vals []ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], error) {
+func Concat[K any](settings component.TelemetrySettings, vals []ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], error) {
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		builder := strings.Builder{}
 		for i, rv := range vals {
@@ -43,6 +44,8 @@ func Concat[K any](vals []ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], e
 				builder.WriteString(fmt.Sprint(v))
 			case nil:
 				builder.WriteString(fmt.Sprint(v))
+			default:
+				settings.Logger.Debug(fmt.Sprintf("Unprintable value passed to Concat at index %v in values list", i))
 			}
 
 			if i != len(vals)-1 {


### PR DESCRIPTION
**Description:**

Print debug logs when any values are passed to Concat which cannot be meaningfully and succinctly stringified.

I chose to make the log a debug log so that it is only printed if the user makes a deliberate choice to increase log output. I think it is likely that many log statements in functions will be used to debug statements while testing, and will be disabled in production environments.

**Link to tracking Issue:**

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13390

**Testing:**

Unit tests were added to verify the log is printed in the correct case.

**Documentation:**

The documentation entry for Concat was updated to mention the log.