### PR TITLE
[chore] Include component name in "ping codeowners on issue" workflow comment

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-issues.sh
+++ b/.github/workflows/scripts/ping-codeowners-issues.sh
@@ -36,4 +36,4 @@ if [[ "${OWNERS}" =~ "${SENDER}" ]]; then
     exit 0
 fi
 
-gh issue comment "${ISSUE}" --body "Pinging code owners: ${OWNERS}. See [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself."
+gh issue comment "${ISSUE}" --body "Pinging code owners for ${COMPONENT}: ${OWNERS}. See [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself."


### PR DESCRIPTION
**Description:**

Puts the component name in the comment created by the workflow.

**Link to tracking Issue:**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14568
