### PR TITLE
Exporter kafka marshaler options

### DIFF
--- a/.chloggen/exporter-kafka-marshaler-options.yaml
+++ b/.chloggen/exporter-kafka-marshaler-options.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter 
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add ExporterFactory options for custom metric and log marshalers"
+
+# One or more tracking issues related to the change
+issues: [14514]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -53,11 +53,36 @@ const (
 // FactoryOption applies changes to kafkaExporterFactory.
 type FactoryOption func(factory *kafkaExporterFactory)
 
-// WithTracesMarshalers adds tracesMarshalers.
+// WithTracesMarshalers adds tracesMarshalers to the exporter factory.
+// This allows custom-built collectors to configure custom Kafka marshaler(s) for trace data.
+// An example use case is keying the message by trace ID so downstream collectors could do tail-based sampling with horizontal scale
 func WithTracesMarshalers(tracesMarshalers ...TracesMarshaler) FactoryOption {
 	return func(factory *kafkaExporterFactory) {
 		for _, marshaler := range tracesMarshalers {
 			factory.tracesMarshalers[marshaler.Encoding()] = marshaler
+		}
+	}
+}
+
+// WithMetricsMarshalers adds metricsMarshalers to the exporter factory.
+// This allows custom-built collectors to configure custom Kafka marshaler(s) for metric data.
+// An example use case is keying the message by resource attribute values so downstream collectors can be horizontally scaled and still deliver metrics in the correct order to the backend.
+// Another use case might be pre-aggregating metrics to reduce backend update throughput.
+func WithMetricsMarshalers(metricsMarshalers ...MetricsMarshaler) FactoryOption {
+	return func(factory *kafkaExporterFactory) {
+		for _, marshaler := range metricsMarshalers {
+			factory.metricsMarshalers[marshaler.Encoding()] = marshaler
+		}
+	}
+}
+
+// WithLogsMarshalers adds logsMarshalers to the exporter factory.
+// This allows custom-built collectors to configure custom Kafka marshaler(s) for log data.
+// An example use case is keying the message by resource attribute values so downstream collectors can be horizontally scaled and still deliver logs in the correct order to the backend.
+func WithLogsMarshalers(logsMarshalers ...LogsMarshaler) FactoryOption {
+	return func(factory *kafkaExporterFactory) {
+		for _, marshaler := range logsMarshalers {
+			factory.logsMarshalers[marshaler.Encoding()] = marshaler
 		}
 	}
 }

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -74,9 +74,10 @@ func TestCreateMetricExporter(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		conf *Config
-		err  error
+		name       string
+		conf       *Config
+		marshalers []MetricsMarshaler
+		err        error
 	}{
 		{
 			name: "valid config (no validating broker)",
@@ -87,7 +88,8 @@ func TestCreateMetricExporter(t *testing.T) {
 				conf.Brokers = []string{"invalid:9092"}
 				conf.ProtocolVersion = "2.0.0"
 			}),
-			err: nil,
+			marshalers: nil,
+			err:        nil,
 		},
 		{
 			name: "invalid config (validating broker)",
@@ -95,7 +97,30 @@ func TestCreateMetricExporter(t *testing.T) {
 				conf.Brokers = []string{"invalid:9092"}
 				conf.ProtocolVersion = "2.0.0"
 			}),
-			err: &net.DNSError{},
+			marshalers: nil,
+			err:        &net.DNSError{},
+		},
+		{
+			name: "default_encoding",
+			conf: applyConfigOption(func(conf *Config) {
+				// Disabling broker check to ensure encoding work
+				conf.Metadata.Full = false
+				conf.Encoding = defaultEncoding
+			}),
+			marshalers: nil,
+			err:        nil,
+		},
+		{
+			name: "custom_encoding",
+			conf: applyConfigOption(func(conf *Config) {
+				// Disabling broker check to ensure encoding work
+				conf.Metadata.Full = false
+				conf.Encoding = "custom"
+			}),
+			marshalers: []MetricsMarshaler{
+				newMockMarshaler[pmetric.Metrics]("custom"),
+			},
+			err: nil,
 		},
 	}
 
@@ -104,7 +129,7 @@ func TestCreateMetricExporter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			f := NewFactory()
+			f := NewFactory(WithMetricsMarshalers(tc.marshalers...))
 			exporter, err := f.CreateMetricsExporter(
 				context.Background(),
 				componenttest.NewNopExporterCreateSettings(),
@@ -125,9 +150,10 @@ func TestCreateLogExporter(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		conf *Config
-		err  error
+		name       string
+		conf       *Config
+		marshalers []LogsMarshaler
+		err        error
 	}{
 		{
 			name: "valid config (no validating broker)",
@@ -138,7 +164,8 @@ func TestCreateLogExporter(t *testing.T) {
 				conf.Brokers = []string{"invalid:9092"}
 				conf.ProtocolVersion = "2.0.0"
 			}),
-			err: nil,
+			marshalers: nil,
+			err:        nil,
 		},
 		{
 			name: "invalid config (validating broker)",
@@ -146,7 +173,30 @@ func TestCreateLogExporter(t *testing.T) {
 				conf.Brokers = []string{"invalid:9092"}
 				conf.ProtocolVersion = "2.0.0"
 			}),
-			err: &net.DNSError{},
+			marshalers: nil,
+			err:        &net.DNSError{},
+		},
+		{
+			name: "default_encoding",
+			conf: applyConfigOption(func(conf *Config) {
+				// Disabling broker check to ensure encoding work
+				conf.Metadata.Full = false
+				conf.Encoding = defaultEncoding
+			}),
+			marshalers: nil,
+			err:        nil,
+		},
+		{
+			name: "custom_encoding",
+			conf: applyConfigOption(func(conf *Config) {
+				// Disabling broker check to ensure encoding work
+				conf.Metadata.Full = false
+				conf.Encoding = "custom"
+			}),
+			marshalers: []LogsMarshaler{
+				newMockMarshaler[plog.Logs]("custom"),
+			},
+			err: nil,
 		},
 	}
 
