### PR TITLE
[receiver/splunkhec] remove path config key

### DIFF
--- a/.chloggen/delete-splunkhecreceiver-path.yaml
+++ b/.chloggen/delete-splunkhecreceiver-path.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Delete the `path` key which is no longer in use and has been deprecated since September 2021.
+
+# One or more tracking issues related to the change
+issues: [16999]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/splunkhecreceiver/config.go
+++ b/receiver/splunkhecreceiver/config.go
@@ -27,8 +27,6 @@ type Config struct {
 	confighttp.HTTPServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	splunk.AccessTokenPassthroughConfig `mapstructure:",squash"`
-	// Path was used to map the receiver to a specific subset of the path. Now ignored as we match all incoming requests.
-	Path string `mapstructure:"path"`
 	// RawPath for raw data collection, default is '/services/collector/raw'
 	RawPath string `mapstructure:"raw_path"`
 	// HealthPath for health API, default is '/services/collector/health'

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
@@ -78,10 +77,6 @@ func createMetricsReceiver(
 
 	rCfg := cfg.(*Config)
 
-	if rCfg.Path != "" {
-		params.Logger.Warn("splunk_hec receiver path is deprecated", zap.String("path", rCfg.Path))
-	}
-
 	return newMetricsReceiver(params, *rCfg, consumer)
 }
 
@@ -94,10 +89,6 @@ func createLogsReceiver(
 ) (receiver.Logs, error) {
 
 	rCfg := cfg.(*Config)
-
-	if rCfg.Path != "" {
-		params.Logger.Warn("splunk_hec receiver path is deprecated", zap.String("path", rCfg.Path))
-	}
 
 	return newLogsReceiver(params, *rCfg, consumer)
 }


### PR DESCRIPTION
**Description:**
Delete the `path` key which is no longer in use and has been deprecated since September 2021.

This is reported as a breaking change.

**Link to tracking Issue:**
#16999

**Testing:**
N/A

**Documentation:**
N/A