### PR TITLE
Testbed OTLP receiver should use compression=none for no-gzip test

### DIFF
--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -127,10 +127,12 @@ func (bor *BaseOTLPDataReceiver) GenConfigYAMLStr() string {
     tls:
       insecure: true`, bor.exporterType, addr)
 
+	comp := "none"
 	if bor.compression != "" {
-		str += fmt.Sprintf(`
-    compression: "%s"`, bor.compression)
+		comp = bor.compression
 	}
+	str += fmt.Sprintf(`
+    compression: "%s"`, comp)
 
 	return str
 }


### PR DESCRIPTION
**Description:** 

The OTLP Exporter testbed receiver has no-gzip tests that are actually configuring gzip, so two identical test scenarios for gRPC and HTTP each. This fixes it.

**Link to tracking Issue:**

Related feature request: https://github.com/open-telemetry/opentelemetry-collector/issues/6638.

**Testing:** 

before

```
Trace10kSPS/OTLP-gRPC                   |PASS  |     15s|    16.7|    18.6|         52|         75|    150000|        150000|
Trace10kSPS/OTLP-gRPC-gzip              |PASS  |     15s|    16.7|    34.1|         54|         76|    149900|        149900|
Trace10kSPS/OTLP-HTTP                   |PASS  |     15s|    16.4|    17.1|         47|         68|    150000|        150000|
Trace10kSPS/OTLP-HTTP-gzip              |PASS  |     15s|    16.9|    18.8|         47|         67|    149800|        149800|
```
after
```
Trace10kSPS/OTLP-gRPC                   |PASS  |     15s|    11.0|    12.8|         54|         77|    149300|        149300|
Trace10kSPS/OTLP-gRPC-gzip              |PASS  |     15s|    14.7|    16.5|         54|         78|    149500|        149500|
Trace10kSPS/OTLP-HTTP                   |PASS  |     15s|     9.6|    11.8|         45|         65|    149000|        149000|
Trace10kSPS/OTLP-HTTP-gzip              |PASS  |     15s|    13.2|    14.4|         47|         68|    148300|        148300|
```
