### PR TITLE
[chore] Do not cancel build-and-test workflows on main

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -16,8 +16,9 @@ env:
   # Cache downloads for this workflow consistently run in under 10 minutes
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 15
 
+# Do not cancel this workflow on main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -61,7 +62,7 @@ jobs:
             ~\AppData\Local\go-build
           key: go-build-cache-${{ runner.os }}-${{ matrix.group }}-go-${{ hashFiles('**/go.sum') }}
       - name: Run Unit tests
-        run: make -j2 gotest GROUP=${{ matrix.group }}      
+        run: make -j2 gotest GROUP=${{ matrix.group }}
       - name: Analyze Test and/or Coverage Results
         if: always()
         uses: runforesight/foresight-test-kit-action@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,9 +11,10 @@ env:
   # Cache downloads for this workflow consistently run in under 1 minute
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
+# Do not cancel this workflow on main. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   setup-environment:


### PR DESCRIPTION
According to [github documentation](https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency#example-using-a-fallback-value), this configuration `cancels in-progress jobs or runs on pull_request events only; if github.head_ref is undefined, the concurrency group will fallback to the run ID, which is guaranteed to be both unique and defined for the run.`

Effectively, these workflows will always run to completion on the main branch, but will still be canceled on PRs when subsequent changes are made.

I've applied this change to two specific workflows:
- `build-and-test`: This is the workflow that populates the repo's status badge. When this workflow is canceled, the badge shows a failure.
- `build-and-test-windows`: A recent decision was made to run this only on main. We should ensure that it actually does run on main for each PR.