### PR TITLE
Remove verbosity flag from tests

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -3,10 +3,10 @@ SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
-GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
+GOTEST_OPT?= -race -timeout 300s --tags=$(GO_BUILD_TAGS)
 GOTEST_INTEGRATION_OPT?= -race -timeout 360s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
-GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
+GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go
 GOTEST=$(GOCMD) test
 GOOS=$(shell $(GOCMD) env GOOS)


### PR DESCRIPTION
Withoug this, logs and test names are printed only for failing tests. This change improved at least 2x for me the tests on "OTHER" group.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
