### PR TITLE
[mdatagen] Make data point attributes `type` to be a required field

### DIFF
--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -52,15 +52,13 @@ func (mn attributeName) RenderUnexported() (string, error) {
 
 // ValueType defines an attribute value type.
 type ValueType struct {
-	// ValueType is type of the metric number, options are "double", "int".
-	ValueType pcommon.ValueType
+	// ValueType is type of the attribute value.
+	ValueType pcommon.ValueType `validate:"required,notblank"`
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (mvt *ValueType) UnmarshalText(text []byte) error {
 	switch vtStr := string(text); vtStr {
-	case "":
-		mvt.ValueType = pcommon.ValueTypeEmpty
 	case "string":
 		mvt.ValueType = pcommon.ValueTypeStr
 	case "int":
@@ -147,7 +145,7 @@ type attribute struct {
 	// Enum can optionally describe the set of values to which the attribute can belong.
 	Enum []string
 	// Type is an attribute type.
-	Type ValueType `mapstructure:"type"`
+	Type ValueType `mapstructure:"type" validate:"dive"`
 }
 
 type metadata struct {

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -41,13 +41,24 @@ func Test_loadMetadata(t *testing.T) {
 						Description: "Attribute with a known set of values.",
 						Value:       "",
 						Enum:        []string{"red", "green", "blue"},
+						Type: ValueType{
+							ValueType: pcommon.ValueTypeStr,
+						},
 					},
 					"freeFormAttribute": {
 						Description: "Attribute that can take on any value.",
-						Value:       ""},
+						Value:       "",
+						Type: ValueType{
+							ValueType: pcommon.ValueTypeStr,
+						},
+					},
 					"freeFormAttributeWithValue": {
 						Description: "Attribute that has alternate value set.",
-						Value:       "state"},
+						Value:       "state",
+						Type: ValueType{
+							ValueType: pcommon.ValueTypeStr,
+						},
+					},
 					"booleanValueType": {
 						Description: "Attribute with a boolean value.",
 						Value:       "0",

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -29,12 +29,14 @@ attributes:
   cpu_type:
     value: type
     description: The type of CPU consumption
+    type: string
     enum:
     - user
     - io_wait
     - system
   host:
     description: The type of CPU consumption
+    type: string
 metrics:
   system.cpu.time:
     enabled: true

--- a/cmd/mdatagen/metric-metadata.yaml
+++ b/cmd/mdatagen/metric-metadata.yaml
@@ -10,7 +10,7 @@ resource_attributes:
   <attribute.name>:
     # Required: description of the attribute.
     description:
-    # Required: attribute type.
+    # Required: attribute value type.
     type: <string|int|double|bool|bytes>
 
 # Optional: map of attribute definitions with the key being the attribute name and value
@@ -24,7 +24,7 @@ attributes:
     description:
     # Optional: array of attribute values if they are static values.
     enum:
-    # Optional: attribute type. Default: string.
+    # Required: attribute value type.
     type: <string|int|double|bool|bytes>
 
 # Required: map of metric names with the key being the metric name and value

--- a/cmd/mdatagen/metrics.tmpl
+++ b/cmd/mdatagen/metrics.tmpl
@@ -117,7 +117,7 @@ func (m *metric{{ $name.Render }}) init() {
 }
 
 func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val {{ $metric.Data.MetricValueType.BasicType }}
-{{- range $metric.Attributes -}}, {{ .RenderUnexported }}AttributeValue {{ if (attributeInfo .).Type.ValueType }} {{ (attributeInfo .).Type.Primitive }}{{ else }}string{{ end }}{{ end }}) {
+{{- range $metric.Attributes -}}, {{ .RenderUnexported }}AttributeValue {{ (attributeInfo .).Type.Primitive }}{{ end }}) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -126,16 +126,10 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetTimestamp(ts)
 	dp.Set{{ $metric.Data.MetricValueType }}Value(val)
 	{{- range $metric.Attributes }}
-	{{- if eq (attributeInfo .).Type.Primitive "bool" }}
-	dp.Attributes().PutBool("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
-	{{- else if eq (attributeInfo .).Type.Primitive "int64" }}
-	dp.Attributes().PutInt("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
-	{{- else if eq (attributeInfo .).Type.Primitive "float64" }}
-	dp.Attributes().PutDouble("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
-	{{- else if eq (attributeInfo .).Type.Primitive "[]byte" }}
+	{{- if eq (attributeInfo .).Type.Primitive "[]byte" }}
 	dp.Attributes().PutEmptyBytes("{{ attributeKey .}}").FromRaw({{ .RenderUnexported }}AttributeValue)
 	{{- else }}
-	dp.Attributes().PutStr("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
+	dp.Attributes().Put{{ (attributeInfo .).Type }}("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
 	{{- end }}
 	{{- end }}
 }
@@ -222,10 +216,10 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // With{{ $name.Render }} sets provided value as "{{ $name }}" attribute for current resource.
 func With{{ $name.Render }}(val {{ $attr.Type.Primitive }}) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
-		{{- if eq $attr.Type.Primitive "string" }}
-		rm.Resource().Attributes().PutStr("{{ $name }}", val)
+		{{- if eq $attr.Type.Primitive "[]byte" }}
+		rm.Resource().Attributes().PutEmptyBytes("{{ attributeKey $name}}").FromRaw(val)
 		{{- else }}
-		rm.Resource().Attributes().Put{{ $attr.Type }}("{{ $name }}", val)
+		rm.Resource().Attributes().Put{{ $attr.Type }}("{{ attributeKey $name}}", val)
 		{{- end }}
 	}
 }
@@ -295,7 +289,7 @@ func (mb *MetricsBuilder) Record{{ $name.Render }}DataPoint(ts pcommon.Timestamp
 	{{- else }}, val {{ $metric.Data.MetricValueType.BasicType }}
 	{{- end }}
 	{{- range $metric.Attributes -}}
-	, {{ .RenderUnexported }}AttributeValue {{ if (attributeInfo .).Enum }}Attribute{{ .Render }}{{ else }}{{ if (attributeInfo .).Type.ValueType }} {{ (attributeInfo .).Type.Primitive }}{{ else }}string{{ end }}{{ end }}
+	, {{ .RenderUnexported }}AttributeValue {{ if (attributeInfo .).Enum }}Attribute{{ .Render }}{{ else }}{{ (attributeInfo .).Type.Primitive }}{{ end }}
 	{{- end }})
 	{{- if $metric.Data.HasMetricInputType }} error{{ end }} {
 	{{- if $metric.Data.HasMetricInputType }}

--- a/cmd/mdatagen/testdata/all_options.yaml
+++ b/cmd/mdatagen/testdata/all_options.yaml
@@ -1,15 +1,20 @@
 name: metricreceiver
+
 sem_conv_version: 1.9.0
+
 attributes:
   freeFormAttribute:
     description: Attribute that can take on any value.
+    type: string
 
   freeFormAttributeWithValue:
     value: state
     description: Attribute that has alternate value set.
+    type: string
 
   enumAttribute:
     description: Attribute with a known set of values.
+    type: string
     enum: [red, green, blue]
 
   booleanValueType:

--- a/receiver/activedirectorydsreceiver/metadata.yaml
+++ b/receiver/activedirectorydsreceiver/metadata.yaml
@@ -3,24 +3,28 @@ name: activedirectorydsreceiver
 attributes:
   direction:
     description: The direction of data flow.
+    type: string
     enum:
       - sent
       - received
   network_data_type:
     value: type
     description: The type of network data sent.
+    type: string
     enum:
       - compressed
       - uncompressed
   value_type:
     value: type
     description: The type of value sent.
+    type: string
     enum:
       - distingushed_names
       - other
   operation_type:
     value: type
     description: The type of operation.
+    type: string
     enum:
       - read
       - write
@@ -28,12 +32,14 @@ attributes:
   suboperation_type:
     value: type
     description: The type of suboperation.
+    type: string
     enum:
       - security_descriptor_propagations_event
       - search
   sync_result:
     value: result
     description: The result status of the sync request.
+    type: string
     enum:
       - success
       - schema_mismatch
@@ -41,6 +47,7 @@ attributes:
   bind_type:
     value: type
     description: The type of bind to the domain server.
+    type: string
     enum:
       - server
       - client

--- a/receiver/aerospikereceiver/metadata.yaml
+++ b/receiver/aerospikereceiver/metadata.yaml
@@ -12,6 +12,7 @@ attributes:
   namespace_component:
     value: component
     description: Individual component of a namespace
+    type: string
     enum:
       - data
       - index
@@ -20,6 +21,7 @@ attributes:
   scan_type:
     value: type
     description: Type of scan operation performed on a namespace
+    type: string
     enum:
       - aggregation
       - basic
@@ -28,6 +30,7 @@ attributes:
   scan_result:
     value: result
     description: Result of a scan operation performed on a namespace
+    type: string
     enum:
       - abort
       - complete
@@ -35,12 +38,14 @@ attributes:
   index_type:
     value: index
     description: Type of index the operation was performed on
+    type: string
     enum:
       - primary
       - secondary
   query_type:
     value: type
     description: Type of query operation performed on a namespace
+    type: string
     enum:
       - aggregation
       - basic
@@ -52,6 +57,7 @@ attributes:
   query_result:
     value: result
     description: Result of a query operation performed on a namespace
+    type: string
     enum:
       - abort
       - complete
@@ -60,6 +66,7 @@ attributes:
   transaction_type:
     value: type
     description: Type of transaction performed on a namespace
+    type: string
     enum:
       - delete
       - read
@@ -68,6 +75,7 @@ attributes:
   transaction_result:
     value: result
     description: Result of a transaction performed on a namespace
+    type: string
     enum:
       - error
       - filtered_out
@@ -77,6 +85,7 @@ attributes:
   connection_type:
     value: type
     description: Type of connection to an Aerospike node
+    type: string
     enum:
       - client
       - fabric
@@ -84,6 +93,7 @@ attributes:
   connection_op:
     value: operation
     description: Operation performed with a connection (open or close)
+    type: string
     enum:
       - close
       - open

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -12,24 +12,28 @@ attributes:
   workers_state:
     value: state
     description: The state of workers.
+    type: string
     enum:
       - busy
       - idle
   cpu_level:
     value: level
     description: Level of processes.
+    type: string
     enum:
       - self
       - children
   cpu_mode:
     value: mode
     description: Mode of processes.
+    type: string
     enum:
     - system
     - user
   scoreboard_state:
     value: state
     description: The state of a connection.
+    type: string
     enum:
       - open
       - waiting

--- a/receiver/bigipreceiver/metadata.yaml
+++ b/receiver/bigipreceiver/metadata.yaml
@@ -27,12 +27,14 @@ attributes:
   direction:
     value: direction
     description: The direction of data.
+    type: string
     enum:
       - sent
       - received
   availability.status:
     value: status
     description: The availability status.
+    type: string
     enum:
       - offline
       - unknown
@@ -40,15 +42,18 @@ attributes:
   enabled.status:
     value: status
     description: The enabled status.
+    type: string
     enum:
       - disabled
       - enabled
   active.status:
     value: status
     description: The active status.
+    type: string
     enum:
       - active
       - inactive
+
 metrics:
   bigip.virtual_server.data.transmitted:
     description: Amount of data transmitted to and from the virtual server.

--- a/receiver/couchdbreceiver/metadata.yaml
+++ b/receiver/couchdbreceiver/metadata.yaml
@@ -8,14 +8,18 @@ resource_attributes:
 attributes:
   http.method:
     description: An HTTP request method.
+    type: string
     enum: [ COPY, DELETE, GET, HEAD, OPTIONS, POST, PUT ]
   http.status_code:
     description: An HTTP status code.
+    type: string
   view:
     description: The view type.
+    type: string
     enum: [ temporary_view_reads, view_reads ]
   operation:
     description: The operation type.
+    type: string
     enum: [ writes, reads ]
 
 metrics:

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -14,35 +14,42 @@ resource_attributes:
 attributes:
   cache_name:
     description: The name of cache.
+    type: string
     enum:
     - fielddata
     - query
   fs_direction:
     value: direction
     description: The direction of filesystem IO.
+    type: string
     enum:
     - read
     - write
   collector_name:
     value: name
     description: The name of the garbage collector.
+    type: string
   memory_pool_name:
     value: name
     description: The name of the JVM memory pool.
+    type: string
   direction:
     description: The direction of network data.
+    type: string
     enum:
     - received
     - sent
   document_state:
     value: state
     description: The state of the document.
+    type: string
     enum:
     - active
     - deleted
   shard_state:
     value: state
     description: The state of the shard.
+    type: string
     enum:
     - active
     - active_primary
@@ -53,6 +60,7 @@ attributes:
   operation:
     value: operation
     description: The type of operation.
+    type: string
     enum:
     - index
     - delete
@@ -67,21 +75,25 @@ attributes:
     - warmer
   thread_pool_name:
     description: The name of the thread pool.
+    type: string
   thread_state:
     value: state
     description: The state of the thread.
+    type: string
     enum:
     - active
     - idle
   task_state:
     value: state
     description: The state of the task.
+    type: string
     enum:
     - rejected
     - completed
   health_status:
     value: status
     description: The health status of the cluster.
+    type: string
     enum:
     - green
     - yellow
@@ -89,33 +101,39 @@ attributes:
   circuit_breaker_name:
     value: name
     description: The name of circuit breaker.
+    type: string
   memory_state:
     value: state
     description: State of the memory
+    type: string
     enum:
       - free
       - used
   indexing_memory_state:
     value: state
     description: State of the indexing memory
+    type: string
     enum:
       - current
       - total
   cluster_published_difference_state:
     value: state
     description: State of the published differences
+    type: string
     enum:
       - incompatible
       - compatible
   cluster_state_queue_state:
     value: state
     description: State of the published differences
+    type: string
     enum:
       - pending
       - committed
   indexing_pressure_stage:
     value: stage
     description: Stage of the indexing pressure
+    type: string
     enum:
       - coordinating
       - primary
@@ -123,9 +141,11 @@ attributes:
   cluster_state_update_state:
     value: state
     description: State of cluster state update
+    type: string
   cluster_state_update_type:
     value: type
     description: Type of cluster state update
+    type: string
     enum:
       - computation
       - context_construction
@@ -136,21 +156,25 @@ attributes:
   ingest_pipeline_name:
     value: name
     description: Name of the ingest pipeline.
+    type: string
   query_cache_count_type:
     value: type
     description: Type of query cache count
+    type: string
     enum:
       - hit
       - miss
   index_aggregation_type:
     value: aggregation
     description: Type of shard aggregation for index statistics
+    type: string
     enum:
       - primary_shards
       - total
   segments_memory_object_type:
     value: object
     description: Type of object in segment
+    type: string
     enum:
       - term
       - doc_value
@@ -159,6 +183,7 @@ attributes:
   get_result:
     value: result
     description: Result of get operation
+    type: string
     enum:
       - hit
       - miss

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -5,9 +5,11 @@ sem_conv_version: 1.9.0
 attributes:
   cpu:
     description: CPU number starting at 0.
+    type: string
 
   state:
     description: Breakdown of CPU usage by type.
+    type: string
     enum: [idle, interrupt, nice, softirq, steal, system, user, wait]
 
 metrics:

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
@@ -5,9 +5,11 @@ sem_conv_version: 1.9.0
 attributes:
   device:
     description: Name of the disk.
+    type: string
 
   direction:
     description: Direction of flow of bytes/operations (read or write).
+    type: string
     enum: [read, write]
 
 metrics:

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -5,18 +5,23 @@ sem_conv_version: 1.9.0
 attributes:
   device:
     description: Identifier of the filesystem.
+    type: string
 
   mode:
     description: Mountpoint mode such "ro", "rw", etc.
+    type: string
 
   mountpoint:
     description: Mountpoint path.
+    type: string
 
   state:
     description: Breakdown of filesystem usage by type.
+    type: string
     enum: [free, reserved, used]
 
   type:
+    type: string
     description: Filesystem type, such as, "ext4", "tmpfs", etc.
 
 metrics:

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
@@ -2,8 +2,6 @@ name: hostmetricsreceiver/load
 
 sem_conv_version: 1.9.0
 
-attributes:
-
 metrics:
   system.cpu.load_average.1m:
     enabled: true

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -5,6 +5,7 @@ sem_conv_version: 1.9.0
 attributes:
   state:
     description: Breakdown of memory usage by type.
+    type: string
     enum: [buffered, cached, inactive, free, slab_reclaimable, slab_unreclaimable, used]
 
 metrics:

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -5,14 +5,18 @@ sem_conv_version: 1.9.0
 attributes:
   device:
     description: Name of the network interface.
+    type: string
   direction:
     description: Direction of flow of bytes/operations (receive or transmit).
+    type: string
     enum: [receive, transmit]
   protocol:
     description: Network protocol, e.g. TCP or UDP.
+    type: string
     enum: [tcp]
   state:
     description: State of the network connection.
+    type: string
 
 metrics:
   system.network.packets:

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -5,17 +5,21 @@ sem_conv_version: 1.9.0
 attributes:
   device:
     description: Name of the page file.
+    type: string
 
   direction:
     description: Page In or Page Out.
+    type: string
     enum: [page_in, page_out]
 
   state:
     description: Breakdown of paging usage by type.
+    type: string
     enum: [cached, free, used]
 
   type:
     description: Type of fault.
+    type: string
     enum: [major, minor]
 
 metrics:

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -5,6 +5,7 @@ sem_conv_version: 1.9.0
 attributes:
   status:
     description: Breakdown status of the processes.
+    type: string
     enum: [blocked, daemon, detached, idle, locked, orphan, paging, running, sleeping, stopped, system, unknown, zombies]
 
 metrics:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -41,20 +41,24 @@ resource_attributes:
 attributes:
   direction:
     description: Direction of flow of bytes (read or write).
+    type: string
     enum: [read, write]
 
   state:
     description: Breakdown of CPU usage by type.
+    type: string
     enum: [system, user, wait]
 
   paging_fault_type:
     value: type
     description: Type of memory paging fault.
+    type: string
     enum: [major, minor]
 
   context_switch_type:
     value: type
     description: Type of context switched.
+    type: string
     enum: [involuntary, voluntary]
 
 metrics:

--- a/receiver/iisreceiver/metadata.yaml
+++ b/receiver/iisreceiver/metadata.yaml
@@ -12,12 +12,14 @@ attributes:
   direction:
     value: direction
     description: The direction data is moving.
+    type: string
     enum:
       - sent
       - received
   request:
     value: request
     description: The type of request sent by a client.
+    type: string
     enum:
       - delete
       - get

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -3,11 +3,13 @@ name: kafkametricsreceiver
 attributes:
   topic:
     description: The ID (integer) of a topic
+    type: string
   partition:
     description: The number (integer) of the partition
     type: int
   group:
     description: The ID (string) of a consumer group
+    type: string
 
 metrics:
 #  brokers scraper

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -50,9 +50,11 @@ resource_attributes:
 attributes:
   interface:
     description: Name of the network interface.
+    type: string
 
   direction:
     description: Direction of flow of bytes/operations (receive or transmit).
+    type: string
     enum: [receive, transmit]
 
 metrics:

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -3,6 +3,7 @@ name: memcachedreceiver
 attributes:
   command:
     description: The type of command.
+    type: string
     enum:
     - get
     - set
@@ -10,22 +11,26 @@ attributes:
     - touch
   direction:
     description: Direction of data flow.
+    type: string
     enum:
     - sent
     - received
   type:
     description: Result of cache request.
+    type: string
     enum:
     - hit
     - miss
   operation:
     description: The type of operation.
+    type: string
     enum:
     - increment
     - decrement
     - get
   state:
     description: The type of CPU usage.
+    type: string
     enum:
     - system
     - user

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -28,9 +28,11 @@ resource_attributes:
   mongodb_atlas.disk.partition:
     description: Name of a disk partition
     type: string
+
 attributes:
   cpu_state:
     description: CPU state
+    type: string
     enum:
       - kernel
       - user
@@ -42,6 +44,7 @@ attributes:
       - steal
   assert_type:
     description: MongoDB assertion type
+    type: string
     enum:
       - regular
       - warning
@@ -49,44 +52,52 @@ attributes:
       - user
   cache_direction:
     description: Whether read into or written from
+    type: string
     enum:
       - read_into
       - written_from
   cache_status:
     description: Cache status
+    type: string
     enum:
       - dirty
       - used
   ticket_type:
     description: Type of ticket available
+    type: string
     enum:
       - available_reads
       - available_writes
   cursor_state:
     description: Whether cursor is open or timed out
+    type: string
     enum:
       - timed_out
       - open
   memory_issue_type:
     description: Type of memory issue encountered
+    type: string
     enum:
       - extra_info
       - global_accesses_not_in_memory
       - exceptions_thrown
   global_lock_state:
     description: Which queue is locked
+    type: string
     enum:
       - current_queue_total
       - current_queue_readers
       - current_queue_writers
   btree_counter_type:
     description: Database index effectiveness
+    type: string
     enum:
       - accesses
       - hits
       - misses
   memory_state:
     description: Memory usage type
+    type: string
     enum:
       - resident
       - virtual
@@ -97,11 +108,13 @@ attributes:
       - used
   direction:
     description: Network traffic direction
+    type: string
     enum:
       - receive
       - transmit
   storage_status:
     description: Views on database size
+    type: string
     enum:
       - total
       - data_size
@@ -109,6 +122,7 @@ attributes:
       - data_size_wo_system
   operation:
     description: Type of database operation
+    type: string
     enum:
       - cmd
       - query
@@ -119,11 +133,13 @@ attributes:
       - scan_and_order
   cluster_role:
     description: Whether process is acting as replica or primary
+    type: string
     enum:
       - primary
       - replica
   document_status:
     description: Status of documents in the database
+    type: string
     enum:
       - returned
       - inserted
@@ -131,28 +147,33 @@ attributes:
       - deleted
   execution_type:
     description: Type of command
+    type: string
     enum:
       - reads
       - writes
       - commands
   scanned_type:
     description: Objects or indexes scanned during query
+    type: string
     enum:
       - index_items
       - objects
   disk_direction:
     description: Measurement type for disk operation
+    type: string
     enum:
       - read
       - write
       - total
   disk_status:
     description: Disk measurement type
+    type: string
     enum:
       - free
       - used
   memory_status:
     description: Memory measurement type
+    type: string
     enum:
       - available
       - buffers
@@ -162,6 +183,7 @@ attributes:
       - used
   object_type:
     description: MongoDB object type
+    type: string
     enum:
       - collection
       - index
@@ -172,6 +194,7 @@ attributes:
       - data
   oplog_type:
     description: Oplog type
+    type: string
     enum:
       - slave_lag_master_time
       - master_time

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -8,16 +8,20 @@ resource_attributes:
 attributes:
   database:
     description: The name of a database.
+    type: string
   collection:
     description: The name of a collection.
+    type: string
   memory_type:
     value: type
     description: The type of memory used.
+    type: string
     enum:
       - resident
       - virtual
   operation:
     description: The MongoDB operation being counted.
+    type: string
     enum:
       - insert
       - query
@@ -28,17 +32,20 @@ attributes:
   connection_type:
     value: type
     description: The status of the connection.
+    type: string
     enum:
       - active
       - available
       - current
   type:
     description: The result of a cache request.
+    type: string
     enum:
       - hit
       - miss
   lock_type:
     description: The Resource over which the Lock controls access
+    type: string
     enum:
       - parallel_batch_write_mode
       - replication_state_transition
@@ -50,6 +57,7 @@ attributes:
       - oplog
   lock_mode:
     description: The mode of Lock which denotes the degree of access
+    type: string
     enum:
       - shared
       - exclusive

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -9,121 +9,152 @@ attributes:
   buffer_pool_pages:
     value: kind
     description: The buffer pool pages types.
+    type: string
     enum: [data, free, misc]
   buffer_pool_data:
     value: status
     description: The status of buffer pool data.
+    type: string
     enum: [dirty, clean]
   buffer_pool_operations:
     value: operation
     description: The buffer pool operations types.
+    type: string
     enum: [read_ahead_rnd, read_ahead, read_ahead_evicted, read_requests, reads, wait_free, write_requests]
   command:
     value: command
     description: The command types.
+    type: string
     enum: [execute, close, fetch, prepare, reset, send_long_data]
   connection_error:
     value: error
     description: The connection error type.
+    type: string
     enum: [accept, internal, max_connections, peer_address, select, tcpwrap]
   handler:
     value: kind
     description: The handler types.
+    type: string
     enum: [commit, delete, discover, external_lock, mrr_init, prepare, read_first, read_key, read_last, read_next, read_prev, read_rnd, read_rnd_next, rollback, savepoint, savepoint_rollback, update, write]
   double_writes:
     value: kind
     description: The doublewrite types.
+    type: string
     enum: [pages_written, writes]
   log_operations:
     value: operation
     description: The log operation types.
+    type: string
     enum: [waits, write_requests, writes]
   operations:
     value: operation
     description: The operation types.
+    type: string
     enum: [fsyncs, reads, writes]
   page_operations:
     value: operation
     description: The page operation types.
+    type: string
     enum: [created, read, written]
   row_locks:
     value: kind
     description: The row lock type.
+    type: string
     enum: [waits, time]
   row_operations:
     value: operation
     description: The row operation type.
+    type: string
     enum: [deleted, inserted, read, updated]
   locks:
     value: kind
     description: The table locks type.
+    type: string
     enum: [immediate, waited]
   sorts:
     value: kind
     description: The sort count type.
+    type: string
     enum: [merge_passes, range, rows, scan]
   threads:
     value: kind
     description: The thread count type.
+    type: string
     enum: [cached, connected, created, running]
   schema:
     value: schema
     description: The schema of the object.
+    type: string
   io_waits_operations:
     value: operation
     description: The io_waits operation type.
+    type: string
     enum: [delete, fetch, insert, update]
   table_name:
     value: table
+    type: string
     description: Table name for event or process.
   index_name:
     value: index
+    type: string
     description: The name of the index.
   direction:
     value: kind
     description: The name of the transmission direction.
+    type: string
     enum: [received, sent]
   digest:
     value: digest
     description: Digest.
+    type: string
   digest_text:
     value: digest_text
     description: Text before digestion.
+    type: string
   event_state:
     value: kind
     description: Possible event states.
+    type: string
     enum: [errors, warnings, rows_affected, rows_sent, rows_examined, created_tmp_disk_tables, created_tmp_tables, sort_merge_passes, sort_rows, no_index_used]
   opened_resources:
     value: kind
     description: The kind of the resource.
+    type: string
     enum: [file, table_definition, table]
   join_kind:
     value: kind
     description: The kind of join.
+    type: string
     enum: [full, full_range, range, range_check, scan]
   read_lock_type:
     value: kind
     description: Read operation types.
+    type: string
     enum: [normal, with_shared_locks, high_priority, no_insert, external]
   write_lock_type:
     value: kind
     description: Write operation types.
+    type: string
     enum: [allow_write, concurrent_insert, low_priority, normal, external]
   tmp_resource:
     value: resource
     description: The kind of temporary resources.
+    type: string
     enum: [disk_tables, files, tables]
   mysqlx_threads:
     value: kind
     description: The worker thread count kind.
+    type: string
     enum: [available, active]
   connection_status:
     value: status
     description: The connection status.
+    type: string
     enum: [accepted, closed, rejected]
   cache_status:
     value: status
     description: The status of cache access.
+    type: string
     enum: [hit, miss, overflow]
 
 metrics:

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -3,6 +3,7 @@ name: nginxreceiver
 attributes:
   state:
     description: The state of a connection
+    type: string
     enum:
     - active
     - reading

--- a/receiver/nsxtreceiver/metadata.yaml
+++ b/receiver/nsxtreceiver/metadata.yaml
@@ -22,24 +22,28 @@ attributes:
   direction:
     value: direction
     description: The direction of network flow.
+    type: string
     enum:
       - received
       - transmitted
   disk_state:
     value: state
     description: The state of storage space.
+    type: string
     enum:
       - used
       - available
   packet.type:
     value: type
     description: The type of packet counter.
+    type: string
     enum:
       - dropped
       - errored
       - success
   class:
     description: The CPU usage of the architecture allocated for either DPDK (datapath) or non-DPDK (services) processes.
+    type: string
     enum:
       - datapath
       - services

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -1,8 +1,10 @@
 name: oracledbreceiver
+
 resource_attributes:
   oracledb.instance.name:
     description: The name of the instance that data is coming from.
     type: string
+
 attributes:
   session_status:
     description: Session status
@@ -12,6 +14,8 @@ attributes:
     type: string
   tablespace_name:
     description: Tablespace name
+    type: string
+
 metrics:
   oracledb.cpu_time:
     description: Cumulative CPU time, in seconds

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -14,6 +14,7 @@ resource_attributes:
 attributes:
   bg_buffer_source:
     description: The source of a buffer write.
+    type: string
     enum:
       - backend
       - backend_fsync
@@ -22,12 +23,14 @@ attributes:
     value: source
   bg_checkpoint_type:
     description: The type of checkpoint state.
+    type: string
     enum:
       - requested
       - scheduled
     value: type
   bg_duration_type:
     description: The type of time spent during the checkpoint.
+    type: string
     enum:
       - sync
       - write
@@ -40,6 +43,7 @@ attributes:
     type: string
   source:
     description: The block read source type.
+    type: string
     enum:
       - heap_read
       - heap_hit
@@ -51,12 +55,14 @@ attributes:
       - tidx_hit
   operation:
     description: The database operation.
+    type: string
     enum: [ins, upd, del, hot_upd]
   replication_client:
     description: The IP address of the client connected to this backend. If this field is "unix", it indicates either that the client is connected via a Unix socket.
     type: string
   state:
     description: The tuple (row) state.
+    type: string
     enum: [dead, live]
   wal_operation_lag:
     value: operation

--- a/receiver/rabbitmqreceiver/metadata.yaml
+++ b/receiver/rabbitmqreceiver/metadata.yaml
@@ -15,6 +15,7 @@ attributes:
   message.state:
     value: state
     description: The state of messages in a queue.
+    type: string
     enum:
       - ready
       - unacknowledged

--- a/receiver/redisreceiver/metadata.yaml
+++ b/receiver/redisreceiver/metadata.yaml
@@ -8,6 +8,7 @@ resource_attributes:
 attributes:
   state:
     description: Redis CPU usage state
+    type: string
     # Redis versions < 6.0 have:
     #   used_cpu_sys: System CPU consumed by the Redis server, which is the sum of system CPU consumed by all threads of the server process (main thread and background threads)
     #   used_cpu_user: User CPU consumed by the Redis server, which is the sum of user CPU consumed by all threads of the server process (main thread and background threads)
@@ -25,13 +26,16 @@ attributes:
       - user_main_thread 
   db:
     description: Redis database identifier
+    type: string
   role:
     description: Redis node's role
+    type: string
     enum:
       - replica
       - primary
   cmd:
     description: Redis command name
+    type: string
 
 metrics:
   redis.maxmemory:

--- a/receiver/riakreceiver/metadata.yaml
+++ b/receiver/riakreceiver/metadata.yaml
@@ -8,11 +8,13 @@ resource_attributes:
 attributes:
   request:
     description: The request operation type.
+    type: string
     enum:
       - put
       - get
   operation:
     description: The operation type for index operations.
+    type: string
     enum:
       - read
       - write

--- a/receiver/saphanareceiver/metadata.yaml
+++ b/receiver/saphanareceiver/metadata.yaml
@@ -10,35 +10,48 @@ resource_attributes:
 attributes:
   database:
     description: The SAP HANA database.
+    type: string
   system:
     description: The SAP HANA system.
+    type: string
   product:
     description: The SAP HANA product.
+    type: string
   primary_host:
     value: primary
     description: The primary SAP HANA host in replication.
+    type: string
   secondary_host:
     value: secondary
     description: The secondary SAP HANA host in replication.
+    type: string
   port:
     description: The SAP HANA port.
+    type: string
   replication_mode:
     value: mode
     description: The replication mode.
+    type: string
   component:
     description: The SAP HANA component.
+    type: string
   schema:
     description: The SAP HANA schema.
+    type: string
   service:
     description: The SAP HANA service.
+    type: string
   path:
     description: The SAP HANA disk path.
+    type: string
   disk_usage_type:
     value: usage_type
     description: The SAP HANA disk & volume usage type.
+    type: string
   transaction_type:
     value: type
     description: The transaction type.
+    type: string
     enum:
     - update
     - commit
@@ -46,6 +59,7 @@ attributes:
   connection_status:
     value: status
     description: The connection status.
+    type: string
     enum:
     - running
     - idle
@@ -53,6 +67,7 @@ attributes:
   cpu_type:
     value: type
     description: The type of cpu.
+    type: string
     enum:
     - user
     - system
@@ -61,15 +76,18 @@ attributes:
   alert_rating:
     value: rating
     description: The alert rating.
+    type: string
   column_memory_type:
     value: type
     description: The type of column store memory.
+    type: string
     enum:
     - main
     - delta
   column_memory_subtype:
     value: subtype
     description: The subtype of column store memory.
+    type: string
     enum:
     - data
     - dict
@@ -78,12 +96,14 @@ attributes:
   row_memory_type:
     value: type
     description: The type of row store memory.
+    type: string
     enum:
     - fixed
     - variable
   schema_memory_type:
     value: type
     description: The type of schema memory.
+    type: string
     enum:
     - main
     - delta
@@ -92,6 +112,7 @@ attributes:
   schema_record_type:
     value: type
     description: The type of schema record.
+    type: string
     enum:
     - main
     - delta
@@ -100,24 +121,28 @@ attributes:
   memory_state_used_free:
     value: state
     description: The state of memory.
+    type: string
     enum:
     - used
     - free
   disk_state_used_free:
     value: state
     description: The state of the disk storage.
+    type: string
     enum:
     - used
     - free
   host_swap_state:
     value: state
     description: The state of swap data.
+    type: string
     enum:
     - used
     - free
   schema_operation_type:
     value: type
     description: The type of operation.
+    type: string
     enum:
     - read
     - write
@@ -125,36 +150,42 @@ attributes:
   service_status:
     value: status
     description: The status of services.
+    type: string
     enum:
     - active
     - inactive
   thread_status:
     value: status
     description: The status of threads.
+    type: string
     enum:
     - active
     - inactive
   service_memory_used_type:
     value: type
     description: The type of service memory.
+    type: string
     enum:
     - logical
     - physical
   volume_operation_type:
     value: type
     description: The type of operation.
+    type: string
     enum:
     - read
     - write
   active_pending_request_state:
     value: state
     description: The state of network request.
+    type: string
     enum:
     - active
     - pending
   internal_external_request_type:
     value: type
     description: The type of network request.
+    type: string
     enum:
     - internal
     - external

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -9,6 +9,7 @@ attributes:
   page.operations:
     value: type
     description: The page operation types.
+    type: string
     enum: [read, write]
 
 metrics:

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -40,12 +40,14 @@ attributes:
   disk_direction:
     value: direction
     description: The direction of disk latency.
+    type: string
     enum:
       - read
       - write
   latency_type:
     value: type
     description: The type of disk latency being reported.
+    type: string
     enum:
       - kernel
       - device

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -11,11 +11,13 @@ resource_attributes:
 attributes:
   state:
     description: State of followers
+    type: string
     enum:
       - synced
       - unsynced
   direction:
     description: State of a packet based on io direction.
+    type: string
     enum:
       - received
       - sent


### PR DESCRIPTION
This is done for consistency, the same `type` field is required for resource attributes.

For all other metadata.yaml fields only zero-values used when values is not provided. I don't think we should make the exception for string type attributes even if it's the most commonly used attribute type. It's not a lot of repetitive lines to add for a new receiver. I would rather keep it explicit but I'm have to hear other opinions on this.
