### PR TITLE
[exporter/splunkhec] add worker_queue for sending data to splunk

### DIFF
--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -1,0 +1,214 @@
+package splunkhecexporter
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"sync"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+var (
+	errOverCapacity = errors.New("over capacity")
+)
+
+// Minimum number of bytes to compress. 1500 is the MTU of an ethernet frame.
+const minCompressionLen = 1500
+
+// Composite index of a record.
+type index struct {
+	// Index in orig list (i.e. root parent index).
+	resource int
+	// Index in ScopeLogs/ScopeMetrics list (i.e. immediate parent index).
+	library int
+	// Index in Logs list (i.e. the log record index).
+	record int
+}
+
+// bufferState encapsulates intermediate buffer state when pushing data
+type bufferState struct {
+	compressionAvailable bool
+	compressionEnabled   bool
+	bufferMaxLen         uint
+	writer               io.Writer
+	buf                  *bytes.Buffer
+	bufFront             *index
+	resource             int
+	library              int
+	gzipWriterPool       *sync.Pool
+	mu                   sync.Mutex
+}
+
+func (b *bufferState) reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf.Reset()
+	b.compressionEnabled = false
+	b.writer = &cancellableBytesWriter{innerWriter: b.buf, maxCapacity: b.bufferMaxLen}
+}
+
+func (b *bufferState) Read(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Read(p)
+}
+
+func (b *bufferState) copyBuffer() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	buffer := make([]byte, b.buf.Len())
+	copy(buffer, b.buf.Bytes())
+	return buffer
+}
+
+func (b *bufferState) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.writer.(*cancellableGzipWriter); ok {
+		return b.writer.(*cancellableGzipWriter).close()
+	}
+	return nil
+}
+
+// accept returns true if data is accepted by the buffer
+func (b *bufferState) accept(data []byte) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	_, err := b.writer.Write(data)
+	overCapacity := errors.Is(err, errOverCapacity)
+	bufLen := b.buf.Len()
+	if overCapacity {
+		bufLen += len(data)
+	}
+	if b.compressionAvailable && !b.compressionEnabled && bufLen > minCompressionLen {
+		// switch over to a zip buffer.
+		tmpBuf := bytes.NewBuffer(make([]byte, 0, b.bufferMaxLen+bufCapPadding))
+		writer := b.gzipWriterPool.Get().(*gzip.Writer)
+		writer.Reset(tmpBuf)
+		zipWriter := &cancellableGzipWriter{
+			innerBuffer: tmpBuf,
+			innerWriter: writer,
+			// 8 bytes required for the zip footer.
+			maxCapacity:    b.bufferMaxLen - 8,
+			gzipWriterPool: b.gzipWriterPool,
+		}
+
+		// the new data is so big, even with a zip writer, we are over the max limit.
+		// abandon and return false, so we can send what is already in our buffer.
+		if _, err2 := zipWriter.Write(b.buf.Bytes()); err2 != nil {
+			return false, err2
+		}
+		b.writer = zipWriter
+		b.buf = tmpBuf
+		b.compressionEnabled = true
+		// if the byte writer was over capacity, try to write the new entry in the zip writer:
+		if overCapacity {
+			if _, err2 := zipWriter.Write(data); err2 != nil {
+				return false, err2
+			}
+
+		}
+		return true, nil
+	}
+	if overCapacity {
+		return false, nil
+	}
+	return true, err
+}
+
+type cancellableBytesWriter struct {
+	innerWriter *bytes.Buffer
+	maxCapacity uint
+}
+
+func (c *cancellableBytesWriter) Write(b []byte) (int, error) {
+	if c.maxCapacity == 0 {
+		return c.innerWriter.Write(b)
+	}
+	if c.innerWriter.Len()+len(b) > int(c.maxCapacity) {
+		return 0, errOverCapacity
+	}
+	return c.innerWriter.Write(b)
+}
+
+type cancellableGzipWriter struct {
+	innerBuffer    *bytes.Buffer
+	innerWriter    *gzip.Writer
+	maxCapacity    uint
+	gzipWriterPool *sync.Pool
+	len            int
+}
+
+func (c *cancellableGzipWriter) Write(b []byte) (int, error) {
+	if c.maxCapacity == 0 {
+		return c.innerWriter.Write(b)
+	}
+	c.len += len(b)
+	// if we see that at a 50% compression rate, we'd be over max capacity, start flushing.
+	if (c.len / 2) > int(c.maxCapacity) {
+		// we flush so the length of the underlying buffer is accurate.
+		if err := c.innerWriter.Flush(); err != nil {
+			return 0, err
+		}
+	}
+	// we find that the new content uncompressed, added to our buffer, would overflow our max capacity.
+	if c.innerBuffer.Len()+len(b) > int(c.maxCapacity) {
+		// so we create a copy of our content and add this new data, compressed, to check that it fits.
+		copyBuf := bytes.NewBuffer(make([]byte, 0, c.maxCapacity+bufCapPadding))
+		copyBuf.Write(c.innerBuffer.Bytes())
+		writerCopy := c.gzipWriterPool.Get().(*gzip.Writer)
+		defer c.gzipWriterPool.Put(writerCopy)
+		writerCopy.Reset(copyBuf)
+		if _, err := writerCopy.Write(b); err != nil {
+			return 0, err
+		}
+		if err := writerCopy.Flush(); err != nil {
+			return 0, err
+		}
+		// we find that even compressed, the data overflows.
+		if copyBuf.Len() > int(c.maxCapacity) {
+			return 0, errOverCapacity
+		}
+	}
+	return c.innerWriter.Write(b)
+}
+
+func (c *cancellableGzipWriter) close() error {
+	err := c.innerWriter.Close()
+	c.gzipWriterPool.Put(c.innerWriter)
+	return err
+}
+
+// A guesstimated value > length of bytes of a single event.
+// Added to buffer capacity so that buffer is likely to grow by reslicing when buf.Len() > bufCap.
+const bufCapPadding = uint(4096)
+const libraryHeaderName = "X-Splunk-Instrumentation-Library"
+const profilingLibraryName = "otel.profiling"
+
+var profilingHeaders = map[string]string{
+	libraryHeaderName: profilingLibraryName,
+}
+
+func isProfilingData(sl plog.ScopeLogs) bool {
+	return sl.Scope().Name() == profilingLibraryName
+}
+
+func makeBlankBufferState(bufCap uint, compressionAvailable bool, pool *sync.Pool) *bufferState {
+	// Buffer of JSON encoded Splunk events, last record is expected to overflow bufCap, hence the padding
+	buf := bytes.NewBuffer(make([]byte, 0, bufCap+bufCapPadding))
+
+	return &bufferState{
+		compressionAvailable: compressionAvailable,
+		compressionEnabled:   false,
+		writer:               &cancellableBytesWriter{innerWriter: buf, maxCapacity: bufCap},
+		buf:                  buf,
+		bufferMaxLen:         bufCap,
+		bufFront:             nil, // Index of the log record of the first unsent event in buffer.
+		resource:             0,   // Index of currently processed Resource
+		library:              0,   // Index of currently processed Library
+		gzipWriterPool:       pool,
+		mu:                   sync.Mutex{},
+	}
+}

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"time"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtls"
@@ -44,6 +45,13 @@ type OtelToHecFields struct {
 	SeverityText string `mapstructure:"severity_text"`
 	// SeverityNumber informs the exporter to map the severity number field to a specific HEC field.
 	SeverityNumber string `mapstructure:"severity_number"`
+}
+
+type WorkerQueueConfig struct {
+	Worker   int           `mapstructure:"worker"`
+	Size     int           `mapstructure:"size"`
+	Retries  int           `mapstructure:"retries_count"`
+	Interval time.Duration `mapstructure:"retry_interval"`
 }
 
 // Config defines configuration for Splunk exporter.
