### PR TITLE
[exporter/datadog] Update metrics export to use datadog-api-client-go instead of Zorkian

### DIFF
--- a/.chloggen/ddog-metric-export.yaml
+++ b/.chloggen/ddog-metric-export.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update datadogexporter metrics export to use datadog-api-client-go instead of Zorkian by default
+
+# One or more tracking issues related to the change
+issues: [16776]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is guarded by feature gate and can be disabled by adding CLI flag --feature-gates=-exporter.datadogexporter.metricexportnativeclient

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -39,8 +39,32 @@ import (
 
 const (
 	// typeStr is the type of the exporter
-	typeStr = "datadog"
+	typeStr                              = "datadog"
+	mertricExportNativeClientFeatureGate = "exporter.datadogexporter.metricexportnativeclient"
 )
+
+func init() {
+	featuregate.GetRegistry().MustRegisterID(
+		mertricExportNativeClientFeatureGate,
+		featuregate.StageBeta,
+		featuregate.WithRegisterDescription("When enabled, metric export in datadogexporter uses native Datadog client APIs instead of Zorkian APIs."),
+	)
+}
+
+// isMetricExportV2Enabled returns true if metric export in datadogexporter uses native Datadog client APIs, false if it uses Zorkian APIs
+func isMetricExportV2Enabled() bool {
+	return featuregate.GetRegistry().IsEnabled(mertricExportNativeClientFeatureGate)
+}
+
+// enableNativeMetricExport switches metric export to call native Datadog APIs instead of Zorkian APIs.
+func enableNativeMetricExport() {
+	featuregate.GetRegistry().Apply(map[string]bool{mertricExportNativeClientFeatureGate: true})
+}
+
+// enableZorkianMetricExport switches metric export to call Zorkian APIs instead of native Datadog APIs.
+func enableZorkianMetricExport() {
+	featuregate.GetRegistry().Apply(map[string]bool{mertricExportNativeClientFeatureGate: false})
+}
 
 type factory struct {
 	onceMetadata sync.Once

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -57,13 +57,13 @@ func isMetricExportV2Enabled() bool {
 }
 
 // enableNativeMetricExport switches metric export to call native Datadog APIs instead of Zorkian APIs.
-func enableNativeMetricExport() {
-	featuregate.GetRegistry().Apply(map[string]bool{mertricExportNativeClientFeatureGate: true})
+func enableNativeMetricExport() error {
+	return featuregate.GetRegistry().Apply(map[string]bool{mertricExportNativeClientFeatureGate: true})
 }
 
 // enableZorkianMetricExport switches metric export to call Zorkian APIs instead of native Datadog APIs.
-func enableZorkianMetricExport() {
-	featuregate.GetRegistry().Apply(map[string]bool{mertricExportNativeClientFeatureGate: false})
+func enableZorkianMetricExport() error {
+	return featuregate.GetRegistry().Apply(map[string]bool{mertricExportNativeClientFeatureGate: false})
 }
 
 type factory struct {

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -393,8 +393,10 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 	server := testutil.DatadogServerMock(testutil.ValidateAPIKeyEndpointInvalid)
 	defer server.Close()
 
-	err := enableZorkianMetricExport()
-	require.NoError(t, err)
+	if isMetricExportV2Enabled() {
+		require.NoError(t, enableZorkianMetricExport())
+		defer require.NoError(t, enableNativeMetricExport())
+	}
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
@@ -471,8 +473,10 @@ func TestCreateAPIExporterFailOnInvalidKey(t *testing.T) {
 	server := testutil.DatadogServerMock(testutil.ValidateAPIKeyEndpointInvalid)
 	defer server.Close()
 
-	err := enableNativeMetricExport()
-	require.NoError(t, err)
+	if !isMetricExportV2Enabled() {
+		require.NoError(t, enableNativeMetricExport())
+		defer require.NoError(t, enableZorkianMetricExport())
+	}
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -393,7 +393,8 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 	server := testutil.DatadogServerMock(testutil.ValidateAPIKeyEndpointInvalid)
 	defer server.Close()
 
-	enableZorkianMetricExport()
+	err := enableZorkianMetricExport()
+	require.NoError(t, err)
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
@@ -415,7 +416,7 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 		// metrics exporter
 		mexp, err := factory.CreateMetricsExporter(
 			ctx,
-			componenttest.NewNopExporterCreateSettings(),
+			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
 		assert.EqualError(t, err, "API Key validation failed")
@@ -423,7 +424,7 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 
 		texp, err := factory.CreateTracesExporter(
 			ctx,
-			componenttest.NewNopExporterCreateSettings(),
+			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
 		assert.EqualError(t, err, "API Key validation failed")
@@ -431,7 +432,7 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 
 		lexp, err := factory.CreateLogsExporter(
 			ctx,
-			componenttest.NewNopExporterCreateSettings(),
+			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
 		assert.EqualError(t, err, "API Key validation failed")
@@ -442,7 +443,7 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 		ctx := context.Background()
 		exp, err := factory.CreateMetricsExporter(
 			ctx,
-			componenttest.NewNopExporterCreateSettings(),
+			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
 		assert.Nil(t, err)
@@ -450,7 +451,7 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 
 		texp, err := factory.CreateTracesExporter(
 			ctx,
-			componenttest.NewNopExporterCreateSettings(),
+			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
 		assert.Nil(t, err)
@@ -458,7 +459,7 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 
 		lexp, err := factory.CreateLogsExporter(
 			ctx,
-			componenttest.NewNopExporterCreateSettings(),
+			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
 		assert.Nil(t, err)
@@ -470,7 +471,8 @@ func TestCreateAPIExporterFailOnInvalidKey(t *testing.T) {
 	server := testutil.DatadogServerMock(testutil.ValidateAPIKeyEndpointInvalid)
 	defer server.Close()
 
-	enableNativeMetricExport()
+	err := enableNativeMetricExport()
+	require.NoError(t, err)
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -389,9 +389,88 @@ func TestCreateAPIMetricsExporter(t *testing.T) {
 	assert.NotNil(t, exp)
 }
 
+func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
+	server := testutil.DatadogServerMock(testutil.ValidateAPIKeyEndpointInvalid)
+	defer server.Close()
+
+	enableZorkianMetricExport()
+
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	sub, err := cm.Sub(component.NewIDWithName(typeStr, "api").String())
+	require.NoError(t, err)
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
+
+	// Use the mock server for API key validation
+	c := cfg.(*Config)
+	c.Metrics.TCPAddr.Endpoint = server.URL
+	c.HostMetadata.Enabled = false
+
+	t.Run("true", func(t *testing.T) {
+		c.API.FailOnInvalidKey = true
+		ctx := context.Background()
+		// metrics exporter
+		mexp, err := factory.CreateMetricsExporter(
+			ctx,
+			componenttest.NewNopExporterCreateSettings(),
+			cfg,
+		)
+		assert.EqualError(t, err, "API Key validation failed")
+		assert.Nil(t, mexp)
+
+		texp, err := factory.CreateTracesExporter(
+			ctx,
+			componenttest.NewNopExporterCreateSettings(),
+			cfg,
+		)
+		assert.EqualError(t, err, "API Key validation failed")
+		assert.Nil(t, texp)
+
+		lexp, err := factory.CreateLogsExporter(
+			ctx,
+			componenttest.NewNopExporterCreateSettings(),
+			cfg,
+		)
+		assert.EqualError(t, err, "API Key validation failed")
+		assert.Nil(t, lexp)
+	})
+	t.Run("false", func(t *testing.T) {
+		c.API.FailOnInvalidKey = false
+		ctx := context.Background()
+		exp, err := factory.CreateMetricsExporter(
+			ctx,
+			componenttest.NewNopExporterCreateSettings(),
+			cfg,
+		)
+		assert.Nil(t, err)
+		assert.NotNil(t, exp)
+
+		texp, err := factory.CreateTracesExporter(
+			ctx,
+			componenttest.NewNopExporterCreateSettings(),
+			cfg,
+		)
+		assert.Nil(t, err)
+		assert.NotNil(t, texp)
+
+		lexp, err := factory.CreateLogsExporter(
+			ctx,
+			componenttest.NewNopExporterCreateSettings(),
+			cfg,
+		)
+		assert.Nil(t, err)
+		assert.NotNil(t, lexp)
+	})
+}
+
 func TestCreateAPIExporterFailOnInvalidKey(t *testing.T) {
 	server := testutil.DatadogServerMock(testutil.ValidateAPIKeyEndpointInvalid)
 	defer server.Close()
+
+	enableNativeMetricExport()
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -47,8 +47,8 @@ func CreateAPIClient(buildInfo component.BuildInfo, endpoint string, settings ex
 // ValidateAPIKey checks if the API key (not the APP key) is valid
 func ValidateAPIKey(ctx context.Context, apiKey string, logger *zap.Logger, apiClient *datadog.APIClient) error {
 	logger.Info("Validating API key.")
-	authApi := datadogV1.NewAuthenticationApi(apiClient)
-	resp, _, err := authApi.Validate(GetRequestContext(ctx, apiKey))
+	authAPI := datadogV1.NewAuthenticationApi(apiClient)
+	resp, _, err := authAPI.Validate(GetRequestContext(ctx, apiKey))
 	if err == nil && *resp.Valid {
 		logger.Info("API key validation successful.")
 		return nil

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -49,7 +49,7 @@ func ValidateAPIKey(ctx context.Context, apiKey string, logger *zap.Logger, apiC
 	logger.Info("Validating API key.")
 	authAPI := datadogV1.NewAuthenticationApi(apiClient)
 	resp, _, err := authAPI.Validate(GetRequestContext(ctx, apiKey))
-	if err == nil && *resp.Valid {
+	if err == nil && resp.Valid != nil && *resp.Valid {
 		logger.Info("API key validation successful.")
 		return nil
 	}

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -31,6 +31,7 @@ func CreateAPIClient(buildInfo component.BuildInfo, endpoint string, settings ex
 	configuration := datadog.NewConfiguration()
 	configuration.UserAgent = UserAgent(buildInfo)
 	configuration.HTTPClient = NewHTTPClient(settings, insecureSkipVerify)
+	configuration.Compress = true
 	if endpoint != "" {
 		configuration.Servers = datadog.ServerConfigurations{
 			{

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -17,6 +17,7 @@ package clientutil // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"context"
 	"errors"
+	"os"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
@@ -63,6 +64,9 @@ func ValidateAPIKey(ctx context.Context, apiKey string, logger *zap.Logger, apiC
 
 // GetRequestContext creates a new context with API key for DatadogV2 requests
 func GetRequestContext(ctx context.Context, apiKey string) context.Context {
+	if _, ok := os.LookupEnv("DD_API_KEY"); ok {
+		return datadog.NewDefaultContext(ctx)
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -17,7 +17,6 @@ package clientutil // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"context"
 	"errors"
-	"os"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
@@ -64,9 +63,6 @@ func ValidateAPIKey(ctx context.Context, apiKey string, logger *zap.Logger, apiC
 
 // GetRequestContext creates a new context with API key for DatadogV2 requests
 func GetRequestContext(ctx context.Context, apiKey string) context.Context {
-	if _, ok := os.LookupEnv("DD_API_KEY"); ok {
-		return datadog.NewDefaultContext(ctx)
-	}
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -15,13 +15,65 @@
 package clientutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/clientutil"
 
 import (
+	"context"
 	"errors"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
 	zorkian "gopkg.in/zorkian/go-datadog-api.v2"
 )
 
+// CreateAPIClient creates a new Datadog API client
+func CreateAPIClient(buildInfo component.BuildInfo, endpoint string, settings exporterhelper.TimeoutSettings, insecureSkipVerify bool) *datadog.APIClient {
+	configuration := datadog.NewConfiguration()
+	configuration.UserAgent = UserAgent(buildInfo)
+	configuration.HTTPClient = NewHTTPClient(settings, insecureSkipVerify)
+	if endpoint != "" {
+		configuration.Servers = datadog.ServerConfigurations{
+			{
+				URL:         "{site}",
+				Description: "No description provided",
+				Variables:   map[string]datadog.ServerVariable{"site": {DefaultValue: endpoint}},
+			},
+		}
+	}
+	return datadog.NewAPIClient(configuration)
+}
+
+// ValidateAPIKey checks if the API key (not the APP key) is valid
+func ValidateAPIKey(ctx context.Context, apiKey string, logger *zap.Logger, apiClient *datadog.APIClient) error {
+	logger.Info("Validating API key.")
+	authApi := datadogV1.NewAuthenticationApi(apiClient)
+	resp, _, err := authApi.Validate(GetRequestContext(ctx, apiKey))
+	if err == nil && *resp.Valid {
+		logger.Info("API key validation successful.")
+		return nil
+	}
+	if err != nil {
+		logger.Warn("Error while validating API key", zap.Error(err))
+		return nil
+	}
+	logger.Warn(ErrInvalidAPI.Error())
+	return ErrInvalidAPI
+}
+
+// GetRequestContext creates a new context with API key for DatadogV2 requests
+func GetRequestContext(ctx context.Context, apiKey string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(
+		ctx,
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{"apiKeyAuth": {Key: apiKey}},
+	)
+}
+
 // CreateZorkianClient creates a new Zorkian Datadog client
+// Deprecated: CreateZorkianClient returns a Zorkian Datadog client and Zorkian is deprecated. Use CreateAPIClient instead.
 func CreateZorkianClient(apiKey string, endpoint string) *zorkian.Client {
 	client := zorkian.NewClient(apiKey, "")
 	client.SetBaseUrl(endpoint)
@@ -32,6 +84,7 @@ func CreateZorkianClient(apiKey string, endpoint string) *zorkian.Client {
 var ErrInvalidAPI = errors.New("API Key validation failed")
 
 // ValidateAPIKeyZorkian checks that the provided client was given a correct API key.
+// Deprecated: ValidateAPIKeyZorkian uses the deprecated Zorkian client. Use ValidateAPIKey instead.
 func ValidateAPIKeyZorkian(logger *zap.Logger, client *zorkian.Client) error {
 	logger.Info("Validating API key.")
 	valid, err := client.Validate()

--- a/exporter/datadogexporter/internal/testutil/test_utils.go
+++ b/exporter/datadogexporter/internal/testutil/test_utils.go
@@ -45,7 +45,7 @@ type DatadogServer struct {
 	MetadataChan chan []byte
 }
 
-/* #nosec G101 */
+/* #nosec G101 -- This is a false positive, these are API endpoints rather than credentials */
 const (
 	ValidateAPIKeyEndpoint = "/api/v1/validate"
 	MetricV1Endpoint       = "/api/v1/series"

--- a/exporter/datadogexporter/internal/testutil/test_utils.go
+++ b/exporter/datadogexporter/internal/testutil/test_utils.go
@@ -45,16 +45,25 @@ type DatadogServer struct {
 	MetadataChan chan []byte
 }
 
+const (
+	ValidateAPIKeyEndpoint = "/api/v1/validate"
+	MetricV1Endpoint       = "/api/v1/series"
+	MetricV2Endpoint       = "/api/v2/series"
+	SketchesMetricEndpoint = "/api/beta/sketches"
+	MetadataEndpoint       = "/intake"
+)
+
 // DatadogServerMock mocks a Datadog backend server
 func DatadogServerMock(overwriteHandlerFuncs ...OverwriteHandleFunc) *DatadogServer {
 	metadataChan := make(chan []byte)
 	mux := http.NewServeMux()
 
 	handlers := map[string]http.HandlerFunc{
-		"/api/v1/validate": validateAPIKeyEndpoint,
-		"/api/v1/series":   metricsEndpoint,
-		"/intake":          newMetadataEndpoint(metadataChan),
-		"/":                func(w http.ResponseWriter, r *http.Request) {},
+		ValidateAPIKeyEndpoint: validateAPIKeyEndpoint,
+		MetricV1Endpoint:       metricsEndpoint,
+		MetricV2Endpoint:       metricsV2Endpoint,
+		MetadataEndpoint:       newMetadataEndpoint(metadataChan),
+		"/":                    func(w http.ResponseWriter, r *http.Request) {},
 	}
 	for _, f := range overwriteHandlerFuncs {
 		p, hf := f()
@@ -125,6 +134,18 @@ type metricsResponse struct {
 }
 
 func metricsEndpoint(w http.ResponseWriter, r *http.Request) {
+	res := metricsResponse{Status: "ok"}
+	resJSON, _ := json.Marshal(res)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_, err := w.Write(resJSON)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func metricsV2Endpoint(w http.ResponseWriter, r *http.Request) {
 	res := metricsResponse{Status: "ok"}
 	resJSON, _ := json.Marshal(res)
 

--- a/exporter/datadogexporter/internal/testutil/test_utils.go
+++ b/exporter/datadogexporter/internal/testutil/test_utils.go
@@ -45,6 +45,7 @@ type DatadogServer struct {
 	MetadataChan chan []byte
 }
 
+/* #nosec G101 */
 const (
 	ValidateAPIKeyEndpoint = "/api/v1/validate"
 	MetricV1Endpoint       = "/api/v1/series"

--- a/exporter/datadogexporter/logs_exporter.go
+++ b/exporter/datadogexporter/logs_exporter.go
@@ -45,9 +45,20 @@ type logsExporter struct {
 func newLogsExporter(ctx context.Context, params exporter.CreateSettings, cfg *Config, onceMetadata *sync.Once, sourceProvider source.Provider) (*logsExporter, error) {
 	// create Datadog client
 	// validation endpoint is provided by Metrics
-	client := clientutil.CreateZorkianClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
+	var err error
+	if isMetricExportV2Enabled() {
+		apiClient := clientutil.CreateAPIClient(
+			params.BuildInfo,
+			cfg.Metrics.TCPAddr.Endpoint,
+			cfg.TimeoutSettings,
+			cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify)
+		err = clientutil.ValidateAPIKey(ctx, cfg.API.Key, params.Logger, apiClient)
+	} else {
+		client := clientutil.CreateZorkianClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
+		err = clientutil.ValidateAPIKeyZorkian(params.Logger, client)
+	}
 	// validate the apiKey
-	if err := clientutil.ValidateAPIKeyZorkian(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
+	if err != nil && cfg.API.FailOnInvalidKey {
 		return nil, err
 	}
 

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -227,7 +227,7 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pmetric.Metr
 				err,
 				exp.retrier.DoWithRetries(ctx, func(context.Context) error {
 					ctx = clientutil.GetRequestContext(ctx, exp.cfg.API.Key)
-					_, _, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: ms}, *datadogV2.NewSubmitMetricsOptionalParameters())
+					_, _, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: ms})
 					return merr
 				}),
 			)

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -25,6 +25,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/source"
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/translator"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -45,6 +47,7 @@ type metricsExporter struct {
 	cfg            *Config
 	ctx            context.Context
 	client         *zorkian.Client
+	metricsApi     *datadogV2.MetricsApi
 	tr             *translator.Translator
 	scrubber       scrub.Scrubber
 	retrier        *clientutil.Retrier
@@ -99,25 +102,16 @@ func translatorFromConfig(logger *zap.Logger, cfg *Config, sourceProvider source
 }
 
 func newMetricsExporter(ctx context.Context, params exporter.CreateSettings, cfg *Config, onceMetadata *sync.Once, sourceProvider source.Provider, apmStatsProcessor api.StatsProcessor) (*metricsExporter, error) {
-	client := clientutil.CreateZorkianClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
-	client.ExtraHeader["User-Agent"] = clientutil.UserAgent(params.BuildInfo)
-	client.HttpClient = clientutil.NewHTTPClient(cfg.TimeoutSettings, cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify)
-
-	if err := clientutil.ValidateAPIKeyZorkian(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
-		return nil, err
-	}
-
 	tr, err := translatorFromConfig(params.Logger, cfg, sourceProvider)
 	if err != nil {
 		return nil, err
 	}
 
 	scrubber := scrub.NewScrubber()
-	return &metricsExporter{
+	exporter := &metricsExporter{
 		params:            params,
 		cfg:               cfg,
 		ctx:               ctx,
-		client:            client,
 		tr:                tr,
 		scrubber:          scrubber,
 		retrier:           clientutil.NewRetrier(params.Logger, cfg.RetrySettings, scrubber),
@@ -125,7 +119,28 @@ func newMetricsExporter(ctx context.Context, params exporter.CreateSettings, cfg
 		sourceProvider:    sourceProvider,
 		getPushTime:       func() uint64 { return uint64(time.Now().UTC().UnixNano()) },
 		apmStatsProcessor: apmStatsProcessor,
-	}, nil
+	}
+	if isMetricExportV2Enabled() {
+		apiClient := clientutil.CreateAPIClient(
+			params.BuildInfo,
+			cfg.Metrics.TCPAddr.Endpoint,
+			cfg.TimeoutSettings,
+			cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify)
+		if err := clientutil.ValidateAPIKey(ctx, cfg.API.Key, params.Logger, apiClient); err != nil && cfg.API.FailOnInvalidKey {
+			return nil, err
+		}
+		exporter.metricsApi = datadogV2.NewMetricsApi(apiClient)
+	} else {
+		client := clientutil.CreateZorkianClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
+		client.ExtraHeader["User-Agent"] = clientutil.UserAgent(params.BuildInfo)
+		client.HttpClient = clientutil.NewHTTPClient(cfg.TimeoutSettings, cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify)
+
+		if err := clientutil.ValidateAPIKeyZorkian(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
+			return nil, err
+		}
+		exporter.client = client
+	}
+	return exporter, nil
 }
 
 func (exp *metricsExporter) pushSketches(ctx context.Context, sl sketches.SketchSeriesList) error {
@@ -145,7 +160,12 @@ func (exp *metricsExporter) pushSketches(ctx context.Context, sl sketches.Sketch
 
 	clientutil.SetDDHeaders(req.Header, exp.params.BuildInfo, exp.cfg.API.Key)
 	clientutil.SetExtraHeaders(req.Header, clientutil.ProtobufHeaders)
-	resp, err := exp.client.HttpClient.Do(req)
+	var resp *http.Response
+	if isMetricExportV2Enabled() {
+		resp, err = exp.metricsApi.Client.Cfg.HTTPClient.Do(req)
+	} else {
+		resp, err = exp.client.HttpClient.Do(req)
+	}
 
 	if err != nil {
 		return fmt.Errorf("failed to do sketches HTTP request: %w", err)
@@ -174,7 +194,12 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pmetric.Metr
 			go metadata.Pusher(exp.ctx, exp.params, newMetadataConfigfromConfig(exp.cfg), exp.sourceProvider, attrs)
 		})
 	}
-	consumer := metrics.NewZorkianConsumer()
+	var consumer translator.Consumer
+	if isMetricExportV2Enabled() {
+		consumer = metrics.NewConsumer()
+	} else {
+		consumer = metrics.NewZorkianConsumer()
+	}
 	err := exp.tr.MapMetrics(ctx, md, consumer)
 	if err != nil {
 		return fmt.Errorf("failed to map metrics: %w", err)
@@ -187,18 +212,41 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pmetric.Metr
 	if src.Kind == source.AWSECSFargateKind {
 		tags = append(tags, exp.cfg.HostMetadata.Tags...)
 	}
-	ms, sl, sp := consumer.All(exp.getPushTime(), exp.params.BuildInfo, tags)
-	ms = metrics.PrepareZorkianSystemMetrics(ms)
 
-	err = nil
-	if len(ms) > 0 {
-		exp.params.Logger.Debug("exporting payload", zap.Any("metric", ms))
-		err = multierr.Append(
-			err,
-			exp.retrier.DoWithRetries(ctx, func(context.Context) error {
-				return exp.client.PostMetrics(ms)
-			}),
-		)
+	var sl sketches.SketchSeriesList
+	var sp []pb.ClientStatsPayload
+	if isMetricExportV2Enabled() {
+		var ms []datadogV2.MetricSeries
+		ms, sl, sp = consumer.(*metrics.Consumer).All(exp.getPushTime(), exp.params.BuildInfo, tags)
+		ms = metrics.PrepareSystemMetrics(ms)
+
+		err = nil
+		if len(ms) > 0 {
+			exp.params.Logger.Debug("exporting native Datadog payload", zap.Any("metric", ms))
+			err = multierr.Append(
+				err,
+				exp.retrier.DoWithRetries(ctx, func(context.Context) error {
+					ctx = clientutil.GetRequestContext(ctx, exp.cfg.API.Key)
+					_, _, err := exp.metricsApi.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: ms}, *datadogV2.NewSubmitMetricsOptionalParameters())
+					return err
+				}),
+			)
+		}
+	} else {
+		var ms []zorkian.Metric
+		ms, sl, sp = consumer.(*metrics.ZorkianConsumer).All(exp.getPushTime(), exp.params.BuildInfo, tags)
+		ms = metrics.PrepareZorkianSystemMetrics(ms)
+
+		err = nil
+		if len(ms) > 0 {
+			exp.params.Logger.Debug("exporting Zorkian Datadog payload", zap.Any("metric", ms))
+			err = multierr.Append(
+				err,
+				exp.retrier.DoWithRetries(ctx, func(context.Context) error {
+					return exp.client.PostMetrics(ms)
+				}),
+			)
+		}
 	}
 
 	if len(sl) > 0 {

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/source"
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/translator"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/confignet"
@@ -41,6 +42,7 @@ import (
 )
 
 func TestNewExporter(t *testing.T) {
+	enableNativeMetricExport()
 	server := testutil.DatadogServerMock()
 	defer server.Close()
 
@@ -89,6 +91,318 @@ func TestNewExporter(t *testing.T) {
 }
 
 func Test_metricsExporter_PushMetricsData(t *testing.T) {
+	enableNativeMetricExport()
+	attrs := map[string]string{
+		conventions.AttributeDeploymentEnvironment: "dev",
+		"custom_attribute":                         "custom_value",
+	}
+	tests := []struct {
+		metrics               pmetric.Metrics
+		source                source.Source
+		hostTags              []string
+		histogramMode         HistogramMode
+		expectedSeries        map[string]interface{}
+		expectedSketchPayload *gogen.SketchPayload
+		expectedErr           error
+		expectedStats         []pb.ClientStatsPayload
+	}{
+		{
+			metrics: createTestMetrics(attrs),
+			source: source.Source{
+				Kind:       source.HostnameKind,
+				Identifier: "test-host",
+			},
+			histogramMode: HistogramModeNoBuckets,
+			hostTags:      []string{"key1:value1", "key2:value2"},
+			expectedErr:   errors.New("no buckets mode and no send count sum are incompatible"),
+		},
+		{
+			metrics: createTestMetrics(attrs),
+			source: source.Source{
+				Kind:       source.HostnameKind,
+				Identifier: "test-host",
+			},
+			histogramMode: HistogramModeCounters,
+			hostTags:      []string{"key1:value1", "key2:value2"},
+			expectedSeries: map[string]interface{}{
+				"series": []interface{}{
+					map[string]interface{}{
+						"metric":    "int.gauge",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(222)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"env:dev"},
+					},
+					map[string]interface{}{
+						"metric":    "otel.system.filesystem.utilization",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(333)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"env:dev"},
+					},
+					map[string]interface{}{
+						"metric":    "double.histogram.bucket",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(2)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_COUNT),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"lower_bound:-inf", "upper_bound:0", "env:dev"},
+					},
+					map[string]interface{}{
+						"metric":    "double.histogram.bucket",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(18)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_COUNT),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"lower_bound:0", "upper_bound:inf", "env:dev"},
+					},
+					map[string]interface{}{
+						"metric":    "otel.datadog_exporter.metrics.running",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(1)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"version:latest", "command:otelcol"},
+					},
+					map[string]interface{}{
+						"metric":    "system.disk.in_use",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(333)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"env:dev"},
+					},
+				},
+			},
+		},
+		{
+			metrics: createTestMetrics(attrs),
+			source: source.Source{
+				Kind:       source.HostnameKind,
+				Identifier: "test-host",
+			},
+			histogramMode: HistogramModeDistributions,
+			hostTags:      []string{"key1:value1", "key2:value2"},
+			expectedSeries: map[string]interface{}{
+				"series": []interface{}{
+					map[string]interface{}{
+						"metric":    "int.gauge",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(222)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"env:dev"},
+					},
+					map[string]interface{}{
+						"metric":    "otel.system.filesystem.utilization",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(333)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"env:dev"},
+					},
+					map[string]interface{}{
+						"metric":    "otel.datadog_exporter.metrics.running",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(1)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"version:latest", "command:otelcol"},
+					},
+					map[string]interface{}{
+						"metric":    "system.disk.in_use",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(333)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"env:dev"},
+					},
+				},
+			},
+			expectedSketchPayload: &gogen.SketchPayload{
+				Sketches: []gogen.SketchPayload_Sketch{
+					{
+						Metric: "double.histogram",
+						Host:   "test-host",
+						Tags:   []string{"env:dev"},
+						Dogsketches: []gogen.SketchPayload_Sketch_Dogsketch{
+							{
+								Cnt: 20,
+								Avg: 0.3,
+								Sum: 6,
+								K:   []int32{0},
+								N:   []uint32{20},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			metrics: createTestMetrics(attrs),
+			source: source.Source{
+				Kind:       source.AWSECSFargateKind,
+				Identifier: "task_arn",
+			},
+			histogramMode: HistogramModeCounters,
+			hostTags:      []string{"key1:value1", "key2:value2"},
+			expectedSeries: map[string]interface{}{
+				"series": []interface{}{
+					map[string]interface{}{
+						"metric":    "int.gauge",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(222)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"env:dev", "key1:value1", "key2:value2"},
+					},
+					map[string]interface{}{
+						"metric":    "otel.system.filesystem.utilization",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(333)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"env:dev", "key1:value1", "key2:value2"},
+					},
+					map[string]interface{}{
+						"metric":    "double.histogram.bucket",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(2)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_COUNT),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"lower_bound:-inf", "upper_bound:0", "env:dev", "key1:value1", "key2:value2"},
+					},
+					map[string]interface{}{
+						"metric":    "double.histogram.bucket",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(18)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_COUNT),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"lower_bound:0", "upper_bound:inf", "env:dev", "key1:value1", "key2:value2"},
+					},
+					map[string]interface{}{
+						"metric":    "otel.datadog_exporter.metrics.running",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(1)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"version:latest", "command:otelcol", "key1:value1", "key2:value2"},
+					},
+					map[string]interface{}{
+						"metric":    "system.disk.in_use",
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(333)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
+						"tags":      []interface{}{"env:dev", "key1:value1", "key2:value2"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("kind=%s,histgramMode=%s", tt.source.Kind, tt.histogramMode), func(t *testing.T) {
+			seriesRecorder := &testutil.HTTPRequestRecorder{Pattern: testutil.MetricV2Endpoint}
+			sketchRecorder := &testutil.HTTPRequestRecorder{Pattern: testutil.SketchesMetricEndpoint}
+			server := testutil.DatadogServerMock(
+				seriesRecorder.HandlerFunc,
+				sketchRecorder.HandlerFunc,
+			)
+			defer server.Close()
+
+			var (
+				once          sync.Once
+				statsRecorder testutil.MockStatsProcessor
+			)
+			exp, err := newMetricsExporter(
+				context.Background(),
+				exportertest.NewNopCreateSettings(),
+				newTestConfig(t, server.URL, tt.hostTags, tt.histogramMode),
+				&once,
+				&testutil.MockSourceProvider{Src: tt.source},
+				&statsRecorder,
+			)
+			if tt.expectedErr == nil {
+				assert.NoError(t, err, "unexpected error")
+			} else {
+				assert.Equal(t, tt.expectedErr, err, "expected error doesn't match")
+				return
+			}
+			exp.getPushTime = func() uint64 { return 0 }
+			err = exp.PushMetricsData(context.Background(), tt.metrics)
+			if tt.expectedErr == nil {
+				assert.NoError(t, err, "unexpected error")
+			} else {
+				assert.Equal(t, tt.expectedErr, err, "expected error doesn't match")
+				return
+			}
+			if len(tt.expectedSeries) == 0 {
+				assert.Nil(t, seriesRecorder.ByteBody)
+			} else {
+				assert.Equal(t, "gzip", seriesRecorder.Header.Get("Accept-Encoding"))
+				assert.Equal(t, "application/json", seriesRecorder.Header.Get("Content-Type"))
+				assert.Equal(t, "otelcol/latest", seriesRecorder.Header.Get("User-Agent"))
+				assert.NoError(t, err)
+				var actual map[string]interface{}
+				assert.NoError(t, json.Unmarshal(seriesRecorder.ByteBody, &actual))
+				assert.EqualValues(t, tt.expectedSeries, actual)
+			}
+			if tt.expectedSketchPayload == nil {
+				assert.Nil(t, sketchRecorder.ByteBody)
+			} else {
+				assert.Equal(t, "gzip", sketchRecorder.Header.Get("Accept-Encoding"))
+				assert.Equal(t, "application/x-protobuf", sketchRecorder.Header.Get("Content-Type"))
+				assert.Equal(t, "otelcol/latest", sketchRecorder.Header.Get("User-Agent"))
+				expected, err := tt.expectedSketchPayload.Marshal()
+				assert.NoError(t, err)
+				assert.Equal(t, expected, sketchRecorder.ByteBody)
+			}
+			if tt.expectedStats == nil {
+				assert.Len(t, statsRecorder.In, 0)
+			} else {
+				assert.ElementsMatch(t, statsRecorder.In, tt.expectedStats)
+			}
+		})
+	}
+}
+
+func TestNewExporter_Zorkian(t *testing.T) {
+	enableZorkianMetricExport()
+	server := testutil.DatadogServerMock()
+	defer server.Close()
+
+	cfg := &Config{
+		API: APIConfig{
+			Key: "ddog_32_characters_long_api_key1",
+		},
+		Metrics: MetricsConfig{
+			TCPAddr: confignet.TCPAddr{
+				Endpoint: server.URL,
+			},
+			DeltaTTL: 3600,
+			HistConfig: HistogramConfig{
+				Mode:         HistogramModeDistributions,
+				SendCountSum: false,
+			},
+			SumConfig: SumConfig{
+				CumulativeMonotonicMode: CumulativeMonotonicSumModeToDelta,
+			},
+		},
+	}
+	params := exportertest.NewNopCreateSettings()
+	f := NewFactory()
+
+	// The client should have been created correctly
+	exp, err := f.CreateMetricsExporter(context.Background(), params, cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, exp)
+	testMetrics := pmetric.NewMetrics()
+	testutil.TestMetrics.CopyTo(testMetrics)
+	err = exp.ConsumeMetrics(context.Background(), testMetrics)
+	require.NoError(t, err)
+	assert.Equal(t, len(server.MetadataChan), 0)
+
+	cfg.HostMetadata.Enabled = true
+	cfg.HostMetadata.HostnameSource = HostnameSourceFirstResource
+	testMetrics = pmetric.NewMetrics()
+	testutil.TestMetrics.CopyTo(testMetrics)
+	err = exp.ConsumeMetrics(context.Background(), testMetrics)
+	require.NoError(t, err)
+	body := <-server.MetadataChan
+	var recvMetadata metadata.HostMetadata
+	err = json.Unmarshal(body, &recvMetadata)
+	require.NoError(t, err)
+	assert.Equal(t, recvMetadata.InternalHostname, "custom-hostname")
+}
+
+func Test_metricsExporter_PushMetricsData_Zorkian(t *testing.T) {
+	enableZorkianMetricExport()
 	attrs := map[string]string{
 		conventions.AttributeDeploymentEnvironment: "dev",
 		"custom_attribute":                         "custom_value",
@@ -351,8 +665,8 @@ func Test_metricsExporter_PushMetricsData(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("kind=%s,histgramMode=%s", tt.source.Kind, tt.histogramMode), func(t *testing.T) {
-			seriesRecorder := &testutil.HTTPRequestRecorder{Pattern: "/api/v1/series"}
-			sketchRecorder := &testutil.HTTPRequestRecorder{Pattern: "/api/beta/sketches"}
+			seriesRecorder := &testutil.HTTPRequestRecorder{Pattern: testutil.MetricV1Endpoint}
+			sketchRecorder := &testutil.HTTPRequestRecorder{Pattern: testutil.SketchesMetricEndpoint}
 			server := testutil.DatadogServerMock(
 				seriesRecorder.HandlerFunc,
 				sketchRecorder.HandlerFunc,

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -42,8 +42,10 @@ import (
 )
 
 func TestNewExporter(t *testing.T) {
-	err := enableNativeMetricExport()
-	require.NoError(t, err)
+	if !isMetricExportV2Enabled() {
+		require.NoError(t, enableNativeMetricExport())
+		defer require.NoError(t, enableZorkianMetricExport())
+	}
 	server := testutil.DatadogServerMock()
 	defer server.Close()
 
@@ -92,8 +94,10 @@ func TestNewExporter(t *testing.T) {
 }
 
 func Test_metricsExporter_PushMetricsData(t *testing.T) {
-	err := enableNativeMetricExport()
-	require.NoError(t, err)
+	if !isMetricExportV2Enabled() {
+		require.NoError(t, enableNativeMetricExport())
+		t.Cleanup(func() { require.NoError(t, enableZorkianMetricExport()) })
+	}
 	attrs := map[string]string{
 		conventions.AttributeDeploymentEnvironment: "dev",
 		"custom_attribute":                         "custom_value",
@@ -355,8 +359,10 @@ func Test_metricsExporter_PushMetricsData(t *testing.T) {
 }
 
 func TestNewExporter_Zorkian(t *testing.T) {
-	err := enableZorkianMetricExport()
-	require.NoError(t, err)
+	if isMetricExportV2Enabled() {
+		require.NoError(t, enableZorkianMetricExport())
+		defer require.NoError(t, enableNativeMetricExport())
+	}
 	server := testutil.DatadogServerMock()
 	defer server.Close()
 
@@ -405,8 +411,10 @@ func TestNewExporter_Zorkian(t *testing.T) {
 }
 
 func Test_metricsExporter_PushMetricsData_Zorkian(t *testing.T) {
-	err := enableZorkianMetricExport()
-	require.NoError(t, err)
+	if isMetricExportV2Enabled() {
+		require.NoError(t, enableZorkianMetricExport())
+		t.Cleanup(func() { require.NoError(t, enableNativeMetricExport()) })
+	}
 	attrs := map[string]string{
 		conventions.AttributeDeploymentEnvironment: "dev",
 		"custom_attribute":                         "custom_value",

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -42,7 +42,8 @@ import (
 )
 
 func TestNewExporter(t *testing.T) {
-	enableNativeMetricExport()
+	err := enableNativeMetricExport()
+	require.NoError(t, err)
 	server := testutil.DatadogServerMock()
 	defer server.Close()
 
@@ -91,7 +92,8 @@ func TestNewExporter(t *testing.T) {
 }
 
 func Test_metricsExporter_PushMetricsData(t *testing.T) {
-	enableNativeMetricExport()
+	err := enableNativeMetricExport()
+	require.NoError(t, err)
 	attrs := map[string]string{
 		conventions.AttributeDeploymentEnvironment: "dev",
 		"custom_attribute":                         "custom_value",
@@ -353,7 +355,8 @@ func Test_metricsExporter_PushMetricsData(t *testing.T) {
 }
 
 func TestNewExporter_Zorkian(t *testing.T) {
-	enableZorkianMetricExport()
+	err := enableZorkianMetricExport()
+	require.NoError(t, err)
 	server := testutil.DatadogServerMock()
 	defer server.Close()
 
@@ -402,7 +405,8 @@ func TestNewExporter_Zorkian(t *testing.T) {
 }
 
 func Test_metricsExporter_PushMetricsData_Zorkian(t *testing.T) {
-	enableZorkianMetricExport()
+	err := enableZorkianMetricExport()
+	require.NoError(t, err)
 	attrs := map[string]string{
 		conventions.AttributeDeploymentEnvironment: "dev",
 		"custom_attribute":                         "custom_value",

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	traceconfig "github.com/DataDog/datadog-agent/pkg/trace/config"
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/featuregate"
@@ -42,12 +43,13 @@ import (
 type traceExporter struct {
 	params         exporter.CreateSettings
 	cfg            *Config
-	ctx            context.Context // ctx triggers shutdown upon cancellation
-	client         *zorkian.Client // client sends runnimg metrics to backend & performs API validation
-	scrubber       scrub.Scrubber  // scrubber scrubs sensitive information from error messages
-	onceMetadata   *sync.Once      // onceMetadata ensures that metadata is sent only once across all exporters
-	agent          *agent.Agent    // agent processes incoming traces
-	sourceProvider source.Provider // is able to source the origin of a trace (hostname, container, etc)
+	ctx            context.Context       // ctx triggers shutdown upon cancellation
+	client         *zorkian.Client       // client sends runnimg metrics to backend & performs API validation
+	metricsApi     *datadogV2.MetricsApi // client sends runnimg metrics to backend
+	scrubber       scrub.Scrubber        // scrubber scrubs sensitive information from error messages
+	onceMetadata   *sync.Once            // onceMetadata ensures that metadata is sent only once across all exporters
+	agent          *agent.Agent          // agent processes incoming traces
+	sourceProvider source.Provider       // is able to source the origin of a trace (hostname, container, etc)
 }
 
 func newTracesExporter(ctx context.Context, params exporter.CreateSettings, cfg *Config, onceMetadata *sync.Once, sourceProvider source.Provider, agent *agent.Agent) (*traceExporter, error) {
@@ -65,6 +67,23 @@ func newTracesExporter(ctx context.Context, params exporter.CreateSettings, cfg 
 		onceMetadata:   onceMetadata,
 		scrubber:       scrub.NewScrubber(),
 		sourceProvider: sourceProvider,
+	}
+	if isMetricExportV2Enabled() {
+		apiClient := clientutil.CreateAPIClient(
+			params.BuildInfo,
+			cfg.Metrics.TCPAddr.Endpoint,
+			cfg.TimeoutSettings,
+			cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify)
+		if err := clientutil.ValidateAPIKey(ctx, cfg.API.Key, params.Logger, apiClient); err != nil && cfg.API.FailOnInvalidKey {
+			return nil, err
+		}
+		exp.metricsApi = datadogV2.NewMetricsApi(apiClient)
+	} else {
+		client := clientutil.CreateZorkianClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
+		if err := clientutil.ValidateAPIKeyZorkian(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
+			return nil, err
+		}
+		exp.client = client
 	}
 	return exp, nil
 }
@@ -90,7 +109,6 @@ func (exp *traceExporter) consumeTraces(
 	rspans := td.ResourceSpans()
 	hosts := make(map[string]struct{})
 	tags := make(map[string]struct{})
-	now := pcommon.NewTimestampFromTime(time.Now())
 	for i := 0; i < rspans.Len(); i++ {
 		rspan := rspans.At(i)
 		src := exp.agent.OTLPReceiver.ReceiveResourceSpans(ctx, rspan, http.Header{}, "otlp-exporter")
@@ -101,21 +119,45 @@ func (exp *traceExporter) consumeTraces(
 			tags[src.Tag()] = struct{}{}
 		}
 	}
-	series := make([]zorkian.Metric, 0, len(hosts)+len(tags))
-	for host := range hosts {
-		series = append(series, metrics.DefaultZorkianMetrics("traces", host, uint64(now), exp.params.BuildInfo)...)
-	}
-	for tag := range tags {
-		ms := metrics.DefaultZorkianMetrics("traces", "", uint64(now), exp.params.BuildInfo)
-		for i := range ms {
-			ms[i].Tags = append(ms[i].Tags, tag)
+
+	exp.exportTraceMetrics(ctx, hosts, tags)
+	return nil
+}
+
+func (exp *traceExporter) exportTraceMetrics(ctx context.Context, hosts map[string]struct{}, tags map[string]struct{}) {
+	now := pcommon.NewTimestampFromTime(time.Now())
+	var err error
+	if isMetricExportV2Enabled() {
+		series := make([]datadogV2.MetricSeries, 0, len(hosts)+len(tags))
+		for host := range hosts {
+			series = append(series, metrics.DefaultMetrics("traces", host, uint64(now), exp.params.BuildInfo)...)
 		}
-		series = append(series, ms...)
+		for tag := range tags {
+			ms := metrics.DefaultMetrics("traces", "", uint64(now), exp.params.BuildInfo)
+			for i := range ms {
+				ms[i].Tags = append(ms[i].Tags, tag)
+			}
+			series = append(series, ms...)
+		}
+		ctx = clientutil.GetRequestContext(ctx, exp.cfg.API.Key)
+		_, _, err = exp.metricsApi.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: series}, *datadogV2.NewSubmitMetricsOptionalParameters())
+	} else {
+		series := make([]zorkian.Metric, 0, len(hosts)+len(tags))
+		for host := range hosts {
+			series = append(series, metrics.DefaultZorkianMetrics("traces", host, uint64(now), exp.params.BuildInfo)...)
+		}
+		for tag := range tags {
+			ms := metrics.DefaultZorkianMetrics("traces", "", uint64(now), exp.params.BuildInfo)
+			for i := range ms {
+				ms[i].Tags = append(ms[i].Tags, tag)
+			}
+			series = append(series, ms...)
+		}
+		err = exp.client.PostMetrics(series)
 	}
-	if err := exp.client.PostMetrics(series); err != nil {
+	if err != nil {
 		exp.params.Logger.Error("Error posting hostname/tags series", zap.Error(err))
 	}
-	return nil
 }
 
 func newTraceAgent(ctx context.Context, params exporter.CreateSettings, cfg *Config, sourceProvider source.Provider) (*agent.Agent, error) {

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -135,7 +135,7 @@ func (exp *traceExporter) exportTraceMetrics(ctx context.Context, hosts map[stri
 			series = append(series, ms...)
 		}
 		ctx = clientutil.GetRequestContext(ctx, exp.cfg.API.Key)
-		_, _, err = exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: series}, *datadogV2.NewSubmitMetricsOptionalParameters())
+		_, _, err = exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: series})
 	} else {
 		series := make([]zorkian.Metric, 0, len(hosts)+len(tags))
 		for host := range hosts {

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -53,21 +53,16 @@ type traceExporter struct {
 }
 
 func newTracesExporter(ctx context.Context, params exporter.CreateSettings, cfg *Config, onceMetadata *sync.Once, sourceProvider source.Provider, agent *agent.Agent) (*traceExporter, error) {
-	// client to send running metric to the backend & perform API key validation
-	client := clientutil.CreateZorkianClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
-	if err := clientutil.ValidateAPIKeyZorkian(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
-		return nil, err
-	}
 	exp := &traceExporter{
 		params:         params,
 		cfg:            cfg,
 		ctx:            ctx,
-		client:         client,
 		agent:          agent,
 		onceMetadata:   onceMetadata,
 		scrubber:       scrub.NewScrubber(),
 		sourceProvider: sourceProvider,
 	}
+	// client to send running metric to the backend & perform API key validation
 	if isMetricExportV2Enabled() {
 		apiClient := clientutil.CreateAPIClient(
 			params.BuildInfo,

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -45,7 +45,7 @@ type traceExporter struct {
 	cfg            *Config
 	ctx            context.Context       // ctx triggers shutdown upon cancellation
 	client         *zorkian.Client       // client sends runnimg metrics to backend & performs API validation
-	metricsApi     *datadogV2.MetricsApi // client sends runnimg metrics to backend
+	metricsAPI     *datadogV2.MetricsApi // client sends runnimg metrics to backend
 	scrubber       scrub.Scrubber        // scrubber scrubs sensitive information from error messages
 	onceMetadata   *sync.Once            // onceMetadata ensures that metadata is sent only once across all exporters
 	agent          *agent.Agent          // agent processes incoming traces
@@ -77,7 +77,7 @@ func newTracesExporter(ctx context.Context, params exporter.CreateSettings, cfg 
 		if err := clientutil.ValidateAPIKey(ctx, cfg.API.Key, params.Logger, apiClient); err != nil && cfg.API.FailOnInvalidKey {
 			return nil, err
 		}
-		exp.metricsApi = datadogV2.NewMetricsApi(apiClient)
+		exp.metricsAPI = datadogV2.NewMetricsApi(apiClient)
 	} else {
 		client := clientutil.CreateZorkianClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
 		if err := clientutil.ValidateAPIKeyZorkian(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
@@ -140,7 +140,7 @@ func (exp *traceExporter) exportTraceMetrics(ctx context.Context, hosts map[stri
 			series = append(series, ms...)
 		}
 		ctx = clientutil.GetRequestContext(ctx, exp.cfg.API.Key)
-		_, _, err = exp.metricsApi.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: series}, *datadogV2.NewSubmitMetricsOptionalParameters())
+		_, _, err = exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: series}, *datadogV2.NewSubmitMetricsOptionalParameters())
 	} else {
 		series := make([]zorkian.Metric, 0, len(hosts)+len(tags))
 		for host := range hosts {

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes"
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/confignet"
@@ -162,20 +163,29 @@ func TestTracesSource(t *testing.T) {
 	exporter, err := f.CreateTracesExporter(context.Background(), params, &cfg)
 	assert.NoError(err)
 
-	// Payload specifies a sub-set of a metrics series payload.
+	// Payload specifies a sub-set of a Zorkian metrics series payload.
 	type Payload struct {
 		Series []struct {
 			Host string   `json:"host,omitempty"`
 			Tags []string `json:"tags,omitempty"`
 		} `json:"series"`
 	}
-	// getHostTags extracts the host and tags from the metrics series payload
+	// getHostTags extracts the host and tags from the Zorkian metrics series payload
 	// body found in data.
 	getHostTags := func(data []byte) (host string, tags []string) {
 		var p Payload
 		assert.NoError(json.Unmarshal(data, &p))
 		assert.Len(p.Series, 1)
 		return p.Series[0].Host, p.Series[0].Tags
+	}
+	// getHostTagsV2 extracts the host and tags from the native DatadogV2 metrics series payload
+	// body found in data.
+	getHostTagsV2 := func(data []byte) (host string, tags []string) {
+		var p datadogV2.MetricPayload
+		assert.NoError(json.Unmarshal(data, &p))
+		assert.Len(p.Series, 1)
+		assert.Len(p.Series[0].Resources, 1)
+		return *p.Series[0].Resources[0].Name, p.Series[0].Tags
 	}
 	for _, tt := range []struct {
 		attrs map[string]interface{}
@@ -214,9 +224,15 @@ func TestTracesSource(t *testing.T) {
 			timeout := time.After(time.Second)
 			select {
 			case data := <-reqs:
-				host, tags := getHostTags(data)
-				assert.Equal(host, tt.host)
-				assert.EqualValues(tags, tt.tags)
+				var host string
+				var tags []string
+				if isMetricExportV2Enabled() {
+					host, tags = getHostTagsV2(data)
+				} else {
+					host, tags = getHostTags(data)
+				}
+				assert.Equal(tt.host, host)
+				assert.EqualValues(tt.tags, tags)
 			case <-timeout:
 				t.Fatal("timeout")
 			}

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -111,7 +111,13 @@ func (testlogger) Flush() {}
 func TestTracesSource(t *testing.T) {
 	reqs := make(chan []byte, 1)
 	metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/series" {
+		var expectedMetricEndpoint string
+		if isMetricExportV2Enabled() {
+			expectedMetricEndpoint = testutil.MetricV2Endpoint
+		} else {
+			expectedMetricEndpoint = testutil.MetricV1Endpoint
+		}
+		if r.URL.Path != expectedMetricEndpoint {
 			// we only want to capture series payloads
 			return
 		}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Migrate metrics export in `datadogexporter` from `gopkg.in/zorkian/go-datadog-api.v2` to `github.com/DataDog/datadog-api-client-go/v2/api/datadog` because the Zorkian library is deprecated. This is guarded by feature gate and can be disabled by adding CLI flag --feature-gates=-exporter.datadogexporter.metricexportnativeclient

**Link to tracking Issue:** <Issue number if applicable>

Fixes #16776.
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6944.

**Testing:** <Describe what testing was performed and which tests were added.>

Tested in the staging environment, verified OTLP metrics are properly displayed on Datadog UI.

**Documentation:** <Describe the documentation added.>