### PR TITLE
[pkg/ottl] Enforce function case

### DIFF
--- a/.chloggen/ottl-enforce-function-type.yaml
+++ b/.chloggen/ottl-enforce-function-type.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enforce functions used as a value to start with an uppercase letter and the statement's invocation to start with a lowercase letter.
+
+# One or more tracking issues related to the change
+issues: [16718]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -14,7 +14,7 @@ The OTTL grammar includes Invocations, Values and Boolean Expressions.
 
 Invocations represent a function call that transform the underlying telemetry payload. Invocations are made up of 2 parts:
 
-- a string identifier. The string identifier must start with a lowercase letter or an underscore (`_`).
+- a string identifier. The string identifier must start with a lowercase letter.
 - zero or more Values (comma separated) surrounded by parentheses (`()`).
 
 **The OTTL does not define any function implementations.**
@@ -113,7 +113,7 @@ When defining a function that will be used as an Invocation by the OTTL, if the 
 Converters are special functions that convert data to a new format before being passed to an Invocation or Boolean Expression.
 Like Invocations, Converters are made up of 2 parts:
 
-- a string identifier. The string identifier must start with an uppercase letter or an underscore (`_`).
+- a string identifier. The string identifier must start with an uppercase letter.
 - zero or more Values (comma separated) surrounded by parentheses (`()`).
 
 **The OTTL does not define any converter implementations.**

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -15,12 +15,16 @@ The OTTL grammar includes Invocations, Values and Boolean Expressions.
 Invocations represent a function call. Invocations are made up of 2 parts:
 
 - a string identifier. The string identifier must start with a letter or an underscore (`_`).
+  - If the invocation is used as a parameter in another function or as part of a boolean expression it must start with an uppercase letter or an underscore (`_`) followed by an uppercase letter. Otherwise, it must start with a lowercase letter or an underscore (`_`) followed by a lowercase letter.
 - zero or more Values (comma separated) surrounded by parentheses (`()`).
 
-**The OTTL does not define any function implementations.** Users must supply a map between string identifiers and the actual function implementation.  The OTTL will use this map and reflection to generate Invocations, that can then be invoked by the user.
+**The OTTL does not define any function implementations.**
+Users must supply a map between string identifiers and the actual function implementation.
+The OTTL will use this map and reflection to generate Invocations, that can then be invoked by the user.
+See [ottlfuncs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/ottlfuncs) for pre-made, usable functions.
 
 Example Invocations
-- `drop()`
+- `route()`
 - `set(field, 1)`
 
 #### Invocation parameters

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -95,7 +95,7 @@ Literals are literal interpretations of the Value into a Go value.  Accepted lit
 Example Literals
 - `"a string"`
 - `1`, `-1`
-- `1.5`, `-.5`z
+- `1.5`, `-.5`
 - `true`, `false`
 - `nil`,
 - `0x0001`

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -12,10 +12,9 @@ The OTTL grammar includes Invocations, Values and Boolean Expressions.
 
 ### Invocations
 
-Invocations represent a function call. Invocations are made up of 2 parts:
+Invocations represent a function call that transform the underlying telemetry payload. Invocations are made up of 2 parts:
 
-- a string identifier. The string identifier must start with a letter or an underscore (`_`).
-  - If the invocation is used as a parameter in another function or as part of a boolean expression it must start with an uppercase letter or an underscore (`_`) followed by an uppercase letter. Otherwise, it must start with a lowercase letter or an underscore (`_`) followed by a lowercase letter.
+- a string identifier. The string identifier must start with a lowercase letter or an underscore (`_`).
 - zero or more Values (comma separated) surrounded by parentheses (`()`).
 
 **The OTTL does not define any function implementations.**
@@ -51,14 +50,12 @@ For slice parameters, the following types are supported:
 ### Values
 
 Values are passed as input to an Invocation or are used in a Boolean Expression. Values can take the form of:
