### PR TITLE
[chore][prometheusreceiver] Simplify metric family and metric group data structures.

### DIFF
--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -102,27 +102,27 @@ func getBoundary(metricType pmetric.MetricType, labels labels.Labels) (float64, 
 }
 
 // convToMetricType returns the data type and if it is monotonic
-func convToMetricType(metricType textparse.MetricType) (pmetric.MetricType, bool) {
+func convToMetricType(metricType textparse.MetricType) pmetric.MetricType {
 	switch metricType {
 	case textparse.MetricTypeCounter:
 		// always use float64, as it's the internal data type used in prometheus
-		return pmetric.MetricTypeSum, true
+		return pmetric.MetricTypeSum
 	// textparse.MetricTypeUnknown is converted to gauge by default to prevent Prometheus untyped metrics from being dropped
 	case textparse.MetricTypeGauge, textparse.MetricTypeUnknown:
-		return pmetric.MetricTypeGauge, false
+		return pmetric.MetricTypeGauge
 	case textparse.MetricTypeHistogram:
-		return pmetric.MetricTypeHistogram, true
+		return pmetric.MetricTypeHistogram
 	// dropping support for gaugehistogram for now until we have an official spec of its implementation
 	// a draft can be found in: https://docs.google.com/document/d/1KwV0mAXwwbvvifBvDKH_LU1YjyXE_wxCkHNoCGq1GX0/edit#heading=h.1cvzqd4ksd23
 	// case textparse.MetricTypeGaugeHistogram:
 	//	return <pdata gauge histogram type>
 	case textparse.MetricTypeSummary:
-		return pmetric.MetricTypeSummary, true
+		return pmetric.MetricTypeSummary
 	case textparse.MetricTypeInfo, textparse.MetricTypeStateset:
-		return pmetric.MetricTypeSum, false
+		return pmetric.MetricTypeSum
 	default:
 		// including: textparse.MetricTypeGaugeHistogram
-		return pmetric.MetricTypeEmpty, false
+		return pmetric.MetricTypeEmpty
 	}
 }
 

--- a/receiver/prometheusreceiver/internal/util_test.go
+++ b/receiver/prometheusreceiver/internal/util_test.go
@@ -63,67 +63,57 @@ func TestTimestampFromFloat64(t *testing.T) {
 
 func TestConvToMetricType(t *testing.T) {
 	tests := []struct {
-		name          string
-		mtype         textparse.MetricType
-		want          pmetric.MetricType
-		wantMonotonic bool
+		name  string
+		mtype textparse.MetricType
+		want  pmetric.MetricType
 	}{
 		{
-			name:          "textparse.counter",
-			mtype:         textparse.MetricTypeCounter,
-			want:          pmetric.MetricTypeSum,
-			wantMonotonic: true,
+			name:  "textparse.counter",
+			mtype: textparse.MetricTypeCounter,
+			want:  pmetric.MetricTypeSum,
 		},
 		{
-			name:          "textparse.gauge",
-			mtype:         textparse.MetricTypeGauge,
-			want:          pmetric.MetricTypeGauge,
-			wantMonotonic: false,
+			name:  "textparse.gauge",
+			mtype: textparse.MetricTypeGauge,
+			want:  pmetric.MetricTypeGauge,
 		},
 		{
-			name:          "textparse.unknown",
-			mtype:         textparse.MetricTypeUnknown,
-			want:          pmetric.MetricTypeGauge,
-			wantMonotonic: false,
+			name:  "textparse.unknown",
+			mtype: textparse.MetricTypeUnknown,
+			want:  pmetric.MetricTypeGauge,
 		},
 		{
-			name:          "textparse.histogram",
-			mtype:         textparse.MetricTypeHistogram,
-			want:          pmetric.MetricTypeHistogram,
-			wantMonotonic: true,
+			name:  "textparse.histogram",
+			mtype: textparse.MetricTypeHistogram,
+			want:  pmetric.MetricTypeHistogram,
 		},
 		{
-			name:          "textparse.summary",
-			mtype:         textparse.MetricTypeSummary,
-			want:          pmetric.MetricTypeSummary,
-			wantMonotonic: true,
+			name:  "textparse.summary",
+			mtype: textparse.MetricTypeSummary,
+			want:  pmetric.MetricTypeSummary,
 		},
 		{
-			name:          "textparse.metric_type_info",
-			mtype:         textparse.MetricTypeInfo,
-			want:          pmetric.MetricTypeSum,
-			wantMonotonic: false,
+			name:  "textparse.metric_type_info",
+			mtype: textparse.MetricTypeInfo,
+			want:  pmetric.MetricTypeSum,
 		},
 		{
-			name:          "textparse.metric_state_set",
-			mtype:         textparse.MetricTypeStateset,
-			want:          pmetric.MetricTypeSum,
-			wantMonotonic: false,
+			name:  "textparse.metric_state_set",
+			mtype: textparse.MetricTypeStateset,
+			want:  pmetric.MetricTypeSum,
 		},
 		{
-			name:          "textparse.metric_gauge_hostogram",
-			mtype:         textparse.MetricTypeGaugeHistogram,
-			want:          pmetric.MetricTypeEmpty,
-			wantMonotonic: false,
+			name:  "textparse.metric_gauge_hostogram",
+			mtype: textparse.MetricTypeGaugeHistogram,
+			want:  pmetric.MetricTypeEmpty,
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, monotonic := convToMetricType(tt.mtype)
+			got := convToMetricType(tt.mtype)
 			require.Equal(t, got.String(), tt.want.String())
-			require.Equal(t, monotonic, tt.wantMonotonic)
 		})
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The motivation for this change is simplifying data structures that convert the Prometheus data model to OTLP metrics so that after a few more changes it can be extracted to a common package and reused for implementation of the Prometheus remote write receiver. https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14751

