### PR TITLE
[chore] Retry deb build once

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -496,7 +496,6 @@ jobs:
         run: ./internal/buildscripts/packaging/fpm/${{ matrix.package_type }}/build.sh "${{ steps.github_tag.outputs.tag }}" "ppc64le" "./dist/"
       - name: Test ${{ matrix.package_type }} package
         with:
-          retry_on: error
           max_attempts: 2  # Deb build is flaky, retry only once
         run: |
           if [[ "${{ matrix.package_type }}" = "deb" ]]; then

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -495,6 +495,9 @@ jobs:
       - name: Build ${{ matrix.package_type }} ppc64le package
         run: ./internal/buildscripts/packaging/fpm/${{ matrix.package_type }}/build.sh "${{ steps.github_tag.outputs.tag }}" "ppc64le" "./dist/"
       - name: Test ${{ matrix.package_type }} package
+        with:
+          retry_on: error
+          max_attempts: 2  # Deb build is flaky, retry only once
         run: |
           if [[ "${{ matrix.package_type }}" = "deb" ]]; then
               ./internal/buildscripts/packaging/fpm/test.sh dist/otel-contrib-collector*amd64.deb examples/tracing/otel-collector-config.yml


### PR DESCRIPTION
This step fails randomly. We've never identified a cause or way to fix it. However, when it fails, it causes the main build status to appear broken. I'm suggesting this as a low impact way to mitigate this issue.