### PR TITLE
[exporter/azuredataexplorerexporter] Change time format to RFC3339Nano

### DIFF
--- a/exporter/azuredataexplorerexporter/logsdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/logsdata_to_adx.go
@@ -25,8 +25,8 @@ import (
 )
 
 type AdxLog struct {
-	Timestamp          string                 // The timestamp of the occurrence. Formatted into string as RFC3339
-	ObservedTimestamp  string                 // The timestamp of logs observed in opentelemetry collector.  Formatted into string as RFC3339
+	Timestamp          string                 // The timestamp of the occurrence. Formatted into string as RFC3339Nano
+	ObservedTimestamp  string                 // The timestamp of logs observed in opentelemetry collector.  Formatted into string as RFC3339Nano
 	TraceID            string                 // TraceId associated to the log
 	SpanID             string                 // SpanId associated to the log
 	SeverityText       string                 // The severity level of the log
@@ -43,8 +43,8 @@ func mapToAdxLog(resource pcommon.Resource, scope pcommon.InstrumentationScope, 
 	clonedLogAttrib := cloneMap(logAttrib)
 	copyMap(clonedLogAttrib, getScopeMap(scope))
 	adxLog := &AdxLog{
-		Timestamp:          logData.Timestamp().AsTime().Format(time.RFC3339),
-		ObservedTimestamp:  logData.ObservedTimestamp().AsTime().Format(time.RFC3339),
+		Timestamp:          logData.Timestamp().AsTime().Format(time.RFC3339Nano),
+		ObservedTimestamp:  logData.ObservedTimestamp().AsTime().Format(time.RFC3339Nano),
 		TraceID:            traceutil.TraceIDToHexOrEmptyString(logData.TraceID()),
 		SpanID:             traceutil.SpanIDToHexOrEmptyString(logData.SpanID()),
 		SeverityText:       logData.SeverityText(),

--- a/exporter/azuredataexplorerexporter/logsdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/logsdata_to_adx_test.go
@@ -29,7 +29,7 @@ import (
 func Test_mapToAdxLog(t *testing.T) {
 	logger := zap.NewNop()
 	epoch, _ := time.Parse("2006-01-02T15:04:05Z07:00", "1970-01-01T00:00:00Z")
-	defaultTime := pcommon.NewTimestampFromTime(epoch).AsTime().Format(time.RFC3339)
+	defaultTime := pcommon.NewTimestampFromTime(epoch).AsTime().Format(time.RFC3339Nano)
 	tmap := make(map[string]interface{})
 	tmap["key"] = "value"
 	tmap[hostkey] = testhost

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
@@ -44,7 +44,7 @@ const (
 
 // This is derived from the specification https://opentelemetry.io/docs/reference/specification/metrics/datamodel/
 type AdxMetric struct {
-	Timestamp string // The timestamp of the occurrence. A metric is measured at a point of time. Formatted into string as RFC3339
+	Timestamp string // The timestamp of the occurrence. A metric is measured at a point of time. Formatted into string as RFC3339Nano
 	// Including name, the Metric object is defined by the following properties:
 	MetricName        string                 // Name of the metric field
 	MetricType        string                 // The data point type (e.g. Sum, Gauge, Histogram ExponentialHistogram, Summary)
@@ -81,7 +81,7 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 			desc = md.Description()
 		}
 		return &AdxMetric{
-			Timestamp:          times.Format(time.RFC3339),
+			Timestamp:          times.Format(time.RFC3339Nano),
 			MetricName:         name,
 			MetricType:         mt.String(),
 			MetricUnit:         md.Unit(),

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
@@ -36,7 +36,7 @@ const (
 // The timestamps used for the tests
 var tsUnix = time.Unix(time.Now().Unix(), time.Now().UnixNano())
 var ts = pcommon.NewTimestampFromTime(tsUnix)
-var tstr = ts.AsTime().Format(time.RFC3339)
+var tstr = ts.AsTime().Format(time.RFC3339Nano)
 
 // the histogram values and distribution for the tests
 var distributionBounds = []float64{1, 2, 4}

--- a/exporter/azuredataexplorerexporter/tracesdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/tracesdata_to_adx.go
@@ -30,8 +30,8 @@ type AdxTrace struct {
 	SpanName           string                 // The SpanName of the Trace
 	SpanStatus         string                 // The SpanStatus associated to the Trace
 	SpanKind           string                 // The SpanKind of the Trace
-	StartTime          string                 // The start time of the occurrence. Formatted into string as RFC3339
-	EndTime            string                 // The end time of the occurrence. Formatted into string as RFC3339
+	StartTime          string                 // The start time of the occurrence. Formatted into string as RFC3339Nano
+	EndTime            string                 // The end time of the occurrence. Formatted into string as RFC3339Nano
 	ResourceAttributes map[string]interface{} // JSON Resource attributes that can then be parsed.
 	TraceAttributes    map[string]interface{} // JSON attributes that can then be parsed.
 	Events             []*Event               // Array containing the events in a span
@@ -64,8 +64,8 @@ func mapToAdxTrace(resource pcommon.Resource, scope pcommon.InstrumentationScope
 		SpanName:           spanData.Name(),
 		SpanStatus:         traceutil.StatusCodeStr(spanData.Status().Code()),
 		SpanKind:           traceutil.SpanKindStr(spanData.Kind()),
-		StartTime:          spanData.StartTimestamp().AsTime().Format(time.RFC3339),
-		EndTime:            spanData.EndTimestamp().AsTime().Format(time.RFC3339),
+		StartTime:          spanData.StartTimestamp().AsTime().Format(time.RFC3339Nano),
+		EndTime:            spanData.EndTimestamp().AsTime().Format(time.RFC3339Nano),
 		ResourceAttributes: resource.Attributes().AsRaw(),
 		TraceAttributes:    clonedTraceAttrib,
 		Events:             getEventsData(spanData),
@@ -78,7 +78,7 @@ func getEventsData(sd ptrace.Span) []*Event {
 
 	for i := 0; i < sd.Events().Len(); i++ {
 		event := &Event{
-			Timestamp:       sd.Events().At(i).Timestamp().AsTime().Format(time.RFC3339),
+			Timestamp:       sd.Events().At(i).Timestamp().AsTime().Format(time.RFC3339Nano),
 			EventName:       sd.Events().At(i).Name(),
 			EventAttributes: sd.Events().At(i).Attributes().AsRaw(),
 		}

--- a/exporter/azuredataexplorerexporter/tracesdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/tracesdata_to_adx_test.go
@@ -26,7 +26,7 @@ import (
 
 func Test_mapToAdxTrace(t *testing.T) {
 	epoch, _ := time.Parse("2006-01-02T15:04:05Z07:00", "1970-01-01T00:00:00Z")
-	defaultTime := pcommon.NewTimestampFromTime(epoch).AsTime().Format(time.RFC3339)
+	defaultTime := pcommon.NewTimestampFromTime(epoch).AsTime().Format(time.RFC3339Nano)
 	tmap := make(map[string]interface{})
 	tmap["key"] = "value"
 	tmap[hostkey] = testhost


### PR DESCRIPTION
**Description:** 
Convert all time formatting from `time.RFC3339` (which excludes nanoseconds) to `time.RFC3339Nano` for increased precision.

**Link to tracking Issue:** <Issue number if applicable>
#16546 

**Testing:**
Timestamps have also been updated in existing tests.
