### PR TITLE
[exporter/dynatrace] Do not mutate the original metrics

### DIFF
--- a/.chloggen/dynatrace-no-sort.yaml
+++ b/.chloggen/dynatrace-no-sort.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/dynatrace
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make sure the original metrics are not mutated
+
+# One or more tracking issues related to the change
+issues: [16506]

--- a/exporter/dynatraceexporter/internal/serialization/sum_test.go
+++ b/exporter/dynatraceexporter/internal/serialization/sum_test.go
@@ -391,3 +391,15 @@ func Test_serializeSum(t *testing.T) {
 		})
 	})
 }
+
+func Test_convertTotalCounterToDelta_notMutating(t *testing.T) {
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetIntValue(5)
+	dp.Attributes().PutStr("attr2", "val2")
+	dp.Attributes().PutStr("attr1", "val1")
+	orig := pmetric.NewNumberDataPoint()
+	dp.CopyTo(orig)
+	_, err := convertTotalCounterToDelta("m", "prefix", dimensions.NormalizedDimensionList{}, dp, ttlmap.New(1, 1))
+	assert.NoError(t, err)
+	assert.Equal(t, orig, dp) // make sure the original data point is not mutated
+}


### PR DESCRIPTION
The  `Map.Sort()` call mutates the original pdata map which can lead to subtle bugs similar to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16499 given that the exporter is marked as not mutating