### PR TITLE
[headerssetter] Disable secure transport for the extension.

### DIFF
--- a/.chloggen/header-setter-transport-security.yaml
+++ b/.chloggen/header-setter-transport-security.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: headerssetter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not require the secure transport for the headers setter extension.
+
+# One or more tracking issues related to the change
+issues: [16508]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/extension/headerssetterextension/extension.go
+++ b/extension/headerssetterextension/extension.go
@@ -89,9 +89,11 @@ func (h *headersPerRPC) GetRequestMetadata(
 	return metadata, nil
 }
 
-// RequireTransportSecurity always returns true for this implementation.
+// RequireTransportSecurity always returns false for this implementation.
+// The header setter is not sending auth data, so it should not require
+// a transport security.
 func (h *headersPerRPC) RequireTransportSecurity() bool {
-	return true
+	return false
 }
 
 // headersRoundTripper intercepts downstream requests and sets headers with


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Disable the secure transport for the headers setter extension.

**Link to tracking Issue:** <Issue number if applicable>
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16508
