### PR TITLE
[chore] Don't fail in cURL call to request reviewers

### DIFF
--- a/.github/workflows/scripts/add-codeowners-to-pr.sh
+++ b/.github/workflows/scripts/add-codeowners-to-pr.sh
@@ -103,7 +103,6 @@ main () {
     # accepts duplicate logins and logins that are already reviewers.
     if [[ -n "${REVIEWERS}" ]]; then
         curl \
-            --fail \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \


### PR DESCRIPTION
**Description:**

Failing skips the call to jq to see the message that GitHub returned, which is useful in debugging. Generally the request will fail because at least one user in the request isn't part of the OpenTelemetry organization.