### PR TITLE
[mdatagen] Improvement on README for mdatagen new codegen file

### DIFF
--- a/cmd/mdatagen/README.md
+++ b/cmd/mdatagen/README.md
@@ -8,12 +8,14 @@ Current examples:
 
 See [metric-metadata.yaml](metric-metadata.yaml) for file format documentation.
 
-If adding a new receiver a `codegen.go` file should also be added to trigger the generation. See below for details.
+If adding a new receiver a `doc.go` file should also be added to trigger the generation. See below for details.
 
 ## Build
 
-When `go generate` is run (it is run automatically in the make build targets) there are a few special build directives in `codegen.go` files:
+When `go generate` is run (it is run automatically in the make build targets) there are a few special build directives in `doc.go` files:
 
-`make install-tools` results in `cmd/mdatagen` being installed to `GOBIN`
+* `make install-tools` results in `cmd/mdatagen` being installed to `GOBIN`
 
-[/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/codegen.go](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/codegen.go) runs `mdatagen` for the `hostmetricsreceiver` metadata.yaml which generates the [/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata) package which has Go files containing metric and label metadata.
+* `make generate` on root `opentelemetry-collector-contrib project` it will results in the code below
+
+[/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/doc.go](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/doc.go) runs `mdatagen` for the `hostmetricsreceiver` metadata.yaml which generates the [/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata) package which has Go files containing metric and label metadata.


### PR DESCRIPTION
There are some outdated info about the generation of mdatagen.go on readme contrib project. Some wrong links like 
[/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/codegen.go](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/codegen.go) is present, but the file itself, doesn't exist anymore beeing the correct name: doc.go

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector/issues/10904