### PR TITLE
[chore] Remove usages of values returned by Map.Sort in tests

### DIFF
--- a/processor/resourcedetectionprocessor/internal/env/env_test.go
+++ b/processor/resourcedetectionprocessor/internal/env/env_test.go
@@ -77,17 +77,17 @@ func TestInitializeAttributeMap(t *testing.T) {
 	cases := []struct {
 		name               string
 		encoded            string
-		expectedAttributes pcommon.Map
+		expectedAttributes map[string]any
 		expectedError      string
 	}{
 		{
 			name:               "multiple valid attributes",
 			encoded:            ` example.org/test-1 =  test $ %3A \" ,  Abc=Def  `,
-			expectedAttributes: internal.NewAttributeMap(map[string]interface{}{"example.org/test-1": `test $ : \"`, "Abc": "Def"}),
+			expectedAttributes: map[string]any{"example.org/test-1": `test $ : \"`, "Abc": "Def"},
 		}, {
 			name:               "single valid attribute",
 			encoded:            `single=key`,
-			expectedAttributes: internal.NewAttributeMap(map[string]interface{}{"single": "key"}),
+			expectedAttributes: map[string]any{"single": "key"},
 		}, {
 			name:          "invalid url escape sequence in value",
 			encoded:       `invalid=url-%3-encoding`,
@@ -120,7 +120,7 @@ func TestInitializeAttributeMap(t *testing.T) {
 				assert.EqualError(t, err, c.expectedError)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, c.expectedAttributes.Sort(), am.Sort())
+				assert.Equal(t, c.expectedAttributes, am.AsRaw())
 			}
 		})
 	}

--- a/receiver/awsxrayreceiver/internal/translator/annotations_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/annotations_test.go
@@ -33,17 +33,16 @@ func TestAddAnnotations(t *testing.T) {
 	attrMap := pcommon.NewMap()
 	attrMap.EnsureCapacity(initAttrCapacity)
 	addAnnotations(input, attrMap)
+	attrMap.Sort()
 
 	expectedAttrMap := pcommon.NewMap()
-	assert.NoError(t, expectedAttrMap.FromRaw(
-		map[string]interface{}{
-			"int":     0,
-			"int32":   int32(1),
-			"int64":   int64(2),
-			"bool":    false,
-			"float32": 4.5,
-			"float64": 5.5,
-		},
-	))
-	assert.Equal(t, expectedAttrMap.Sort(), attrMap.Sort(), "attribute maps differ")
+	expectedAttrMap.PutBool("bool", false)
+	expectedAttrMap.PutDouble("float32", 4.5)
+	expectedAttrMap.PutDouble("float64", 5.5)
+	expectedAttrMap.PutInt("int", 0)
+	expectedAttrMap.PutInt("int32", 1)
+	expectedAttrMap.PutInt("int64", 2)
+	expectedAttrMap.Sort()
+
+	assert.Equal(t, expectedAttrMap, attrMap, "attribute maps differ")
 }

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -1001,9 +1001,11 @@ func compare2ResourceSpans(t *testing.T, testCase string, exp, act ptrace.Resour
 		act.ScopeSpans().Len(),
 		testCase+": ScopeSpans.Len() differ")
 
+	exp.Resource().Attributes().Sort()
+	act.Resource().Attributes().Sort()
 	assert.Equal(t,
-		exp.Resource().Attributes().Sort(),
-		act.Resource().Attributes().Sort(),
+		exp.Resource().Attributes(),
+		act.Resource().Attributes(),
 		testCase+": Resource.Attributes() differ")
 
 	actSpans := act.ScopeSpans().At(0).Spans()
@@ -1018,9 +1020,11 @@ func compare2ResourceSpans(t *testing.T, testCase string, exp, act ptrace.Resour
 		expS := expSpans.At(i)
 		actS := actSpans.At(i)
 
+		expS.Attributes().Sort()
+		actS.Attributes().Sort()
 		assert.Equal(t,
-			expS.Attributes().Sort(),
-			actS.Attributes().Sort(),
+			expS.Attributes(),
+			actS.Attributes(),
 			fmt.Sprintf("%s: span[%s].Attributes() differ", testCase, expS.SpanID()),
 		)
 		expS.Attributes().Clear()
@@ -1038,9 +1042,11 @@ func compare2ResourceSpans(t *testing.T, testCase string, exp, act ptrace.Resour
 			expEvt := expEvts.At(j)
 			actEvt := actEvts.At(j)
 
+			expEvt.Attributes().Sort()
+			actEvt.Attributes().Sort()
 			assert.Equal(t,
-				expEvt.Attributes().Sort(),
-				actEvt.Attributes().Sort(),
+				expEvt.Attributes(),
+				actEvt.Attributes(),
 				fmt.Sprintf("%s: span[%s], event[%d].Attributes() differ", testCase, expS.SpanID(), j),
 			)
 			expEvt.Attributes().Clear()

--- a/receiver/solacereceiver/unmarshaller_test.go
+++ b/receiver/solacereceiver/unmarshaller_test.go
@@ -261,7 +261,7 @@ func TestSolaceMessageUnmarshallerUnmarshal(t *testing.T) {
 				require.Equal(t, 1, traces.ResourceSpans().Len())
 				expectedResource := tt.want.ResourceSpans().At(0)
 				resource := traces.ResourceSpans().At(0)
-				assert.Equal(t, expectedResource.Resource().Attributes().Sort(), resource.Resource().Attributes().Sort())
+				assert.Equal(t, expectedResource.Resource().Attributes().AsRaw(), resource.Resource().Attributes().AsRaw())
 				require.Equal(t, 1, resource.ScopeSpans().Len())
 				expectedInstrumentation := expectedResource.ScopeSpans().At(0)
 				instrumentation := resource.ScopeSpans().At(0)
@@ -820,7 +820,7 @@ func TestUnmarshallerEvents(t *testing.T) {
 }
 
 func compareSpans(t *testing.T, expected, actual ptrace.Span) {
-	assert.Equal(t, expected.Attributes().Sort(), actual.Attributes().Sort())
+	assert.Equal(t, expected.Attributes().AsRaw(), actual.Attributes().AsRaw())
 	require.Equal(t, expected.Events().Len(), actual.Events().Len())
 	for i := 0; i < expected.Events().Len(); i++ {
 		lessFunc := func(a, b ptrace.SpanEvent) bool {
@@ -830,7 +830,7 @@ func compareSpans(t *testing.T, expected, actual ptrace.Span) {
 		actualEvent := actual.Events().Sort(lessFunc).At(i)
 		assert.Equal(t, expectedEvent.Name(), actualEvent.Name())
 		assert.Equal(t, expectedEvent.Timestamp(), actualEvent.Timestamp())
-		assert.Equal(t, expectedEvent.Attributes().Sort(), actualEvent.Attributes().Sort())
+		assert.Equal(t, expectedEvent.Attributes().AsRaw(), actualEvent.Attributes().AsRaw())
 	}
 }
 


### PR DESCRIPTION
Some usages of Sort in tests were missed to be updated in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16574

Needed for https://github.com/open-telemetry/opentelemetry-collector/issues/6660