### PR TITLE
[chore] Don't use value returned by pcommon.Map.Sort methods in tests

### DIFF
--- a/internal/scrapertest/compare.go
+++ b/internal/scrapertest/compare.go
@@ -61,7 +61,7 @@ func CompareMetrics(expected, actual pmetric.Metrics, options ...CompareOption) 
 			if _, ok := matchingResources[ar]; ok {
 				continue
 			}
-			if reflect.DeepEqual(er.Resource().Attributes().Sort().AsRaw(), ar.Resource().Attributes().Sort().AsRaw()) {
+			if reflect.DeepEqual(er.Resource().Attributes().AsRaw(), ar.Resource().Attributes().AsRaw()) {
 				foundMatch = true
 				matchingResources[ar] = er
 				break
@@ -212,7 +212,7 @@ func CompareNumberDataPointSlices(expected, actual pmetric.NumberDataPointSlice)
 			if _, ok := matchingDPS[adp]; ok {
 				continue
 			}
-			if reflect.DeepEqual(edp.Attributes().Sort().AsRaw(), adp.Attributes().Sort().AsRaw()) {
+			if reflect.DeepEqual(edp.Attributes().AsRaw(), adp.Attributes().AsRaw()) {
 				foundMatch = true
 				matchingDPS[adp] = edp
 				break

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -183,15 +183,17 @@ func TestConvert(t *testing.T) {
 	pLogs := Convert(ent)
 	require.Equal(t, 1, pLogs.ResourceLogs().Len())
 	rls := pLogs.ResourceLogs().At(0)
+	resAttrs := rls.Resource().Attributes()
+	resAttrs.Sort()
 
-	if resAtts := rls.Resource().Attributes(); assert.Equal(t, 5, resAtts.Len()) {
+	if assert.Equal(t, 5, resAttrs.Len()) {
 		m := pcommon.NewMap()
 		m.PutBool("bool", true)
-		m.PutInt("int", 123)
 		m.PutDouble("double", 12.34)
-		m.PutStr("string", "hello")
+		m.PutInt("int", 123)
 		m.PutEmptyMap("object")
-		assert.EqualValues(t, m.Sort(), resAtts.Sort())
+		m.PutStr("string", "hello")
+		assert.EqualValues(t, m, resAttrs)
 	}
 
 	ills := rls.ScopeLogs()
@@ -201,30 +203,32 @@ func TestConvert(t *testing.T) {
 	require.Equal(t, 1, logs.Len())
 
 	lr := logs.At(0)
+	lrAttrs := lr.Attributes()
+	lrAttrs.Sort()
 
 	assert.Equal(t, plog.SeverityNumberError, lr.SeverityNumber())
 	assert.Equal(t, "E", lr.SeverityText())
 
-	if atts := lr.Attributes(); assert.Equal(t, 5, atts.Len()) {
+	if assert.Equal(t, 5, lrAttrs.Len()) {
+		lrAttrs.Sort()
 		m := pcommon.NewMap()
 		m.PutBool("bool", true)
-		m.PutInt("int", 123)
 		m.PutDouble("double", 12.34)
-		m.PutStr("string", "hello")
+		m.PutInt("int", 123)
 		m.PutEmptyMap("object")
-		assert.EqualValues(t, m.Sort(), atts.Sort())
+		m.PutStr("string", "hello")
+		assert.EqualValues(t, m, lrAttrs)
 	}
 
 	if assert.Equal(t, pcommon.ValueTypeMap, lr.Body().Type()) {
+		lr.Body().Map().Sort()
 		m := pcommon.NewMap()
-		// Don't include a nested object because AttributeValueMap sorting
-		// doesn't sort recursively.
 		m.PutBool("bool", true)
-		m.PutInt("int", 123)
-		m.PutDouble("double", 12.34)
-		m.PutStr("string", "hello")
 		m.PutEmptyBytes("bytes").FromRaw([]byte("asdf"))
-		assert.EqualValues(t, m.Sort(), lr.Body().Map().Sort())
+		m.PutDouble("double", 12.34)
+		m.PutInt("int", 123)
+		m.PutStr("string", "hello")
+		assert.EqualValues(t, m, lr.Body().Map())
 	}
 }
 

--- a/pkg/translator/opencensus/oc_to_resource_test.go
+++ b/pkg/translator/opencensus/oc_to_resource_test.go
@@ -43,8 +43,10 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 	expectedAttrs := generateResourceWithOcNodeAndResource().Attributes()
 	// We don't have type information in ocResource, so need to make int attr string
 	expectedAttrs.PutStr("resource-int-attr", "123")
+	expectedAttrs.Sort()
 	ocNodeResourceToInternal(ocNode, ocResource, resource)
-	assert.EqualValues(t, expectedAttrs.Sort(), resource.Attributes().Sort())
+	resource.Attributes().Sort()
+	assert.EqualValues(t, expectedAttrs, resource.Attributes())
 
 	// Make sure hard-coded fields override same-name values in Attributes.
 	// To do that add Attributes with same-name.
@@ -55,13 +57,15 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 		}
 		return true
 	})
+	expectedAttrs.Sort()
 	ocResource.Labels[occonventions.AttributeResourceType] = "this will be overridden 2"
 
 	// Convert again.
 	resource = pcommon.NewResource()
 	ocNodeResourceToInternal(ocNode, ocResource, resource)
+	resource.Attributes().Sort()
 	// And verify that same-name attributes were ignored.
-	assert.EqualValues(t, expectedAttrs.Sort(), resource.Attributes().Sort())
+	assert.EqualValues(t, expectedAttrs, resource.Attributes())
 }
 
 func BenchmarkOcNodeResourceToInternal(b *testing.B) {

--- a/pkg/translator/zipkin/zipkinv1/json_test.go
+++ b/pkg/translator/zipkin/zipkinv1/json_test.go
@@ -455,7 +455,8 @@ func TestZipkinAnnotationsToSpanStatus(t *testing.T) {
 			td, err := jsonBatchToTraces(zBytes, true)
 			require.NoError(t, err)
 			gs := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-			require.Equal(t, c.wantAttributes.Sort(), gs.Attributes().Sort(), "Unsuccessful conversion %d", i)
+			gs.Attributes().Sort()
+			require.Equal(t, c.wantAttributes, gs.Attributes(), "Unsuccessful conversion %d", i)
 			require.Equal(t, c.wantStatus, gs.Status(), "Unsuccessful conversion %d", i)
 		})
 	}

--- a/pkg/translator/zipkin/zipkinv1/thrift_test.go
+++ b/pkg/translator/zipkin/zipkinv1/thrift_test.go
@@ -431,7 +431,8 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 			td, err := thriftBatchToTraces(zSpans)
 			require.NoError(t, err)
 			gs := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-			require.Equal(t, c.wantAttributes.Sort(), gs.Attributes().Sort())
+			gs.Attributes().Sort()
+			require.Equal(t, c.wantAttributes, gs.Attributes())
 			require.Equal(t, c.wantStatus, gs.Status())
 		})
 	}

