### PR TITLE
[exporter/instana] Remove redundant Sort call making exporter mutating

### DIFF
--- a/.chloggen/remove-instana-mutations.yaml
+++ b/.chloggen/remove-instana-mutations.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/instana
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make sure the original traces are not mutated
+
+# One or more tracking issues related to the change
+issues: [16505]
+

--- a/exporter/instanaexporter/internal/converter/model/span.go
+++ b/exporter/instanaexporter/internal/converter/model/span.go
@@ -123,7 +123,7 @@ func ConvertPDataSpanToInstanaSpan(fromS FromS, otelSpan ptrace.Span, serviceNam
 
 	instanaSpan.Data.TraceState = otelSpan.TraceState().AsRaw()
 
-	otelSpan.Attributes().Sort().Range(func(k string, v pcommon.Value) bool {
+	otelSpan.Attributes().Range(func(k string, v pcommon.Value) bool {
 		instanaSpan.Data.Tags[k] = v.AsString()
 
 		return true


### PR DESCRIPTION
The Sort call is redundant because the range function is applied on a map so there is no reason to preserve order. The call unnecessarily mutates the original data which can lead to subtle bugs similar to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16499 given that the exporter marked as not mutating