### PR TITLE
[exporter/coralogix] Mark as unmaintained

### DIFF
--- a/.chloggen/mx-psi_coralogix-unmaintained.yaml
+++ b/.chloggen/mx-psi_coralogix-unmaintained.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/coralogix
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark Coralogix exporter as unmaintained
+
+# One or more tracking issues related to the change
+issues: [16548]

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -2,8 +2,7 @@
 
 | Status                   |                        |
 | ------------------------ |----------------------- |
-| Stability                | traces, metrics [beta] |
-|                          | logs [alpha]           |
+| Stability                | [unmaintained]         |
 | Supported pipeline types | traces, metrics, logs  |
 | Distributions            | [contrib]              |
 
@@ -231,6 +230,5 @@ exporters:
 Our world-class customer success team is available 24/7 to walk you through the setup for this exporter and answer any questions that may come up.
 Feel free to reach out to us **via our in-app chat** or by sending us an email to [support@coralogix.com](mailto:support@coralogix.com).
 
-[alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
-[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
+[unmaintained]:https://github.com/open-telemetry/opentelemetry-collector#unmaintained
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -6,6 +6,8 @@
 | Supported pipeline types | traces, metrics, logs  |
 | Distributions            | [contrib]              |
 
+**Note**: This component was marked as unmaintained on 2022-11-30, it will be removed from official builds on 2023-05-30
+
 The Coralogix exporter sends traces, metrics and logs to [Coralogix](https://coralogix.com/).
 
 > Please review the Collector's [security

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -27,7 +27,8 @@ import (
 const (
 	typeStr = "coralogix"
 	// The stability level of the exporter.
-	stability = component.StabilityLevelBeta
+	// Marked as unmantained on 2022-11-30, will be removed from official builds on 2023-05-30.
+	stability = component.StabilityLevelUnmaintained
 )
 
 // Config defines by Coralogix.

--- a/exporter/coralogixexporter/factory.go
+++ b/exporter/coralogixexporter/factory.go
@@ -32,7 +32,8 @@ func NewFactory() component.ExporterFactory {
 		createDefaultConfig,
 		component.WithTracesExporter(createTraceExporter, stability),
 		component.WithMetricsExporter(createMetricsExporter, stability),
-		component.WithLogsExporter(createLogsExporter, component.StabilityLevelAlpha),
+		// Marked as unmantained on 2022-11-30, will be removed from official builds on 2023-05-30.
+		component.WithLogsExporter(createLogsExporter, component.StabilityLevelUnmaintained),
 	)
 }
 


### PR DESCRIPTION
**Description:** 

Per the [unmaintained rules](https://github.com/open-telemetry/opentelemetry-collector/#unmaintained), since there has been no answer on #7931 for over 13 weeks, we are marking the Coralogix exporter as unmaintained on 2022-11-30.
This means that if no action is taken it will be removed from official builds on 2023-05-30.

**Link to tracking Issue:** Relates to #7931
