### PR TITLE
Disable running windows tests unless Run Windows lebel set

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
 env:
   TEST_RESULTS: testbed/tests/results/junit/results.xml
   # See: https://github.com/actions/cache/issues/810#issuecomment-1222550359
@@ -28,7 +31,7 @@ jobs:
           - internal
           - other
     runs-on: windows-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'Run Windows') }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -53,7 +56,7 @@ jobs:
       - name: Run Unit tests
         run: make -j2 gotest GROUP=${{ matrix.group }}
   windows-unittest:
-    if: ${{ always() }}
+    if: ${{ github.actor != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'Run Windows') }}
     runs-on: windows-latest
     needs: [windows-unittest-matrix]
     steps:


### PR DESCRIPTION
Tests will still be run on main, so we will not release without them passing, but we don't run on each PR unless approver/maintainer believes they are needed (windows specific code is changed) then use "Run Windows" label

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
