### PR TITLE
[receiver/apache]: change feature gates for server name and port resource attributes to beta

### DIFF
--- a/.chloggen/apache-server-port-feature-gates-beta.yaml
+++ b/.chloggen/apache-server-port-feature-gates-beta.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: apachereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: turn on by default feature gates for server name and port resource attributes
+
+# One or more tracking issues related to the change
+issues: [14791]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/apachereceiver/README.md
+++ b/receiver/apachereceiver/README.md
@@ -46,22 +46,22 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 See the [Collector feature gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md#collector-feature-gates) for an overview of feature gates in the collector.
 
-**ALPHA**: `receiver.apache.emitServerNameAsResourceAttribute`
+**BETA**: `receiver.apache.emitServerNameAsResourceAttribute`
 
 The feature gate `receiver.apache.emitServerNameAsResourceAttribute` once enabled starts emitting the metrics with a resource attribute `apache.server.name`. When the feature gate is disabled, the metrics are emitted with a `server_name` metric-level attribute instead.
 
 This is considered a breaking change for existing users of this receiver, and it is recommended to migrate to the new implementation when possible. Any new users planning to adopt this receiver should enable this feature gate to avoid having to migrate any visualisations or alerts.
 
-This feature gate will eventually be enabled by default, and eventually the old implementation will be removed. It aims
-to give users time to migrate to the new implementation. The target release for this featuregate to be enabled by default
-is 0.66.0.
+This feature gate is enabled by default, and eventually the old implementation will be removed. It aims
+to give users time to migrate to the new implementation. The target release for the old implementation to be removed
+is 0.69.0.
 
-**ALPHA**: `receiver.apache.emitPortAsResourceAttribute`
+**BETA**: `receiver.apache.emitPortAsResourceAttribute`
 
 The feature gate `receiver.apache.emitPortAsResourceAttribute` once enabled starts emitting the metrics with a resource attribute `apache.server.port`.
 
 This is considered a breaking change for existing users of this receiver, and it is recommended to migrate to the new implementation when possible. Any new users planning to adopt this receiver should enable this feature gate to avoid having to migrate any visualisations or alerts.
 
-This feature gate will eventually be enabled by default, and eventually the old implementation will be removed. It aims
-to give users time to migrate to the new implementation. The target release for this featuregate to be enabled by default
-is 0.66.0.
+This feature gate is enabled by default, and eventually the old implementation will be removed. It aims
+to give users time to migrate to the new implementation. The target release for the old implementation to be removed
+is 0.69.0.

--- a/receiver/apachereceiver/integration_test.go
+++ b/receiver/apachereceiver/integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest/golden"
@@ -53,6 +54,10 @@ func TestApacheIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(context.Background()))
 	}()
 	hostname, err := container.Host(context.Background())
+	require.NoError(t, err)
+
+	// Let this test check if it works with the features disabled and the unit test will test the feature enabled.
+	err = featuregate.GetRegistry().Apply(map[string]bool{EmitServerNameAsResourceAttribute: false, EmitPortAsResourceAttribute: false})
 	require.NoError(t, err)
 
 	f := NewFactory()

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -43,12 +43,12 @@ const (
 func init() {
 	featuregate.GetRegistry().MustRegisterID(
 		EmitServerNameAsResourceAttribute,
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("When enabled, the name of the server will be sent as an apache.server.name resource attribute instead of a metric-level server_name attribute."),
 	)
 	featuregate.GetRegistry().MustRegisterID(
 		EmitPortAsResourceAttribute,
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("When enabled, the port of the server will be sent as an apache.server.port resource attribute."),
 	)
 }

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -29,7 +29,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
-	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest/golden"
@@ -43,8 +42,6 @@ func TestScraper(t *testing.T) {
 	require.NoError(t, component.ValidateConfig(cfg))
 
 	// Let this test check if it works with the feature enabled and the integration test will test the feature disabled.
-	err := featuregate.GetRegistry().Apply(map[string]bool{EmitServerNameAsResourceAttribute: true, EmitPortAsResourceAttribute: true})
-	require.NoError(t, err)
 
 	serverName, port, err := parseResourseAttributes(cfg.Endpoint)
 	require.NoError(t, err)


### PR DESCRIPTION
**Description:** 
The feature gates in apachereceiver were supposed to be changed to Beta in `v0.66.0`, but because this version has been released earlier than expected, the change was not included in this version.

Does this need a changelog entry? Is this a breaking change in that case?

**Link to tracking Issue:** #14791

**Testing:** 
Unit and integration tests. Integration tests have this feature disabled.

**Documentation:** 
Readme has been updated.