### PR TITLE
[receiver/purefa] Announce component on changelog

### DIFF
--- a/.chloggen/add-purefa-receiver.yaml
+++ b/.chloggen/add-purefa-receiver.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/purefareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a new receiver that scrapes metrics using Purestorage FlashArray API
+
+# One or more tracking issues related to the change
+issues: [14886]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
This file was supposed to be attached at the beginning of the project, however, due to an oversight, I am making the change right now to fulfill the requirements

**Link to tracking Issue:**
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14886

**Testing:**
no needed

**Documentation:**
Present on README for the moment