@@ -155,7 +205,7 @@ func TestCreateLogExporter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			f := NewFactory()
+			f := NewFactory(WithLogsMarshalers(tc.marshalers...))
 			exporter, err := f.CreateLogsExporter(
 				context.Background(),
 				componenttest.NewNopExporterCreateSettings(),

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -26,6 +26,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // data is a simple means of allowing
@@ -129,10 +132,14 @@ func TestCreateMetricExporter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			core, observed := observer.New(zapcore.DebugLevel)
+			exporterSettings := componenttest.NewNopExporterCreateSettings()
+			exporterSettings.Logger = zap.New(core)
+
 			f := NewFactory(WithMetricsMarshalers(tc.marshalers...))
 			exporter, err := f.CreateMetricsExporter(
 				context.Background(),
-				componenttest.NewNopExporterCreateSettings(),
+				exporterSettings,
 				tc.conf,
 			)
 			if tc.err != nil {
@@ -142,6 +149,11 @@ func TestCreateMetricExporter(t *testing.T) {
 			}
 			assert.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
+
+			// confirm marshaler selected matches the encoding we asked for
+			logEntries := observed.FilterField(zap.String("encoding", tc.conf.Encoding))
+			assert.NotNil(t, logEntries)
+			assert.Equal(t, 1, logEntries.Len())
 		})
 	}
 }
@@ -205,10 +217,14 @@ func TestCreateLogExporter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			core, observed := observer.New(zapcore.DebugLevel)
+			exporterSettings := componenttest.NewNopExporterCreateSettings()
+			exporterSettings.Logger = zap.New(core)
+
 			f := NewFactory(WithLogsMarshalers(tc.marshalers...))
 			exporter, err := f.CreateLogsExporter(
 				context.Background(),
-				componenttest.NewNopExporterCreateSettings(),
+				exporterSettings,
 				tc.conf,
 			)
 			if tc.err != nil {
@@ -218,6 +234,11 @@ func TestCreateLogExporter(t *testing.T) {
 			}
 			assert.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
+
+			// confirm marshaler selected matches the encoding we asked for
+			logEntries := observed.FilterField(zap.String("encoding", tc.conf.Encoding))
+			assert.NotNil(t, logEntries)
+			assert.Equal(t, 1, logEntries.Len())
 		})
 	}
 }
@@ -279,10 +300,14 @@ func TestCreateTraceExporter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			core, observed := observer.New(zapcore.DebugLevel)
+			exporterSettings := componenttest.NewNopExporterCreateSettings()
+			exporterSettings.Logger = zap.New(core)
+
 			f := NewFactory(WithTracesMarshalers(tc.marshalers...))
 			exporter, err := f.CreateTracesExporter(
 				context.Background(),
-				componenttest.NewNopExporterCreateSettings(),
+				exporterSettings,
 				tc.conf,
 			)
 			if tc.err != nil {
@@ -292,6 +317,11 @@ func TestCreateTraceExporter(t *testing.T) {
 			}
 			assert.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
+
+			// confirm marshaler selected matches the encoding we asked for
+			logEntries := observed.FilterField(zap.String("encoding", tc.conf.Encoding))
+			assert.NotNil(t, logEntries)
+			assert.Equal(t, 1, logEntries.Len())
 		})
 	}
 }

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -22,6 +22,7 @@ require (
 
 require (
 	github.com/apache/thrift v0.17.0 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eapache/go-resiliency v1.3.0 // indirect

--- a/exporter/kafkaexporter/go.sum
+++ b/exporter/kafkaexporter/go.sum
@@ -31,6 +31,7 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+
 github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21TfrhJ8AEMzVybRNSb/b4g=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -173,6 +173,7 @@ func newMetricsExporter(config Config, set component.ExporterCreateSettings, mar
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
+	set.Logger.Debug("Configured marshaller", zap.String("encoding", marshaler.Encoding()))
 	producer, err := newSaramaProducer(config)
 	if err != nil {
 		return nil, err
@@ -193,6 +194,7 @@ func newTracesExporter(config Config, set component.ExporterCreateSettings, mars
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
+	set.Logger.Debug("Configured marshaller", zap.String("encoding", marshaler.Encoding()))
 	producer, err := newSaramaProducer(config)
 	if err != nil {
 		return nil, err
@@ -210,6 +212,7 @@ func newLogsExporter(config Config, set component.ExporterCreateSettings, marsha
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
+	set.Logger.Debug("Configured marshaller", zap.String("encoding", marshaler.Encoding()))
 	producer, err := newSaramaProducer(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Description:
Adding ExportFactory options to add custom log/metric marshalers (similar to existing: WithTracesMarshalers)

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14514

Testing:
Tests were added for the new options as well as adapting the previous test for WithTracesMarshalers to the new method.