### PR TITLE
[receiver/vcenter] Memory metrics

### DIFF
--- a/.chloggen/feat_vCenterMemoryMetrics.yaml
+++ b/.chloggen/feat_vCenterMemoryMetrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added `vcenter.vm.memory.ssdswapped` and `vcenter.vm.memory.swapped` metrics.
+
+# One or more tracking issues related to the change
+issues: [16727]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -325,6 +325,22 @@ The amount of memory that is ballooned due to virtualization.
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | MiBy | Sum | Int | Cumulative | false |
 
+### vcenter.vm.memory.ssdswapped
+
+The amount of memory swapped to fast disk device such as SSD.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| KiBy | Sum | Int | Cumulative | false |
+
+### vcenter.vm.memory.swapped
+
+The portion of memory that is granted to this VM from the host's swap space.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| MiBy | Sum | Int | Cumulative | false |
+
 ### vcenter.vm.memory.usage
 
 The amount of memory that is used by the virtual machine.

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -325,14 +325,6 @@ The amount of memory that is ballooned due to virtualization.
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | MiBy | Sum | Int | Cumulative | false |
 
-### vcenter.vm.memory.ssdswapped
-
-The amount of memory swapped to fast disk device such as SSD.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| KiBy | Sum | Int | Cumulative | false |
-
 ### vcenter.vm.memory.swapped
 
 The portion of memory that is granted to this VM from the host's swap space.
