### PR TITLE
[chore] Remove name mapping in hec

### DIFF
--- a/.chloggen/remove-name-mapping-in-hec.yaml
+++ b/.chloggen/remove-name-mapping-in-hec.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove all use of the name attribute from logs as it is deprecated.
+
+# One or more tracking issues related to the change
+issues: [16611]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -44,8 +44,6 @@ type OtelToHecFields struct {
 	SeverityText string `mapstructure:"severity_text"`
 	// SeverityNumber informs the exporter to map the severity number field to a specific HEC field.
 	SeverityNumber string `mapstructure:"severity_number"`
-	// Name informs the exporter to map the name field to a specific HEC field.
-	Name string `mapstructure:"name"`
 }
 
 // Config defines configuration for Splunk exporter.

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -98,7 +98,6 @@ func TestLoadConfig(t *testing.T) {
 				HecFields: OtelToHecFields{
 					SeverityText:   "myseverityfield",
 					SeverityNumber: "myseveritynumfield",
-					Name:           "mynamefield",
 				},
 			},
 		},

--- a/exporter/splunkhecexporter/exporter.go
+++ b/exporter/splunkhecexporter/exporter.go
@@ -73,10 +73,6 @@ func createExporter(
 		config.SplunkAppVersion = buildinfo.Version
 	}
 
-	if config.HecFields.Name != "" {
-		logger.Warn("otel_to_hec_fields.name setting is deprecated and will be removed soon.")
-	}
-
 	options, err := config.getOptionsFromConfig()
 	if err != nil {
 		return nil, err

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -84,7 +84,6 @@ func createDefaultConfig() component.Config {
 		HecFields: OtelToHecFields{
 			SeverityText:   splunk.DefaultSeverityTextLabel,
 			SeverityNumber: splunk.DefaultSeverityNumberLabel,
-			Name:           splunk.DefaultNameLabel,
 		},
 	}
 }

--- a/exporter/splunkhecexporter/testdata/config.yaml
+++ b/exporter/splunkhecexporter/testdata/config.yaml
@@ -34,4 +34,3 @@ splunk_hec/allsettings:
   otel_to_hec_fields:
     severity_text: "myseverityfield"
     severity_number: "myseveritynumfield"
-    name: "mynamefield"


### PR DESCRIPTION
**Description:** Removed all use of the name attribute from logs as it is deprecated. Remove the mapping from HEC exporter and receiver code, and remove from docs.
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** #16611 