### PR TITLE
[chore] [receiver/hostmetrics] Extend the deprecation timeline

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -194,10 +194,10 @@ the following process will be followed to phase out the old metrics:
 
 - Until and including `v0.63.0`, only the old metrics `process.memory.physical_usage` and `process.memory.virtual_usage` are emitted.
   You can use the [Metrics Transform processor][metricstransformprocessor_docs] to rename them.
-- Between `v0.64.0` and `v0.66.0`, the new metrics are introduced as optional (disabled by default) and the old metrics are marked as deprecated.
+- Between `v0.64.0` and `v0.69.0`, the new metrics are introduced as optional (disabled by default) and the old metrics are marked as deprecated.
   Only the old metrics are emitted by default.
-- Between `v0.67.0` and `v0.69.0`, the new metrics are enabled and the old metrics are disabled by default.
-- In `v0.70.0` and up, the old metrics are removed.
+- Between `v0.69.0` and `v0.71.0`, the new metrics are enabled and the old metrics are disabled by default.
+- In `v0.72.0` and up, the old metrics are removed.
 
 To change the enabled state for the specific metrics, use the standard configuration options that are available for all metrics.
 


### PR DESCRIPTION
for process memory metrics rename. Reasons for that:
- 0.65.0 was skipped
- warnings will be added only in 0.67.0 with https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16536
