### PR TITLE
[exporter/datadogexporter] Prefix function names with Zorkian if they use Zorkian APIs

### DIFF
--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -18,12 +18,12 @@ import (
 	"errors"
 
 	"go.uber.org/zap"
-	"gopkg.in/zorkian/go-datadog-api.v2"
+	zorkian "gopkg.in/zorkian/go-datadog-api.v2"
 )
 
-// CreateClient creates a new Datadog client
-func CreateClient(apiKey string, endpoint string) *datadog.Client {
-	client := datadog.NewClient(apiKey, "")
+// CreateZorkianClient creates a new Zorkian Datadog client
+func CreateZorkianClient(apiKey string, endpoint string) *zorkian.Client {
+	client := zorkian.NewClient(apiKey, "")
 	client.SetBaseUrl(endpoint)
 
 	return client
@@ -31,8 +31,8 @@ func CreateClient(apiKey string, endpoint string) *datadog.Client {
 
 var ErrInvalidAPI = errors.New("API Key validation failed")
 
-// ValidateAPIKey checks that the provided client was given a correct API key.
-func ValidateAPIKey(logger *zap.Logger, client *datadog.Client) error {
+// ValidateAPIKeyZorkian checks that the provided client was given a correct API key.
+func ValidateAPIKeyZorkian(logger *zap.Logger, client *zorkian.Client) error {
 	logger.Info("Validating API key.")
 	valid, err := client.Validate()
 	if err == nil && valid {

--- a/exporter/datadogexporter/internal/metrics/consumer_test.go
+++ b/exporter/datadogexporter/internal/metrics/consumer_test.go
@@ -69,7 +69,7 @@ func TestRunningMetrics(t *testing.T) {
 	tr := newTranslator(t, logger)
 
 	ctx := context.Background()
-	consumer := NewConsumer()
+	consumer := NewZorkianConsumer()
 	assert.NoError(t, tr.MapMetrics(ctx, ms, consumer))
 
 	var runningHostnames []string
@@ -113,7 +113,7 @@ func TestTagsMetrics(t *testing.T) {
 	tr := newTranslator(t, logger)
 
 	ctx := context.Background()
-	consumer := NewConsumer()
+	consumer := NewZorkianConsumer()
 	assert.NoError(t, tr.MapMetrics(ctx, ms, consumer))
 
 	runningMetrics := consumer.runningMetrics(0, component.BuildInfo{})

--- a/exporter/datadogexporter/internal/metrics/system.go
+++ b/exporter/datadogexporter/internal/metrics/system.go
@@ -17,15 +17,15 @@ package metrics // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"strings"
 
-	"gopkg.in/zorkian/go-datadog-api.v2"
+	zorkian "gopkg.in/zorkian/go-datadog-api.v2"
 )
 
-// copySystemMetric copies the metric from src by giving it a new name. If div differs from 1, it scales all
+// copyZorkianSystemMetric copies the metric from src by giving it a new name. If div differs from 1, it scales all
 // data points.
 //
 // Warning: this is not a deep copy. Only some fields are fully copied, others remain shared. This is intentional.
 // Do not alter the returned metric (or the source one) after copying.
-func copySystemMetric(src datadog.Metric, name string, div float64) datadog.Metric {
+func copyZorkianSystemMetric(src zorkian.Metric, name string, div float64) zorkian.Metric {
 	cp := src
 	cp.Metric = &name
 	i := 1
@@ -36,7 +36,7 @@ func copySystemMetric(src datadog.Metric, name string, div float64) datadog.Metr
 		// division by 0 or 1 should not have an impact
 		return cp
 	}
-	cp.Points = make([]datadog.DataPoint, len(src.Points))
+	cp.Points = make([]zorkian.DataPoint, len(src.Points))
 	for i, dp := range src.Points {
 		cp.Points[i][0] = dp[0]
 		if dp[1] != nil {
@@ -54,60 +54,60 @@ const (
 	divPercentage = 0.01
 )
 
-// extractSystemMetrics takes an OpenTelemetry metric m and extracts Datadog system metrics from it,
+// extractZorkianSystemMetric takes an OpenTelemetry metric m and extracts Datadog system metrics from it,
 // if m is a valid system metric. The boolean argument reports whether any system metrics were extractd.
-func extractSystemMetrics(m datadog.Metric) []datadog.Metric {
-	var series []datadog.Metric
+func extractZorkianSystemMetric(m zorkian.Metric) []zorkian.Metric {
+	var series []zorkian.Metric
 	switch *m.Metric {
 	case "system.cpu.load_average.1m":
-		series = append(series, copySystemMetric(m, "system.load.1", 1))
+		series = append(series, copyZorkianSystemMetric(m, "system.load.1", 1))
 	case "system.cpu.load_average.5m":
-		series = append(series, copySystemMetric(m, "system.load.5", 1))
+		series = append(series, copyZorkianSystemMetric(m, "system.load.5", 1))
 	case "system.cpu.load_average.15m":
-		series = append(series, copySystemMetric(m, "system.load.15", 1))
+		series = append(series, copyZorkianSystemMetric(m, "system.load.15", 1))
 	case "system.cpu.utilization":
 		for _, tag := range m.Tags {
 			switch tag {
 			case "state:idle":
-				series = append(series, copySystemMetric(m, "system.cpu.idle", divPercentage))
+				series = append(series, copyZorkianSystemMetric(m, "system.cpu.idle", divPercentage))
 			case "state:user":
-				series = append(series, copySystemMetric(m, "system.cpu.user", divPercentage))
+				series = append(series, copyZorkianSystemMetric(m, "system.cpu.user", divPercentage))
 			case "state:system":
-				series = append(series, copySystemMetric(m, "system.cpu.system", divPercentage))
+				series = append(series, copyZorkianSystemMetric(m, "system.cpu.system", divPercentage))
 			case "state:wait":
-				series = append(series, copySystemMetric(m, "system.cpu.iowait", divPercentage))
+				series = append(series, copyZorkianSystemMetric(m, "system.cpu.iowait", divPercentage))
 			case "state:steal":
-				series = append(series, copySystemMetric(m, "system.cpu.stolen", divPercentage))
+				series = append(series, copyZorkianSystemMetric(m, "system.cpu.stolen", divPercentage))
 			}
 		}
 	case "system.memory.usage":
-		series = append(series, copySystemMetric(m, "system.mem.total", divMebibytes))
+		series = append(series, copyZorkianSystemMetric(m, "system.mem.total", divMebibytes))
 		for _, tag := range m.Tags {
 			switch tag {
 			case "state:free", "state:cached", "state:buffered":
-				series = append(series, copySystemMetric(m, "system.mem.usable", divMebibytes))
+				series = append(series, copyZorkianSystemMetric(m, "system.mem.usable", divMebibytes))
 			}
 		}
 	case "system.network.io":
 		for _, tag := range m.Tags {
 			switch tag {
 			case "direction:receive":
-				series = append(series, copySystemMetric(m, "system.net.bytes_rcvd", 1))
+				series = append(series, copyZorkianSystemMetric(m, "system.net.bytes_rcvd", 1))
 			case "direction:transmit":
-				series = append(series, copySystemMetric(m, "system.net.bytes_sent", 1))
+				series = append(series, copyZorkianSystemMetric(m, "system.net.bytes_sent", 1))
 			}
 		}
 	case "system.paging.usage":
 		for _, tag := range m.Tags {
 			switch tag {
 			case "state:free":
-				series = append(series, copySystemMetric(m, "system.swap.free", divMebibytes))
+				series = append(series, copyZorkianSystemMetric(m, "system.swap.free", divMebibytes))
 			case "state:used":
-				series = append(series, copySystemMetric(m, "system.swap.used", divMebibytes))
+				series = append(series, copyZorkianSystemMetric(m, "system.swap.used", divMebibytes))
 			}
 		}
 	case "system.filesystem.utilization":
-		series = append(series, copySystemMetric(m, "system.disk.in_use", 1))
+		series = append(series, copyZorkianSystemMetric(m, "system.disk.in_use", 1))
 	}
 	return series
 }
@@ -115,10 +115,10 @@ func extractSystemMetrics(m datadog.Metric) []datadog.Metric {
 // otelNamespacePrefix specifies the namespace used for OpenTelemetry host metrics.
 const otelNamespacePrefix = "otel."
 
-// PrepareSystemMetrics prepends system hosts metrics with the otel.* prefix to identify
+// PrepareZorkianSystemMetrics prepends system hosts metrics with the otel.* prefix to identify
 // them as part of the Datadog OpenTelemetry Integration. It also extracts Datadog compatible
 // system metrics and returns the full set of metrics to be used.
-func PrepareSystemMetrics(ms []datadog.Metric) []datadog.Metric {
+func PrepareZorkianSystemMetrics(ms []zorkian.Metric) []zorkian.Metric {
 	series := ms
 	for i, m := range ms {
 		if !strings.HasPrefix(*m.Metric, "system.") &&
@@ -126,7 +126,7 @@ func PrepareSystemMetrics(ms []datadog.Metric) []datadog.Metric {
 			// not a system metric
 			continue
 		}
-		series = append(series, extractSystemMetrics(m)...)
+		series = append(series, extractZorkianSystemMetric(m)...)
 		// all existing system metrics need to be prepended
 		newname := otelNamespacePrefix + *m.Metric
 		series[i].Metric = &newname

--- a/exporter/datadogexporter/internal/metrics/system_test.go
+++ b/exporter/datadogexporter/internal/metrics/system_test.go
@@ -20,26 +20,26 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/zorkian/go-datadog-api.v2"
+	zorkian "gopkg.in/zorkian/go-datadog-api.v2"
 )
 
-func TestCopyMetric(t *testing.T) {
+func TestCopyZorkianMetric(t *testing.T) {
 	sptr := func(s string) *string { return &s }
 	dptr := func(d int) *int { return &d }
-	dp := func(a, b float64) datadog.DataPoint { return datadog.DataPoint{&a, &b} }
+	dp := func(a, b float64) zorkian.DataPoint { return zorkian.DataPoint{&a, &b} }
 
 	t.Run("renaming", func(t *testing.T) {
-		require.EqualValues(t, copySystemMetric(datadog.Metric{
+		require.EqualValues(t, copyZorkianSystemMetric(zorkian.Metric{
 			Metric:   sptr("oldname"),
-			Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+			Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			Type:     sptr("oldtype"),
 			Host:     sptr("oldhost"),
 			Tags:     []string{"x", "y", "z"},
 			Unit:     sptr("oldunit"),
 			Interval: dptr(3),
-		}, "newname", 1), datadog.Metric{
+		}, "newname", 1), zorkian.Metric{
 			Metric:   sptr("newname"),
-			Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+			Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			Type:     sptr("gauge"),
 			Host:     sptr("oldhost"),
 			Tags:     []string{"x", "y", "z"},
@@ -47,17 +47,17 @@ func TestCopyMetric(t *testing.T) {
 			Interval: dptr(1),
 		})
 
-		require.EqualValues(t, copySystemMetric(datadog.Metric{
+		require.EqualValues(t, copyZorkianSystemMetric(zorkian.Metric{
 			Metric:   sptr("oldname"),
-			Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+			Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			Type:     sptr("oldtype"),
 			Host:     sptr("oldhost"),
 			Tags:     []string{"x", "y", "z"},
 			Unit:     sptr("oldunit"),
 			Interval: dptr(3),
-		}, "", 1), datadog.Metric{
+		}, "", 1), zorkian.Metric{
 			Metric:   sptr(""),
-			Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+			Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			Type:     sptr("gauge"),
 			Host:     sptr("oldhost"),
 			Tags:     []string{"x", "y", "z"},
@@ -65,17 +65,17 @@ func TestCopyMetric(t *testing.T) {
 			Interval: dptr(1),
 		})
 
-		require.EqualValues(t, copySystemMetric(datadog.Metric{
+		require.EqualValues(t, copyZorkianSystemMetric(zorkian.Metric{
 			Metric:   nil,
-			Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+			Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			Type:     sptr("oldtype"),
 			Host:     sptr("oldhost"),
 			Tags:     []string{"x", "y", "z"},
 			Unit:     sptr("oldunit"),
 			Interval: dptr(3),
-		}, "", 1), datadog.Metric{
+		}, "", 1), zorkian.Metric{
 			Metric:   sptr(""),
-			Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+			Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			Type:     sptr("gauge"),
 			Host:     sptr("oldhost"),
 			Tags:     []string{"x", "y", "z"},
@@ -85,17 +85,17 @@ func TestCopyMetric(t *testing.T) {
 	})
 
 	t.Run("interval", func(t *testing.T) {
-		require.EqualValues(t, copySystemMetric(datadog.Metric{
+		require.EqualValues(t, copyZorkianSystemMetric(zorkian.Metric{
 			Metric:   nil,
-			Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+			Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			Type:     sptr("oldtype"),
 			Host:     sptr("oldhost"),
 			Tags:     []string{"x", "y", "z"},
 			Unit:     sptr("oldunit"),
 			Interval: dptr(3),
-		}, "", 1), datadog.Metric{
+		}, "", 1), zorkian.Metric{
 			Metric:   sptr(""),
-			Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+			Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			Type:     sptr("gauge"),
 			Host:     sptr("oldhost"),
 			Tags:     []string{"x", "y", "z"},
@@ -106,334 +106,334 @@ func TestCopyMetric(t *testing.T) {
 
 	t.Run("division", func(t *testing.T) {
 		for _, tt := range []struct {
-			in, out []datadog.DataPoint
+			in, out []zorkian.DataPoint
 			div     float64
 		}{
 			{
-				in:  []datadog.DataPoint{dp(0, 0), dp(1, 20)},
+				in:  []zorkian.DataPoint{dp(0, 0), dp(1, 20)},
 				div: 0,
-				out: []datadog.DataPoint{dp(0, 0), dp(1, 20)},
+				out: []zorkian.DataPoint{dp(0, 0), dp(1, 20)},
 			},
 			{
-				in:  []datadog.DataPoint{dp(0, 0), dp(1, 20)},
+				in:  []zorkian.DataPoint{dp(0, 0), dp(1, 20)},
 				div: 1,
-				out: []datadog.DataPoint{dp(0, 0), dp(1, 20)},
+				out: []zorkian.DataPoint{dp(0, 0), dp(1, 20)},
 			},
 			{
-				in:  []datadog.DataPoint{dp(1.1, 0), {}},
+				in:  []zorkian.DataPoint{dp(1.1, 0), {}},
 				div: 2,
-				out: []datadog.DataPoint{dp(1.1, 0), {}},
+				out: []zorkian.DataPoint{dp(1.1, 0), {}},
 			},
 			{
-				in:  []datadog.DataPoint{dp(0, 0), dp(1, 20)},
+				in:  []zorkian.DataPoint{dp(0, 0), dp(1, 20)},
 				div: 10,
-				out: []datadog.DataPoint{dp(0, 0), dp(1, 2)},
+				out: []zorkian.DataPoint{dp(0, 0), dp(1, 2)},
 			},
 			{
-				in:  []datadog.DataPoint{dp(1.1, 0), dp(55.5, math.MaxFloat64)},
+				in:  []zorkian.DataPoint{dp(1.1, 0), dp(55.5, math.MaxFloat64)},
 				div: 1024 * 1024.5,
-				out: []datadog.DataPoint{dp(1.1, 0), dp(55.5, 1.713577063947272e+302)},
+				out: []zorkian.DataPoint{dp(1.1, 0), dp(55.5, 1.713577063947272e+302)},
 			},
 			{
-				in:  []datadog.DataPoint{dp(1.1, 0), dp(55.5, 20)},
+				in:  []zorkian.DataPoint{dp(1.1, 0), dp(55.5, 20)},
 				div: math.MaxFloat64,
-				out: []datadog.DataPoint{dp(1.1, 0), dp(55.5, 1.1125369292536009e-307)},
+				out: []zorkian.DataPoint{dp(1.1, 0), dp(55.5, 1.1125369292536009e-307)},
 			},
 		} {
 			t.Run(fmt.Sprintf("%.0f", tt.div), func(t *testing.T) {
 				require.EqualValues(t,
-					copySystemMetric(datadog.Metric{Points: tt.in}, "", tt.div),
-					datadog.Metric{Metric: sptr(""), Type: sptr("gauge"), Points: tt.out, Interval: dptr(1)},
+					copyZorkianSystemMetric(zorkian.Metric{Points: tt.in}, "", tt.div),
+					zorkian.Metric{Metric: sptr(""), Type: sptr("gauge"), Points: tt.out, Interval: dptr(1)},
 				)
 			})
 		}
 	})
 }
 
-func TestExtractSystemMetrics(t *testing.T) {
+func TestExtractZorkianSystemMetrics(t *testing.T) {
 	sptr := func(s string) *string { return &s }
 	dptr := func(d int) *int { return &d }
-	dp := func(a, b float64) datadog.DataPoint { return datadog.DataPoint{&a, &b} }
+	dp := func(a, b float64) zorkian.DataPoint { return zorkian.DataPoint{&a, &b} }
 
 	for _, tt := range []struct {
-		in  datadog.Metric
-		out []datadog.Metric
+		in  zorkian.Metric
+		out []zorkian.Metric
 	}{
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.cpu.load_average.1m"),
-				Points: []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.load.1"),
-				Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+				Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.cpu.load_average.5m"),
-				Points: []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.load.5"),
-				Points:   []datadog.DataPoint{dp(1, 2), dp(3, 4)},
+				Points:   []zorkian.DataPoint{dp(1, 2), dp(3, 4)},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.cpu.load_average.15m"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.load.15"),
-				Points:   []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points:   []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.cpu.utilization"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:idle"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.cpu.idle"),
-				Points:   []datadog.DataPoint{dp(2, 200), dp(3, 400)},
+				Points:   []zorkian.DataPoint{dp(2, 200), dp(3, 400)},
 				Interval: dptr(1),
 				Tags:     []string{"state:idle"},
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.cpu.utilization"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:user"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.cpu.user"),
-				Points:   []datadog.DataPoint{dp(2, 200), dp(3, 400)},
+				Points:   []zorkian.DataPoint{dp(2, 200), dp(3, 400)},
 				Interval: dptr(1),
 				Tags:     []string{"state:user"},
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.cpu.utilization"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:system"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.cpu.system"),
-				Points:   []datadog.DataPoint{dp(2, 200), dp(3, 400)},
+				Points:   []zorkian.DataPoint{dp(2, 200), dp(3, 400)},
 				Interval: dptr(1),
 				Tags:     []string{"state:system"},
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.cpu.utilization"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:wait"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.cpu.iowait"),
-				Points:   []datadog.DataPoint{dp(2, 200), dp(3, 400)},
+				Points:   []zorkian.DataPoint{dp(2, 200), dp(3, 400)},
 				Interval: dptr(1),
 				Tags:     []string{"state:wait"},
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.cpu.utilization"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:steal"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.cpu.stolen"),
-				Points:   []datadog.DataPoint{dp(2, 200), dp(3, 400)},
+				Points:   []zorkian.DataPoint{dp(2, 200), dp(3, 400)},
 				Tags:     []string{"state:steal"},
 				Type:     sptr("gauge"),
 				Interval: dptr(1),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.memory.usage"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:other"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.mem.total"),
-				Points:   []datadog.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
+				Points:   []zorkian.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
 				Tags:     []string{"state:other"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.memory.usage"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:free"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.mem.total"),
-				Points:   []datadog.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
+				Points:   []zorkian.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
 				Tags:     []string{"state:free"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}, {
 				Metric:   sptr("system.mem.usable"),
-				Points:   []datadog.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
+				Points:   []zorkian.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
 				Tags:     []string{"state:free"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.memory.usage"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:cached"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.mem.total"),
-				Points:   []datadog.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
+				Points:   []zorkian.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
 				Tags:     []string{"state:cached"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}, {
 				Metric:   sptr("system.mem.usable"),
-				Points:   []datadog.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
+				Points:   []zorkian.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
 				Tags:     []string{"state:cached"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.memory.usage"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:buffered"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.mem.total"),
-				Points:   []datadog.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
+				Points:   []zorkian.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
 				Tags:     []string{"state:buffered"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}, {
 				Metric:   sptr("system.mem.usable"),
-				Points:   []datadog.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
+				Points:   []zorkian.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
 				Tags:     []string{"state:buffered"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.network.io"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"direction:receive"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.net.bytes_rcvd"),
-				Points:   []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points:   []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:     []string{"direction:receive"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.network.io"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"direction:transmit"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.net.bytes_sent"),
-				Points:   []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points:   []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:     []string{"direction:transmit"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.paging.usage"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:free"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.swap.free"),
-				Points:   []datadog.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
+				Points:   []zorkian.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
 				Tags:     []string{"state:free"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.paging.usage"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Tags:   []string{"state:used"},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.swap.used"),
-				Points:   []datadog.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
+				Points:   []zorkian.DataPoint{dp(2, 1.9073486328125e-06), dp(3, 3.814697265625e-06)},
 				Tags:     []string{"state:used"},
 				Interval: dptr(1),
 				Type:     sptr("gauge"),
 			}},
 		},
 		{
-			in: datadog.Metric{
+			in: zorkian.Metric{
 				Metric: sptr("system.filesystem.utilization"),
-				Points: []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points: []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 			},
-			out: []datadog.Metric{{
+			out: []zorkian.Metric{{
 				Metric:   sptr("system.disk.in_use"),
-				Points:   []datadog.DataPoint{dp(2, 2), dp(3, 4)},
+				Points:   []zorkian.DataPoint{dp(2, 2), dp(3, 4)},
 				Type:     sptr("gauge"),
 				Interval: dptr(1),
 			}},
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			out := extractSystemMetrics(tt.in)
+			out := extractZorkianSystemMetric(tt.in)
 			require.EqualValues(t, tt.out, out, fmt.Sprintf("%s[%#v]", *tt.in.Metric, tt.in.Tags))
 		})
 	}
 }
 
-func TestPrepareSystemMetrics(t *testing.T) {
-	m := func(name string, tags []string, points ...float64) datadog.Metric {
-		met := datadog.Metric{
+func TestPrepareZorkianSystemMetrics(t *testing.T) {
+	m := func(name string, tags []string, points ...float64) zorkian.Metric {
+		met := zorkian.Metric{
 			Metric: &name,
 			Tags:   tags,
 		}
 		if len(points)%2 != 0 {
 			t.Fatal("Number of data point arguments passed to function must be even.")
 		}
-		met.Points = make([]datadog.DataPoint, 0, len(points)/2)
+		met.Points = make([]zorkian.DataPoint, 0, len(points)/2)
 		for i := 0; i < len(points); i += 2 {
-			met.Points = append(met.Points, datadog.DataPoint{&points[i], &points[i+1]})
+			met.Points = append(met.Points, zorkian.DataPoint{&points[i], &points[i+1]})
 		}
 		return met
 	}
 	fptr := func(d float64) *float64 { return &d }
 	dptr := func(d int) *int { return &d }
 	sptr := func(s string) *string { return &s }
-	require.EqualValues(t, PrepareSystemMetrics([]datadog.Metric{
+	require.EqualValues(t, PrepareZorkianSystemMetrics([]zorkian.Metric{
 		m("system.metric.1", nil, 0.1, 0.2),
 		m("system.metric.2", nil, 0.3, 0.4),
 		m("process.metric.1", nil, 0.5, 0.6),
@@ -457,250 +457,250 @@ func TestPrepareSystemMetrics(t *testing.T) {
 		m("system.paging.usage", []string{"state:free"}, 1, 4.37, 2, 5.22),
 		m("system.paging.usage", []string{"state:used"}, 1, 4.3, 2, 8.22),
 		m("system.filesystem.utilization", nil, 1, 4.3, 2, 5.5, 3, 12.1),
-	}), []datadog.Metric{
+	}), []zorkian.Metric{
 		{
 			Metric: sptr("otel.system.metric.1"),
-			Points: []datadog.DataPoint{{fptr(0.1), fptr(0.2)}},
+			Points: []zorkian.DataPoint{{fptr(0.1), fptr(0.2)}},
 		},
 		{
 			Metric: sptr("otel.system.metric.2"),
-			Points: []datadog.DataPoint{{fptr(0.3), fptr(0.4)}},
+			Points: []zorkian.DataPoint{{fptr(0.3), fptr(0.4)}},
 		},
 		{
 			Metric: sptr("otel.process.metric.1"),
-			Points: []datadog.DataPoint{{fptr(0.5), fptr(0.6)}},
+			Points: []zorkian.DataPoint{{fptr(0.5), fptr(0.6)}},
 		},
 		{
 			Metric: sptr("otel.process.metric.2"),
-			Points: []datadog.DataPoint{{fptr(0.7), fptr(0.8)}},
+			Points: []zorkian.DataPoint{{fptr(0.7), fptr(0.8)}},
 		},
 		{
 			Metric: sptr("otel.system.cpu.load_average.1m"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(2)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(2)}},
 		},
 		{
 			Metric: sptr("otel.system.cpu.load_average.5m"),
-			Points: []datadog.DataPoint{{fptr(3), fptr(4)}},
+			Points: []zorkian.DataPoint{{fptr(3), fptr(4)}},
 		},
 		{
 			Metric: sptr("otel.system.cpu.load_average.15m"),
-			Points: []datadog.DataPoint{{fptr(5), fptr(6)}},
+			Points: []zorkian.DataPoint{{fptr(5), fptr(6)}},
 		},
 		{
 			Metric: sptr("otel.system.cpu.utilization"),
-			Points: []datadog.DataPoint{{fptr(0.15), fptr(0.17)}},
+			Points: []zorkian.DataPoint{{fptr(0.15), fptr(0.17)}},
 			Tags:   []string{"state:idle"},
 		},
 		{
 			Metric: sptr("otel.system.cpu.utilization"),
-			Points: []datadog.DataPoint{{fptr(0.18), fptr(0.19)}},
+			Points: []zorkian.DataPoint{{fptr(0.18), fptr(0.19)}},
 			Tags:   []string{"state:user"},
 		},
 		{
 			Metric: sptr("otel.system.cpu.utilization"),
-			Points: []datadog.DataPoint{{fptr(0.2), fptr(0.21)}},
+			Points: []zorkian.DataPoint{{fptr(0.2), fptr(0.21)}},
 			Tags:   []string{"state:system"},
 		},
 		{
 			Metric: sptr("otel.system.cpu.utilization"),
-			Points: []datadog.DataPoint{{fptr(0.22), fptr(0.23)}},
+			Points: []zorkian.DataPoint{{fptr(0.22), fptr(0.23)}},
 			Tags:   []string{"state:wait"}},
 		{
 			Metric: sptr("otel.system.cpu.utilization"),
-			Points: []datadog.DataPoint{{fptr(0.24), fptr(0.25)}},
+			Points: []zorkian.DataPoint{{fptr(0.24), fptr(0.25)}},
 			Tags:   []string{"state:steal"},
 		},
 		{
 			Metric: sptr("otel.system.cpu.utilization"),
-			Points: []datadog.DataPoint{{fptr(0.26), fptr(0.27)}},
+			Points: []zorkian.DataPoint{{fptr(0.26), fptr(0.27)}},
 			Tags:   []string{"state:other"}},
 		{
 			Metric: sptr("otel.system.memory.usage"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(0.3)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(0.3)}},
 		},
 		{
 			Metric: sptr("otel.system.memory.usage"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(1.35)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(1.35)}},
 			Tags:   []string{"state:other"},
 		},
 		{
 			Metric: sptr("otel.system.memory.usage"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(1.3)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(1.3)}},
 			Tags:   []string{"state:free"},
 		},
 		{
 			Metric: sptr("otel.system.memory.usage"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(1.35)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(1.35)}},
 			Tags:   []string{"state:cached"},
 		},
 		{
 			Metric: sptr("otel.system.memory.usage"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(1.37)}, {fptr(2), fptr(2.22)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(1.37)}, {fptr(2), fptr(2.22)}},
 			Tags:   []string{"state:buffered"},
 		},
 		{
 			Metric: sptr("otel.system.network.io"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(2.37)}, {fptr(2), fptr(3.22)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(2.37)}, {fptr(2), fptr(3.22)}},
 			Tags:   []string{"direction:receive"},
 		},
 		{
 			Metric: sptr("otel.system.network.io"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(4.37)}, {fptr(2), fptr(5.22)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(4.37)}, {fptr(2), fptr(5.22)}},
 			Tags:   []string{"direction:transmit"},
 		},
 		{
 			Metric: sptr("otel.system.paging.usage"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(4.37)}, {fptr(2), fptr(5.22)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(4.37)}, {fptr(2), fptr(5.22)}},
 			Tags:   []string{"state:free"},
 		},
 		{
 			Metric: sptr("otel.system.paging.usage"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(4.3)}, {fptr(2), fptr(8.22)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(4.3)}, {fptr(2), fptr(8.22)}},
 			Tags:   []string{"state:used"},
 		},
 		{
 			Metric: sptr("otel.system.filesystem.utilization"),
-			Points: []datadog.DataPoint{{fptr(1), fptr(4.3)}, {fptr(2), fptr(5.5)}, {fptr(3), fptr(12.1)}},
+			Points: []zorkian.DataPoint{{fptr(1), fptr(4.3)}, {fptr(2), fptr(5.5)}, {fptr(3), fptr(12.1)}},
 		},
 		{
 			Metric:   sptr("system.load.1"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(2)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(2)}},
 			Type:     sptr("gauge"),
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.load.5"),
-			Points:   []datadog.DataPoint{{fptr(3), fptr(4)}},
+			Points:   []zorkian.DataPoint{{fptr(3), fptr(4)}},
 			Type:     sptr("gauge"),
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.load.15"),
-			Points:   []datadog.DataPoint{{fptr(5), fptr(6)}},
+			Points:   []zorkian.DataPoint{{fptr(5), fptr(6)}},
 			Type:     sptr("gauge"),
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.cpu.idle"),
-			Points:   []datadog.DataPoint{{fptr(0.15), fptr(17)}},
+			Points:   []zorkian.DataPoint{{fptr(0.15), fptr(17)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:idle"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.cpu.user"),
-			Points:   []datadog.DataPoint{{fptr(0.18), fptr(19)}},
+			Points:   []zorkian.DataPoint{{fptr(0.18), fptr(19)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:user"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.cpu.system"),
-			Points:   []datadog.DataPoint{{fptr(0.2), fptr(21)}},
+			Points:   []zorkian.DataPoint{{fptr(0.2), fptr(21)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:system"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.cpu.iowait"),
-			Points:   []datadog.DataPoint{{fptr(0.22), fptr(23)}},
+			Points:   []zorkian.DataPoint{{fptr(0.22), fptr(23)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:wait"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.cpu.stolen"),
-			Points:   []datadog.DataPoint{{fptr(0.24), fptr(25)}},
+			Points:   []zorkian.DataPoint{{fptr(0.24), fptr(25)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:steal"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.mem.total"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(2.86102294921875e-07)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(2.86102294921875e-07)}},
 			Type:     sptr("gauge"),
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.mem.total"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(1.2874603271484376e-06)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(1.2874603271484376e-06)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:other"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.mem.total"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(1.239776611328125e-06)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(1.239776611328125e-06)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:free"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.mem.usable"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(1.239776611328125e-06)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(1.239776611328125e-06)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:free"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.mem.total"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(1.2874603271484376e-06)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(1.2874603271484376e-06)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:cached"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.mem.usable"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(1.2874603271484376e-06)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(1.2874603271484376e-06)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:cached"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.mem.total"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(1.3065338134765626e-06)}, {fptr(2), fptr(2.117156982421875e-06)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(1.3065338134765626e-06)}, {fptr(2), fptr(2.117156982421875e-06)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:buffered"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.mem.usable"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(1.3065338134765626e-06)}, {fptr(2), fptr(2.117156982421875e-06)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(1.3065338134765626e-06)}, {fptr(2), fptr(2.117156982421875e-06)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:buffered"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.net.bytes_rcvd"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(2.37)}, {fptr(2), fptr(3.22)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(2.37)}, {fptr(2), fptr(3.22)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"direction:receive"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.net.bytes_sent"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(4.37)}, {fptr(2), fptr(5.22)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(4.37)}, {fptr(2), fptr(5.22)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"direction:transmit"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.swap.free"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(4.37 / 1024 / 1024)}, {fptr(2), fptr(5.22 / 1024 / 1024)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(4.37 / 1024 / 1024)}, {fptr(2), fptr(5.22 / 1024 / 1024)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:free"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.swap.used"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(4.3 / 1024 / 1024)}, {fptr(2), fptr(8.22 / 1024 / 1024)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(4.3 / 1024 / 1024)}, {fptr(2), fptr(8.22 / 1024 / 1024)}},
 			Type:     sptr("gauge"),
 			Tags:     []string{"state:used"},
 			Interval: dptr(1),
 		},
 		{
 			Metric:   sptr("system.disk.in_use"),
-			Points:   []datadog.DataPoint{{fptr(1), fptr(4.3)}, {fptr(2), fptr(5.5)}, {fptr(3), fptr(12.1)}},
+			Points:   []zorkian.DataPoint{{fptr(1), fptr(4.3)}, {fptr(2), fptr(5.5)}, {fptr(3), fptr(12.1)}},
 			Type:     sptr("gauge"),
 			Interval: dptr(1),
 		},

--- a/exporter/datadogexporter/internal/metrics/utils.go
+++ b/exporter/datadogexporter/internal/metrics/utils.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
-	"gopkg.in/zorkian/go-datadog-api.v2"
+	zorkian "gopkg.in/zorkian/go-datadog-api.v2"
 )
 
 type MetricType string
@@ -30,43 +30,43 @@ const (
 	Count MetricType = "count"
 )
 
-// newMetric creates a new Datadog metric given a name, a Unix nanoseconds timestamp
+// newZorkianMetric creates a new Zorkian Datadog metric given a name, a Unix nanoseconds timestamp
 // a value and a slice of tags
-func newMetric(name string, ts uint64, value float64, tags []string) datadog.Metric {
+func newZorkianMetric(name string, ts uint64, value float64, tags []string) zorkian.Metric {
 	// Transform UnixNano timestamp into Unix timestamp
 	// 1 second = 1e9 ns
 	timestamp := float64(ts / 1e9)
 
-	metric := datadog.Metric{
-		Points: []datadog.DataPoint{[2]*float64{&timestamp, &value}},
+	metric := zorkian.Metric{
+		Points: []zorkian.DataPoint{[2]*float64{&timestamp, &value}},
 		Tags:   tags,
 	}
 	metric.SetMetric(name)
 	return metric
 }
 
-// NewMetric creates a new Datadog metric given a name, a type, a Unix nanoseconds timestamp
+// NewZorkianMetric creates a new Zorkian Datadog metric given a name, a type, a Unix nanoseconds timestamp
 // a value and a slice of tags
-func NewMetric(name string, dt MetricType, ts uint64, value float64, tags []string) datadog.Metric {
-	metric := newMetric(name, ts, value, tags)
+func NewZorkianMetric(name string, dt MetricType, ts uint64, value float64, tags []string) zorkian.Metric {
+	metric := newZorkianMetric(name, ts, value, tags)
 	metric.SetType(string(dt))
 	return metric
 }
 
-// NewGauge creates a new Datadog Gauge metric given a name, a Unix nanoseconds timestamp
+// NewZorkianGauge creates a new Datadog Gauge metric given a name, a Unix nanoseconds timestamp
 // a value and a slice of tags
-func NewGauge(name string, ts uint64, value float64, tags []string) datadog.Metric {
-	return NewMetric(name, Gauge, ts, value, tags)
+func NewZorkianGauge(name string, ts uint64, value float64, tags []string) zorkian.Metric {
+	return NewZorkianMetric(name, Gauge, ts, value, tags)
 }
 
-// NewCount creates a new Datadog count metric given a name, a Unix nanoseconds timestamp
+// NewZorkianCount creates a new Datadog count metric given a name, a Unix nanoseconds timestamp
 // a value and a slice of tags
-func NewCount(name string, ts uint64, value float64, tags []string) datadog.Metric {
-	return NewMetric(name, Count, ts, value, tags)
+func NewZorkianCount(name string, ts uint64, value float64, tags []string) zorkian.Metric {
+	return NewZorkianMetric(name, Count, ts, value, tags)
 }
 
-// DefaultMetrics creates built-in metrics to report that an exporter is running
-func DefaultMetrics(exporterType string, hostname string, timestamp uint64, buildInfo component.BuildInfo) []datadog.Metric {
+// DefaultZorkianMetrics creates built-in metrics to report that an exporter is running
+func DefaultZorkianMetrics(exporterType string, hostname string, timestamp uint64, buildInfo component.BuildInfo) []zorkian.Metric {
 	var tags []string
 
 	if buildInfo.Version != "" {
@@ -77,8 +77,8 @@ func DefaultMetrics(exporterType string, hostname string, timestamp uint64, buil
 		tags = append(tags, "command:"+buildInfo.Command)
 	}
 
-	metrics := []datadog.Metric{
-		NewGauge(fmt.Sprintf("otel.datadog_exporter.%s.running", exporterType), timestamp, 1.0, tags),
+	metrics := []zorkian.Metric{
+		NewZorkianGauge(fmt.Sprintf("otel.datadog_exporter.%s.running", exporterType), timestamp, 1.0, tags),
 	}
 
 	for i := range metrics {

--- a/exporter/datadogexporter/internal/metrics/utils_test.go
+++ b/exporter/datadogexporter/internal/metrics/utils_test.go
@@ -21,13 +21,13 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-func TestNewMetric(t *testing.T) {
+func TestNewZorkianMetric(t *testing.T) {
 	name := "test.metric"
 	ts := uint64(1e9)
 	value := 2.0
 	tags := []string{"tag:value"}
 
-	metric := newMetric(name, ts, value, tags)
+	metric := newZorkianMetric(name, ts, value, tags)
 
 	assert.Equal(t, "test.metric", *metric.Metric)
 	// Assert timestamp conversion from uint64 ns to float64 s
@@ -38,27 +38,27 @@ func TestNewMetric(t *testing.T) {
 	assert.Equal(t, []string{"tag:value"}, metric.Tags)
 }
 
-func TestNewType(t *testing.T) {
+func TestNewZorkianType(t *testing.T) {
 	name := "test.metric"
 	ts := uint64(1e9)
 	value := 2.0
 	tags := []string{"tag:value"}
 
-	gauge := NewGauge(name, ts, value, tags)
+	gauge := NewZorkianGauge(name, ts, value, tags)
 	assert.Equal(t, gauge.GetType(), string(Gauge))
 
-	count := NewCount(name, ts, value, tags)
+	count := NewZorkianCount(name, ts, value, tags)
 	assert.Equal(t, count.GetType(), string(Count))
 
 }
 
-func TestDefaultMetrics(t *testing.T) {
+func TestDefaultZorkianMetrics(t *testing.T) {
 	buildInfo := component.BuildInfo{
 		Version: "1.0",
 		Command: "otelcontribcol",
 	}
 
-	ms := DefaultMetrics("metrics", "test-host", uint64(2e9), buildInfo)
+	ms := DefaultZorkianMetrics("metrics", "test-host", uint64(2e9), buildInfo)
 
 	assert.Equal(t, "otel.datadog_exporter.metrics.running", *ms[0].Metric)
 	// Assert metrics list length (should be 1)

--- a/exporter/datadogexporter/logs_exporter.go
+++ b/exporter/datadogexporter/logs_exporter.go
@@ -45,9 +45,9 @@ type logsExporter struct {
 func newLogsExporter(ctx context.Context, params component.ExporterCreateSettings, cfg *Config, onceMetadata *sync.Once, sourceProvider source.Provider) (*logsExporter, error) {
 	// create Datadog client
 	// validation endpoint is provided by Metrics
-	client := clientutil.CreateClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
+	client := clientutil.CreateZorkianClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
 	// validate the apiKey
-	if err := clientutil.ValidateAPIKey(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
+	if err := clientutil.ValidateAPIKeyZorkian(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
 		return nil, err
 	}
 

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
-	"gopkg.in/zorkian/go-datadog-api.v2"
+	zorkian "gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/clientutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
@@ -43,7 +43,7 @@ type traceExporter struct {
 	params         component.ExporterCreateSettings
 	cfg            *Config
 	ctx            context.Context // ctx triggers shutdown upon cancellation
-	client         *datadog.Client // client sends runnimg metrics to backend & performs API validation
+	client         *zorkian.Client // client sends runnimg metrics to backend & performs API validation
 	scrubber       scrub.Scrubber  // scrubber scrubs sensitive information from error messages
 	onceMetadata   *sync.Once      // onceMetadata ensures that metadata is sent only once across all exporters
 	wg             sync.WaitGroup  // wg waits for graceful shutdown
@@ -53,8 +53,8 @@ type traceExporter struct {
 
 func newTracesExporter(ctx context.Context, params component.ExporterCreateSettings, cfg *Config, onceMetadata *sync.Once, sourceProvider source.Provider) (*traceExporter, error) {
 	// client to send running metric to the backend & perform API key validation
-	client := clientutil.CreateClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
-	if err := clientutil.ValidateAPIKey(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
+	client := clientutil.CreateZorkianClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
+	if err := clientutil.ValidateAPIKeyZorkian(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
 		return nil, err
 	}
 	acfg := traceconfig.New()
@@ -130,12 +130,12 @@ func (exp *traceExporter) consumeTraces(
 			tags[src.Tag()] = struct{}{}
 		}
 	}
-	series := make([]datadog.Metric, 0, len(hosts)+len(tags))
+	series := make([]zorkian.Metric, 0, len(hosts)+len(tags))
 	for host := range hosts {
-		series = append(series, metrics.DefaultMetrics("traces", host, uint64(now), exp.params.BuildInfo)...)
+		series = append(series, metrics.DefaultZorkianMetrics("traces", host, uint64(now), exp.params.BuildInfo)...)
 	}
 	for tag := range tags {
-		ms := metrics.DefaultMetrics("traces", "", uint64(now), exp.params.BuildInfo)
+		ms := metrics.DefaultZorkianMetrics("traces", "", uint64(now), exp.params.BuildInfo)
 		for i := range ms {
 			ms[i].Tags = append(ms[i].Tags, tag)
 		}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Metric export in datadogexporter currently uses the deprecated Zorkian library. Soon the datadogexporter will migrate to use the native Datadog client APIs by default. This PR is an attempt to reduce the number of diffs in the upcoming refactor PRs by renaming current functions to have a Zorkian* prefix / suffix.

This PR only contains naming changes. No functionality changes are introduced.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>