### PR TITLE
[processor/k8sattributes] assume current container if restart_count i…

### DIFF
--- a/.chloggen/k8sattributesprocessor-containerid-default.yaml
+++ b/.chloggen/k8sattributesprocessor-containerid-default.yaml
@@ -1,0 +1,4 @@
+change_type: breaking
+component: k8sattributesprocessor
+note: Remove `container.id` as default metadata given possible ambiguity matching a container run to a container ID
+issues: [16432]

--- a/.chloggen/k8sattributesprocessor-containerid.yaml
+++ b/.chloggen/k8sattributesprocessor-containerid.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: k8sattributesprocessor
+note: Default `container.id` to latest instance unless `k8s.container.restart_count` is specified
+issues: [16432]

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -88,7 +88,6 @@ type ExtractConfig struct {
 	//  - k8s.deployment.name (if the pod is controlled by a deployment)
 	//  - container.image.name (requires an additional attribute to be set: k8s.container.name)
 	//  - container.image.tag (requires an additional attribute to be set: k8s.container.name)
-	//  - container.id (requires additional attributes to be set: k8s.container.name, k8s.container.restart_count)
 	Metadata []string `mapstructure:"metadata"`
 
 	// Annotations allows extracting data from pod annotations and record it

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -67,9 +67,9 @@
 //     as a resource attribute (similar to all other attributes, pod has to be identified as well):
 //     - container.image.name
 //     - container.image.tag
-//  2. Container status attributes - in addition to pod identifier and `k8s.container.name` attribute, these attributes
-//     require identifier of a particular container run set as `k8s.container.restart_count` in resource attributes:
-//     - container.id
+//  2. Container ID attribute - in addition to pod identifier and `k8s.container.name` attribute, `container.id` must
+//     be explicitly requested in `metadata`. Specifying `k8s.container.restart_count` in the resource
+//     attributes will match only the specified container run; if omitted, the current instance is assumed.
 //
 // The k8sattributesprocessor can be used for automatic tagging of spans, metrics and logs with k8s labels and annotations from pods and namespaces.
 // The config for associating the data passing through the processor (spans, metrics and logs) with specific Pod/Namespace annotations/labels is configured via "annotations"  and "labels" keys.

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -79,7 +79,6 @@ func withExtractMetadata(fields ...string) option {
 				metadataPodStartTime,
 				conventions.AttributeK8SDeploymentName,
 				conventions.AttributeK8SNodeName,
-				conventions.AttributeContainerID,
 				conventions.AttributeContainerImageName,
 				conventions.AttributeContainerImageTag,
 			}

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -170,17 +170,28 @@ func (kp *kubernetesprocessor) addContainerAttributes(attrs pcommon.Map, pod *ku
 		}
 	}
 
+	runID := -1
 	runIDAttr, ok := attrs.Get(conventions.AttributeK8SContainerRestartCount)
 	if ok {
-		runID, err := intFromAttribute(runIDAttr)
-		if err == nil {
-			if containerStatus, ok := containerSpec.Statuses[runID]; ok && containerStatus.ContainerID != "" {
-				if _, found := attrs.Get(conventions.AttributeContainerID); !found {
-					attrs.PutStr(conventions.AttributeContainerID, containerStatus.ContainerID)
-				}
-			}
-		} else {
+		containerRunID, err := intFromAttribute(runIDAttr)
+		if err != nil {
 			kp.logger.Debug(err.Error())
+		} else {
+			runID = containerRunID
+		}
+	} else {
+		// take the highest runID (restart count) which represents the currently running container in most cases
+		for containerRunID := range containerSpec.Statuses {
+			if containerRunID > runID {
+				runID = containerRunID
+			}
+		}
+	}
+	if runID != -1 {
+		if containerStatus, ok := containerSpec.Statuses[runID]; ok && containerStatus.ContainerID != "" {
+			if _, found := attrs.Get(conventions.AttributeContainerID); !found {
+				attrs.PutStr(conventions.AttributeContainerID, containerStatus.ContainerID)
+			}
 		}
 	}
 }

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -811,6 +811,31 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 			},
 		},
 		{
+			name: "container-id-latest",
+			op: func(kp *kubernetesprocessor) {
+				kp.kc.(*fakeClient).Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")] = &kube.Pod{
+					Containers: map[string]*kube.Container{
+						"app": {
+							Statuses: map[int]kube.ContainerStatus{
+								0: {ContainerID: "fcd58c97330c1dc6615bd520031f6a703a7317cd92adc96013c4dd57daad0b5f"},
+								1: {ContainerID: "6a7f1a598b5dafec9c193f8f8d63f6e5839b8b0acd2fe780f94285e26c05580e"},
+								2: {ContainerID: "5ba4e0e5a5eb1f37bc6e7fc76495914400a3ee309d8828d16407e4b3d5410848"},
+							},
+						},
+					},
+				}
+			},
+			resourceGens: []generateResourceFunc{
+				withPassthroughIP("1.1.1.1"),
+				withContainerName("app"),
+			},
+			wantAttrs: map[string]string{
+				kube.K8sIPLabelName:                   "1.1.1.1",
+				conventions.AttributeK8SContainerName: "app",
+				conventions.AttributeContainerID:      "5ba4e0e5a5eb1f37bc6e7fc76495914400a3ee309d8828d16407e4b3d5410848",
+			},
+		},
+		{
 			name: "container-name-mismatch",
 			op: func(kp *kubernetesprocessor) {
 				kp.kc.(*fakeClient).Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")] = &kube.Pod{


### PR DESCRIPTION
Assume current instance of container when looking up `container.id` if `k8s.container.restart_count` isn't explicitly specified.

**Description:** <Describe what has changed.>
* check if `k8s.container.restart_count` is asserted
* if it is, only match container to specified restart_count
* if it is not, match container to currently running container

**Link to tracking Issue:** #16431

**Testing:**
* asserted `k8s.container.restart_count=0` and verified that code still matches only the first instance of the container
* did not assert `k8s.container.restart_count` and verified that code matches the currently running instance of container

**Documentation:**
* where would be the most helpful place to explain this behavior?