### PR TITLE
[chore] Remove reliance on GNU sed functionality in issue template Make target

### DIFF
--- a/.github/workflows/scripts/add-component-options.sh
+++ b/.github/workflows/scripts/add-component-options.sh
@@ -20,7 +20,7 @@
 #
 # Note that this is script is intended to be POSIX-compliant since it is
 # intended to also be called from the Makefile on developer machines,
-# which aren't guaranteed to have Bash installed.
+# which aren't guaranteed to have Bash or a GNU userland installed.
 
 if [ -z "${FILE}" ]; then
   echo 'FILE is empty, please ensure it is set.'
@@ -37,14 +37,26 @@ get_line_number() {
   grep -n "${text}" "${file}" | awk '{ print $1 }' | grep -oE '[0-9]+'
 }
 
+LABELS=""
+
 START_LINE=$(get_line_number '# Start Collector components list' "${FILE}")
 END_LINE=$(get_line_number '# End Collector components list' "${FILE}")
 TOTAL_LINES=$(wc -l "${FILE}" | awk '{ print $1 }')
 
 head -n "${START_LINE}" "${FILE}"
-sh "${CUR_DIRECTORY}/get-components.sh" | \
-  sed -E 's%^(.+)/(.+)\1%\1/\2%' | \
-  sort | \
-  awk '{ printf "      - %s\n",$1 }'
+for COMPONENT in $(sh "${CUR_DIRECTORY}/get-components.sh"); do
+  TYPE=$(echo "${COMPONENT}" | cut -f1 -d'/')
+  REST=$(echo "${COMPONENT}" | cut -f2- -d'/' | sed "s%${TYPE}/%/%" | sed "s%${TYPE}\$%%")
+  LABEL=""
+
+  if [ -z "${TYPE}" ] | [ -z "${REST}" ]; then
+    LABEL="${COMPONENT}"
+  else
+    LABEL="${TYPE}/${REST}"
+  fi
+
+  LABELS="${LABELS}${LABEL}\n"
+done
+printf "${LABELS}" | sort | awk '{ printf "      - %s\n",$1 }'
 tail -n $((TOTAL_LINES-END_LINE+1)) "${FILE}"
 


### PR DESCRIPTION
**Description:**

Back references inside regular expressions are not supported by most sed implementations, so in this script we use an alternate approach to convert the component paths to the names used in labels.

**Link to tracking Issue:**

Fixes: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16721

**Testing:**

I tested this on a Linux machine with GNU sed and a Mac with FreeBSD sed. Running the script on either produces no changes from the existing issue templates.