@@ -111,6 +119,8 @@ type Config struct {
 
 	// HecHealthCheckEnabled can be used to verify Splunk HEC health on exporter's startup
 	HecHealthCheckEnabled bool `mapstructure:"health_check_enabled"`
+	// Internal worker queue for sending batches to splunk
+	WorkerQueueConfig WorkerQueueConfig `mapstructure:"worker_queue"`
 }
 
 func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -101,6 +101,12 @@ func TestLoadConfig(t *testing.T) {
 				},
 				HealthPath:            "/services/collector/health",
 				HecHealthCheckEnabled: false,
+				WorkerQueueConfig: WorkerQueueConfig{
+					Size:     10,
+					Worker:   5,
+					Retries:  5,
+					Interval: time.Minute,
+				},
 			},
 		},
 	}

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -87,6 +87,12 @@ func createDefaultConfig() component.Config {
 		},
 		HealthPath:            splunk.DefaultHealthPath,
 		HecHealthCheckEnabled: false,
+		WorkerQueueConfig: WorkerQueueConfig{
+			Size:     10,
+			Worker:   5,
+			Retries:  5,
+			Interval: time.Minute,
+		},
 	}
 }
 

--- a/exporter/splunkhecexporter/hec_worker.go
+++ b/exporter/splunkhecexporter/hec_worker.go
@@ -1,0 +1,71 @@
+package splunkhecexporter
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/multierr"
+)
+
+type hecWorker interface {
+	Send(context.Context, *request) error
+}
+
+type hecWorkerWithoutAck struct {
+	url     *url.URL
+	headers map[string]string
+	client  *http.Client
+}
+
+func newHecWorkerWithoutAck(config *Config, clientFunc func() *http.Client) *hecWorkerWithoutAck {
+	url, _ := config.getURL()
+	return &hecWorkerWithoutAck{
+		client:  clientFunc(),
+		headers: buildHttpHeaders(config),
+		url:     url,
+	}
+}
+
+func (hec *hecWorkerWithoutAck) Send(ctx context.Context, request *request) error {
+	req, err := http.NewRequestWithContext(ctx, "POST", hec.url.String(), bytes.NewBuffer(request.bytes))
+	if err != nil {
+		return consumererror.NewPermanent(err)
+	}
+	req.ContentLength = int64(len(request.bytes))
+
+	// Set the headers configured for the client
+	for k, v := range hec.headers {
+		req.Header.Set(k, v)
+	}
+
+	// Set extra headers passed by the caller
+	for k, v := range request.localHeaders {
+		req.Header.Set(k, v)
+	}
+
+	if request.compressionEnabled {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
+
+	resp, err := hec.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	err = splunk.HandleHTTPCode(resp)
+	if err != nil {
+		return err
+	}
+
+	_, errCopy := io.Copy(io.Discard, resp.Body)
+	return multierr.Combine(err, errCopy)
+}
+
+var _ hecWorker = &hecWorkerWithoutAck{}

--- a/exporter/splunkhecexporter/hec_worker_test.go
+++ b/exporter/splunkhecexporter/hec_worker_test.go
@@ -1,0 +1,45 @@
+package splunkhecexporter
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO: move this test to hecWorker
+func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
+	worker := &hecWorkerWithoutAck{
+		url:     &url.URL{Scheme: "http", Host: "splunk"},
+		headers: map[string]string{},
+	}
+
+	responseBody := `some error occurred`
+
+	// An HTTP client that returns status code 400 and response body responseBody.
+	worker.client, _ = newTestClient(400, responseBody)
+	request := &request{
+		bytes:              []byte("request body"),
+		compressionEnabled: false,
+		localHeaders:       map[string]string{},
+	}
+	// Sending logs using the client.
+	err := worker.Send(context.Background(), request)
+	// TODO: Uncomment after consumererror.Logs implements method Unwrap.
+	// require.True(t, consumererror.IsPermanent(err), "Expecting permanent error")
+	require.Contains(t, err.Error(), "HTTP/0.0 400")
+	// The returned error should contain the response body responseBody.
+	assert.Contains(t, err.Error(), responseBody)
+
+	// An HTTP client that returns some other status code other than 400 and response body responseBody.
+	worker.client, _ = newTestClient(500, responseBody)
+	// Sending logs using the client.
+	err = worker.Send(context.Background(), request)
+	// TODO: Uncomment after consumererror.Logs implements method Unwrap.
+	// require.False(t, consumererror.IsPermanent(err), "Expecting non-permanent error")
+	require.Contains(t, err.Error(), "HTTP 500")
+	// The returned error should not contain the response body responseBody.
+	assert.NotContains(t, err.Error(), responseBody)
+}

