### PR TITLE
update action/setup-ruby to ruby/setup-ruby

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -380,7 +380,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
       - name: Install fpm


### PR DESCRIPTION
The former has been deprecated.