@@ -340,6 +332,14 @@ The portion of memory that is granted to this VM from the host's swap space.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | MiBy | Sum | Int | Cumulative | false |
+
+### vcenter.vm.memory.swapped_ssd
+
+The amount of memory swapped to fast disk device such as SSD.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| KiBy | Sum | Int | Cumulative | false |
 
 ### vcenter.vm.memory.usage
 

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -67,6 +67,8 @@ type MetricsSettings struct {
 	VcenterVMDiskUsage              MetricSettings `mapstructure:"vcenter.vm.disk.usage"`
 	VcenterVMDiskUtilization        MetricSettings `mapstructure:"vcenter.vm.disk.utilization"`
 	VcenterVMMemoryBallooned        MetricSettings `mapstructure:"vcenter.vm.memory.ballooned"`
+	VcenterVMMemorySsdswapped       MetricSettings `mapstructure:"vcenter.vm.memory.ssdswapped"`
+	VcenterVMMemorySwapped          MetricSettings `mapstructure:"vcenter.vm.memory.swapped"`
 	VcenterVMMemoryUsage            MetricSettings `mapstructure:"vcenter.vm.memory.usage"`
 	VcenterVMNetworkPacketCount     MetricSettings `mapstructure:"vcenter.vm.network.packet.count"`
 	VcenterVMNetworkThroughput      MetricSettings `mapstructure:"vcenter.vm.network.throughput"`
@@ -163,6 +165,12 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		VcenterVMMemoryBallooned: MetricSettings{
+			Enabled: true,
+		},
+		VcenterVMMemorySsdswapped: MetricSettings{
+			Enabled: true,
+		},
+		VcenterVMMemorySwapped: MetricSettings{
 			Enabled: true,
 		},
 		VcenterVMMemoryUsage: MetricSettings{
@@ -1871,6 +1879,108 @@ func newMetricVcenterVMMemoryBallooned(settings MetricSettings) metricVcenterVMM
 	return m
 }
 
+type metricVcenterVMMemorySsdswapped struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills vcenter.vm.memory.ssdswapped metric with initial data.
+func (m *metricVcenterVMMemorySsdswapped) init() {
+	m.data.SetName("vcenter.vm.memory.ssdswapped")
+	m.data.SetDescription("The amount of memory swapped to fast disk device such as SSD.")
+	m.data.SetUnit("KiBy")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricVcenterVMMemorySsdswapped) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricVcenterVMMemorySsdswapped) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricVcenterVMMemorySsdswapped) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricVcenterVMMemorySsdswapped(settings MetricSettings) metricVcenterVMMemorySsdswapped {
+	m := metricVcenterVMMemorySsdswapped{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricVcenterVMMemorySwapped struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills vcenter.vm.memory.swapped metric with initial data.
+func (m *metricVcenterVMMemorySwapped) init() {
+	m.data.SetName("vcenter.vm.memory.swapped")
+	m.data.SetDescription("The portion of memory that is granted to this VM from the host's swap space.")
+	m.data.SetUnit("MiBy")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricVcenterVMMemorySwapped) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricVcenterVMMemorySwapped) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricVcenterVMMemorySwapped) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricVcenterVMMemorySwapped(settings MetricSettings) metricVcenterVMMemorySwapped {
+	m := metricVcenterVMMemorySwapped{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricVcenterVMMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -2117,6 +2227,8 @@ type MetricsBuilder struct {
 	metricVcenterVMDiskUsage              metricVcenterVMDiskUsage
 	metricVcenterVMDiskUtilization        metricVcenterVMDiskUtilization
 	metricVcenterVMMemoryBallooned        metricVcenterVMMemoryBallooned
+	metricVcenterVMMemorySsdswapped       metricVcenterVMMemorySsdswapped
+	metricVcenterVMMemorySwapped          metricVcenterVMMemorySwapped
 	metricVcenterVMMemoryUsage            metricVcenterVMMemoryUsage
 	metricVcenterVMNetworkPacketCount     metricVcenterVMNetworkPacketCount
 	metricVcenterVMNetworkThroughput      metricVcenterVMNetworkThroughput
@@ -2168,6 +2280,8 @@ func NewMetricsBuilder(ms MetricsSettings, settings component.ReceiverCreateSett
 		metricVcenterVMDiskUsage:              newMetricVcenterVMDiskUsage(ms.VcenterVMDiskUsage),
 		metricVcenterVMDiskUtilization:        newMetricVcenterVMDiskUtilization(ms.VcenterVMDiskUtilization),
 		metricVcenterVMMemoryBallooned:        newMetricVcenterVMMemoryBallooned(ms.VcenterVMMemoryBallooned),
+		metricVcenterVMMemorySsdswapped:       newMetricVcenterVMMemorySsdswapped(ms.VcenterVMMemorySsdswapped),
+		metricVcenterVMMemorySwapped:          newMetricVcenterVMMemorySwapped(ms.VcenterVMMemorySwapped),
 		metricVcenterVMMemoryUsage:            newMetricVcenterVMMemoryUsage(ms.VcenterVMMemoryUsage),
 		metricVcenterVMNetworkPacketCount:     newMetricVcenterVMNetworkPacketCount(ms.VcenterVMNetworkPacketCount),
 		metricVcenterVMNetworkThroughput:      newMetricVcenterVMNetworkThroughput(ms.VcenterVMNetworkThroughput),
@@ -2296,6 +2410,8 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricVcenterVMDiskUsage.emit(ils.Metrics())
 	mb.metricVcenterVMDiskUtilization.emit(ils.Metrics())
 	mb.metricVcenterVMMemoryBallooned.emit(ils.Metrics())
+	mb.metricVcenterVMMemorySsdswapped.emit(ils.Metrics())
+	mb.metricVcenterVMMemorySwapped.emit(ils.Metrics())
 	mb.metricVcenterVMMemoryUsage.emit(ils.Metrics())
 	mb.metricVcenterVMNetworkPacketCount.emit(ils.Metrics())
 	mb.metricVcenterVMNetworkThroughput.emit(ils.Metrics())
@@ -2467,6 +2583,16 @@ func (mb *MetricsBuilder) RecordVcenterVMDiskUtilizationDataPoint(ts pcommon.Tim
 // RecordVcenterVMMemoryBalloonedDataPoint adds a data point to vcenter.vm.memory.ballooned metric.
 func (mb *MetricsBuilder) RecordVcenterVMMemoryBalloonedDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricVcenterVMMemoryBallooned.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordVcenterVMMemorySsdswappedDataPoint adds a data point to vcenter.vm.memory.ssdswapped metric.
+func (mb *MetricsBuilder) RecordVcenterVMMemorySsdswappedDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricVcenterVMMemorySsdswapped.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordVcenterVMMemorySwappedDataPoint adds a data point to vcenter.vm.memory.swapped metric.
+func (mb *MetricsBuilder) RecordVcenterVMMemorySwappedDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricVcenterVMMemorySwapped.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordVcenterVMMemoryUsageDataPoint adds a data point to vcenter.vm.memory.usage metric.

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -110,11 +110,11 @@ func TestDefaultMetrics(t *testing.T) {
 	enabledMetrics["vcenter.vm.memory.ballooned"] = true
 	mb.RecordVcenterVMMemoryBalloonedDataPoint(ts, 1)
 
-	enabledMetrics["vcenter.vm.memory.ssdswapped"] = true
-	mb.RecordVcenterVMMemorySsdswappedDataPoint(ts, 1)
-
 	enabledMetrics["vcenter.vm.memory.swapped"] = true
 	mb.RecordVcenterVMMemorySwappedDataPoint(ts, 1)
+
+	enabledMetrics["vcenter.vm.memory.swapped_ssd"] = true
+	mb.RecordVcenterVMMemorySwappedSsdDataPoint(ts, 1)
 
 	enabledMetrics["vcenter.vm.memory.usage"] = true
 	mb.RecordVcenterVMMemoryUsageDataPoint(ts, 1)
@@ -177,8 +177,8 @@ func TestAllMetrics(t *testing.T) {
 		VcenterVMDiskUsage:              MetricSettings{Enabled: true},
 		VcenterVMDiskUtilization:        MetricSettings{Enabled: true},
 		VcenterVMMemoryBallooned:        MetricSettings{Enabled: true},
-		VcenterVMMemorySsdswapped:       MetricSettings{Enabled: true},
 		VcenterVMMemorySwapped:          MetricSettings{Enabled: true},
+		VcenterVMMemorySwappedSsd:       MetricSettings{Enabled: true},
 		VcenterVMMemoryUsage:            MetricSettings{Enabled: true},
 		VcenterVMNetworkPacketCount:     MetricSettings{Enabled: true},
 		VcenterVMNetworkThroughput:      MetricSettings{Enabled: true},
@@ -221,8 +221,8 @@ func TestAllMetrics(t *testing.T) {
 	mb.RecordVcenterVMDiskUsageDataPoint(ts, 1, AttributeDiskState(1))
 	mb.RecordVcenterVMDiskUtilizationDataPoint(ts, 1)
 	mb.RecordVcenterVMMemoryBalloonedDataPoint(ts, 1)
-	mb.RecordVcenterVMMemorySsdswappedDataPoint(ts, 1)
 	mb.RecordVcenterVMMemorySwappedDataPoint(ts, 1)
+	mb.RecordVcenterVMMemorySwappedSsdDataPoint(ts, 1)
 	mb.RecordVcenterVMMemoryUsageDataPoint(ts, 1)
 	mb.RecordVcenterVMNetworkPacketCountDataPoint(ts, 1, AttributeThroughputDirection(1))
 	mb.RecordVcenterVMNetworkThroughputDataPoint(ts, 1, AttributeThroughputDirection(1))
@@ -673,19 +673,6 @@ func TestAllMetrics(t *testing.T) {
 			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 			assert.Equal(t, int64(1), dp.IntValue())
 			validatedMetrics["vcenter.vm.memory.ballooned"] = struct{}{}
-		case "vcenter.vm.memory.ssdswapped":
-			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
-			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-			assert.Equal(t, "The amount of memory swapped to fast disk device such as SSD.", ms.At(i).Description())
-			assert.Equal(t, "KiBy", ms.At(i).Unit())
-			assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
-			assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
-			dp := ms.At(i).Sum().DataPoints().At(0)
-			assert.Equal(t, start, dp.StartTimestamp())
-			assert.Equal(t, ts, dp.Timestamp())
-			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-			assert.Equal(t, int64(1), dp.IntValue())
-			validatedMetrics["vcenter.vm.memory.ssdswapped"] = struct{}{}
 		case "vcenter.vm.memory.swapped":
 			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
@@ -699,6 +686,19 @@ func TestAllMetrics(t *testing.T) {
 			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 			assert.Equal(t, int64(1), dp.IntValue())
 			validatedMetrics["vcenter.vm.memory.swapped"] = struct{}{}
+		case "vcenter.vm.memory.swapped_ssd":
+			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+			assert.Equal(t, "The amount of memory swapped to fast disk device such as SSD.", ms.At(i).Description())
+			assert.Equal(t, "KiBy", ms.At(i).Unit())
+			assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
+			assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+			dp := ms.At(i).Sum().DataPoints().At(0)
+			assert.Equal(t, start, dp.StartTimestamp())
+			assert.Equal(t, ts, dp.Timestamp())
+			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+			assert.Equal(t, int64(1), dp.IntValue())
+			validatedMetrics["vcenter.vm.memory.swapped_ssd"] = struct{}{}
 		case "vcenter.vm.memory.usage":
 			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
@@ -796,8 +796,8 @@ func TestNoMetrics(t *testing.T) {
 		VcenterVMDiskUsage:              MetricSettings{Enabled: false},
 		VcenterVMDiskUtilization:        MetricSettings{Enabled: false},
 		VcenterVMMemoryBallooned:        MetricSettings{Enabled: false},
-		VcenterVMMemorySsdswapped:       MetricSettings{Enabled: false},
 		VcenterVMMemorySwapped:          MetricSettings{Enabled: false},
+		VcenterVMMemorySwappedSsd:       MetricSettings{Enabled: false},
 		VcenterVMMemoryUsage:            MetricSettings{Enabled: false},
 		VcenterVMNetworkPacketCount:     MetricSettings{Enabled: false},
 		VcenterVMNetworkThroughput:      MetricSettings{Enabled: false},
@@ -839,8 +839,8 @@ func TestNoMetrics(t *testing.T) {
 	mb.RecordVcenterVMDiskUsageDataPoint(ts, 1, AttributeDiskState(1))
 	mb.RecordVcenterVMDiskUtilizationDataPoint(ts, 1)
 	mb.RecordVcenterVMMemoryBalloonedDataPoint(ts, 1)
-	mb.RecordVcenterVMMemorySsdswappedDataPoint(ts, 1)
 	mb.RecordVcenterVMMemorySwappedDataPoint(ts, 1)
+	mb.RecordVcenterVMMemorySwappedSsdDataPoint(ts, 1)
 	mb.RecordVcenterVMMemoryUsageDataPoint(ts, 1)
 	mb.RecordVcenterVMNetworkPacketCountDataPoint(ts, 1, AttributeThroughputDirection(1))
 	mb.RecordVcenterVMNetworkThroughputDataPoint(ts, 1, AttributeThroughputDirection(1))

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -110,6 +110,12 @@ func TestDefaultMetrics(t *testing.T) {
 	enabledMetrics["vcenter.vm.memory.ballooned"] = true
 	mb.RecordVcenterVMMemoryBalloonedDataPoint(ts, 1)
 
+	enabledMetrics["vcenter.vm.memory.ssdswapped"] = true
+	mb.RecordVcenterVMMemorySsdswappedDataPoint(ts, 1)
+
+	enabledMetrics["vcenter.vm.memory.swapped"] = true
+	mb.RecordVcenterVMMemorySwappedDataPoint(ts, 1)
+
 	enabledMetrics["vcenter.vm.memory.usage"] = true
 	mb.RecordVcenterVMMemoryUsageDataPoint(ts, 1)
 
@@ -171,6 +177,8 @@ func TestAllMetrics(t *testing.T) {
 		VcenterVMDiskUsage:              MetricSettings{Enabled: true},
 		VcenterVMDiskUtilization:        MetricSettings{Enabled: true},
 		VcenterVMMemoryBallooned:        MetricSettings{Enabled: true},
+		VcenterVMMemorySsdswapped:       MetricSettings{Enabled: true},
+		VcenterVMMemorySwapped:          MetricSettings{Enabled: true},
 		VcenterVMMemoryUsage:            MetricSettings{Enabled: true},
 		VcenterVMNetworkPacketCount:     MetricSettings{Enabled: true},
 		VcenterVMNetworkThroughput:      MetricSettings{Enabled: true},
@@ -213,6 +221,8 @@ func TestAllMetrics(t *testing.T) {
 	mb.RecordVcenterVMDiskUsageDataPoint(ts, 1, AttributeDiskState(1))
 	mb.RecordVcenterVMDiskUtilizationDataPoint(ts, 1)
 	mb.RecordVcenterVMMemoryBalloonedDataPoint(ts, 1)
+	mb.RecordVcenterVMMemorySsdswappedDataPoint(ts, 1)
+	mb.RecordVcenterVMMemorySwappedDataPoint(ts, 1)
 	mb.RecordVcenterVMMemoryUsageDataPoint(ts, 1)
 	mb.RecordVcenterVMNetworkPacketCountDataPoint(ts, 1, AttributeThroughputDirection(1))
 	mb.RecordVcenterVMNetworkThroughputDataPoint(ts, 1, AttributeThroughputDirection(1))
@@ -663,6 +673,32 @@ func TestAllMetrics(t *testing.T) {
 			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 			assert.Equal(t, int64(1), dp.IntValue())
 			validatedMetrics["vcenter.vm.memory.ballooned"] = struct{}{}
+		case "vcenter.vm.memory.ssdswapped":
+			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+			assert.Equal(t, "The amount of memory swapped to fast disk device such as SSD.", ms.At(i).Description())
+			assert.Equal(t, "KiBy", ms.At(i).Unit())
+			assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
+			assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+			dp := ms.At(i).Sum().DataPoints().At(0)
+			assert.Equal(t, start, dp.StartTimestamp())
+			assert.Equal(t, ts, dp.Timestamp())
+			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+			assert.Equal(t, int64(1), dp.IntValue())
+			validatedMetrics["vcenter.vm.memory.ssdswapped"] = struct{}{}
+		case "vcenter.vm.memory.swapped":
+			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+			assert.Equal(t, "The portion of memory that is granted to this VM from the host's swap space.", ms.At(i).Description())
+			assert.Equal(t, "MiBy", ms.At(i).Unit())
+			assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
+			assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+			dp := ms.At(i).Sum().DataPoints().At(0)
+			assert.Equal(t, start, dp.StartTimestamp())
+			assert.Equal(t, ts, dp.Timestamp())
+			assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+			assert.Equal(t, int64(1), dp.IntValue())
+			validatedMetrics["vcenter.vm.memory.swapped"] = struct{}{}
 		case "vcenter.vm.memory.usage":
 			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
@@ -760,6 +796,8 @@ func TestNoMetrics(t *testing.T) {
 		VcenterVMDiskUsage:              MetricSettings{Enabled: false},
 		VcenterVMDiskUtilization:        MetricSettings{Enabled: false},
 		VcenterVMMemoryBallooned:        MetricSettings{Enabled: false},
+		VcenterVMMemorySsdswapped:       MetricSettings{Enabled: false},
+		VcenterVMMemorySwapped:          MetricSettings{Enabled: false},
 		VcenterVMMemoryUsage:            MetricSettings{Enabled: false},
 		VcenterVMNetworkPacketCount:     MetricSettings{Enabled: false},
 		VcenterVMNetworkThroughput:      MetricSettings{Enabled: false},
@@ -801,6 +839,8 @@ func TestNoMetrics(t *testing.T) {
 	mb.RecordVcenterVMDiskUsageDataPoint(ts, 1, AttributeDiskState(1))
 	mb.RecordVcenterVMDiskUtilizationDataPoint(ts, 1)
 	mb.RecordVcenterVMMemoryBalloonedDataPoint(ts, 1)
+	mb.RecordVcenterVMMemorySsdswappedDataPoint(ts, 1)
+	mb.RecordVcenterVMMemorySwappedDataPoint(ts, 1)
 	mb.RecordVcenterVMMemoryUsageDataPoint(ts, 1)
 	mb.RecordVcenterVMNetworkPacketCountDataPoint(ts, 1, AttributeThroughputDirection(1))
 	mb.RecordVcenterVMNetworkThroughputDataPoint(ts, 1, AttributeThroughputDirection(1))

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -305,7 +305,7 @@ metrics:
       value_type: int
       aggregation: cumulative
     attributes: []
-  vcenter.vm.memory.ssdswapped:
+  vcenter.vm.memory.swapped_ssd:
     enabled: true
     description: The amount of memory swapped to fast disk device such as SSD.
     unit: KiBy

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -296,6 +296,24 @@ metrics:
       value_type: int
       aggregation: cumulative
     attributes: []
+  vcenter.vm.memory.swapped:
+    enabled: true
+    description: The portion of memory that is granted to this VM from the host's swap space.
+    unit: MiBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation: cumulative
+    attributes: []
+  vcenter.vm.memory.ssdswapped:
+    enabled: true
+    description: The amount of memory swapped to fast disk device such as SSD.
+    unit: KiBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation: cumulative
+    attributes: []
   vcenter.vm.disk.usage:
     enabled: true
     description: The amount of storage space used by the virtual machine.

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -55,12 +55,12 @@ func (v *vcenterMetricScraper) recordVMUsages(
 	memUsage := vm.Summary.QuickStats.GuestMemoryUsage
 	balloonedMem := vm.Summary.QuickStats.BalloonedMemory
 	swappedMem := vm.Summary.QuickStats.SwappedMemory
-	ssdSwappedMem := vm.Summary.QuickStats.SsdSwappedMemory
+	swappedSSDMem := vm.Summary.QuickStats.SsdSwappedMemory
 
 	v.mb.RecordVcenterVMMemoryUsageDataPoint(now, int64(memUsage))
 	v.mb.RecordVcenterVMMemoryBalloonedDataPoint(now, int64(balloonedMem))
 	v.mb.RecordVcenterVMMemorySwappedDataPoint(now, int64(swappedMem))
-	v.mb.RecordVcenterVMMemorySsdswappedDataPoint(now, ssdSwappedMem)
+	v.mb.RecordVcenterVMMemorySwappedSsdDataPoint(now, swappedSSDMem)
 
 	diskUsed := vm.Summary.Storage.Committed
 	diskFree := vm.Summary.Storage.Uncommitted

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -54,8 +54,13 @@ func (v *vcenterMetricScraper) recordVMUsages(
 ) {
 	memUsage := vm.Summary.QuickStats.GuestMemoryUsage
 	balloonedMem := vm.Summary.QuickStats.BalloonedMemory
+	swappedMem := vm.Summary.QuickStats.SwappedMemory
+	ssdSwappedMem := vm.Summary.QuickStats.SsdSwappedMemory
+
 	v.mb.RecordVcenterVMMemoryUsageDataPoint(now, int64(memUsage))
 	v.mb.RecordVcenterVMMemoryBalloonedDataPoint(now, int64(balloonedMem))
+	v.mb.RecordVcenterVMMemorySwappedDataPoint(now, int64(swappedMem))
+	v.mb.RecordVcenterVMMemorySsdswappedDataPoint(now, ssdSwappedMem)
 
 	diskUsed := vm.Summary.Storage.Committed
 	diskFree := vm.Summary.Storage.Uncommitted

--- a/receiver/vcenterreceiver/testdata/metrics/expected.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.json
@@ -3355,7 +3355,7 @@
                             }
                         },
                         {
-                            "name": "vcenter.vm.memory.ssdswapped",
+                            "name": "vcenter.vm.memory.swapped_ssd",
                             "description": "The amount of memory swapped to fast disk device such as SSD.",
                             "unit": "KiBy",
                             "sum": {

--- a/receiver/vcenterreceiver/testdata/metrics/expected.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.json
@@ -3355,6 +3355,36 @@
                             }
                         },
                         {
+                            "name": "vcenter.vm.memory.ssdswapped",
+                            "description": "The amount of memory swapped to fast disk device such as SSD.",
+                            "unit": "KiBy",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653335619966318000",
+                                        "timeUnixNano": "1653335619974183000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
+                            "name": "vcenter.vm.memory.swapped",
+                            "description": "The portion of memory that is granted to this VM from the host's swap space.",
+                            "unit": "MiBy",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653335619966318000",
+                                        "timeUnixNano": "1653335619974183000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
                             "name": "vcenter.vm.network.packet.count",
                             "description": "The amount of packets that was received or transmitted over the instance's network.",
                             "unit": "{packets/sec}",

--- a/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
@@ -1681,6 +1681,36 @@
                             }
                         },
                         {
+                            "name": "vcenter.vm.memory.ssdswapped",
+                            "description": "The amount of memory swapped to fast disk device such as SSD.",
+                            "unit": "KiBy",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653335619966318000",
+                                        "timeUnixNano": "1653335619974183000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
+                            "name": "vcenter.vm.memory.swapped",
+                            "description": "The portion of memory that is granted to this VM from the host's swap space.",
+                            "unit": "MiBy",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653335619966318000",
+                                        "timeUnixNano": "1653335619974183000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
                             "name": "vcenter.vm.network.packet.count.transmit",
                             "description": "The amount of packets that was transmitted over the instance's network.",
                             "unit": "{packets/sec}",

--- a/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
@@ -1681,7 +1681,7 @@
                             }
                         },
                         {
-                            "name": "vcenter.vm.memory.ssdswapped",
+                            "name": "vcenter.vm.memory.swapped_ssd",
                             "description": "The amount of memory swapped to fast disk device such as SSD.",
                             "unit": "KiBy",
                             "sum": {

--- a/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
+++ b/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
@@ -424,7 +424,7 @@
                             }
                         },
                         {
-                            "name": "vcenter.vm.memory.ssdswapped",
+                            "name": "vcenter.vm.memory.swapped_ssd",
                             "description": "The amount of memory swapped to fast disk device such as SSD.",
                             "unit": "KiBy",
                             "sum": {

--- a/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
+++ b/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
@@ -424,6 +424,36 @@
                             }
                         },
                         {
+                            "name": "vcenter.vm.memory.ssdswapped",
+                            "description": "The amount of memory swapped to fast disk device such as SSD.",
+                            "unit": "KiBy",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653335619966318000",
+                                        "timeUnixNano": "1653335619974183000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
+                            "name": "vcenter.vm.memory.swapped",
+                            "description": "The portion of memory that is granted to this VM from the host's swap space.",
+                            "unit": "MiBy",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653335619966318000",
+                                        "timeUnixNano": "1653335619974183000",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
                             "name": "vcenter.vm.memory.usage",
                             "description": "The amount of memory that is used by the virtual machine.",
                             "unit": "MiBy",


### PR DESCRIPTION
This PR aims to add acouple metrics Documented [here](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/790263bc-bd30-48f1-af12-ed36055d718b/e5f17bfc-ecba-40bf-a04f-376bbb11e811/vim.vm.Summary.QuickStats.html):
 - swapped
 - ssdswapped
 

Fix #16727