### PR TITLE
Mark prometheus exporter as mutable since it sorts attributes

### DIFF
--- a/.chloggen/fixprommuta.yaml
+++ b/.chloggen/fixprommuta.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark prometheus exporter as mutable since it sorts attributes
+
+# One or more tracking issues related to the change
+issues: [16499]
+

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -68,7 +68,8 @@ func createMetricsExporter(
 		set,
 		cfg,
 		prometheus.ConsumeMetrics,
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		// TODO: Consider to revert to non mutable data, need to not modify the incoming data, like sorting when calculating the signature.
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 		exporterhelper.WithStart(prometheus.Start),
 		exporterhelper.WithShutdown(prometheus.Shutdown),
 	)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16499

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
