### PR TITLE
[chore] Set GH actions runner to Ubuntu 20.04 for build-package job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -368,7 +368,8 @@ jobs:
           path: ./bin/*
 
   build-package:
-    runs-on: ubuntu-latest
+    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+    runs-on: ubuntu-20.04
     needs: [cross-compile]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Temporarily, to restore failing `build-package` jobs

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450
