### PR TITLE
[WIP] Testbed network usage reporting, new OTLP-gRPC compression settings test cases

### DIFF
--- a/testbed/datasenders/carbon.go
+++ b/testbed/datasenders/carbon.go
@@ -20,10 +20,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
@@ -57,10 +55,8 @@ func (cs *CarbonDataSender) Start() error {
 		Endpoint:         cs.GetEndpoint().String(),
 		Timeout:          5 * time.Second,
 	}
-	params := componenttest.NewNopExporterCreateSettings()
-	params.Logger = zap.L()
 
-	exporter, err := factory.CreateMetricsExporter(context.Background(), params, cfg)
+	exporter, err := factory.CreateMetricsExporter(context.Background(), testbed.ExporterCreateSettings(), cfg)
 	if err != nil {
 		return err
 	}

--- a/testbed/datasenders/jaeger.go
+++ b/testbed/datasenders/jaeger.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
@@ -55,10 +54,8 @@ func (je *jaegerGRPCDataSender) Start() error {
 	cfg.TLSSetting = configtls.TLSClientSetting{
 		Insecure: true,
 	}
-	params := componenttest.NewNopExporterCreateSettings()
-	params.Logger = zap.L()
 
-	exp, err := factory.CreateTracesExporter(context.Background(), params, cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), testbed.ExporterCreateSettings(), cfg)
 	if err != nil {
 		return err
 	}

--- a/testbed/datasenders/opencensus.go
+++ b/testbed/datasenders/opencensus.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
@@ -72,10 +71,8 @@ func NewOCTraceDataSender(host string, port int) testbed.TraceDataSender {
 func (ote *ocTracesDataSender) Start() error {
 	factory := opencensusexporter.NewFactory()
 	cfg := ote.fillConfig(factory.CreateDefaultConfig().(*opencensusexporter.Config))
-	params := componenttest.NewNopExporterCreateSettings()
-	params.Logger = zap.L()
 
-	exp, err := factory.CreateTracesExporter(context.Background(), params, cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), testbed.ExporterCreateSettings(), cfg)
 	if err != nil {
 		return err
 	}
@@ -106,10 +103,8 @@ func NewOCMetricDataSender(host string, port int) testbed.MetricDataSender {
 func (ome *ocMetricsDataSender) Start() error {
 	factory := opencensusexporter.NewFactory()
 	cfg := ome.fillConfig(factory.CreateDefaultConfig().(*opencensusexporter.Config))
-	params := componenttest.NewNopExporterCreateSettings()
-	params.Logger = zap.L()
 
-	exp, err := factory.CreateMetricsExporter(context.Background(), params, cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), testbed.ExporterCreateSettings(), cfg)
 	if err != nil {
 		return err
 	}

--- a/testbed/datasenders/prometheus.go
+++ b/testbed/datasenders/prometheus.go
@@ -20,7 +20,6 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
@@ -48,10 +47,8 @@ func (pds *prometheusDataSender) Start() error {
 	cfg := factory.CreateDefaultConfig().(*prometheusexporter.Config)
 	cfg.Endpoint = pds.GetEndpoint().String()
 	cfg.Namespace = pds.namespace
-	params := componenttest.NewNopExporterCreateSettings()
-	params.Logger = zap.L()
 
-	exp, err := factory.CreateMetricsExporter(context.Background(), params, cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), testbed.ExporterCreateSettings(), cfg)
 	if err != nil {
 		return err
 	}

--- a/testbed/datasenders/sapm.go
+++ b/testbed/datasenders/sapm.go
@@ -19,10 +19,8 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
@@ -57,10 +55,8 @@ func (je *SapmDataSender) Start() error {
 		DisableCompression: true,
 		AccessToken:        "MyToken",
 	}
-	params := componenttest.NewNopExporterCreateSettings()
-	params.Logger = zap.L()
 
-	exporter, err := factory.CreateTracesExporter(context.Background(), params, cfg)
+	exporter, err := factory.CreateTracesExporter(context.Background(), testbed.ExporterCreateSettings(), cfg)
 	if err != nil {
 		return err
 	}

--- a/testbed/datasenders/signalfx.go
+++ b/testbed/datasenders/signalfx.go
@@ -19,10 +19,8 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
@@ -57,10 +55,8 @@ func (sf *SFxMetricsDataSender) Start() error {
 		APIURL:           "http://127.0.0.1",
 		AccessToken:      "access_token",
 	}
-	params := componenttest.NewNopExporterCreateSettings()
-	params.Logger = zap.L()
 
-	exporter, err := factory.CreateMetricsExporter(context.Background(), params, cfg)
+	exporter, err := factory.CreateMetricsExporter(context.Background(), testbed.ExporterCreateSettings(), cfg)
 	if err != nil {
 		return err
 	}

--- a/testbed/datasenders/zipkin.go
+++ b/testbed/datasenders/zipkin.go
@@ -20,7 +20,6 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
@@ -51,10 +50,8 @@ func (zs *zipkinDataSender) Start() error {
 	cfg.RetrySettings.Enabled = false
 	// Disable sending queue, we should push data from the caller goroutine.
 	cfg.QueueSettings.Enabled = false
-	params := componenttest.NewNopExporterCreateSettings()
-	params.Logger = zap.L()
 
-	exp, err := factory.CreateTracesExporter(context.Background(), params, cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), testbed.ExporterCreateSettings(), cfg)
 	if err != nil {
 		return err
 	}

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.66.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.66.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatareceivers/mockawsxrayreceiver v0.66.0
+	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.37.0
 	github.com/prometheus/prometheus v0.39.1
 	github.com/shirou/gopsutil/v3 v3.22.10
@@ -170,7 +171,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/prometheus/statsd_exporter v0.22.7 // indirect

--- a/testbed/testbed/options.go
+++ b/testbed/testbed/options.go
@@ -77,3 +77,14 @@ func WithResourceLimits(resourceSpec ResourceSpec) TestCaseOption {
 		}
 	}
 }
