### PR TITLE
[receiver/k8sobjects] Fix empty `event.name` attribute when using watch mode

### DIFF
--- a/.chloggen/k8sobjects-fix-empty-event-name.yaml
+++ b/.chloggen/k8sobjects-fix-empty-event-name.yaml
@@ -1,0 +1,15 @@
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sobjects
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix empty `event.name` attribute when using watch mode"
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/k8sobjects-fix-empty-event-name.yaml
+++ b/.chloggen/k8sobjects-fix-empty-event-name.yaml
@@ -7,7 +7,7 @@ component: k8sobjects
 note: "Fix empty `event.name` attribute when using watch mode"
 
 # One or more tracking issues related to the change
-issues: []
+issues: [16542]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -125,7 +125,7 @@ func (kr *k8sobjectsreceiver) startPull(ctx context.Context, config *K8sObjectsC
 			if err != nil {
 				kr.setting.Logger.Error("error in pulling object", zap.String("resource", config.gvr.String()), zap.Error(err))
 			} else if len(objects.Items) > 0 {
-				logs := unstructuredListToLogData(objects)
+				logs := unstructuredListToLogData(objects, *config.gvr)
 				obsCtx := kr.obsrecv.StartLogsOp(ctx)
 				err = kr.consumer.ConsumeLogs(obsCtx, logs)
 				kr.obsrecv.EndLogsOp(obsCtx, typeStr, logs.LogRecordCount(), err)
@@ -162,7 +162,7 @@ func (kr *k8sobjectsreceiver) startWatch(ctx context.Context, config *K8sObjects
 				kr.setting.Logger.Warn("Watch channel closed unexpectedly", zap.String("resource", config.gvr.String()))
 				return
 			}
-			logs := watchEventToLogData(&data)
+			logs := watchEventToLogData(&data, *config.gvr)
 
 			obsCtx := kr.obsrecv.StartLogsOp(ctx)
 			err := kr.consumer.ConsumeLogs(obsCtx, logs)

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -125,7 +125,7 @@ func (kr *k8sobjectsreceiver) startPull(ctx context.Context, config *K8sObjectsC
 			if err != nil {
 				kr.setting.Logger.Error("error in pulling object", zap.String("resource", config.gvr.String()), zap.Error(err))
 			} else if len(objects.Items) > 0 {
-				logs := unstructuredListToLogData(objects, *config.gvr)
+				logs := pullObjectsToLogData(objects, config)
 				obsCtx := kr.obsrecv.StartLogsOp(ctx)
 				err = kr.consumer.ConsumeLogs(obsCtx, logs)
 				kr.obsrecv.EndLogsOp(obsCtx, typeStr, logs.LogRecordCount(), err)
@@ -162,7 +162,7 @@ func (kr *k8sobjectsreceiver) startWatch(ctx context.Context, config *K8sObjects
 				kr.setting.Logger.Warn("Watch channel closed unexpectedly", zap.String("resource", config.gvr.String()))
 				return
 			}
-			logs := watchEventToLogData(&data, *config.gvr)
+			logs := watchObjectsToLogData(&data, config)
 
 			obsCtx := kr.obsrecv.StartLogsOp(ctx)
 			err := kr.consumer.ConsumeLogs(obsCtx, logs)

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
@@ -40,12 +40,15 @@ func TestUnstructuredListToLogData(t *testing.T) {
 			object.SetName(fmt.Sprintf("pod-%d", i))
 			objects.Items = append(objects.Items, object)
 		}
-		gvr := schema.GroupVersionResource{
-			Group:    "",
-			Version:  "v1",
-			Resource: "pods",
+
+		config := &K8sObjectsConfig{
+			gvr: &schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "pods",
+			},
 		}
-		logs := unstructuredListToLogData(&objects, gvr)
+		logs := pullObjectsToLogData(&objects, config)
 
 		assert.Equal(t, logs.LogRecordCount(), 4)
 
@@ -69,7 +72,7 @@ func TestUnstructuredListToLogData(t *testing.T) {
 
 				name, ok := logRecords.At(j).Attributes().Get("event.name")
 				require.Equal(t, true, ok)
-				assert.Equal(t, "pods", name.AsString())
+				assert.Equal(t, "Pull pods", name.AsString())
 			}
 
 		}
@@ -86,13 +89,15 @@ func TestUnstructuredListToLogData(t *testing.T) {
 			objects.Items = append(objects.Items, object)
 		}
 
-		gvr := schema.GroupVersionResource{
-			Group:    "",
-			Version:  "v1",
-			Resource: "nodes",
+		config := &K8sObjectsConfig{
+			gvr: &schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "nodes",
+			},
 		}
 
-		logs := unstructuredListToLogData(&objects, gvr)
+		logs := pullObjectsToLogData(&objects, config)
 
 		assert.Equal(t, logs.LogRecordCount(), 3)
 
@@ -114,7 +119,7 @@ func TestUnstructuredListToLogData(t *testing.T) {
 
 			name, ok := logRecords.At(i).Attributes().Get("event.name")
 			require.Equal(t, true, ok)
-			assert.Equal(t, "nodes", name.AsString())
+			assert.Equal(t, "Pull nodes", name.AsString())
 		}
 
 	})


### PR DESCRIPTION
**Description:** 
event.name attribute is empty when collecting any resource using watch mode. 

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16542