### PR TITLE
[pkg/ottl] Experiment with Factory Function definition of existing Function

### DIFF
--- a/pkg/ottl/ottlfuncs/func_factory_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_factory_keep_keys_test.go
@@ -86,8 +86,11 @@ func Test_KeepKeysFactory(t *testing.T) {
 			exprFunc, err := KeepKeysFactory(tt.target, tt.keys)
 			assert.NoError(t, err)
 
-			result, err := exprFunc(nil, scenarioMap)
+			origScenarioMap := pcommon.NewMap()
+			scenarioMap.CopyTo(origScenarioMap)
+			result, err := exprFunc(context.Background(), scenarioMap)
 			assert.Nil(t, err)
+			assert.Equal(t, origScenarioMap, scenarioMap)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -110,6 +113,21 @@ func Test_KeepKeysFactory_bad_input(t *testing.T) {
 	exprFunc, err := KeepKeysFactory[interface{}](target, keys)
 	assert.NoError(t, err)
 
-	_, err = exprFunc(nil, input)
+	_, err = exprFunc(context.Background(), input)
+	assert.Error(t, err)
+}
+
+func Test_KeepKeysFactory_get_nil(t *testing.T) {
+	target := &ottl.StandardGetSetter[interface{}]{
+		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+			return tCtx, nil
+		},
+	}
+
+	keys := []string{"anything"}
+	exprFunc, err := KeepKeysFactory[interface{}](target, keys)
+	assert.NoError(t, err)
+
+	_, err = exprFunc(context.Background(), nil)
 	assert.Error(t, err)
 }

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -103,21 +103,14 @@ func Test_keepKeys_bad_input(t *testing.T) {
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
-		},
 	}
 
 	keys := []string{"anything"}
-
 	exprFunc, err := KeepKeys[interface{}](target, keys)
 	assert.NoError(t, err)
 
-	_, err = exprFunc(nil, input)
-	assert.Nil(t, err)
-
-	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
+	_, err = exprFunc(context.Background(), input)
+	assert.Error(t, err)
 }
 
 func Test_keepKeys_get_nil(t *testing.T) {
@@ -125,17 +118,12 @@ func Test_keepKeys_get_nil(t *testing.T) {
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
-		},
 	}
 
 	keys := []string{"anything"}
-
 	exprFunc, err := KeepKeys[interface{}](target, keys)
 	assert.NoError(t, err)
-	result, err := exprFunc(nil, nil)
-	assert.NoError(t, err)
-	assert.Nil(t, result)
+
+	_, err = exprFunc(context.Background(), nil)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
**Description:** 
This PR is mainly to have a discussion about how OTTL/transformprocessor should support situations where a functionality is needed both as a factory function and as a standard function.  I'm using KeepKeys to center the conversation but there will be other functions/factory functions that fit as well.

(KeepKeys should do regex matching like `DeleteAllMatches` but let's ignore that for now)

At the moment the OTTL has a function called `KeepKeys`, referenced as `keep_keys` in the transform processor, that takes a map and a list of string keys and drops all entries from the map that aren't in the list. 

There is also a need to be able to adjust a map returned from parsing (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14938 and https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9410).  For this we need a Factory Function so that we can do something like `merge_maps(attributes, KeepKeys(ParseJSON(body), ["log_type"]), "upsert")`.

Both `keep_keys` and `KeepKeys` have the same intention, but `keep_keys` returns `nil` and `KeepKeys` returns the map that was modified.

## Non-exhaustive Options

1. Introduce "keep keys" functionality as a function and a factory function.  The function's implementation can rely on the factory function's.  This is the implementation in this PR.  This solution require's users to understand the difference between a Factory Function and a Function, which is currently only a conceptual difference; nothing in the grammar enforces this (but it could).
2. Update the existing `keep_keys` function to return the value it modifies.  This will allow statements like `merge_maps(attributes, keep_keys(ParseJSON(body), ["log_type"]), "upsert")` but it also allows stuff like `set(attributes["test"], keep_keys(resource.attributes, ["log"]))`.  Since `keep_keys` is not pure, it would allow modifying multiple paths in the same statement, which could get users into bad situations unexpectedly.
3. Remove `keep_keys` and only allow modifying the map with the factory function of `KeepKeys`.  This would require `KeepKeys` to always be used with `set`.  `keep_keys(attributes, ["test"])` would become `set(attributes, KeepKeys(attributes, ["test"]))`.

Personally I like option 1 in combination with a grammar/package change to make factory functions a core concept in the language.  I don't think I want to go to the extreme of removing standard function's ability to return yet. But I do think we can restrict the grammar's value type to functions that start with a capital letter and the Invocation function name to start with a lower case letter.  This starts to enforce a difference between the 2 types of functions (although there is still a problem of the transformprocessor being the one that actually defines the function map, but that can also be adjusted).