+
+// WithMetricsPort allows allows the testbed to gather obsreport
+// metrics from the system under test.  The same portt should have
+// been configured in the agent's test config.yaml.  If this option is
+// not used, the testbed skips reporting MiB/sec transfered and
+// compression ratios.
+func WithMetricsPort(port int) TestCaseOption {
+	return func(tc *TestCase) {
+		tc.metricsPort = port
+	}
+}

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -69,6 +69,8 @@ func (v *PerfTestValidator) RecordResults(tc *TestCase) {
 		cpuPercentageMax:  rc.CPUPercentMax,
 		ramMibAvg:         rc.RAMMiBAvg,
 		ramMibMax:         rc.RAMMiBMax,
+		exported:          tc.exporterStats,
+		received:          tc.receiverStats,
 		errorCause:        tc.errorCause,
 	})
 }

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -39,7 +39,7 @@ func TestIdleMode(t *testing.T) {
 
 	sender := testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t))
 	receiver := testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t))
-	cfg := createConfigYaml(t, sender, receiver, resultDir, nil, nil)
+	cfg, metricsPort := createConfigYaml(t, sender, receiver, resultDir, nil, nil)
 	cp := testbed.NewChildProcessCollector()
 	cleanup, err := cp.PrepareConfig(cfg)
 	require.NoError(t, err)
@@ -54,6 +54,7 @@ func TestIdleMode(t *testing.T) {
 		&testbed.PerfTestValidator{},
 		performanceResultsSummary,
 		testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 20, ExpectedMaxRAM: 83}),
+		testbed.WithMetricsPort(metricsPort),
 	)
 	tc.StartAgent()
 
@@ -86,7 +87,7 @@ func TestBallastMemory(t *testing.T) {
 		t.Run(fmt.Sprintf("ballast-size-%d", test.ballastSize), func(t *testing.T) {
 			sender := testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t))
 			receiver := testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t))
-			ballastCfg := createConfigYaml(
+			ballastCfg, metricsPort := createConfigYaml(
 				t, sender, receiver, resultDir, nil,
 				map[string]string{"memory_ballast": fmt.Sprintf(ballastConfig, test.ballastSize)})
 			cp := testbed.NewChildProcessCollector()
@@ -108,6 +109,7 @@ func TestBallastMemory(t *testing.T) {
 						MaxConsecutiveFailures: 5,
 					},
 				),
+				testbed.WithMetricsPort(metricsPort),
 			)
 			tc.StartAgent()
 

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -127,7 +127,7 @@ func TestMetricsFromFile(t *testing.T) {
 	sender := testbed.NewOTLPMetricDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t))
 	receiver := testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t))
 
