### PR TITLE
[processor/cumulativetodelta] Remove Min and Max when histogram is converted

### DIFF
--- a/.chloggen/ctd-clear-min-max.yaml
+++ b/.chloggen/ctd-clear-min-max.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cumulativetodeltaprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updates histogram conversion logic to correctly remove Min and Max when a histogram is converted.
+
+# One or more tracking issues related to the change
+issues: [16520]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/cumulativetodeltaprocessor/processor.go
+++ b/processor/cumulativetodeltaprocessor/processor.go
@@ -211,6 +211,8 @@ func (ctdp *cumulativeToDeltaProcessor) convertHistogramDataPoints(in interface{
 					dp.SetSum(delta.HistogramValue.Sum)
 				}
 				dp.BucketCounts().FromRaw(delta.HistogramValue.Buckets)
+				dp.RemoveMin()
+				dp.RemoveMax()
 				return false
 			}
 

--- a/processor/cumulativetodeltaprocessor/processor_test.go
+++ b/processor/cumulativetodeltaprocessor/processor_test.go
@@ -44,6 +44,8 @@ type testHistogramMetric struct {
 	metricNames   []string
 	metricCounts  [][]uint64
 	metricSums    [][]float64
+	metricMins    [][]float64
+	metricMaxes   [][]float64
 	metricBuckets [][][]uint64
 	isCumulative  []bool
 }
@@ -57,8 +59,8 @@ type cumulativeToDeltaTest struct {
 	histogramSupportEnabled bool
 }
 
-var (
-	testCases = []cumulativeToDeltaTest{
+func TestCumulativeToDeltaProcessor(t *testing.T) {
+	testCases := []cumulativeToDeltaTest{
 		{
 			name: "cumulative_to_delta_convert_nothing",
 			exclude: MatchMetrics{
@@ -145,6 +147,53 @@ var (
 				metricValues: [][]float64{{100}, {4}},
 				isCumulative: []bool{true, true},
 			}),
+		},
+		{
+			name: "cumulative_to_delta_histogram_min_and_max",
+			include: MatchMetrics{
+				Metrics: []string{"metric_1"},
+				Config: filterset.Config{
+					MatchType:    "strict",
+					RegexpConfig: nil,
+				},
+			},
+			inMetrics: generateTestHistogramMetrics(testHistogramMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricCounts: [][]uint64{{100, 200, 500}, {4}},
+				metricSums:   [][]float64{{100, 200, 500}, {4}},
+				metricBuckets: [][][]uint64{
+					{{50, 25, 25}, {100, 50, 50}, {250, 125, 125}},
+					{{4, 4, 4}},
+				},
+				metricMins: [][]float64{
+					{5.0, 2.0, 3.0},
+					{2.0, 2.0, 2.0},
+				},
+				metricMaxes: [][]float64{
+					{800.0, 825.0, 800.0},
+					{3.0, 3.0, 3.0},
+				},
+				isCumulative: []bool{true, true},
+			}),
+			outMetrics: generateTestHistogramMetrics(testHistogramMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricCounts: [][]uint64{{100, 100, 300}, {4}},
+				metricSums:   [][]float64{{100, 100, 300}, {4}},
+				metricBuckets: [][][]uint64{
+					{{50, 25, 25}, {50, 25, 25}, {150, 75, 75}},
+					{{4, 4, 4}},
+				},
+				metricMins: [][]float64{
+					nil,
+					{2.0, 2.0, 2.0},
+				},
+				metricMaxes: [][]float64{
+					nil,
+					{3.0, 3.0, 3.0},
+				},
+				isCumulative: []bool{false, true},
+			}),
+			histogramSupportEnabled: true,
 		},
 		{
 			name: "cumulative_to_delta_histogram_one_positive",
@@ -318,9 +367,7 @@ var (
 			}),
 		},
 	}
-)
 
-func TestCumulativeToDeltaProcessor(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			registry := featuregate.GetRegistry()
@@ -403,6 +450,8 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 					for j := 0; j < eDataPoints.Len(); j++ {
 						require.Equal(t, eDataPoints.At(j).Count(), aDataPoints.At(j).Count())
 						require.Equal(t, eDataPoints.At(j).HasSum(), aDataPoints.At(j).HasSum())
+						require.Equal(t, eDataPoints.At(j).HasMin(), aDataPoints.At(j).HasMin())
+						require.Equal(t, eDataPoints.At(j).HasMax(), aDataPoints.At(j).HasMax())
 						if math.IsNaN(eDataPoints.At(j).Sum()) {
 							require.True(t, math.IsNaN(aDataPoints.At(j).Sum()))
 						} else {
@@ -471,6 +520,18 @@ func generateTestHistogramMetrics(tm testHistogramMetric) pmetric.Metrics {
 			sums := tm.metricSums[i]
 			if len(sums) > 0 {
 				dp.SetSum(sums[index])
+			}
+			if tm.metricMins != nil {
+				mins := tm.metricMins[i]
+				if len(mins) > 0 {
+					dp.SetMin(sums[index])
+				}
+			}
+			if tm.metricMaxes != nil {
+				maxes := tm.metricMaxes[i]
+				if len(maxes) > 0 {
+					dp.SetMax(maxes[index])
+				}
 			}
 			dp.BucketCounts().FromRaw(tm.metricBuckets[i][index])
 		}


### PR DESCRIPTION
**Description:** 
Updates the conversion logic to remove the histogram's min and max if it is converted.

**Link to tracking Issue:**
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15658

**Testing:** 
Added unit tests