### PR TITLE
exporter/datadogexporter: supress payload dump when logging at debug level

### DIFF
--- a/.chloggen/gbbr_dump_logs.yaml
+++ b/.chloggen/gbbr_dump_logs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Suppress logs exporter payload dump to avoid filelogreceiver escape loop"
+
+# One or more tracking issues related to the change
+issues: [16380]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -248,6 +248,9 @@ type LogsConfig struct {
 	// TCPAddr.Endpoint is the host of the Datadog intake server to send logs to.
 	// If unset, the value is obtained from the Site.
 	confignet.TCPAddr `mapstructure:",squash"`
+
+	// DumpPayloads report whether payloads should be dumped when logging level is debug.
+	DumpPayloads bool `mapstructure:"dump_payloads"`
 }
 
 // TagsConfig defines the tag-related configuration

--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -271,6 +271,17 @@ exporters:
       #
       # tags: []
 
+    ## @param logs - custom object - optional
+    ## Logs exporter specific configuration.
+    #
+    # logs:
+      ## @param dump_payloads - bool - optional
+      ## If set to true, payloads will be dumped when logging level is set to debug. Please note that
+      ## This may result in an escaping loop if a filelog receiver is watching the collector log output.
+      ## See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16380
+      #
+      # dump_payloads: false
+
 # `service` defines the Collector pipelines, observability settings and extensions.
 service:
   # `pipelines` defines the data pipelines. Multiple data pipelines for a type may be defined.

--- a/exporter/datadogexporter/internal/logs/sender.go
+++ b/exporter/datadogexporter/internal/logs/sender.go
@@ -29,9 +29,10 @@ import (
 
 // Sender submits logs to Datadog intake
 type Sender struct {
-	logger *zap.Logger
-	api    *datadogV2.LogsApi
-	opts   datadogV2.SubmitLogOptionalParameters
+	logger  *zap.Logger
+	api     *datadogV2.LogsApi
+	opts    datadogV2.SubmitLogOptionalParameters
+	verbose bool // reports whether payload contents should be dumped when logging at debug level
 }
 
 // logsV2 is the key in datadog ServerConfiguration
@@ -40,7 +41,7 @@ type Sender struct {
 const logsV2 = "v2.LogsApi.SubmitLog"
 
 // NewSender creates a new Sender
-func NewSender(endpoint string, logger *zap.Logger, s exporterhelper.TimeoutSettings, insecureSkipVerify bool, apiKey string) *Sender {
+func NewSender(endpoint string, logger *zap.Logger, s exporterhelper.TimeoutSettings, insecureSkipVerify, verbose bool, apiKey string) *Sender {
 	cfg := datadog.NewConfiguration()
 	logger.Info("Logs sender initialized", zap.String("endpoint", endpoint))
 	cfg.OperationServers[logsV2] = datadog.ServerConfigurations{
@@ -54,15 +55,20 @@ func NewSender(endpoint string, logger *zap.Logger, s exporterhelper.TimeoutSett
 	// enable sending gzip
 	opts := *datadogV2.NewSubmitLogOptionalParameters().WithContentEncoding(datadogV2.CONTENTENCODING_GZIP)
 	return &Sender{
-		api:    datadogV2.NewLogsApi(apiClient),
-		logger: logger,
-		opts:   opts,
+		api:     datadogV2.NewLogsApi(apiClient),
+		logger:  logger,
+		opts:    opts,
+		verbose: verbose,
 	}
 }
 
 // SubmitLogs submits the logs contained in payload to the Datadog intake
 func (s *Sender) SubmitLogs(ctx context.Context, payload []datadogV2.HTTPLogItem) error {
-	s.logger.Debug("Submitting logs", zap.Any("payload", payload))
+	var fields []zap.Field
+	if s.verbose {
+		fields = append(fields, zap.Any("payload", payload))
+	}
+	s.logger.Debug("Submitting logs", fields...)
 
 	// Correctly sets apiSubmitLogRequest ddtags field based on tags from translator Transform method
 	if payload[0].HasDdtags() {

--- a/exporter/datadogexporter/internal/logs/sender.go
+++ b/exporter/datadogexporter/internal/logs/sender.go
@@ -64,11 +64,9 @@ func NewSender(endpoint string, logger *zap.Logger, s exporterhelper.TimeoutSett
 
 // SubmitLogs submits the logs contained in payload to the Datadog intake
 func (s *Sender) SubmitLogs(ctx context.Context, payload []datadogV2.HTTPLogItem) error {
-	var fields []zap.Field
 	if s.verbose {
-		fields = append(fields, zap.Any("payload", payload))
+		s.logger.Debug("Submitting logs", zap.Any("payload", payload))
 	}
-	s.logger.Debug("Submitting logs", fields...)
 
 	// Correctly sets apiSubmitLogRequest ddtags field based on tags from translator Transform method
 	if payload[0].HasDdtags() {

--- a/exporter/datadogexporter/logs_exporter.go
+++ b/exporter/datadogexporter/logs_exporter.go
@@ -51,7 +51,7 @@ func newLogsExporter(ctx context.Context, params component.ExporterCreateSetting
 		return nil, err
 	}
 
-	s := logs.NewSender(cfg.Logs.TCPAddr.Endpoint, params.Logger, cfg.TimeoutSettings, cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify, cfg.API.Key)
+	s := logs.NewSender(cfg.Logs.TCPAddr.Endpoint, params.Logger, cfg.TimeoutSettings, cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify, cfg.Logs.DumpPayloads, cfg.API.Key)
 
 	return &logsExporter{
 		params:         params,


### PR DESCRIPTION
This change removes the dumping of the payload at 'debug' logging level. It can be re-enabled using exporter::datadog::logs::dump_payload if desired.

Updates #16380