### PR TITLE
[exporter/prometheus] Make the exporter not mutating

### DIFF
--- a/.chloggen/fixprommuta.yaml
+++ b/.chloggen/fixprommuta.yaml
@@ -5,8 +5,8 @@ change_type: bug_fix
 component: prometheusexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Mark prometheus exporter as mutable since it sorts attributes
+note: Make sure the exporter doesn't mutate metrics
 
 # One or more tracking issues related to the change
-issues: [16499]
+issues: [16499, 16572]
 

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -16,6 +16,7 @@ package prometheusexporter // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -302,11 +303,13 @@ func timeseriesSignature(ilmName string, metric pmetric.Metric, attributes pcomm
 	b.WriteString(metric.Type().String())
 	b.WriteString("*" + ilmName)
 	b.WriteString("*" + metric.Name())
-	attributes.Sort().Range(func(k string, v pcommon.Value) bool {
-		b.WriteString("*" + k + "*" + v.AsString())
+	attrs := make([]string, 0, attributes.Len())
+	attributes.Range(func(k string, v pcommon.Value) bool {
+		attrs = append(attrs, k+"*"+v.AsString())
 		return true
 	})
-
+	sort.Strings(attrs)
+	b.WriteString("*" + strings.Join(attrs, "*"))
 	if job, ok := extractJob(resourceAttrs); ok {
 		b.WriteString("*" + model.JobLabel + "*" + job)
 	}

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -509,6 +509,16 @@ func TestAccumulateDroppedMetrics(t *testing.T) {
 	}
 }
 
+func TestTimeseriesSignatureNotMutating(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("label_2", "2")
+	attrs.PutStr("label_1", "1")
+	origAttrs := pcommon.NewMap()
+	attrs.CopyTo(origAttrs)
+	timeseriesSignature("test_il", pmetric.NewMetric(), attrs, attrs)
+	require.Equal(t, origAttrs, attrs) // make sure attrs are not mutated
+}
+
 func getMetricProperties(metric pmetric.Metric) (
 	attributes pcommon.Map,
 	ts time.Time,

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -20,7 +20,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry"
@@ -68,8 +67,6 @@ func createMetricsExporter(
 		set,
 		cfg,
 		prometheus.ConsumeMetrics,
-		// TODO: Consider to revert to non mutable data, need to not modify the incoming data, like sorting when calculating the signature.
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 		exporterhelper.WithStart(prometheus.Start),
 		exporterhelper.WithShutdown(prometheus.Shutdown),
 	)

--- a/exporter/prometheusexporter/go.mod
+++ b/exporter/prometheusexporter/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.66.1-0.20221128222955-4ff1ff379b90
 	go.opentelemetry.io/collector/component v0.66.1-0.20221128222955-4ff1ff379b90
-	go.opentelemetry.io/collector/consumer v0.66.1-0.20221128222955-4ff1ff379b90
 	go.opentelemetry.io/collector/pdata v0.66.1-0.20221128222955-4ff1ff379b90
 	go.opentelemetry.io/collector/semconv v0.66.1-0.20221128222955-4ff1ff379b90
 	go.uber.org/zap v1.23.0
@@ -127,6 +126,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/collector/consumer v0.66.1-0.20221128222955-4ff1ff379b90 // indirect
 	go.opentelemetry.io/collector/featuregate v0.66.1-0.20221128222955-4ff1ff379b90 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.4 // indirect
 	go.opentelemetry.io/otel v1.11.1 // indirect


### PR DESCRIPTION
by removing an unnecessary Sort method.

This is also one of the prerequisites for https://github.com/open-telemetry/opentelemetry-collector/issues/6660