-	configStr := createConfigYaml(t, sender, receiver, resultDir, nil, nil)
+	configStr, metricsPort := createConfigYaml(t, sender, receiver, resultDir, nil, nil)
 	configCleanup, err := agentProc.PrepareConfig(configStr)
 	require.NoError(t, err)
 	defer configCleanup()
@@ -141,6 +141,7 @@ func TestMetricsFromFile(t *testing.T) {
 		&testbed.PerfTestValidator{},
 		performanceResultsSummary,
 		testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 120, ExpectedMaxRAM: 110}),
+		testbed.WithMetricsPort(metricsPort),
 	)
 	defer tc.Stop()
 

--- a/testbed/tests/resource_processor_test.go
+++ b/testbed/tests/resource_processor_test.go
@@ -122,7 +122,7 @@ func TestMetricResourceProcessor(t *testing.T) {
 			processors := map[string]string{
 				"resource": test.resourceProcessorConfig,
 			}
-			configStr := createConfigYaml(t, sender, receiver, resultDir, processors, nil)
+			configStr, metricsPort := createConfigYaml(t, sender, receiver, resultDir, processors, nil)
 			configCleanup, err := agentProc.PrepareConfig(configStr)
 			require.NoError(t, err)
 			defer configCleanup()
@@ -137,6 +137,7 @@ func TestMetricResourceProcessor(t *testing.T) {
 				agentProc,
 				&testbed.PerfTestValidator{},
 				performanceResultsSummary,
+				testbed.WithMetricsPort(metricsPort),
 			)
 			defer tc.Stop()
 


### PR DESCRIPTION
**Description:**

Adds optional support to the testbed for scraping the /metrics endpoint of the collector under test. Coupled with proposed [obsreport metrics support](https://github.com/open-telemetry/opentelemetry-collector/pull/6712), this change reports on the compression performance and network bandwidth used.

Depends on https://github.com/open-telemetry/opentelemetry-collector/pull/6712.

Also: this code looks to be in need of some maintenance. I removed a repetitive bit of code used in every test while I was applying the same fix to the OTLP test sender/receiver. See the new `ExporterCreateSettings()` helper.

**Link to tracking Issue:** 

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/6638.

**Testing:** 

Ran the standard testbed tests, with output for the OTLP-* cases (including gRPC which is instrumented and HTTP which is not):

```
Test                                    |Result|Duration|CPU Avg%|CPU Max%|RAM Avg MiB|RAM Max MiB|Sent Items|Received Items|MiB/sec in  |MiB/sec out |I/O Comp    |In Comp     |Out Comp    
----------------------------------------|------|-------:|-------:|-------:|----------:|----------:|---------:|-------------:|-----------:|-----------:|-----------:|-----------:|----------:|
Trace10kSPS/OTLP-gRPC-gzipIn-plainOut   |PASS  |     15s|     5.5|     8.2|         54|         78|    150000|        150000|      1.2876|     21.4445|     16.1002|      0.0600|      1.0000|            
Trace10kSPS/OTLP-gRPC-plainIn-plainOut  |PASS  |     15s|     4.4|     5.8|         47|         67|    150000|        150000|     21.4513|     21.4445|      0.9992|      1.0003|      1.0000|            
Trace10kSPS/OTLP-gRPC-gzipIn-gzipOut    |PASS  |     16s|     6.1|     7.6|         54|         77|    150000|        150000|      1.2862|      1.0411|      0.7841|      0.0600|      0.0485|            
Trace10kSPS/OTLP-gRPC-plainIn-gzipOut   |PASS  |     15s|     5.5|     7.0|         53|         76|    149900|        149900|     21.4370|      1.0424|      0.0487|      1.0003|      0.0486|            
Trace10kSPS/OTLP-gRPC-plainIn-zstdOut   |PASS  |     15s|     4.3|     6.6|         97|        161|    150000|        150000|     21.4513|      0.6824|      0.0319|      1.0003|      0.0318|            
Trace10kSPS/OTLP-gRPC-gzipIn-zstdOut    |PASS  |     15s|     5.3|     7.4|        104|        171|    149900|        149900|      1.2880|      0.6842|      0.5146|      0.0601|      0.0319|            
Trace10kSPS/OTLP-HTTP                   |PASS  |     15s|     4.4|     5.8|         47|         66|    149900|        149900|            |            |            |            |            |            
Trace10kSPS/OTLP-HTTP-gzip              |PASS  |     15s|     5.7|     7.5|         48|         68|    150000|        150000|            |            |            |            |            |            
```

