### PR TITLE
[processor/filter] Add TylerHelmuth as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,7 +123,7 @@ pkg/experimentalmetricmetadata/                      @open-telemetry/collector-c
 processor/attributesprocessor/                       @open-telemetry/collector-contrib-approvers @boostchicken
 processor/cumulativetodeltaprocessor/                @open-telemetry/collector-contrib-approvers @TylerHelmuth
 processor/deltatorateprocessor/                      @open-telemetry/collector-contrib-approvers @Aneurysm9
-processor/filterprocessor/                           @open-telemetry/collector-contrib-approvers @boostchicken
+processor/filterprocessor/                           @open-telemetry/collector-contrib-approvers @boostchicken @TylerHelmuth
 processor/groupbyattrsprocessor/                     @open-telemetry/collector-contrib-approvers
 processor/groupbytraceprocessor/                     @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/k8sattributesprocessor/                    @open-telemetry/collector-contrib-approvers @owais @dmitryax

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,7 +123,7 @@ pkg/experimentalmetricmetadata/                      @open-telemetry/collector-c
 processor/attributesprocessor/                       @open-telemetry/collector-contrib-approvers @boostchicken
 processor/cumulativetodeltaprocessor/                @open-telemetry/collector-contrib-approvers @TylerHelmuth
 processor/deltatorateprocessor/                      @open-telemetry/collector-contrib-approvers @Aneurysm9
-processor/filterprocessor/                           @open-telemetry/collector-contrib-approvers @boostchicken @TylerHelmuth
+processor/filterprocessor/                           @open-telemetry/collector-contrib-approvers @TylerHelmuth @boostchicken
 processor/groupbyattrsprocessor/                     @open-telemetry/collector-contrib-approvers
 processor/groupbytraceprocessor/                     @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/k8sattributesprocessor/                    @open-telemetry/collector-contrib-approvers @owais @dmitryax


### PR DESCRIPTION
With the recent addition of OTTL to the filterprocessor as a solution for dropping telemetry in the collector, I'd like to be a code owner of the filterprocessor to ensure continued support.