### PR TITLE
[routingprocessor] Fix configuration validation bug.

### DIFF
--- a/.chloggen/routing-processor-ottl-config.yaml
+++ b/.chloggen/routing-processor-ottl-config.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: routingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug in routing processor that prevented collector from starting if `from_attribute` is not provided with `OTTL` routing statements.
+
+# One or more tracking issues related to the change
+issues: [16555]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/routingprocessor/README.md
+++ b/processor/routingprocessor/README.md
@@ -87,7 +87,7 @@ exporters:
 A signal may get matched by routing conditions of more than one routing table entry. In this case, the signal will be routed to all exporters of matching routes.
 Respectively, if none of the routing conditions met, then a signal is routed to default exporters.
 
-It is also possible to use both the conventional routing items configuration and the routing items with [OTTL] conditions.
+It is also possible to mix both the conventional routing configuration and the routing configuration with [OTTL] conditions.
 
 #### Limitations:
 

--- a/processor/routingprocessor/config.go
+++ b/processor/routingprocessor/config.go
@@ -70,6 +70,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid routing table: %w", errNoTableItems)
 	}
 
+	ottlRoutingOnly := true
 	// validate that every route has a value for the routing attribute and has
 	// at least one exporter
 	for _, item := range c.Table {
@@ -84,10 +85,17 @@ func (c *Config) Validate() error {
 		if len(item.Exporters) == 0 {
 			return fmt.Errorf("invalid route %s: %w", item.Value, errNoExporters)
 		}
+
+		if item.Value != "" {
+			ottlRoutingOnly = false
+		}
 	}
 
-	// we also need a "FromAttribute" value
-	if len(c.FromAttribute) == 0 {
+	if ottlRoutingOnly {
+		c.AttributeSource = ""
+		c.FromAttribute = ""
+	} else if len(c.FromAttribute) == 0 {
+		// we also need a "FromAttribute" value
 		return fmt.Errorf(
 			"invalid attribute to read the route's value from: %w",
 			errNoMissingFromAttribute,

--- a/processor/routingprocessor/config_test.go
+++ b/processor/routingprocessor/config_test.go
@@ -28,10 +28,12 @@ import (
 func TestLoadConfig(t *testing.T) {
 	testcases := []struct {
 		configPath string
+		id         component.ID
 		expected   component.Config
 	}{
 		{
 			configPath: "config_traces.yaml",
+			id:         component.NewIDWithName(typeStr, ""),
 			expected: &Config{
 				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
 				DefaultExporters:  []string{"otlp"},
@@ -51,6 +53,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			configPath: "config_metrics.yaml",
+			id:         component.NewIDWithName(typeStr, ""),
 			expected: &Config{
 				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
 				DefaultExporters:  []string{"logging/default"},
@@ -70,6 +73,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			configPath: "config_logs.yaml",
+			id:         component.NewIDWithName(typeStr, ""),
 			expected: &Config{
 				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
 				DefaultExporters:  []string{"logging/default"},
@@ -87,6 +91,40 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			configPath: "config.yaml",
+			id:         component.NewIDWithName(typeStr, ""),
+			expected: &Config{
+				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
+				DefaultExporters:  []string{"jaeger"},
+				AttributeSource:   resourceAttributeSource,
+				FromAttribute:     "X-Tenant",
+				Table: []RoutingTableItem{
+					{
+						Value:     "acme",
+						Exporters: []string{"otlp/traces"},
+					},
+				},
+			},
+		},
+		{
+			configPath: "config.yaml",
+			id:         component.NewIDWithName(typeStr, "ottl"),
+			expected: &Config{
+				ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
+				DefaultExporters:  []string{"jaeger"},
+				Table: []RoutingTableItem{
+					{
+						Statement: "route() where resource.attributes[\"X-Tenant\"] == \"acme\"",
+						Exporters: []string{"jaeger/acme"},
+					},
+					{
+						Statement: "delete_key(resource.attributes, \"X-Tenant\") where IsMatch(resource.attributes[\"X-Tenant\"], \".*corp\") == true",
+						Exporters: []string{"jaeger/ecorp"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range testcases {
@@ -97,7 +135,7 @@ func TestLoadConfig(t *testing.T) {
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
 
-			sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+			sub, err := cm.Sub(tt.id.String())
 			require.NoError(t, err)
 			require.NoError(t, component.UnmarshalConfig(sub, cfg))
 

--- a/processor/routingprocessor/testdata/config.yaml
+++ b/processor/routingprocessor/testdata/config.yaml
@@ -1,7 +1,18 @@
 routing:
+  default_exporters:
+    - jaeger
   attribute_source: resource
   from_attribute: X-Tenant
   table:
     - value: acme
       exporters:
         - otlp/traces
+
+routing/ottl:
+  default_exporters:
+    - jaeger
+  table:
+    - statement: route() where resource.attributes["X-Tenant"] == "acme"
+      exporters: [jaeger/acme]
+    - statement: delete_key(resource.attributes, "X-Tenant") where IsMatch(resource.attributes["X-Tenant"], ".*corp") == true
+      exporters: [jaeger/ecorp]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fix bug in routing processor that prevented collector from starting if `from_attribute` is not provided with `OTTL` routing statements. ``from_attribute` is not required for OTTL statements, only for conventional configuration approach.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16555

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests.