### PR TITLE
[exporter/awsemfexporter] Export fields of MetricDescriptor to enable decoding

### DIFF
--- a/.chloggen/metricdescriptor-export-fields.yaml
+++ b/.chloggen/metricdescriptor-export-fields.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Export fields of MetricDescriptor to enable decoding
+
+# One or more tracking issues related to the change
+issues: [16566]

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -86,13 +86,13 @@ type Config struct {
 }
 
 type MetricDescriptor struct {
-	// metricName is the name of the metric
-	metricName string `mapstructure:"metric_name"`
-	// unit defines the override value of metric descriptor `unit`
-	unit string `mapstructure:"unit"`
-	// overwrite set to true means the existing metric descriptor will be overwritten or a new metric descriptor will be created; false means
+	// MetricName is the name of the metric
+	MetricName string `mapstructure:"metric_name"`
+	// Unit defines the override value of metric descriptor `unit`
+	Unit string `mapstructure:"unit"`
+	// Overwrite set to true means the existing metric descriptor will be overwritten or a new metric descriptor will be created; false means
 	// the descriptor will only be configured if empty.
-	overwrite bool `mapstructure:"overwrite"`
+	Overwrite bool `mapstructure:"overwrite"`
 }
 
 // Validate filters out invalid metricDeclarations and metricDescriptors
