### PR TITLE
[receiver/mongodbreceiver] remove deprecated io/ioutil for golang

### DIFF
--- a/receiver/mongodbatlasreceiver/alerts_integration_test.go
+++ b/receiver/mongodbatlasreceiver/alerts_integration_test.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -198,7 +197,7 @@ func TestAtlasPoll(t *testing.T) {
 
 	alerts := []mongodbatlas.Alert{}
 	for _, pl := range testPayloads {
-		payloadFile, err := ioutil.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", pl))
+		payloadFile, err := os.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", pl))
 		require.NoError(t, err)
 
 		alert := mongodbatlas.Alert{}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The `io/ioutil` has been deprecated for golang since 1.16
https://go.dev/doc/go1.16#ioutil

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>