### PR TITLE
[receiver/postgresql] Fix issue with postgresql query for pg_stat_replication

### DIFF
--- a/.chloggen/postgresql-wal-lag-coalesce-fix.yaml
+++ b/.chloggen/postgresql-wal-lag-coalesce-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where WAL stats query was incorrectly coalescing intervals.
+
+# One or more tracking issues related to the change
+issues: [16769]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -458,9 +458,9 @@ func (c *postgreSQLClient) getReplicationStats(ctx context.Context) ([]replicati
 	query := `SELECT
 	client_addr,
 	coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn), -1) AS replication_bytes_pending,
-	coalesce(write_lag, -1),
-	coalesce(flush_lag, -1),
-	coalesce(replay_lag, -1)
+	extract('epoch' from coalesce(write_lag, '-1 seconds')),
+	extract('epoch' from coalesce(flush_lag, '-1 seconds')),
+	extract('epoch' from coalesce(replay_lag, '-1 seconds'))
 	FROM pg_stat_replication;
 	`
 	rows, err := c.client.QueryContext(ctx, query)


### PR DESCRIPTION
**Description:** Fixes a bug where the postgresql query for replication data had incorrect `coalesce` calls combining `interval` and `integer` data types.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16769

**Testing:** Tested locally against a different table with interval types, but do not have capacity to set up a postgresql replication system to validate right now.