### PR TITLE
[mdatagen] Add support of enum field in resource attributes

### DIFF
--- a/.chloggen/mdatagen-enum-resource-attrs.yaml
+++ b/.chloggen/mdatagen-enum-resource-attrs.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for `resource_attributes::enum` field
+
+# One or more tracking issues related to the change
+issues: [16464]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `resource_attributes::enum` values in metadata.yaml are now properly supported in metrics builder developer interface.

--- a/cmd/mdatagen/metrics.tmpl
+++ b/cmd/mdatagen/metrics.tmpl
@@ -213,6 +213,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 type ResourceMetricsOption func(pmetric.ResourceMetrics)
 
 {{- range $name, $attr := .ResourceAttributes }}
+{{- range $attr.Enum }}
+// With{{ $name.Render }}{{ . | publicVar }} sets "{{ $name }}={{ . }}" attribute for current resource.
+func With{{ $name.Render }}{{ . | publicVar }}(rm pmetric.ResourceMetrics) {
+	rm.Resource().Attributes().PutStr("{{ attributeKey $name}}", "{{ . }}")
+}
+{{- else }}
 // With{{ $name.Render }} sets provided value as "{{ $name }}" attribute for current resource.
 func With{{ $name.Render }}(val {{ $attr.Type.Primitive }}) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
@@ -223,6 +229,7 @@ func With{{ $name.Render }}(val {{ $attr.Type.Primitive }}) ResourceMetricsOptio
 		{{- end }}
 	}
 }
+{{- end }}
 {{ end }}
 
 // WithStartTimeOverride overrides start time for all the resource metrics data points.

