### PR TITLE
[receiver/prometheus] fix: use prometheus default config when no config given

### DIFF
--- a/.chloggen/fix_promreceiver-panic-on-startup.yaml
+++ b/.chloggen/fix_promreceiver-panic-on-startup.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug in prometheus receiver that panics if no configuration is given.
+
+# One or more tracking issues related to the change
+issues: [16538]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -70,7 +70,7 @@ func TestLoadTargetAllocatorConfig(t *testing.T) {
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	r0 := cfg.(*Config)
-	assert.Nil(t, r0.PrometheusConfig)
+	assert.NotNil(t, r0.PrometheusConfig)
 	assert.Equal(t, "http://localhost:8080", r0.TargetAllocator.Endpoint)
 	assert.Equal(t, 30*time.Second, r0.TargetAllocator.Interval)
 	assert.Equal(t, "collector-1", r0.TargetAllocator.CollectorID)
@@ -81,7 +81,7 @@ func TestLoadTargetAllocatorConfig(t *testing.T) {
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	r1 := cfg.(*Config)
-	assert.Nil(t, r0.PrometheusConfig)
+	assert.NotNil(t, r0.PrometheusConfig)
 	assert.Equal(t, "http://localhost:8080", r0.TargetAllocator.Endpoint)
 	assert.Equal(t, 30*time.Second, r0.TargetAllocator.Interval)
 	assert.Equal(t, "collector-1", r0.TargetAllocator.CollectorID)

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 
+	promconfig "github.com/prometheus/prometheus/config"
 	_ "github.com/prometheus/prometheus/discovery/install" // init() of this package registers service discovery impl.
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -43,7 +44,11 @@ func NewFactory() receiver.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		PrometheusConfig: &promconfig.Config{
+			GlobalConfig: promconfig.DefaultGlobalConfig,
+		},
+	}
 }
 
 func createMetricsReceiver(

--- a/receiver/prometheusreceiver/factory_test.go
+++ b/receiver/prometheusreceiver/factory_test.go
@@ -41,6 +41,7 @@ func TestCreateReceiver(t *testing.T) {
 	creationSet := receivertest.NewNopCreateSettings()
 	mReceiver, _ := createMetricsReceiver(context.Background(), creationSet, cfg, nil)
 	assert.NotNil(t, mReceiver)
+	assert.NotNil(t, mReceiver.(*pReceiver).cfg.PrometheusConfig.GlobalConfig)
 }
 
 func TestFactoryCanParseServiceDiscoveryConfigs(t *testing.T) {


### PR DESCRIPTION
**Description:**
Fix #16538 . Current implementation doesn't take into consideration of the config's `GlobalConfig` can be `nil`. ( Ex. https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/metrics_receiver.go#L302 )
When no configuration given, I made to use [prometheus' default configuration](https://github.com/prometheus/prometheus/blob/main/config/config.go#L144-L148) to avoid panic.

**Testing:**
- Add an additional assertion to `TestCreateReceiver()` to make sure that `GlobalConfig` can't be `nil`

**Documentation:**
No docs added.