### PR TITLE
[receiver/elasticsearch]: fix the list of operations for which metrics are fetched on index level

### DIFF
--- a/.chloggen/elastic-fix-fetched-index-ops.yaml
+++ b/.chloggen/elastic-fix-fetched-index-ops.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix the set of operations for which the data is fetched on index-level
+
+# One or more tracking issues related to the change
+issues: [14635]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -89,7 +89,7 @@ const nodeStatsMetrics = "breaker,indices,process,jvm,thread_pool,transport,http
 // nodeStatsIndexMetrics is a comma separated list of index metrics that will be gathered from NodeStats.
 const nodeStatsIndexMetrics = "store,docs,indexing,get,search,merge,refresh,flush,warmer,query_cache,fielddata,translog"
 
-const indexStatsMetrics = "search"
+const indexStatsMetrics = "_all"
 
 func (c defaultElasticsearchClient) NodeStats(ctx context.Context, nodes []string) (*model.NodeStats, error) {
 	var nodeSpec string


### PR DESCRIPTION
**Description:** 
When I introduced scraping the metrics on index level in #14748, I set the [query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html#index-stats-api-path-params) so that the receiver fetched only metrics related to `search` operations (which are query, fetch, scroll and suggest). I forgot to update that list as I added new metrics and datapoints. Because of that, most of metrics emitted by this receiver were sent with Golang's zero values (as this is a result of how JSONs are deserialised when a given field does not exist).

Please also note that the integration tests did not cover it, because they ignore the exact values of metrics.

**Link to tracking Issue:** #14635

**Testing:** 
Manual (checking the values before and after the fix)
