### PR TITLE
[exporter/datadogexporter] Do not append duplicate ddtags on each log submission.

### DIFF
--- a/.chloggen/unreleased/dd-exporter-duplicate-tags.yaml
+++ b/.chloggen/unreleased/dd-exporter-duplicate-tags.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Doesn't append duplicate ddtags on each log submission leading to 414 API errors."
+
+# One or more tracking issues related to the change
+issues: [16380]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/internal/logs/sender.go
+++ b/exporter/datadogexporter/internal/logs/sender.go
@@ -51,12 +51,9 @@ func NewSender(endpoint string, logger *zap.Logger, s exporterhelper.TimeoutSett
 	cfg.HTTPClient = clientutil.NewHTTPClient(s, insecureSkipVerify)
 	cfg.AddDefaultHeader("DD-API-KEY", apiKey)
 	apiClient := datadog.NewAPIClient(cfg)
-	// enable sending gzip
-	opts := *datadogV2.NewSubmitLogOptionalParameters().WithContentEncoding(datadogV2.CONTENTENCODING_GZIP)
 	return &Sender{
 		api:     datadogV2.NewLogsApi(apiClient),
 		logger:  logger,
-		opts:    opts,
 		verbose: verbose,
 	}
 }
@@ -67,11 +64,15 @@ func (s *Sender) SubmitLogs(ctx context.Context, payload []datadogV2.HTTPLogItem
 		s.logger.Debug("Submitting logs", zap.Any("payload", payload))
 	}
 
+	// enable sending gzip
+	// Get a fresh opts for each request to avoid duplicating ddtags
+	s.opts = *datadogV2.NewSubmitLogOptionalParameters().WithContentEncoding(datadogV2.CONTENTENCODING_GZIP)
+
 	// Correctly sets apiSubmitLogRequest ddtags field based on tags from translator Transform method
 	if payload[0].HasDdtags() {
 		tags := datadog.PtrString(payload[0].GetDdtags())
-		if s.verbose {
-			s.logger.Debug("Tags", zap.String("tags", *tags))
+		if s.opts.Ddtags != nil {
+			tags = datadog.PtrString(fmt.Sprint(*s.opts.Ddtags, ",", payload[0].GetDdtags()))
 		}
 		s.opts.Ddtags = tags
 	}

--- a/exporter/datadogexporter/internal/logs/sender.go
+++ b/exporter/datadogexporter/internal/logs/sender.go
@@ -16,7 +16,6 @@ package logs // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
@@ -71,8 +70,8 @@ func (s *Sender) SubmitLogs(ctx context.Context, payload []datadogV2.HTTPLogItem
 	// Correctly sets apiSubmitLogRequest ddtags field based on tags from translator Transform method
 	if payload[0].HasDdtags() {
 		tags := datadog.PtrString(payload[0].GetDdtags())
-		if s.opts.Ddtags != nil {
-			tags = datadog.PtrString(fmt.Sprint(*s.opts.Ddtags, ",", payload[0].GetDdtags()))
+		if s.verbose {
+			s.logger.Debug("Tags", zap.String("tags", *tags))
 		}
 		s.opts.Ddtags = tags
 	}

--- a/exporter/datadogexporter/internal/logs/sender.go
+++ b/exporter/datadogexporter/internal/logs/sender.go
@@ -16,6 +16,7 @@ package logs // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"

--- a/exporter/datadogexporter/internal/logs/sender.go
+++ b/exporter/datadogexporter/internal/logs/sender.go
@@ -31,7 +31,6 @@ import (
 type Sender struct {
 	logger  *zap.Logger
 	api     *datadogV2.LogsApi
-	opts    datadogV2.SubmitLogOptionalParameters
 	verbose bool // reports whether payload contents should be dumped when logging at debug level
 }
 
@@ -67,17 +66,17 @@ func (s *Sender) SubmitLogs(ctx context.Context, payload []datadogV2.HTTPLogItem
 
 	// enable sending gzip
 	// Get a fresh opts for each request to avoid duplicating ddtags
-	s.opts = *datadogV2.NewSubmitLogOptionalParameters().WithContentEncoding(datadogV2.CONTENTENCODING_GZIP)
+	opts := *datadogV2.NewSubmitLogOptionalParameters().WithContentEncoding(datadogV2.CONTENTENCODING_GZIP)
 
 	// Correctly sets apiSubmitLogRequest ddtags field based on tags from translator Transform method
 	if payload[0].HasDdtags() {
 		tags := datadog.PtrString(payload[0].GetDdtags())
-		if s.opts.Ddtags != nil {
-			tags = datadog.PtrString(fmt.Sprint(*s.opts.Ddtags, ",", payload[0].GetDdtags()))
+		if opts.Ddtags != nil {
+			tags = datadog.PtrString(fmt.Sprint(*opts.Ddtags, ",", payload[0].GetDdtags()))
 		}
-		s.opts.Ddtags = tags
+		opts.Ddtags = tags
 	}
-	_, r, err := s.api.SubmitLog(ctx, payload, s.opts)
+	_, r, err := s.api.SubmitLog(ctx, payload, opts)
 	if err != nil {
 		if r != nil {
 			b := make([]byte, 1024) // 1KB message max


### PR DESCRIPTION

**Description:** 
Datadog exporter is appending tags to each log submission to the DD API, to those sent on previous requests. This leads to duplication in tags and growth of the query string that is sent to the DD API, eventually leading to 414 errors and prevention of log ingestion.

NOTE: I'm not aware of what the side effects of not appending this are, as I am new to the project, so would appreciate any input.

**Link to tracking Issue:** #16380

**Testing:** I have tested that the 414 errors no longer appear after running the datadog exporter with logs.

**Documentation:** nil, bugfix.