### PR TITLE
[exporter/loki] Allow nested attribute to be promoted to label

### DIFF
--- a/.chloggen/loki-nested-attributes.yaml
+++ b/.chloggen/loki-nested-attributes.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/loki
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow nested attributes to be used in labels
+
+# One or more tracking issues related to the change
+issues: [16475]

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -82,13 +82,34 @@ func convertAttributesToLabels(attributes pcommon.Map, attrsToSelect pcommon.Val
 	attrs := parseAttributeNames(attrsToSelect)
 	for _, attr := range attrs {
 		attr = strings.TrimSpace(attr)
-		av, ok := attributes.Get(attr) // do we need to trim this?
+
+		av, ok := attributes.Get(attr)
+		if !ok {
+			// couldn't find the attribute under the given name directly
+			// perhaps it's a nested attribute?
+			av, ok = getNestedAttribute(attr, attributes) // shadows the OK from above on purpose
+		}
+
 		if ok {
 			out[model.LabelName(attr)] = model.LabelValue(av.AsString())
 		}
 	}
 
 	return out
+}
+
+func getNestedAttribute(attr string, attributes pcommon.Map) (pcommon.Value, bool) {
+	left, right, _ := strings.Cut(attr, ".")
+	av, ok := attributes.Get(left)
+	if !ok {
+		return pcommon.Value{}, false
+	}
+
+	if len(right) == 0 {
+		return av, ok
+	}
+
+	return getNestedAttribute(right, av.Map())
 }
 
 func parseAttributeNames(attrsToSelect pcommon.Value) []string {

--- a/pkg/translator/loki/convert_test.go
+++ b/pkg/translator/loki/convert_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -231,11 +232,12 @@ func TestRemoveAttributes(t *testing.T) {
 func TestGetNestedAttribute(t *testing.T) {
 	// prepare
 	attrs := pcommon.NewMap()
-	attrs.FromRaw(map[string]interface{}{
+	err := attrs.FromRaw(map[string]interface{}{
 		"host": map[string]interface{}{
 			"name": "guarana",
 		},
 	})
+	require.NoError(t, err)
 
 	// test
 	attr, ok := getNestedAttribute("host.name", attrs)

--- a/pkg/translator/loki/convert_test.go
+++ b/pkg/translator/loki/convert_test.go
@@ -158,6 +158,20 @@ func TestConvertAttributesToLabels(t *testing.T) {
 				"pod.name":  "pod-123",
 			},
 		},
+		{
+			desc: "nested attributes",
+			attrsAvailable: map[string]interface{}{
+				"host": map[string]interface{}{
+					"name": "guarana",
+				},
+				"pod.name": "pod-123",
+			},
+			attrsToSelect: attrsToSelectSlice,
+			expected: model.LabelSet{
+				"host.name": "guarana",
+				"pod.name":  "pod-123",
+			},
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
@@ -212,4 +226,21 @@ func TestRemoveAttributes(t *testing.T) {
 			assert.Equal(t, tC.expected, attrs.AsRaw())
 		})
 	}
+}
+
+func TestGetNestedAttribute(t *testing.T) {
+	// prepare
+	attrs := pcommon.NewMap()
+	attrs.FromRaw(map[string]interface{}{
+		"host": map[string]interface{}{
+			"name": "guarana",
+		},
+	})
+
+	// test
+	attr, ok := getNestedAttribute("host.name", attrs)
+
+	// verify
+	assert.Equal(t, "guarana", attr.AsString())
+	assert.True(t, ok)
 }


### PR DESCRIPTION
Adds the possibility of looking up nested attributes using dot notation, in case no attribute matching the name exists.

Fixes #16475

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
