### PR TITLE
[mdatagen] Rename metadata.yaml attribute field value -> name_override

### DIFF
--- a/.chloggen/mdatagen-rename-attribute-value-field.yaml
+++ b/.chloggen/mdatagen-rename-attribute-value-field.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename metadata.yaml attribute field from `value` to `name_override`
+
+# One or more tracking issues related to the change
+issues: [16561]

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -156,10 +156,8 @@ func (m metric) IsEnabled() bool {
 type attribute struct {
 	// Description describes the purpose of the attribute.
 	Description string `validate:"notblank"`
-	// Value can optionally specify the value this attribute will have.
-	// For example, the attribute may have the identifier `MemState` to its
-	// value may be `state` when used.
-	Value string
+	// NameOverride can be used to override the attribute name.
+	NameOverride string `mapstructure:"name_override"`
 	// Enum can optionally describe the set of values to which the attribute can belong.
 	Enum []string
 	// Type is an attribute type.

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -38,30 +38,30 @@ func Test_loadMetadata(t *testing.T) {
 				SemConvVersion: "1.9.0",
 				Attributes: map[attributeName]attribute{
 					"enumAttribute": {
-						Description: "Attribute with a known set of values.",
-						Value:       "",
-						Enum:        []string{"red", "green", "blue"},
+						Description:  "Attribute with a known set of values.",
+						NameOverride: "",
+						Enum:         []string{"red", "green", "blue"},
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
 					},
 					"freeFormAttribute": {
-						Description: "Attribute that can take on any value.",
-						Value:       "",
+						Description:  "Attribute that can take on any value.",
+						NameOverride: "",
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
 					},
 					"freeFormAttributeWithValue": {
-						Description: "Attribute that has alternate value set.",
-						Value:       "state",
+						Description:  "Attribute that has alternate value set.",
+						NameOverride: "state",
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
 					},
 					"booleanValueType": {
-						Description: "Attribute with a boolean value.",
-						Value:       "0",
+						Description:  "Attribute with a boolean value.",
+						NameOverride: "0",
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeBool,
 						},

--- a/cmd/mdatagen/main.go
+++ b/cmd/mdatagen/main.go
@@ -81,9 +81,9 @@ func generateFile(tmplFile string, outputFile string, md metadata) error {
 				"attributeInfo": func(an attributeName) attribute {
 					return md.Attributes[an]
 				},
-				"attributeKey": func(an attributeName) string {
-					if md.Attributes[an].Value != "" {
-						return md.Attributes[an].Value
+				"attributeName": func(an attributeName) string {
+					if md.Attributes[an].NameOverride != "" {
+						return md.Attributes[an].NameOverride
 					}
 					return string(an)
 				},

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -27,7 +27,7 @@ const (
 name: metricreceiver
 attributes:
   cpu_type:
-    value: type
+    name_override: type
     description: The type of CPU consumption
     type: string
     enum:

--- a/cmd/mdatagen/metric-metadata.yaml
+++ b/cmd/mdatagen/metric-metadata.yaml
@@ -17,9 +17,9 @@ resource_attributes:
 # being described below.
 attributes:
   <attribute.name>:
-    # Optional: if the attribute name as described by the key is not the actual attribute
-    # value to be reported that value can be overridden here.
-    value:
+    # Optional: this field can be used to override the actual attribute name defined by the key.
+    # It should be used if multiple metrics have different attributes with the same name.
+    name_override:
     # Required: description of the attribute.
     description:
     # Optional: array of attribute values if they are static values.

--- a/cmd/mdatagen/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/templates/documentation.md.tmpl
@@ -26,7 +26,7 @@
 | ---- | ----------- | ------ |
 {{- range $metric.Attributes }}
 {{- $attribute := . | attributeInfo }}
-| {{ . | attributeKey }} | {{ $attribute.Description }} |
+| {{ attributeName . }} | {{ $attribute.Description }} |
 {{- if $attribute.Enum }} {{ $attribute.Type }}: ``{{ stringsJoin $attribute.Enum "``, ``" }}``{{ else }} Any {{ $attribute.Type }}{{ end }} |
 {{- end }}
 

--- a/cmd/mdatagen/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/templates/metrics.go.tmpl
@@ -127,9 +127,9 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.Set{{ $metric.Data.MetricValueType }}Value(val)
 	{{- range $metric.Attributes }}
 	{{- if eq (attributeInfo .).Type.Primitive "[]byte" }}
-	dp.Attributes().PutEmptyBytes("{{ attributeKey .}}").FromRaw({{ .RenderUnexported }}AttributeValue)
+	dp.Attributes().PutEmptyBytes("{{ attributeName . }}").FromRaw({{ .RenderUnexported }}AttributeValue)
 	{{- else }}
-	dp.Attributes().Put{{ (attributeInfo .).Type }}("{{ attributeKey .}}", {{ .RenderUnexported }}AttributeValue)
+	dp.Attributes().Put{{ (attributeInfo .).Type }}("{{ attributeName .}}", {{ .RenderUnexported }}AttributeValue)
 	{{- end }}
 	{{- end }}
 }
@@ -216,16 +216,16 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 {{- range $attr.Enum }}
 // With{{ $name.Render }}{{ . | publicVar }} sets "{{ $name }}={{ . }}" attribute for current resource.
 func With{{ $name.Render }}{{ . | publicVar }}(rm pmetric.ResourceMetrics) {
-	rm.Resource().Attributes().PutStr("{{ attributeKey $name}}", "{{ . }}")
+	rm.Resource().Attributes().PutStr("{{ attributeName $name}}", "{{ . }}")
 }
 {{- else }}
 // With{{ $name.Render }} sets provided value as "{{ $name }}" attribute for current resource.
 func With{{ $name.Render }}(val {{ $attr.Type.Primitive }}) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
 		{{- if eq $attr.Type.Primitive "[]byte" }}
-		rm.Resource().Attributes().PutEmptyBytes("{{ attributeKey $name}}").FromRaw(val)
+		rm.Resource().Attributes().PutEmptyBytes("{{ attributeName $name}}").FromRaw(val)
 		{{- else }}
-		rm.Resource().Attributes().Put{{ $attr.Type }}("{{ attributeKey $name}}", val)
+		rm.Resource().Attributes().Put{{ $attr.Type }}("{{ attributeName $name}}", val)
 		{{- end }}
 	}
 }

--- a/cmd/mdatagen/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/templates/metrics_test.go.tmpl
@@ -108,7 +108,7 @@ func TestAllMetrics(t *testing.T) {
 			assert.Equal(t, pmetric.NumberDataPointValueType{{ $metric.Data.MetricValueType }}, dp.ValueType())
 			assert.Equal(t, {{ $metric.Data.MetricValueType.BasicType }}(1), dp.{{ $metric.Data.MetricValueType }}Value())
 			{{- range $i, $attr := $metric.Attributes }}
-			attrVal, ok {{ if eq $i 0 }}:{{ end }}= dp.Attributes().Get("{{ attributeKey $attr }}")
+			attrVal, ok {{ if eq $i 0 }}:{{ end }}= dp.Attributes().Get("{{ attributeName $attr }}")
 			assert.True(t, ok)
 			{{- if (attributeInfo $attr).Enum }}
 			assert.Equal(t, "{{ index (attributeInfo $attr).Enum 0 }}", attrVal.Str())

--- a/cmd/mdatagen/testdata/all_options.yaml
+++ b/cmd/mdatagen/testdata/all_options.yaml
@@ -8,7 +8,7 @@ attributes:
     type: string
 
   freeFormAttributeWithValue:
-    value: state
+    name_override: state
     description: Attribute that has alternate value set.
     type: string
 
@@ -18,9 +18,9 @@ attributes:
     enum: [red, green, blue]
 
   booleanValueType:
+    name_override: false
     description: Attribute with a boolean value.
     type: bool
-    value: false
 
 metrics:
   # A metric enabled by default.

--- a/receiver/activedirectorydsreceiver/metadata.yaml
+++ b/receiver/activedirectorydsreceiver/metadata.yaml
@@ -8,21 +8,21 @@ attributes:
       - sent
       - received
   network_data_type:
-    value: type
+    name_override: type
     description: The type of network data sent.
     type: string
     enum:
       - compressed
       - uncompressed
   value_type:
-    value: type
+    name_override: type
     description: The type of value sent.
     type: string
     enum:
       - distingushed_names
       - other
   operation_type:
-    value: type
+    name_override: type
     description: The type of operation.
     type: string
     enum:
@@ -30,14 +30,14 @@ attributes:
       - write
       - search
   suboperation_type:
-    value: type
+    name_override: type
     description: The type of suboperation.
     type: string
     enum:
       - security_descriptor_propagations_event
       - search
   sync_result:
-    value: result
+    name_override: result
     description: The result status of the sync request.
     type: string
     enum:
@@ -45,7 +45,7 @@ attributes:
       - schema_mismatch
       - other
   bind_type:
-    value: type
+    name_override: type
     description: The type of bind to the domain server.
     type: string
     enum:

--- a/receiver/aerospikereceiver/metadata.yaml
+++ b/receiver/aerospikereceiver/metadata.yaml
@@ -10,7 +10,7 @@ resource_attributes:
 
 attributes:
   namespace_component:
-    value: component
+    name_override: component
     description: Individual component of a namespace
     type: string
     enum:
@@ -19,7 +19,7 @@ attributes:
       - set_index
       - secondary_index
   scan_type:
-    value: type
+    name_override: type
     description: Type of scan operation performed on a namespace
     type: string
     enum:
@@ -28,7 +28,7 @@ attributes:
       - ops_background
       - udf_background
   scan_result:
-    value: result
+    name_override: result
     description: Result of a scan operation performed on a namespace
     type: string
     enum:
@@ -36,14 +36,14 @@ attributes:
       - complete
       - error
   index_type:
-    value: index
+    name_override: index
     description: Type of index the operation was performed on
     type: string
     enum:
       - primary
       - secondary
   query_type:
-    value: type
+    name_override: type
     description: Type of query operation performed on a namespace
     type: string
     enum:
@@ -55,7 +55,7 @@ attributes:
       - ops_background
       - udf_background
   query_result:
-    value: result
+    name_override: result
     description: Result of a query operation performed on a namespace
     type: string
     enum:
@@ -64,7 +64,7 @@ attributes:
       - error
       - timeout # short_basic queries only
   transaction_type:
-    value: type
+    name_override: type
     description: Type of transaction performed on a namespace
     type: string
     enum:
@@ -73,7 +73,7 @@ attributes:
       - udf
       - write
   transaction_result:
-    value: result
+    name_override: result
     description: Result of a transaction performed on a namespace
     type: string
     enum:
@@ -83,7 +83,7 @@ attributes:
       - success
       - timeout
   connection_type:
-    value: type
+    name_override: type
     description: Type of connection to an Aerospike node
     type: string
     enum:
@@ -91,7 +91,7 @@ attributes:
       - fabric
       - heartbeat
   connection_op:
-    value: operation
+    name_override: operation
     description: Operation performed with a connection (open or close)
     type: string
     enum:

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -10,28 +10,28 @@ resource_attributes:
 
 attributes:
   workers_state:
-    value: state
+    name_override: state
     description: The state of workers.
     type: string
     enum:
       - busy
       - idle
   cpu_level:
-    value: level
+    name_override: level
     description: Level of processes.
     type: string
     enum:
       - self
       - children
   cpu_mode:
-    value: mode
+    name_override: mode
     description: Mode of processes.
     type: string
     enum:
     - system
     - user
   scoreboard_state:
-    value: state
+    name_override: state
     description: The state of a connection.
     type: string
     enum:

--- a/receiver/bigipreceiver/metadata.yaml
+++ b/receiver/bigipreceiver/metadata.yaml
@@ -25,14 +25,13 @@ resource_attributes:
 
 attributes:
   direction:
-    value: direction
     description: The direction of data.
     type: string
     enum:
       - sent
       - received
   availability.status:
-    value: status
+    name_override: status
     description: The availability status.
     type: string
     enum:
@@ -40,14 +39,14 @@ attributes:
       - unknown
       - available
   enabled.status:
-    value: status
+    name_override: status
     description: The enabled status.
     type: string
     enum:
       - disabled
       - enabled
   active.status:
-    value: status
+    name_override: status
     description: The active status.
     type: string
     enum:

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -19,18 +19,18 @@ attributes:
     - fielddata
     - query
   fs_direction:
-    value: direction
+    name_override: direction
     description: The direction of filesystem IO.
     type: string
     enum:
     - read
     - write
   collector_name:
-    value: name
+    name_override: name
     description: The name of the garbage collector.
     type: string
   memory_pool_name:
-    value: name
+    name_override: name
     description: The name of the JVM memory pool.
     type: string
   direction:
@@ -40,14 +40,14 @@ attributes:
     - received
     - sent
   document_state:
-    value: state
+    name_override: state
     description: The state of the document.
     type: string
     enum:
     - active
     - deleted
   shard_state:
-    value: state
+    name_override: state
     description: The state of the shard.
     type: string
     enum:
@@ -58,7 +58,7 @@ attributes:
     - unassigned
     - unassigned_delayed
   operation:
-    value: operation
+    name_override: operation
     description: The type of operation.
     type: string
     enum:
@@ -77,21 +77,21 @@ attributes:
     description: The name of the thread pool.
     type: string
   thread_state:
-    value: state
+    name_override: state
     description: The state of the thread.
     type: string
     enum:
     - active
     - idle
   task_state:
-    value: state
+    name_override: state
     description: The state of the task.
     type: string
     enum:
     - rejected
     - completed
   health_status:
-    value: status
+    name_override: status
     description: The health status of the cluster.
     type: string
     enum:
@@ -99,39 +99,39 @@ attributes:
     - yellow
     - red
   circuit_breaker_name:
-    value: name
+    name_override: name
     description: The name of circuit breaker.
     type: string
   memory_state:
-    value: state
+    name_override: state
     description: State of the memory
     type: string
     enum:
       - free
       - used
   indexing_memory_state:
-    value: state
+    name_override: state
     description: State of the indexing memory
     type: string
     enum:
       - current
       - total
   cluster_published_difference_state:
-    value: state
+    name_override: state
     description: State of the published differences
     type: string
     enum:
       - incompatible
       - compatible
   cluster_state_queue_state:
-    value: state
+    name_override: state
     description: State of the published differences
     type: string
     enum:
       - pending
       - committed
   indexing_pressure_stage:
-    value: stage
+    name_override: stage
     description: Stage of the indexing pressure
     type: string
     enum:
@@ -139,11 +139,11 @@ attributes:
       - primary
       - replica
   cluster_state_update_state:
-    value: state
+    name_override: state
     description: State of cluster state update
     type: string
   cluster_state_update_type:
-    value: type
+    name_override: type
     description: Type of cluster state update
     type: string
     enum:
@@ -154,25 +154,25 @@ attributes:
       - master_apply
       - notification
   ingest_pipeline_name:
-    value: name
+    name_override: name
     description: Name of the ingest pipeline.
     type: string
   query_cache_count_type:
-    value: type
+    name_override: type
     description: Type of query cache count
     type: string
     enum:
       - hit
       - miss
   index_aggregation_type:
-    value: aggregation
+    name_override: aggregation
     description: Type of shard aggregation for index statistics
     type: string
     enum:
       - primary_shards
       - total
   segments_memory_object_type:
-    value: object
+    name_override: object
     description: Type of object in segment
     type: string
     enum:
@@ -181,7 +181,7 @@ attributes:
       - index_writer
       - fixed_bit_set
   get_result:
-    value: result
+    name_override: result
     description: Result of get operation
     type: string
     enum:

--- a/receiver/flinkmetricsreceiver/metadata.yaml
+++ b/receiver/flinkmetricsreceiver/metadata.yaml
@@ -24,11 +24,11 @@ resource_attributes:
 
 attributes:
   operator_name:
-    value: name
+    name_override: name
     description: The operator name.
     type: string
   garbage_collector_name:
-    value: name
+    name_override: name
     description: The names for the parallel scavenge and garbage first garbage collectors.
     type: string
     enum: [ PS_MarkSweep, PS_Scavenge, G1_Young_Generation, G1_Old_Generation ]

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -50,13 +50,13 @@ attributes:
     enum: [system, user, wait]
 
   paging_fault_type:
-    value: type
+    name_override: type
     description: Type of memory paging fault.
     type: string
     enum: [major, minor]
 
   context_switch_type:
-    value: type
+    name_override: type
     description: Type of context switched.
     type: string
     enum: [involuntary, voluntary]

--- a/receiver/iisreceiver/metadata.yaml
+++ b/receiver/iisreceiver/metadata.yaml
@@ -10,14 +10,12 @@ resource_attributes:
 
 attributes:
   direction:
-    value: direction
     description: The direction data is moving.
     type: string
     enum:
       - sent
       - received
   request:
-    value: request
     description: The type of request sent by a client.
     type: string
     enum:

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -13,7 +13,7 @@ attributes:
     description: The name of a collection.
     type: string
   memory_type:
-    value: type
+    name_override: type
     description: The type of memory used.
     type: string
     enum:
@@ -30,7 +30,7 @@ attributes:
       - getmore
       - command
   connection_type:
-    value: type
+    name_override: type
     description: The status of the connection.
     type: string
     enum:

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -7,152 +7,149 @@ resource_attributes:
 
 attributes:
   buffer_pool_pages:
-    value: kind
+    name_override: kind
     description: The buffer pool pages types.
     type: string
     enum: [data, free, misc]
   buffer_pool_data:
-    value: status
+    name_override: status
     description: The status of buffer pool data.
     type: string
     enum: [dirty, clean]
   buffer_pool_operations:
-    value: operation
+    name_override: operation
     description: The buffer pool operations types.
     type: string
     enum: [read_ahead_rnd, read_ahead, read_ahead_evicted, read_requests, reads, wait_free, write_requests]
   prepared_statements_command:
-    value: command
+    name_override: command
     description: The prepare statement command types.
     type: string
     enum: [execute, close, fetch, prepare, reset, send_long_data]
   connection_error:
-    value: error
+    name_override: error
     description: The connection error type.
     type: string
     enum: [accept, internal, max_connections, peer_address, select, tcpwrap]
   handler:
-    value: kind
+    name_override: kind
     description: The handler types.
     type: string
     enum: [commit, delete, discover, external_lock, mrr_init, prepare, read_first, read_key, read_last, read_next, read_prev, read_rnd, read_rnd_next, rollback, savepoint, savepoint_rollback, update, write]
   double_writes:
-    value: kind
+    name_override: kind
     description: The doublewrite types.
     type: string
     enum: [pages_written, writes]
   log_operations:
-    value: operation
+    name_override: operation
     description: The log operation types.
     type: string
     enum: [waits, write_requests, writes]
   operations:
-    value: operation
+    name_override: operation
     description: The operation types.
     type: string
     enum: [fsyncs, reads, writes]
   page_operations:
-    value: operation
+    name_override: operation
     description: The page operation types.
     type: string
     enum: [created, read, written]
   row_locks:
-    value: kind
+    name_override: kind
     description: The row lock type.
     type: string
     enum: [waits, time]
   row_operations:
-    value: operation
+    name_override: operation
     description: The row operation type.
     type: string
     enum: [deleted, inserted, read, updated]
   locks:
-    value: kind
+    name_override: kind
     description: The table locks type.
     type: string
     enum: [immediate, waited]
   sorts:
-    value: kind
+    name_override: kind
     description: The sort count type.
     type: string
     enum: [merge_passes, range, rows, scan]
   threads:
-    value: kind
+    name_override: kind
     description: The thread count type.
     type: string
     enum: [cached, connected, created, running]
   schema:
-    value: schema
     description: The schema of the object.
     type: string
   io_waits_operations:
-    value: operation
+    name_override: operation
     description: The io_waits operation type.
     type: string
     enum: [delete, fetch, insert, update]
   table_name:
-    value: table
+    name_override: table
     type: string
     description: Table name for event or process.
   index_name:
-    value: index
+    name_override: index
     type: string
     description: The name of the index.
   direction:
-    value: kind
+    name_override: kind
     description: The name of the transmission direction.
     type: string
     enum: [received, sent]
   digest:
-    value: digest
     description: Digest.
     type: string
   digest_text:
-    value: digest_text
     description: Text before digestion.
     type: string
   event_state:
-    value: kind
+    name_override: kind
     description: Possible event states.
     type: string
     enum: [errors, warnings, rows_affected, rows_sent, rows_examined, created_tmp_disk_tables, created_tmp_tables, sort_merge_passes, sort_rows, no_index_used]
   opened_resources:
-    value: kind
+    name_override: kind
     description: The kind of the resource.
     type: string
     enum: [file, table_definition, table]
   join_kind:
-    value: kind
+    name_override: kind
     description: The kind of join.
     type: string
     enum: [full, full_range, range, range_check, scan]
   read_lock_type:
-    value: kind
+    name_override: kind
     description: Read operation types.
     type: string
     enum: [normal, with_shared_locks, high_priority, no_insert, external]
   write_lock_type:
-    value: kind
+    name_override: kind
     description: Write operation types.
     type: string
     enum: [allow_write, concurrent_insert, low_priority, normal, external]
   tmp_resource:
-    value: resource
+    name_override: resource
     description: The kind of temporary resources.
     type: string
     enum: [disk_tables, files, tables]
   mysqlx_threads:
-    value: kind
+    name_override: kind
     description: The worker thread count kind.
     type: string
     enum: [available, active]
   connection_status:
-    value: status
+    name_override: status
     description: The connection status.
     type: string
     enum: [accepted, closed, rejected]
   cache_status:
-    value: status
+    name_override: status
     description: The status of cache access.
     type: string
     enum: [hit, miss, overflow]

--- a/receiver/nsxtreceiver/metadata.yaml
+++ b/receiver/nsxtreceiver/metadata.yaml
@@ -16,21 +16,20 @@ resource_attributes:
 
 attributes:
   direction:
-    value: direction
     description: The direction of network flow.
     type: string
     enum:
       - received
       - transmitted
   disk_state:
-    value: state
+    name_override: state
     description: The state of storage space.
     type: string
     enum:
       - used
       - available
   packet.type:
-    value: type
+    name_override: type
     description: The type of packet counter.
     type: string
     enum:

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -20,21 +20,21 @@ attributes:
       - backend_fsync
       - checkpoints
       - bgwriter
-    value: source
+    name_override: source
   bg_checkpoint_type:
     description: The type of checkpoint state.
     type: string
     enum:
       - requested
       - scheduled
-    value: type
+    name_override: type
   bg_duration_type:
     description: The type of time spent during the checkpoint.
     type: string
     enum:
       - sync
       - write
-    value: type
+    name_override: type
   database:
     description: The name of the database.
     type: string
@@ -65,7 +65,7 @@ attributes:
     type: string
     enum: [dead, live]
   wal_operation_lag:
-    value: operation
+    name_override: operation
     description: The operation which is responsible for the lag.
     type: string
     enum: [flush, replay, write]

--- a/receiver/rabbitmqreceiver/metadata.yaml
+++ b/receiver/rabbitmqreceiver/metadata.yaml
@@ -13,7 +13,7 @@ resource_attributes:
 
 attributes:
   message.state:
-    value: state
+    name_override: state
     description: The state of messages in a queue.
     type: string
     enum:

--- a/receiver/saphanareceiver/metadata.yaml
+++ b/receiver/saphanareceiver/metadata.yaml
@@ -18,18 +18,18 @@ attributes:
     description: The SAP HANA product.
     type: string
   primary_host:
-    value: primary
+    name_override: primary
     description: The primary SAP HANA host in replication.
     type: string
   secondary_host:
-    value: secondary
+    name_override: secondary
     description: The secondary SAP HANA host in replication.
     type: string
   port:
     description: The SAP HANA port.
     type: string
   replication_mode:
-    value: mode
+    name_override: mode
     description: The replication mode.
     type: string
   component:
@@ -45,11 +45,11 @@ attributes:
     description: The SAP HANA disk path.
     type: string
   disk_usage_type:
-    value: usage_type
+    name_override: usage_type
     description: The SAP HANA disk & volume usage type.
     type: string
   transaction_type:
-    value: type
+    name_override: type
     description: The transaction type.
     type: string
     enum:
@@ -57,7 +57,7 @@ attributes:
     - commit
     - rollback
   connection_status:
-    value: status
+    name_override: status
     description: The connection status.
     type: string
     enum:
@@ -65,7 +65,7 @@ attributes:
     - idle
     - queueing
   cpu_type:
-    value: type
+    name_override: type
     description: The type of cpu.
     type: string
     enum:
@@ -74,18 +74,18 @@ attributes:
     - io_wait
     - idle
   alert_rating:
-    value: rating
+    name_override: rating
     description: The alert rating.
     type: string
   column_memory_type:
-    value: type
+    name_override: type
     description: The type of column store memory.
     type: string
     enum:
     - main
     - delta
   column_memory_subtype:
-    value: subtype
+    name_override: subtype
     description: The subtype of column store memory.
     type: string
     enum:
@@ -94,14 +94,14 @@ attributes:
     - index
     - misc
   row_memory_type:
-    value: type
+    name_override: type
     description: The type of row store memory.
     type: string
     enum:
     - fixed
     - variable
   schema_memory_type:
-    value: type
+    name_override: type
     description: The type of schema memory.
     type: string
     enum:
@@ -110,7 +110,7 @@ attributes:
     - history_main
     - history_delta
   schema_record_type:
-    value: type
+    name_override: type
     description: The type of schema record.
     type: string
     enum:
@@ -119,28 +119,28 @@ attributes:
     - history_main
     - history_delta
   memory_state_used_free:
-    value: state
+    name_override: state
     description: The state of memory.
     type: string
     enum:
     - used
     - free
   disk_state_used_free:
-    value: state
+    name_override: state
     description: The state of the disk storage.
     type: string
     enum:
     - used
     - free
   host_swap_state:
-    value: state
+    name_override: state
     description: The state of swap data.
     type: string
     enum:
     - used
     - free
   schema_operation_type:
-    value: type
+    name_override: type
     description: The type of operation.
     type: string
     enum:
@@ -148,42 +148,42 @@ attributes:
     - write
     - merge
   service_status:
-    value: status
+    name_override: status
     description: The status of services.
     type: string
     enum:
     - active
     - inactive
   thread_status:
-    value: status
+    name_override: status
     description: The status of threads.
     type: string
     enum:
     - active
     - inactive
   service_memory_used_type:
-    value: type
+    name_override: type
     description: The type of service memory.
     type: string
     enum:
     - logical
     - physical
   volume_operation_type:
-    value: type
+    name_override: type
     description: The type of operation.
     type: string
     enum:
     - read
     - write
   active_pending_request_state:
-    value: state
+    name_override: state
     description: The state of network request.
     type: string
     enum:
     - active
     - pending
   internal_external_request_type:
-    value: type
+    name_override: type
     description: The type of network request.
     type: string
     enum:

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -7,7 +7,7 @@ resource_attributes:
 
 attributes:
   page.operations:
-    value: type
+    name_override: type
     description: The page operation types.
     type: string
     enum: [read, write]

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -35,31 +35,31 @@ attributes:
       - physical
   host_effective:
     type: bool
-    value: effective
+    name_override: effective
     description: Whether the host is effective in the vCenter cluster.
   disk_direction:
-    value: direction
+    name_override: direction
     description: The direction of disk latency.
     type: string
     enum:
       - read
       - write
   latency_type:
-    value: type
+    name_override: type
     description: The type of disk latency being reported.
     type: string
     enum:
       - kernel
       - device
   throughput_direction:
-    value: direction
+    name_override: direction
     description: The direction of network throughput.
     type: string
     enum:
       - transmitted
       - received
   vm_count_power_state:
-    value: power_state
+    name_override: power_state
     description: Whether the virtual machines are powered on or off.
     type: string
     enum:


### PR DESCRIPTION
`value` is a confusing name for an optional field that is used to override the attribute name defined in the key