--- a/exporter/splunkhecexporter/worker_queue.go
+++ b/exporter/splunkhecexporter/worker_queue.go
@@ -1,0 +1,121 @@
+package splunkhecexporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+var errSendingQueueIsFull = errors.New("worker_queue is full")
+
+type request struct {
+	bytes              []byte
+	localHeaders       map[string]string
+	compressionEnabled bool
+}
+
+type WorkerQueue interface {
+	Start() error
+	Stop() error
+	Produce(*bufferState, map[string]string) error
+}
+
+type workerQueue struct {
+	config  *Config
+	workers []hecWorker
+	queue   chan *request
+	wg      sync.WaitGroup
+	logger  *zap.Logger
+}
+
+func newWorkerQueue(config *Config, logger *zap.Logger, clientFunc func() *http.Client) *workerQueue {
+
+	workers := make([]hecWorker, 0, config.WorkerQueueConfig.Worker)
+	for i := 0; i < config.WorkerQueueConfig.Worker; i++ {
+		workers = append(workers, newHecWorkerWithoutAck(config, clientFunc))
+	}
+	queue := make(chan *request, config.WorkerQueueConfig.Size)
+
+	return &workerQueue{
+		config:  config,
+		workers: workers,
+		queue:   queue,
+	}
+}
+
+func (l *workerQueue) Start() error {
+	if l == nil {
+		return fmt.Errorf("uninitialised worker queue")
+	}
+	l.wg.Add(l.config.WorkerQueueConfig.Worker)
+	for _, worker := range l.workers {
+		go l.consume(worker)
+	}
+	return nil
+}
+
+func (l *workerQueue) consume(worker hecWorker) {
+	defer l.wg.Done()
+CONSUMER_LOOP:
+	for request := range l.queue {
+		if !l.config.RetrySettings.Enabled {
+			if err := worker.Send(context.Background(), request); err != nil {
+				l.logger.Error("Failed to send data to splunk", zap.Error(err))
+				continue
+			}
+		}
+
+		var err error
+		for i := 0; i < l.config.WorkerQueueConfig.Retries; i++ {
+			err = worker.Send(context.Background(), request)
+			if err == nil {
+				continue CONSUMER_LOOP
+			}
+			l.logger.Error("Unable to send data to Splunk", zap.Error(err), zap.Int("Retry attempt", i+1))
+			if i < l.config.WorkerQueueConfig.Retries {
+				time.Sleep(l.config.WorkerQueueConfig.Interval)
+			}
+		}
+		l.logger.Error("Finished retrying and dropping events", zap.Error(err))
+
+	}
+}
+
+func requestFrom(bufState *bufferState, headers map[string]string) (*request, error) {
+	if err := bufState.Close(); err != nil {
+		return nil, err
+	}
+
+	return &request{
+		bytes:              bufState.copyBuffer(),
+		localHeaders:       headers,
+		compressionEnabled: bufState.compressionEnabled,
+	}, nil
+
+}
+
+func (l *workerQueue) Produce(bufState *bufferState, headers map[string]string) error {
+	request, err := requestFrom(bufState, headers)
+	if err != nil {
+		return err
+	}
+	select {
+	case l.queue <- request:
+	default:
+		err = errSendingQueueIsFull
+	}
+	return err
+}
+
+func (l *workerQueue) Stop() error {
+	close(l.queue)
+	l.wg.Wait()
+	return nil
+}
+
+var _ *workerQueue = &workerQueue{}

