### PR TITLE
[receiver/vcenter] Express ballooned memory in MB

### DIFF
--- a/.chloggen/fix_metricType.yaml
+++ b/.chloggen/fix_metricType.yaml
@@ -5,7 +5,7 @@ change_type: 'bug_fix'
 component: vcenterreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: `vcenter.vm.memory.ballooned` is taken from `vm.Summary.QuickStats.BalloonedMemory` that is expressed `MiBy`, not `By`.
+note: vcenter.vm.memory.ballooned is taken from vm.Summary.QuickStats.BalloonedMemory that is expressed MiBy, not By.
 
 # One or more tracking issues related to the change
 issues: [16728]

--- a/.chloggen/vcenter-metric-type.yaml
+++ b/.chloggen/vcenter-metric-type.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: `vcenter.vm.memory.ballooned` is taken from `vm.Summary.QuickStats.BalloonedMemory` that is expressed `MiBy`, not `By`.
+
+# One or more tracking issues related to the change
+issues: [16728]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -323,7 +323,7 @@ The amount of memory that is ballooned due to virtualization.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| MiBy | Sum | Int | Cumulative | false |
 
 ### vcenter.vm.memory.usage
 

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -1830,7 +1830,7 @@ type metricVcenterVMMemoryBallooned struct {
 func (m *metricVcenterVMMemoryBallooned) init() {
 	m.data.SetName("vcenter.vm.memory.ballooned")
 	m.data.SetDescription("The amount of memory that is ballooned due to virtualization.")
-	m.data.SetUnit("By")
+	m.data.SetUnit("MiBy")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -647,7 +647,7 @@ func TestAllMetrics(t *testing.T) {
 			assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 			assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
 			assert.Equal(t, "The amount of memory that is ballooned due to virtualization.", ms.At(i).Description())
-			assert.Equal(t, "By", ms.At(i).Unit())
+			assert.Equal(t, "MiBy", ms.At(i).Unit())
 			assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
 			assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
 			dp := ms.At(i).Sum().DataPoints().At(0)

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -281,7 +281,7 @@ metrics:
   vcenter.vm.memory.ballooned:
     enabled: true
     description: The amount of memory that is ballooned due to virtualization.
-    unit: By
+    unit: MiBy
     sum:
       monotonic: false
       value_type: int

--- a/receiver/vcenterreceiver/testdata/metrics/expected.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.json
@@ -3327,7 +3327,7 @@
                         {
                             "name": "vcenter.vm.memory.ballooned",
                             "description": "The amount of memory that is ballooned due to virtualization.",
-                            "unit": "By",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {

--- a/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
@@ -1653,7 +1653,7 @@
                         {
                             "name": "vcenter.vm.memory.ballooned",
                             "description": "The amount of memory that is ballooned due to virtualization.",
-                            "unit": "By",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {

--- a/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
+++ b/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
@@ -411,7 +411,7 @@
                         {
                             "name": "vcenter.vm.memory.ballooned",
                             "description": "The amount of memory that is ballooned due to virtualization.",
-                            "unit": "By",
+                            "unit": "MiBy",
                             "sum": {
                                 "dataPoints": [
                                     {


### PR DESCRIPTION
`vcenter.vm.memory.ballooned` is taken from `vm.Summary.QuickStats.BalloonedMemory` that is expressed `MiBy`, not `By`.

Fix https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16728