### PR TITLE
Add Foresight Github actions to collect detailed workflow metrics and test results

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -35,6 +35,11 @@ jobs:
     runs-on: windows-latest
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - if: matrix.group == 'receiver-0'
@@ -56,7 +61,16 @@ jobs:
             ~\AppData\Local\go-build
           key: go-build-cache-${{ runner.os }}-${{ matrix.group }}-go-${{ hashFiles('**/go.sum') }}
       - name: Run Unit tests
-        run: make -j2 gotest GROUP=${{ matrix.group }}
+        run: make -j2 gotest GROUP=${{ matrix.group }}      
+      - name: Analyze Test and/or Coverage Results
+        if: always()
+        uses: runforesight/foresight-test-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          test_framework: golang
+          test_format: json
+          test_path: |
+            ./**/foresight-test*.json
   windows-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
     runs-on: windows-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -75,6 +80,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -122,6 +132,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -180,6 +195,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -207,6 +227,15 @@ jobs:
           key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
         run: make gotest GROUP=${{ matrix.group }}
+      - name: Analyze Test and/or Coverage Results
+        if: always()
+        uses: runforesight/foresight-test-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          test_framework: golang
+          test_format: json
+          test_path: |
+            ./**/foresight-test*.json
   unittest:
     if: ${{ always() }}
     strategy:
@@ -231,6 +260,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -247,11 +281,28 @@ jobs:
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Run Integration Tests
         run: make integration-tests-with-cover
+      - name: Analyze Test and/or Coverage Results
+        if: always()
+        uses: runforesight/foresight-test-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          test_framework: golang
+          test_format: json
+          test_path: |
+            ./**/foresight-test-report-integration*.json
+          coverage_format: golang
+          coverage_path: |
+            ./**/integration-coverage.txt
 
   correctness-traces:
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -274,10 +325,24 @@ jobs:
         run: make install-tools
       - name: Correctness
         run: make -C testbed run-correctness-traces-tests
+      - name: Analyze Test and/or Coverage Results
+        if: always()
+        uses: runforesight/foresight-test-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          test_framework: golang
+          test_format: json
+          test_path: |
+            ./**/foresight-test*.json
   correctness-metrics:
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -300,11 +365,25 @@ jobs:
         run: make install-tools
       - name: Correctness
         run: make -C testbed run-correctness-metrics-tests
+      - name: Analyze Test and/or Coverage Results
+        if: always()
+        uses: runforesight/foresight-test-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          test_framework: golang
+          test_format: json
+          test_path: |
+            ./**/foresight-test*.json
 
   build-examples:
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Build Examples
@@ -339,6 +418,11 @@ jobs:
           - os: windows
             arch: ppc64le
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -376,6 +460,11 @@ jobs:
       matrix:
         package_type: ["deb", "rpm"]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
@@ -418,6 +507,11 @@ jobs:
     runs-on: windows-latest
     needs: [cross-compile]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
@@ -454,6 +548,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-package]
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Download Binaries
@@ -473,6 +572,11 @@ jobs:
     needs: [lint, unittest, integration-tests, build-package]
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -538,6 +642,11 @@ jobs:
     needs: [lint, unittest, integration-tests, build-package]
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,12 @@ jobs:
       CODEQL_EXTRACTOR_GO_BUILD_TRACING: 'on'
 
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -23,6 +23,11 @@ jobs:
     outputs:
       loadtest_matrix: ${{ steps.splitloadtest.outputs.loadtest_matrix }}
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -61,6 +66,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup-environment.outputs.loadtest_matrix) }}
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - run: sudo chmod 0777 -R /opt
@@ -119,6 +129,15 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: ./*.tar
+      - name: Analyze Test and/or Coverage Results
+        if: always()
+        uses: runforesight/foresight-test-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          test_framework: JUNIT
+          test_format: JUNIT
+          test_path: |
+            ./testbed/tests/results/junit/*.xml
       - name: GitHub Issue Generator
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         run: issuegenerator $TEST_RESULTS

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
@@ -48,5 +53,14 @@ jobs:
       - name: Copy binary to compliance directory
         run: mkdir compliance/remote_write_sender/bin && cp opentelemetry-collector-contrib/bin/otelcontribcol_linux_amd64 compliance/remote_write_sender/bin/otelcol_linux_amd64
       - name: Run compliance tests
-        run: go test --tags=compliance -run "TestRemoteWrite/otel/.+" -v ./
+        run: go test -v -json --tags=compliance -run "TestRemoteWrite/otel/.+" ./ > ./test-report.json
         working-directory: compliance/remote_write_sender
+      - name: Analyze Test and/or Coverage Results
+        if: always()
+        uses: runforesight/foresight-test-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          working_directory: compliance/remote_write_sender
+          test_framework: golang
+          test_format: json
+          test_path: ./test-report.json

--- a/.github/workflows/tracegen.yml
+++ b/.github/workflows/tracegen.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Build tracegen
@@ -30,6 +35,11 @@ jobs:
     permissions:
       packages: write
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Login to GitHub Container Registry
@@ -51,6 +61,11 @@ jobs:
     permissions:
       packages: write
     steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Set Release Tag

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -19,6 +19,7 @@ LINT=golangci-lint
 IMPI=impi
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
+RUNNING_ON_GITHUB_ACTION=$(GITHUB_ACTIONS)
 
 ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | sort)
 
@@ -54,18 +55,30 @@ common: checklicense impi lint misspell
 
 .PHONY: test
 test:
-	$(GOTEST) $(GOTEST_OPT) ./...
-
+	if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
+		$(GOTEST) $(GOTEST_OPT) ./... -json > ./foresight-test-report.json; \
+	else \
+		$(GOTEST) $(GOTEST_OPT) ./...; \
+	fi
+	
 .PHONY: do-unit-tests-with-cover
 do-unit-tests-with-cover:
 	@echo "running $(GOCMD) unit test ./... + coverage in `pwd`"
-	@$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./...
+	@if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
+		$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./... -json > ./foresight-test-report-unit-tests-with-cover.json; \
+	else \
+		$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./...; \
+	fi
 	$(GOCMD) tool cover -html=coverage.txt -o coverage.html
 
 .PHONY: do-integration-tests-with-cover
 do-integration-tests-with-cover:
 	@echo "running $(GOCMD) integration test ./... + coverage in `pwd`"
-	@$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) ./...
+	@if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
+		$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) ./... -json > ./foresight-test-report-integration-tests-with-cover.json; \
+	else \
+		$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) ./...; \
+	fi
 	@if [ -e integration-coverage.txt ]; then \
   		$(GOCMD) tool cover -html=integration-coverage.txt -o integration-coverage.html; \
   	fi

--- a/testbed/runtests.sh
+++ b/testbed/runtests.sh
@@ -14,7 +14,7 @@ TEST_COLORIZE="${SED} 's/PASS/${PASS_COLOR}/' | ${SED} 's/FAIL/${FAIL_COLOR}/'"
 
 mkdir -p results/junit
 
-RUN_TESTBED=1 go test -v ${TEST_ARGS} 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}"
+RUN_TESTBED=1 go test -v ${TEST_ARGS} 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}" -json > ./foresight-test-report.json
 
 testStatus=${PIPESTATUS[0]}
 


### PR DESCRIPTION
Hi Otel community,

Thanks for using Foresight to monitor your Github actions. 

Currently OTEL Foresight public view is open to everyone here: [otel.app.runforesight.com](https://otel.app.runforesight.com/)

**Description:**
This PR adds Foresight **workflow-kit** and **test-kit** Github actions into workflows to collect detailed workflow metrics (process traces, CPU/Memory/IO metrics) and test results.
