### PR TITLE
Print test results in text format to both stdout and file to be collected by Foresight

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -68,9 +68,9 @@ jobs:
         with:
           api_key: ${{ secrets.FORESIGHT_API_KEY }}
           test_framework: golang
-          test_format: json
+          test_format: text
           test_path: |
-            ./**/foresight-test*.json
+            ./**/foresight-test*.txt
   windows-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
     runs-on: windows-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -233,9 +233,9 @@ jobs:
         with:
           api_key: ${{ secrets.FORESIGHT_API_KEY }}
           test_framework: golang
-          test_format: json
+          test_format: text
           test_path: |
-            ./**/foresight-test*.json
+            ./**/foresight-test*.txt
   unittest:
     if: ${{ always() }}
     strategy:
@@ -287,9 +287,9 @@ jobs:
         with:
           api_key: ${{ secrets.FORESIGHT_API_KEY }}
           test_framework: golang
-          test_format: json
+          test_format: text
           test_path: |
-            ./**/foresight-test-report-integration*.json
+            ./**/foresight-test-report-integration*.txt
           coverage_format: golang
           coverage_path: |
             ./**/integration-coverage.txt
@@ -331,9 +331,9 @@ jobs:
         with:
           api_key: ${{ secrets.FORESIGHT_API_KEY }}
           test_framework: golang
-          test_format: json
+          test_format: text
           test_path: |
-            ./**/foresight-test*.json
+            ./**/foresight-test*.txt
   correctness-metrics:
     runs-on: ubuntu-latest
     needs: [setup-environment]
@@ -371,9 +371,9 @@ jobs:
         with:
           api_key: ${{ secrets.FORESIGHT_API_KEY }}
           test_framework: golang
-          test_format: json
+          test_format: text
           test_path: |
-            ./**/foresight-test*.json
+            ./**/foresight-test*.txt
 
   build-examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Copy binary to compliance directory
         run: mkdir compliance/remote_write_sender/bin && cp opentelemetry-collector-contrib/bin/otelcontribcol_linux_amd64 compliance/remote_write_sender/bin/otelcol_linux_amd64
       - name: Run compliance tests
-        run: go test -v -json --tags=compliance -run "TestRemoteWrite/otel/.+" ./ > ./test-report.json
+        run: go test -v --tags=compliance -run "TestRemoteWrite/otel/.+" ./ |& tee ./test-report.txt
         working-directory: compliance/remote_write_sender
       - name: Analyze Test and/or Coverage Results
         if: always()
@@ -62,5 +62,5 @@ jobs:
           api_key: ${{ secrets.FORESIGHT_API_KEY }}
           working_directory: compliance/remote_write_sender
           test_framework: golang
-          test_format: json
-          test_path: ./test-report.json
+          test_format: text
+          test_path: ./test-report.txt

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -56,7 +56,7 @@ common: checklicense impi lint misspell
 .PHONY: test
 test:
 	if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
-		$(GOTEST) $(GOTEST_OPT) ./... -json > ./foresight-test-report.json; \
+		$(GOTEST) $(GOTEST_OPT) -v ./... 2>&1 | tee -a ./foresight-test-report.txt; \
 	else \
 		$(GOTEST) $(GOTEST_OPT) ./...; \
 	fi
@@ -65,7 +65,7 @@ test:
 do-unit-tests-with-cover:
 	@echo "running $(GOCMD) unit test ./... + coverage in `pwd`"
 	@if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
-		$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./... -json > ./foresight-test-report-unit-tests-with-cover.json; \
+		$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) -v ./... 2>&1 | tee -a ./foresight-test-report-unit-tests-with-cover.txt; \
 	else \
 		$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./...; \
 	fi
@@ -75,7 +75,7 @@ do-unit-tests-with-cover:
 do-integration-tests-with-cover:
 	@echo "running $(GOCMD) integration test ./... + coverage in `pwd`"
 	@if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
-		$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) ./... -json > ./foresight-test-report-integration-tests-with-cover.json; \
+		$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) -v ./... 2>&1 | tee -a ./foresight-test-report-integration-tests-with-cover.txt; \
 	else \
 		$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) ./...; \
 	fi

--- a/testbed/runtests.sh
+++ b/testbed/runtests.sh
@@ -14,7 +14,7 @@ TEST_COLORIZE="${SED} 's/PASS/${PASS_COLOR}/' | ${SED} 's/FAIL/${FAIL_COLOR}/'"
 
 mkdir -p results/junit
 
-RUN_TESTBED=1 go test -v ${TEST_ARGS} 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}" -json > ./foresight-test-report.json
+RUN_TESTBED=1 go test -v ${TEST_ARGS} 2>&1 | tee -a results/testoutput.log ./foresight-test-report.txt | bash -c "${TEST_COLORIZE}"
 
 testStatus=${PIPESTATUS[0]}
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>

With the PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16427, test results started to be produced in **json** format and piped to file.
On the other hand, by another PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16416, verbose mode had disabled before so no test output has been written to stdout.

With this PR, test results are produced in **text** format and piped to both stdout and file to be consumed by Foresight.