--- a/cmd/mdatagen/metrics_test.tmpl
+++ b/cmd/mdatagen/metrics_test.tmpl
@@ -58,11 +58,12 @@ func TestAllMetrics(t *testing.T) {
 	{{- end }}
 
 	metrics := mb.Emit(
-	{{- $sep := "" }}
-	{{- range $name, $info := .ResourceAttributes -}}
-	{{ $sep }}With{{ $name.Render }}({{- if $info.Enum }}Attribute{{ $name.Render }}(1){{ else }}{{ $info.Type.TestValue }}{{ end }})
-	{{- $sep = ", " }}
-	{{- end -}}
+		{{- $sep := "" }}
+		{{- range $name, $info := .ResourceAttributes -}}
+			{{- $sep }}With{{ $name.Render }}
+			{{- if $info.Enum }}{{ index $info.Enum 0 | publicVar }}{{ else }}({{- $info.Type.TestValue }}){{ end }}
+			{{- $sep = ", " }}
+		{{- end -}}
 	)
 
 	assert.Equal(t, 1, metrics.ResourceMetrics().Len())
@@ -74,7 +75,7 @@ func TestAllMetrics(t *testing.T) {
 	attrVal, ok {{ $assignSign }} rm.Resource().Attributes().Get("{{ $name }}")
 	assert.True(t, ok)
 	{{- if $info.Enum }}
-	assert.Equal(t, Attribute{{ $name.Render }}(1).String(), attrVal.Str())
+	assert.Equal(t, "{{ index $info.Enum 0 }}", attrVal.Str())
 	{{- else }}
 	assert.EqualValues(t, {{ $info.Type.TestValue }}, attrVal.{{ $info.Type }}())
 	{{- end }}

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
@@ -1850,11 +1850,14 @@ func WithFlinkJobName(val string) ResourceMetricsOption {
 	}
 }
 
-// WithFlinkResourceType sets provided value as "flink.resource.type" attribute for current resource.
-func WithFlinkResourceType(val string) ResourceMetricsOption {
-	return func(rm pmetric.ResourceMetrics) {
-		rm.Resource().Attributes().PutStr("flink.resource.type", val)
-	}
+// WithFlinkResourceTypeJobmanager sets "flink.resource.type=jobmanager" attribute for current resource.
+func WithFlinkResourceTypeJobmanager(rm pmetric.ResourceMetrics) {
+	rm.Resource().Attributes().PutStr("flink.resource.type", "jobmanager")
+}
+
+// WithFlinkResourceTypeTaskmanager sets "flink.resource.type=taskmanager" attribute for current resource.
+func WithFlinkResourceTypeTaskmanager(rm pmetric.ResourceMetrics) {
+	rm.Resource().Attributes().PutStr("flink.resource.type", "taskmanager")
 }
 
 // WithFlinkSubtaskIndex sets provided value as "flink.subtask.index" attribute for current resource.

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics_test.go
@@ -186,7 +186,7 @@ func TestAllMetrics(t *testing.T) {
 	mb.RecordFlinkOperatorWatermarkOutputDataPoint(ts, "1", "attr-val")
 	mb.RecordFlinkTaskRecordCountDataPoint(ts, "1", AttributeRecord(1))
 
-	metrics := mb.Emit(WithFlinkJobName("attr-val"), WithFlinkResourceType("attr-val"), WithFlinkSubtaskIndex("attr-val"), WithFlinkTaskName("attr-val"), WithFlinkTaskmanagerID("attr-val"), WithHostName("attr-val"))
+	metrics := mb.Emit(WithFlinkJobName("attr-val"), WithFlinkResourceTypeJobmanager, WithFlinkSubtaskIndex("attr-val"), WithFlinkTaskName("attr-val"), WithFlinkTaskmanagerID("attr-val"), WithHostName("attr-val"))
 
 	assert.Equal(t, 1, metrics.ResourceMetrics().Len())
 	rm := metrics.ResourceMetrics().At(0)
@@ -198,7 +198,7 @@ func TestAllMetrics(t *testing.T) {
 	attrCount++
 	attrVal, ok = rm.Resource().Attributes().Get("flink.resource.type")
 	assert.True(t, ok)
-	assert.EqualValues(t, "attr-val", attrVal.Str())
+	assert.Equal(t, "jobmanager", attrVal.Str())
 	attrCount++
 	attrVal, ok = rm.Resource().Attributes().Get("flink.subtask.index")
 	assert.True(t, ok)

--- a/receiver/flinkmetricsreceiver/metadata.yaml
+++ b/receiver/flinkmetricsreceiver/metadata.yaml
@@ -20,8 +20,7 @@ resource_attributes:
   flink.resource.type:
     description: The flink scope type in which a metric belongs to.
     type: string
-    # TODO: Add enum support to resource attributes
-    # enum: [ jobmanager, taskmanager ]
+    enum: [ jobmanager, taskmanager ]
 
 attributes:
   operator_name:

--- a/receiver/flinkmetricsreceiver/process.go
+++ b/receiver/flinkmetricsreceiver/process.go
@@ -76,7 +76,7 @@ func (s *flinkmetricsScraper) processJobmanagerMetrics(now pcommon.Timestamp, jo
 	}
 	s.mb.EmitForResource(
 		metadata.WithHostName(jobmanagerMetrics.Host),
-		metadata.WithFlinkResourceType("jobmanager"),
+		metadata.WithFlinkResourceTypeJobmanager,
 	)
 }
 
@@ -135,7 +135,7 @@ func (s *flinkmetricsScraper) processTaskmanagerMetrics(now pcommon.Timestamp, t
 		s.mb.EmitForResource(
 			metadata.WithHostName(taskmanagerMetrics.Host),
 			metadata.WithFlinkTaskmanagerID(taskmanagerMetrics.TaskmanagerID),
-			metadata.WithFlinkResourceType("taskmanager"),
+			metadata.WithFlinkResourceTypeTaskmanager,
 		)
 	}
 }

--- a/receiver/nsxtreceiver/metadata.yaml
+++ b/receiver/nsxtreceiver/metadata.yaml
@@ -10,11 +10,6 @@ resource_attributes:
   nsxt.node.type:
     description: The type of NSX Node.
     type: string
-    # TODO: Add support for enum in resource attributes
-    # enum:
-    #   - manager
-    #   - host
-    #   - edge
   device.id:
     description: The name of the network interface.
     type: string


### PR DESCRIPTION
`resource_attributes::enum` values in metadata.yaml are now properly supported in metrics builder developer interface.