### PR TITLE
[chore]Bump examples demo image to 0.67.0

### DIFF
--- a/examples/demo/.env
+++ b/examples/demo/.env
@@ -1,2 +1,2 @@
-OTELCOL_IMG=otel/opentelemetry-collector:0.66.0
+OTELCOL_IMG=otel/opentelemetry-collector:0.67.0
 OTELCOL_ARGS=

--- a/examples/demo/.env
+++ b/examples/demo/.env
@@ -1,2 +1,2 @@
-OTELCOL_IMG=otel/opentelemetry-collector-contrib-dev:latest
+OTELCOL_IMG=otel/opentelemetry-collector:0.66.0
 OTELCOL_ARGS=

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -20,7 +20,7 @@ OpenTelemetry Collectors deployed:
  Jaeger, Zipkin, and Prometheus;
 
 This demo uses `docker-compose` and by default runs against the
-`otel/opentelemetry-collector:0.66.0` image. To run the demo, switch
+`otel/opentelemetry-collector:0.67.0` image. To run the demo, switch
 to the `examples/demo` folder and run:
 
 ```shell

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -19,8 +19,8 @@ OpenTelemetry Collectors deployed:
 - The OTel Collector then sends the data to the appropriate backend, in this demo
  Jaeger, Zipkin, and Prometheus;
 
-This demo uses `docker-compose` and by default runs against the 
-`otel/opentelemetry-collector-contrib-dev:latest` image. To run the demo, switch
+This demo uses `docker-compose` and by default runs against the
+`otel/opentelemetry-collector:0.66.0` image. To run the demo, switch
 to the `examples/demo` folder and run:
 
 ```shell
@@ -31,14 +31,14 @@ The demo exposes the following backends:
 
 - Jaeger at http://0.0.0.0:16686
 - Zipkin at http://0.0.0.0:9411
-- Prometheus at http://0.0.0.0:9090 
+- Prometheus at http://0.0.0.0:9090
 
 Notes:
 
 - It may take some time for the application metrics to appear on the Prometheus
  dashboard;
 
-To clean up any docker container from the demo run `docker-compose down` from 
+To clean up any docker container from the demo run `docker-compose down` from
 the `examples/demo` folder.
 
 ### Using a Locally Built Image
@@ -49,7 +49,5 @@ docker image using the command below:
 make docker-otelcontribcol
 ```
 
-And set an environment variable `OTELCOL_IMG` to `otelcontribcol` before 
+And set an environment variable `OTELCOL_IMG` to `otelcontribcol` before
 launching the command `docker-compose up -d`.
-
-


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Update the docker image used from `otel/opentelemetry-collector-contrib-dev:latest` to `otel/opentelemetry-collector:0.66.0`

**Link to tracking Issue:** 
#16613

**Testing:** <Describe what testing was performed and which tests were added.>
Run docker-compose up and make sure Jaegar, Zipkin, and Prometheus can display the data.

**Documentation:** <Describe the documentation added.>
[Opentelemtry Demo Documentation](https://opentelemetry.io/docs/collector/getting-started/#demo) is still relevant. 