--- a/testbed/tests/resource_processor_test.go
+++ b/testbed/tests/resource_processor_test.go
@@ -79,8 +79,8 @@ func getResourceProcessorTestCases() []resourceProcessorTestCase {
 			expectedMetrics: func() pmetric.Metrics {
 				md := pmetric.NewMetrics()
 				rm := md.ResourceMetrics().AppendEmpty()
-				rm.Resource().Attributes().PutStr("resource-type", "host")
 				rm.Resource().Attributes().PutStr("label-key", "new-label-value")
+				rm.Resource().Attributes().PutStr("resource-type", "host")
 				return md
 			}(),
 		},
@@ -168,11 +168,12 @@ func TestMetricResourceProcessor(t *testing.T) {
 			m := tc.MockBackend.ReceivedMetrics[0]
 			rm := m.ResourceMetrics()
 			require.Equal(t, 1, rm.Len())
+			rm.At(0).Resource().Attributes().Sort()
 
 			expectidMD := test.expectedMetrics
 			require.Equal(t,
-				expectidMD.ResourceMetrics().At(0).Resource().Attributes().Sort(),
-				rm.At(0).Resource().Attributes().Sort(),
+				expectidMD.ResourceMetrics().At(0).Resource().Attributes(),
+				rm.At(0).Resource().Attributes(),
 			)
 		})
 	}


### PR DESCRIPTION
In preparation for https://github.com/open-telemetry/opentelemetry-collector/issues/6660