@@ -110,13 +110,13 @@ func (config *Config) Validate() error {
 
 	var validDescriptors []MetricDescriptor
 	for _, descriptor := range config.MetricDescriptors {
-		if descriptor.metricName == "" {
+		if descriptor.MetricName == "" {
 			continue
 		}
-		if _, ok := eMFSupportedUnits[descriptor.unit]; ok {
+		if _, ok := eMFSupportedUnits[descriptor.Unit]; ok {
 			validDescriptors = append(validDescriptors, descriptor)
 		} else {
-			config.logger.Warn("Dropped unsupported metric desctriptor.", zap.String("unit", descriptor.unit))
+			config.logger.Warn("Dropped unsupported metric desctriptor.", zap.String("unit", descriptor.Unit))
 		}
 	}
 	config.MetricDescriptors = validDescriptors

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -84,6 +84,31 @@ func TestLoadConfig(t *testing.T) {
 				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
 			},
 		},
+		{
+			id: component.NewIDWithName(typeStr, "metric_descriptors"),
+			expected: &Config{
+				ExporterSettings: config.NewExporterSettings(component.NewID(typeStr)),
+				AWSSessionSettings: awsutil.AWSSessionSettings{
+					NumberOfWorkers:       8,
+					Endpoint:              "",
+					RequestTimeoutSeconds: 30,
+					MaxRetries:            2,
+					NoVerifySSL:           false,
+					ProxyAddress:          "",
+					Region:                "",
+					RoleARN:               "",
+				},
+				LogGroupName:          "",
+				LogStreamName:         "",
+				DimensionRollupOption: "ZeroAndSingleDimensionRollup",
+				OutputDestination:     "cloudwatch",
+				MetricDescriptors: []MetricDescriptor{{
+					MetricName: "memcached_current_items",
+					Unit:       "Count",
+					Overwrite:  true,
+				}},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -103,10 +128,10 @@ func TestLoadConfig(t *testing.T) {
 
 func TestConfigValidate(t *testing.T) {
 	incorrectDescriptor := []MetricDescriptor{
-		{metricName: ""},
-		{unit: "Count", metricName: "apiserver_total", overwrite: true},
-		{unit: "INVALID", metricName: "404"},
-		{unit: "Megabytes", metricName: "memory_usage"},
+		{MetricName: ""},
+		{Unit: "Count", MetricName: "apiserver_total", Overwrite: true},
+		{Unit: "INVALID", MetricName: "404"},
+		{Unit: "Megabytes", MetricName: "memory_usage"},
 	}
 	cfg := &Config{
 		ExporterSettings: config.NewExporterSettings(component.NewIDWithName(typeStr, "1")),
@@ -123,8 +148,8 @@ func TestConfigValidate(t *testing.T) {
 
 	assert.Equal(t, 2, len(cfg.MetricDescriptors))
 	assert.Equal(t, []MetricDescriptor{
-		{unit: "Count", metricName: "apiserver_total", overwrite: true},
-		{unit: "Megabytes", metricName: "memory_usage"},
+		{Unit: "Count", MetricName: "apiserver_total", Overwrite: true},
+		{Unit: "Megabytes", MetricName: "memory_usage"},
 	}, cfg.MetricDescriptors)
 }
 

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -82,7 +82,7 @@ func addToGroupedMetric(pmd pmetric.Metric, groupedMetrics map[interface{}]*grou
 		// Extra params to use when grouping metrics
 		groupKey := groupedMetricKey(metadata.groupedMetricMetadata, labels)
 		if _, ok := groupedMetrics[groupKey]; ok {
-			// if metricName already exists in metrics map, print warning log
+			// if MetricName already exists in metrics map, print warning log
 			if _, ok := groupedMetrics[groupKey].metrics[metricName]; ok {
 				logger.Warn(
 					"Duplicate metric found",
@@ -185,8 +185,8 @@ func groupedMetricKey(metadata groupedMetricMetadata, labels map[string]string) 
 func translateUnit(metric pmetric.Metric, descriptor map[string]MetricDescriptor) string {
 	unit := metric.Unit()
 	if descriptor, exists := descriptor[metric.Name()]; exists {
-		if unit == "" || descriptor.overwrite {
-			return descriptor.unit
+		if unit == "" || descriptor.Overwrite {
+			return descriptor.Unit
 		}
 	}
 	switch unit {

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -511,14 +511,14 @@ func TestTranslateUnit(t *testing.T) {
 	translator := &metricTranslator{
 		metricDescriptor: map[string]MetricDescriptor{
 			"writeIfNotExist": {
-				metricName: "writeIfNotExist",
-				unit:       "Count",
-				overwrite:  false,
+				MetricName: "writeIfNotExist",
+				Unit:       "Count",
+				Overwrite:  false,
 			},
 			"forceOverwrite": {
-				metricName: "forceOverwrite",
-				unit:       "Count",
-				overwrite:  true,
+				MetricName: "forceOverwrite",
+				Unit:       "Count",
+				Overwrite:  true,
 			},
 		},
 	}

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -91,7 +91,7 @@ type metricTranslator struct {
 func newMetricTranslator(config Config) metricTranslator {
 	mt := map[string]MetricDescriptor{}
 	for _, descriptor := range config.MetricDescriptors {
-		mt[descriptor.metricName] = descriptor
+		mt[descriptor.MetricName] = descriptor
 	}
 	return metricTranslator{
 		metricDescriptor: mt,

--- a/exporter/awsemfexporter/testdata/config.yaml
+++ b/exporter/awsemfexporter/testdata/config.yaml
@@ -5,3 +5,8 @@ awsemf/1:
 awsemf/resource_attr_to_label:
   resource_to_telemetry_conversion:
     enabled: true
+awsemf/metric_descriptors:
+  metric_descriptors:
+    - metric_name: memcached_current_items
+      unit: Count
+      overwrite: true


### PR DESCRIPTION
**Description:** Fixing a bug - Export fields of MetricDescriptor to enable decoding

Currently, mapstructure decoding fails due to [this](https://github.com/mitchellh/mapstructure/blob/bf980b35cac4dfd34e05254ee5aba086504c3f96/mapstructure.go#L1400-L1402) logic since the fields of `MetricDescriptor` are unexported.
OTel collector fails to startup with the following error if the YAML has any `metric_descriptors`:
```
'metric_descriptors[0]' has invalid keys: metric_name, unit
```

**Testing:** Unit test added to ensure bug is fixed