-- [Paths](#paths).
-- [Lists](#lists).
-- [Literals](#literals).
-- [Enums](#enums).
-- [Invocations](#invocations).
+- [Paths](#paths)
+- [Lists](#lists)
+- [Literals](#literals)
+- [Enums](#enums)
+- [Converters](#converters)
 - [Math Expressions](#math_expressions)
-
-Invocations as Values allows calling functions as parameters to other functions. See [Invocations](#invocations) for details on Invocation syntax.
 
 #### Paths
 
@@ -98,7 +95,7 @@ Literals are literal interpretations of the Value into a Go value.  Accepted lit
 Example Literals
 - `"a string"`
 - `1`, `-1`
-- `1.5`, `-.5`
+- `1.5`, `-.5`z
 - `true`, `false`
 - `nil`,
 - `0x0001`
@@ -110,6 +107,24 @@ Enums are uppercase identifiers that get interpreted during parsing and converte
 Within the grammar Enums are always used as `int64`.  As a result, the Enum's symbol can be used as if it is an Int value.
 
 When defining a function that will be used as an Invocation by the OTTL, if the function needs to take an Enum then the function must use the `Enum` type for that argument, not an `int64`.
+
+#### Converters
+
+Converters are special functions that convert data to a new format before being passed to an Invocation or Boolean Expression.
+Like Invocations, Converters are made up of 2 parts:
+
+- a string identifier. The string identifier must start with an uppercase letter or an underscore (`_`).
+- zero or more Values (comma separated) surrounded by parentheses (`()`).
+
+**The OTTL does not define any converter implementations.**
+Users must include converters in the same map that invocations are supplied.
+The OTTL will use this map and reflection to generate Converters that can then be invoked by the user.
+See [ottlfuncs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/ottlfuncs#converters) for pre-made, usable Converters.
+
+Example Converters
+- `Int()`
+- `IsMatch(field, ".*")`
+
 
 #### Math Expressions
 
@@ -180,7 +195,7 @@ A `not equal` notation in the table below means that the "!=" operator returns t
 
 
 | base type | bool        | int64               | float64             | string                          | Bytes                    | nil                    |
-| --------- | ----------- | ------------------- | ------------------- | ------------------------------- | ------------------------ | ---------------------- |
+|-----------|-------------|---------------------|---------------------|---------------------------------|--------------------------|------------------------|
 | bool      | normal, T>F | not equal           | not equal           | not equal                       | not equal                | not equal              |
 | int64     | not equal   | compared as largest | compared as float64 | not equal                       | not equal                | not equal              |
 | float64   | not equal   | compared as float64 | compared as largest | not equal                       | not equal                | not equal              |

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -123,7 +123,10 @@ func (p *Parser[K]) newGetter(val value) (Getter[K], error) {
 			return p.pathParser(eL.Path)
 		}
 		if eL.Invocation != nil {
-			call, err := p.newFunctionCall(*eL.Invocation)
+			call, err := p.newFunctionCall(invocation{
+				Function:  eL.Invocation.Function,
+				Arguments: eL.Invocation.Arguments,
+			})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -122,10 +122,10 @@ func (p *Parser[K]) newGetter(val value) (Getter[K], error) {
 		if eL.Path != nil {
 			return p.pathParser(eL.Path)
 		}
-		if eL.Invocation != nil {
+		if eL.Converter != nil {
 			call, err := p.newFunctionCall(invocation{
-				Function:  eL.Invocation.Function,
-				Arguments: eL.Invocation.Arguments,
+				Function:  eL.Converter.Function,
+				Arguments: eL.Converter.Arguments,
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -102,8 +102,8 @@ func Test_newGetter(t *testing.T) {
 			name: "function call",
 			val: value{
 				Literal: &mathExprLiteral{
-					Invocation: &invocation{
-						Function: "hello",
+					Invocation: &factoryFunction{
+						Function: "Hello",
 					},
 				},
 			},
@@ -242,8 +242,8 @@ func Test_newGetter(t *testing.T) {
 					Values: []value{
 						{
 							Literal: &mathExprLiteral{
-								Invocation: &invocation{
-									Function: "hello",
+								Invocation: &factoryFunction{
+									Function: "Hello",
 								},
 							},
 						},
@@ -288,7 +288,7 @@ func Test_newGetter(t *testing.T) {
 		},
 	}
 
-	functions := map[string]interface{}{"hello": hello[interface{}]}
+	functions := map[string]interface{}{"Hello": hello[interface{}]}
 
 	p := NewParser(
 		functions,

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -102,7 +102,7 @@ func Test_newGetter(t *testing.T) {
 			name: "function call",
 			val: value{
 				Literal: &mathExprLiteral{
-					Invocation: &factoryFunction{
+					Invocation: &converter{
 						Function: "Hello",
 					},
 				},
@@ -242,7 +242,7 @@ func Test_newGetter(t *testing.T) {
 					Values: []value{
 						{
 							Literal: &mathExprLiteral{
-								Invocation: &factoryFunction{
+								Invocation: &converter{
 									Function: "Hello",
 								},
 							},

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -102,7 +102,7 @@ func Test_newGetter(t *testing.T) {
 			name: "function call",
 			val: value{
 				Literal: &mathExprLiteral{
-					Invocation: &converter{
+					Converter: &converter{
 						Function: "Hello",
 					},
 				},
@@ -242,7 +242,7 @@ func Test_newGetter(t *testing.T) {
 					Values: []value{
 						{
 							Literal: &mathExprLiteral{
-								Invocation: &converter{
+								Converter: &converter{
 									Function: "Hello",
 								},
 							},

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -73,7 +73,7 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 				Arguments: []value{
 					{
 						Literal: &mathExprLiteral{
-							Invocation: &factoryFunction{
+							Invocation: &converter{
 								Function: "Unknownfunc",
 							},
 						},
@@ -461,7 +461,7 @@ func Test_NewFunctionCall(t *testing.T) {
 								},
 								{
 									Literal: &mathExprLiteral{
-										Invocation: &factoryFunction{
+										Invocation: &converter{
 											Function: "Testing_getter",
 											Arguments: []value{
 												{
@@ -598,7 +598,7 @@ func Test_NewFunctionCall(t *testing.T) {
 								},
 								{
 									Literal: &mathExprLiteral{
-										Invocation: &factoryFunction{
+										Invocation: &converter{
 											Function: "Testing_getter",
 											Arguments: []value{
 												{

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -73,7 +73,7 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 				Arguments: []value{
 					{
 						Literal: &mathExprLiteral{
-							Invocation: &converter{
+							Converter: &converter{
 								Function: "Unknownfunc",
 							},
 						},
@@ -461,7 +461,7 @@ func Test_NewFunctionCall(t *testing.T) {
 								},
 								{
 									Literal: &mathExprLiteral{
-										Invocation: &converter{
+										Converter: &converter{
 											Function: "Testing_getter",
 											Arguments: []value{
 												{
@@ -598,7 +598,7 @@ func Test_NewFunctionCall(t *testing.T) {
 								},
 								{
 									Literal: &mathExprLiteral{
-										Invocation: &converter{
+										Converter: &converter{
 											Function: "Testing_getter",
 											Arguments: []value{
 												{

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -73,8 +73,8 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 				Arguments: []value{
 					{
 						Literal: &mathExprLiteral{
-							Invocation: &invocation{
-								Function: "unknownfunc",
+							Invocation: &factoryFunction{
+								Function: "Unknownfunc",
 							},
 						},
 					},
@@ -461,8 +461,8 @@ func Test_NewFunctionCall(t *testing.T) {
 								},
 								{
 									Literal: &mathExprLiteral{
-										Invocation: &invocation{
-											Function: "testing_getter",
+										Invocation: &factoryFunction{
+											Function: "Testing_getter",
 											Arguments: []value{
 												{
 													Literal: &mathExprLiteral{
@@ -598,8 +598,8 @@ func Test_NewFunctionCall(t *testing.T) {
 								},
 								{
 									Literal: &mathExprLiteral{
-										Invocation: &invocation{
-											Function: "testing_getter",
+										Invocation: &factoryFunction{
+											Function: "Testing_getter",
 											Arguments: []value{
 												{
 													Literal: &mathExprLiteral{
@@ -943,6 +943,7 @@ func defaultFunctionsForTests() map[string]interface{} {
 	functions["testing_setter"] = functionWithSetter
 	functions["testing_getsetter"] = functionWithGetSetter
 	functions["testing_getter"] = functionWithGetter
+	functions["Testing_getter"] = functionWithGetter
 	functions["testing_string"] = functionWithString
 	functions["testing_float"] = functionWithFloat
 	functions["testing_int"] = functionWithInt

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -121,13 +121,13 @@ type comparison struct {
 	Right value     `parser:"@@"`
 }
 
-// invocation represents a function call.
+// invocation represents the function call of a statement.
 type invocation struct {
 	Function  string  `parser:"@(Lowercase(Uppercase | Lowercase)*)"`
 	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
 }
 
-// invocation represents a function call.
+// factoryFunction represents a factory function call.
 type factoryFunction struct {
 	Function  string  `parser:"@(Uppercase(Uppercase | Lowercase)*)"`
 	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -209,7 +209,7 @@ func (i *invocation) checkForCustomError() error {
 	return nil
 }
 
-// converter represents a factory function call.
+// converter represents a converter function call.
 type converter struct {
 	Function  string  `parser:"@(Uppercase(Uppercase | Lowercase)*)"`
 	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -22,8 +22,24 @@ import (
 
 // parsedStatement represents a parsed statement. It is the entry point into the statement DSL.
 type parsedStatement struct {
-	Invocation  invocation         `parser:"@@"`
+	Invocation invocation `parser:"(@@"`
+	// If converter is matched then return error
+	Converter   *converter         `parser:"|@@)"`
 	WhereClause *booleanExpression `parser:"( 'where' @@ )?"`
+}
+
+func (p *parsedStatement) checkForCustomError() error {
+	if p.Converter != nil {
+		return fmt.Errorf("invocation names must start with a lowercase letter but got '%v'", p.Converter.Function)
+	}
+	err := p.Invocation.checkForCustomError()
+	if err != nil {
+		return err
+	}
+	if p.WhereClause != nil {
+		return p.WhereClause.checkForCustomError()
+	}
+	return nil
 }
 
 // booleanValue represents something that evaluates to a boolean --
@@ -36,10 +52,24 @@ type booleanValue struct {
 	SubExpr    *booleanExpression `parser:"| '(' @@ ')' )"`
 }
 
+func (b *booleanValue) checkForCustomError() error {
+	if b.Comparison != nil {
+		return b.Comparison.checkForCustomError()
+	}
+	if b.SubExpr != nil {
+		return b.SubExpr.checkForCustomError()
+	}
+	return nil
+}
+
 // opAndBooleanValue represents the right side of an AND boolean expression.
 type opAndBooleanValue struct {
 	Operator string        `parser:"@OpAnd"`
 	Value    *booleanValue `parser:"@@"`
+}
+
+func (b *opAndBooleanValue) checkForCustomError() error {
+	return b.Value.checkForCustomError()
 }
 
 // term represents an arbitrary number of boolean values joined by AND.
@@ -48,10 +78,28 @@ type term struct {
 	Right []*opAndBooleanValue `parser:"@@*"`
 }
 
+func (b *term) checkForCustomError() error {
+	err := b.Left.checkForCustomError()
+	if err != nil {
+		return err
+	}
+	for _, r := range b.Right {
+		err = r.checkForCustomError()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // opOrTerm represents the right side of an OR boolean expression.
 type opOrTerm struct {
 	Operator string `parser:"@OpOr"`
 	Term     *term  `parser:"@@"`
+}
+
+func (b *opOrTerm) checkForCustomError() error {
+	return b.Term.checkForCustomError()
 }
 
 // booleanExpression represents a true/false decision expressed
@@ -59,6 +107,20 @@ type opOrTerm struct {
 type booleanExpression struct {
 	Left  *term       `parser:"@@"`
 	Right []*opOrTerm `parser:"@@*"`
+}
+
+func (b *booleanExpression) checkForCustomError() error {
+	err := b.Left.checkForCustomError()
+	if err != nil {
+		return err
+	}
+	for _, r := range b.Right {
+		err = r.checkForCustomError()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // compareOp is the type of a comparison operator.
@@ -121,10 +183,30 @@ type comparison struct {
 	Right value     `parser:"@@"`
 }
 
+func (c *comparison) checkForCustomError() error {
+	err := c.Left.checkForCustomError()
+	if err != nil {
+		return err
+	}
+	err = c.Right.checkForCustomError()
+	return err
+}
+
 // invocation represents the function call of a statement.
 type invocation struct {
 	Function  string  `parser:"@(Lowercase(Uppercase | Lowercase)*)"`
 	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
+}
+
+func (i *invocation) checkForCustomError() error {
+	var err error
+	for _, arg := range i.Arguments {
+		err = arg.checkForCustomError()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // converter represents a factory function call.
@@ -144,6 +226,16 @@ type value struct {
 	Bool           *boolean         `parser:"| @Boolean"`
 	Enum           *EnumSymbol      `parser:"| @Uppercase"`
 	List           *list            `parser:"| @@)"`
+}
+
+func (v *value) checkForCustomError() error {
+	if v.Literal != nil {
+		return v.Literal.checkForCustomError()
+	}
+	if v.MathExpression != nil {
+		return v.MathExpression.checkForCustomError()
+	}
+	return nil
 }
 
 // Path represents a telemetry path mathExpression.
@@ -191,10 +283,19 @@ func (n *isNil) Capture(_ []string) error {
 }
 
 type mathExprLiteral struct {
-	Invocation *converter `parser:"( @@"`
-	Float      *float64   `parser:"| @Float"`
-	Int        *int64     `parser:"| @Int"`
-	Path       *Path      `parser:"| @@ )"`
+	// If invocation is matched then error
+	Invocation *invocation `parser:"( @@"`
+	Converter  *converter  `parser:"| @@"`
+	Float      *float64    `parser:"| @Float"`
+	Int        *int64      `parser:"| @Int"`
+	Path       *Path       `parser:"| @@ )"`
+}
+
+func (m *mathExprLiteral) checkForCustomError() error {
+	if m.Invocation != nil {
+		return fmt.Errorf("converter names must start with an uppercase letter but got '%v'", m.Invocation.Function)
+	}
+	return nil
 }
 
 type mathValue struct {
@@ -202,9 +303,20 @@ type mathValue struct {
 	SubExpression *mathExpression  `parser:"| '(' @@ ')' )"`
 }
 
+func (m *mathValue) checkForCustomError() error {
+	if m.Literal != nil {
+		return m.Literal.checkForCustomError()
+	}
+	return m.SubExpression.checkForCustomError()
+}
+
 type opMultDivValue struct {
 	Operator mathOp     `parser:"@OpMultDiv"`
 	Value    *mathValue `parser:"@@"`
+}
+
+func (m *opMultDivValue) checkForCustomError() error {
+	return m.Value.checkForCustomError()
 }
 
 type addSubTerm struct {
@@ -212,14 +324,46 @@ type addSubTerm struct {
 	Right []*opMultDivValue `parser:"@@*"`
 }
 
+func (m *addSubTerm) checkForCustomError() error {
+	err := m.Left.checkForCustomError()
+	if err != nil {
+		return err
+	}
+	for _, r := range m.Right {
+		err = r.checkForCustomError()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type opAddSubTerm struct {
 	Operator mathOp      `parser:"@OpAddSub"`
 	Term     *addSubTerm `parser:"@@"`
 }
 
+func (m *opAddSubTerm) checkForCustomError() error {
+	return m.Term.checkForCustomError()
+}
+
 type mathExpression struct {
 	Left  *addSubTerm     `parser:"@@"`
 	Right []*opAddSubTerm `parser:"@@*"`
+}
+
+func (m *mathExpression) checkForCustomError() error {
+	err := m.Left.checkForCustomError()
+	if err != nil {
+		return err
+	}
+	for _, r := range m.Right {
+		err = r.checkForCustomError()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type mathOp int

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -127,8 +127,8 @@ type invocation struct {
 	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
 }
 
-// factoryFunction represents a factory function call.
-type factoryFunction struct {
+// converter represents a factory function call.
+type converter struct {
 	Function  string  `parser:"@(Uppercase(Uppercase | Lowercase)*)"`
 	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
 }
@@ -191,10 +191,10 @@ func (n *isNil) Capture(_ []string) error {
 }
 
 type mathExprLiteral struct {
-	Invocation *factoryFunction `parser:"( @@"`
-	Float      *float64         `parser:"| @Float"`
-	Int        *int64           `parser:"| @Int"`
-	Path       *Path            `parser:"| @@ )"`
+	Invocation *converter `parser:"( @@"`
+	Float      *float64   `parser:"| @Float"`
+	Int        *int64     `parser:"| @Int"`
+	Path       *Path      `parser:"| @@ )"`
 }
 
 type mathValue struct {

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -123,7 +123,13 @@ type comparison struct {
 
 // invocation represents a function call.
 type invocation struct {
-	Function  string  `parser:"@(Uppercase | Lowercase)+"`
+	Function  string  `parser:"@(Lowercase(Uppercase | Lowercase)*)"`
+	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
+}
+
+// invocation represents a function call.
+type factoryFunction struct {
+	Function  string  `parser:"@(Uppercase(Uppercase | Lowercase)*)"`
 	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
 }
 
@@ -185,10 +191,10 @@ func (n *isNil) Capture(_ []string) error {
 }
 
 type mathExprLiteral struct {
-	Invocation *invocation `parser:"( @@"`
-	Float      *float64    `parser:"| @Float"`
-	Int        *int64      `parser:"| @Int"`
-	Path       *Path       `parser:"| @@ )"`
+	Invocation *factoryFunction `parser:"( @@"`
+	Float      *float64         `parser:"| @Float"`
+	Int        *int64           `parser:"| @Int"`
+	Path       *Path            `parser:"| @@ )"`
 }
 
 type mathValue struct {

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -427,8 +427,8 @@ func buildLexer() *lexer.StatefulDefinition {
 		{Name: `LParen`, Pattern: `\(`},
 		{Name: `RParen`, Pattern: `\)`},
 		{Name: `Punct`, Pattern: `[,.\[\]]`},
-		{Name: `Uppercase`, Pattern: `[A-Z_][A-Z0-9_]*`},
-		{Name: `Lowercase`, Pattern: `[a-z_][a-z0-9_]*`},
+		{Name: `Uppercase`, Pattern: `[A-Z][A-Z0-9_]*`},
+		{Name: `Lowercase`, Pattern: `[a-z][a-z0-9_]*`},
 		{Name: "whitespace", Pattern: `\s+`},
 	})
 }

--- a/pkg/ottl/lexer_test.go
+++ b/pkg/ottl/lexer_test.go
@@ -103,10 +103,11 @@ func Test_lexer(t *testing.T) {
 			{"Bytes", "0x0102030405060708"},
 			{"RParen", ")"},
 		}},
-		{"Mixing case", `aBCd`, false, []result{
+		{"Mixing case numbers and underscores", `aBCd_123E_4`, false, []result{
 			{"Lowercase", "a"},
 			{"Uppercase", "BC"},
-			{"Lowercase", "d"},
+			{"Lowercase", "d_123"},
+			{"Uppercase", "E_4"},
 		}},
 		{"Math Operations", `+-*/`, false, []result{
 			{"OpAddSub", "+"},

--- a/pkg/ottl/math_test.go
+++ b/pkg/ottl/math_test.go
@@ -135,17 +135,17 @@ func Test_evaluateMathExpression(t *testing.T) {
 		},
 		{
 			name:     "int functions",
-			input:    "one() + two()",
+			input:    "One() + Two()",
 			expected: 3,
 		},
 		{
 			name:     "functions",
-			input:    "threePointOne() + threePointOne()",
+			input:    "ThreePointOne() + ThreePointOne()",
 			expected: 6.2,
 		},
 		{
 			name:     "functions",
-			input:    "sum([1, 2, 3, 4]) / (1 * 10)",
+			input:    "Sum([1, 2, 3, 4]) / (1 * 10)",
 			expected: 1,
 		},
 		{
@@ -206,10 +206,10 @@ func Test_evaluateMathExpression(t *testing.T) {
 	}
 
 	functions := map[string]interface{}{
-		"one":           one[any],
-		"two":           two[any],
-		"threePointOne": threePointOne[any],
-		"sum":           sum[any],
+		"One":           one[any],
+		"Two":           two[any],
+		"ThreePointOne": threePointOne[any],
+		"Sum":           sum[any],
 	}
 
 	p := NewParser[any](

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -24,16 +24,16 @@ List of available Functions:
 - [set](#set)
 - [truncate_all](#truncate_all)
 
-## Factory Functions
+## Converters
 
-Factory Functions are functions that help translate between the OTTL grammar and the underlying pdata structure.
+Converters are functions that help translate between the OTTL grammar and the underlying pdata structure.
 They manipulate the OTTL grammar value into a form that will make working with the telemetry easier or more efficient.
 
-Factory Functions:
+Converters:
 - Are pure functions.  They should never change the underlying telemetry and the same inputs should always result in the same output.
 - Always return something.  
 
-List of available Factory Functions:
+List of available Converters:
 - [Concat](#concat)
 - [ConvertCase](#convertcase)
 - [Int](#int)

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -103,7 +103,7 @@ func parseStatement(raw string) (*parsedStatement, error) {
 	parsed, err := parser.ParseString("", raw)
 
 	if err != nil {
-		return nil, multierr.Append(err, fmt.Errorf("unable to parse OTTL statement, enurse the grammar's syntax is correct; common mistakes include missing parentheses, missing double quotes and incorrect function name case"))
+		return nil, multierr.Append(err, fmt.Errorf("unable to parse OTTL statement, ensure the statement's syntax is correct; common mistakes include missing parentheses, missing double quotes and incorrect function name case"))
 	}
 	err = parsed.checkForCustomError()
 	if err != nil {

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -101,23 +101,16 @@ var parser = newParser[parsedStatement]()
 
 func parseStatement(raw string) (*parsedStatement, error) {
 	parsed, err := parser.ParseString("", raw)
-	if err != nil {
-		return nil, handleParseError(err)
-	}
-	return parsed, nil
-}
 
-func handleParseError(err error) error {
-	switch parserErr := err.(type) {
-	case *participle.UnexpectedTokenError:
-		if parserErr.Unexpected.Pos.Offset == 0 {
-			return multierr.Append(err, fmt.Errorf("invocation names must start with a lowercase letter but got %v", parserErr.Unexpected.Value))
-		}
-		if parserErr.Unexpected.Value == "(" {
-			return multierr.Append(err, fmt.Errorf("ensure all functions being used as parameters or within conditions start with an uppercase letter"))
-		}
+	if err != nil {
+		return nil, multierr.Append(err, fmt.Errorf("unable to parse OTTL statement, enurse the grammar's syntax is correct; common mistakes include missing parentheses, missing double quotes and incorrect function name case"))
 	}
-	return multierr.Append(err, fmt.Errorf("unable to parse OTTL statement. Enurse the grammar's syntax is correct.  Common mistakes include missing parentheses, missing double quotes, and incorrect function name case."))
+	err = parsed.checkForCustomError()
+	if err != nil {
+		return nil, err
+	}
+
+	return parsed, nil
 }
 
 // newParser returns a parser that can be used to read a string into a parsedStatement. An error will be returned if the string

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -98,7 +98,7 @@ func Test_parse(t *testing.T) {
 						},
 						{
 							Literal: &mathExprLiteral{
-								Invocation: &factoryFunction{
+								Invocation: &converter{
 									Function: "GetSomething",
 									Arguments: []value{
 										{
@@ -576,7 +576,7 @@ func Test_parse(t *testing.T) {
 								Values: []value{
 									{
 										Literal: &mathExprLiteral{
-											Invocation: &factoryFunction{
+											Invocation: &converter{
 												Function: "Concat",
 												Arguments: []value{
 													{
@@ -741,7 +741,7 @@ func Test_parse(t *testing.T) {
 													Operator: DIV,
 													Value: &mathValue{
 														Literal: &mathExprLiteral{
-															Invocation: &factoryFunction{
+															Invocation: &converter{
 																Function: "One",
 															},
 														},

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -88,7 +88,7 @@ func Test_parse(t *testing.T) {
 		},
 		{
 			name:      "complex invocation",
-			statement: `set("foo", getSomething(bear.honey))`,
+			statement: `set("foo", GetSomething(bear.honey))`,
 			expected: &parsedStatement{
 				Invocation: invocation{
 					Function: "set",
@@ -98,8 +98,8 @@ func Test_parse(t *testing.T) {
 						},
 						{
 							Literal: &mathExprLiteral{
-								Invocation: &invocation{
-									Function: "getSomething",
+								Invocation: &factoryFunction{
+									Function: "GetSomething",
 									Arguments: []value{
 										{
 											Literal: &mathExprLiteral{
@@ -576,7 +576,7 @@ func Test_parse(t *testing.T) {
 								Values: []value{
 									{
 										Literal: &mathExprLiteral{
-											Invocation: &invocation{
+											Invocation: &factoryFunction{
 												Function: "Concat",
 												Arguments: []value{
 													{
@@ -642,7 +642,7 @@ func Test_parse(t *testing.T) {
 		},
 		{
 			name:      "Invocation math mathExpression",
-			statement: `set(attributes["test"], 1000 - 600) where 1 + 1 * 2 == three / one()`,
+			statement: `set(attributes["test"], 1000 - 600) where 1 + 1 * 2 == three / One()`,
 			expected: &parsedStatement{
 				Invocation: invocation{
 					Function: "set",
@@ -741,8 +741,8 @@ func Test_parse(t *testing.T) {
 													Operator: DIV,
 													Value: &mathValue{
 														Literal: &mathExprLiteral{
-															Invocation: &invocation{
-																Function: "one",
+															Invocation: &factoryFunction{
+																Function: "One",
 															},
 														},
 													},
@@ -1229,21 +1229,24 @@ func Test_parseStatement(t *testing.T) {
 	}{
 		{`set(foo.attributes["bar"].cat, "dog")`, false},
 		{`set(foo.attributes["animal"], "dog") where animal == "cat"`, false},
-		{`drop() where service == "pinger" or foo.attributes["endpoint"] == "/x/alive"`, false},
-		{`drop() where service == "pinger" or foo.attributes["verb"] == "GET" and foo.attributes["endpoint"] == "/x/alive"`, false},
-		{`drop() where animal > "cat"`, false},
-		{`drop() where animal >= "cat"`, false},
-		{`drop() where animal <= "cat"`, false},
-		{`drop() where animal < "cat"`, false},
-		{`drop() where animal =< "dog"`, true},
-		{`drop() where animal => "dog"`, true},
-		{`drop() where animal <> "dog"`, true},
-		{`drop() where animal = "dog"`, true},
-		{`drop() where animal`, true},
-		{`drop() where animal ==`, true},
-		{`drop() where ==`, true},
-		{`drop() where == animal`, true},
-		{`drop() where attributes["path"] == "/healthcheck"`, false},
+		{`test() where service == "pinger" or foo.attributes["endpoint"] == "/x/alive"`, false},
+		{`test() where service == "pinger" or foo.attributes["verb"] == "GET" and foo.attributes["endpoint"] == "/x/alive"`, false},
+		{`test() where animal > "cat"`, false},
+		{`test() where animal >= "cat"`, false},
+		{`test() where animal <= "cat"`, false},
+		{`test() where animal < "cat"`, false},
+		{`test() where animal =< "dog"`, true},
+		{`test() where animal => "dog"`, true},
+		{`test() where animal <> "dog"`, true},
+		{`test() where animal = "dog"`, true},
+		{`test() where animal`, true},
+		{`test() where animal ==`, true},
+		{`test() where ==`, true},
+		{`test() where == animal`, true},
+		{`test() where attributes["path"] == "/healthcheck"`, false},
+		{`test() where one() == 1`, true},
+		{`test(fail())`, true},
+		{`Test()`, true},
 	}
 	pat := regexp.MustCompile("[^a-zA-Z0-9]+")
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:** 
Updates the OTTL grammar to be more prescriptive with its function names by enforcing that invocations start with a lowercase letter and factory functions (functions that can be used as inputs to other functions or expressions) start with an uppercase letter.

**Link to tracking Issue:** <Issue number if applicable>
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16571
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16592

**Testing:** 
Updated tests

**Documentation:** 
Updated documentation