--- a/exporter/splunkhecexporter/worker_queue_test.go
+++ b/exporter/splunkhecexporter/worker_queue_test.go
@@ -1,0 +1,40 @@
+package splunkhecexporter
+
+import (
+	"fmt"
+	"sync"
+)
+
+type mockWorkerQueue struct {
+	produceResult []error
+	current       int
+	mu            *sync.Mutex
+}
+
+func newMockWorkerQueue(result ...error) *mockWorkerQueue {
+	return &mockWorkerQueue{
+		produceResult: result,
+		current:       0,
+		mu:            &sync.Mutex{},
+	}
+}
+
+func (mock *mockWorkerQueue) Start() error {
+	return nil
+}
+
+func (mock *mockWorkerQueue) Stop() error {
+	return nil
+}
+
+func (mock *mockWorkerQueue) Produce(*bufferState, map[string]string) error {
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	mock.current++
+	if mock.current > len(mock.produceResult) {
+		panic(fmt.Sprintf("mockWorkerQueue.Produce was called more than %d times", len(mock.produceResult)))
+	}
+	return mock.produceResult[mock.current-1]
+}
+
+var _ WorkerQueue = &mockWorkerQueue{}


### PR DESCRIPTION
**Description:** 
This is an early draft to isolate batching the HEC event and sending it to splunk. 

Current Implementation
![image](https://user-images.githubusercontent.com/89519921/206454896-34f2619d-b458-44ef-947d-95c274782aa9.png)

Suggested Implementation
![image](https://user-images.githubusercontent.com/89519921/206454927-86517c05-1f07-476f-973c-6f49eca68ff4.png)

The suggested approach has some advantages, like:
- It will not have the overhead recreating sub log or sub metric in case of failure when sending events to splunk (unless the worker queue is full)
- All events will be marshalled and compressed only once (unless worker queue is full)
- It makes it easier to add support for [HEC Indexer Acknowledgement](https://docs.splunk.com/Documentation/Splunk/9.0.1/Data/AboutHECIDXAck) since batching and sending are running on separate go routines, ack check can be done asynchronously. 
