### PR TITLE
[exporter/fileexporter] fix fileexporter nil pointer due to shared component

### DIFF
--- a/.chloggen/fix-fileexporter-nil-pointer.yaml
+++ b/.chloggen/fix-fileexporter-nil-pointer.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: fileexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix nil pointer in `fileexporter` when reusing configuration for multiple telemetry signals or pipelines.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/fix-fileexporter-nil-pointer.yaml
+++ b/.chloggen/fix-fileexporter-nil-pointer.yaml
@@ -8,7 +8,7 @@ component: fileexporter
 note: Fix nil pointer in `fileexporter` when reusing configuration for multiple telemetry signals or pipelines.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [16733]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -73,15 +73,7 @@ func createTracesExporter(
 		return nil, err
 	}
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
-		return &fileExporter{
-			path:            conf.Path,
-			formatType:      conf.FormatType,
-			file:            writer,
-			tracesMarshaler: tracesMarshalers[conf.FormatType],
-			exporter:        buildExportFunc(conf),
-			compression:     conf.Compression,
-			compressor:      buildCompressor(conf.Compression),
-		}
+		return newFileExporter(conf, writer)
 	})
 	return exporterhelper.NewTracesExporter(
 		ctx,
@@ -104,15 +96,7 @@ func createMetricsExporter(
 		return nil, err
 	}
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
-		return &fileExporter{
-			path:             conf.Path,
-			formatType:       conf.FormatType,
-			file:             writer,
-			metricsMarshaler: metricsMarshalers[conf.FormatType],
-			exporter:         buildExportFunc(conf),
-			compression:      conf.Compression,
-			compressor:       buildCompressor(conf.Compression),
-		}
+		return newFileExporter(conf, writer)
 	})
 	return exporterhelper.NewMetricsExporter(
 		ctx,
@@ -135,15 +119,7 @@ func createLogsExporter(
 		return nil, err
 	}
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
-		return &fileExporter{
-			path:          conf.Path,
-			formatType:    conf.FormatType,
-			file:          writer,
-			logsMarshaler: logsMarshalers[conf.FormatType],
-			exporter:      buildExportFunc(conf),
-			compression:   conf.Compression,
-			compressor:    buildCompressor(conf.Compression),
-		}
+		return newFileExporter(conf, writer)
 	})
 	return exporterhelper.NewLogsExporter(
 		ctx,
@@ -153,6 +129,20 @@ func createLogsExporter(
 		exporterhelper.WithStart(fe.Start),
 		exporterhelper.WithShutdown(fe.Shutdown),
 	)
+}
+
+func newFileExporter(conf *Config, writer io.WriteCloser) *fileExporter {
+	return &fileExporter{
+		path:             conf.Path,
+		formatType:       conf.FormatType,
+		file:             writer,
+		tracesMarshaler:  tracesMarshalers[conf.FormatType],
+		metricsMarshaler: metricsMarshalers[conf.FormatType],
+		logsMarshaler:    logsMarshalers[conf.FormatType],
+		exporter:         buildExportFunc(conf),
+		compression:      conf.Compression,
+		compressor:       buildCompressor(conf.Compression),
+	}
 }
 
 func buildFileWriter(cfg *Config) (io.WriteCloser, error) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

If the file exporter is used in multiple pipelines, the underlying marshaller is only instantiated for one of the telemetry signal types. This is because a shared component cache is used. The cache returns the first instantiation which doesn't instantiate the appropriate marshaler for any proceeding usage of the exporter.

This issue is probably pretty rare as any usage of the file exporter probably has the telemetry signals going to different files. In my case, I use the file exporter for locally debugging the collector (having all signals go to /dev/stdout) as well as performance/load testing the collector (having all signals go to /dev/null). Either way, I get panics due to nil pointers.

**Link to tracking Issue:** <Issue number if applicable> https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16733

**Testing:** <Describe what testing was performed and which tests were added.>

Start the collector with the following config:

```yaml
receivers:
  otlp:
    protocols:
      http:
exporters:
  file:
    path: /dev/stdout
processors:
service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: []
      exporters: [file]
    metrics:
      receivers: [otlp]
      processors: []
      exporters: [file]
```

Before my change, sending spans to the collector resulted in a panic similar to the following:

```bash
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x51c20a1]

goroutine 783 [running]:
github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter.(*fileExporter).ConsumeTraces(0xc00015c2d0, {0xc00052ef30?, 0x40b86aa?}, {0x5b5cb78?})
	<REDACTED>/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter@v0.66.0/file_exporter.go:69 +0x21
```

After my change, no panic!

**Documentation:** <Describe the documentation added.> N/A