### PR TITLE
processor/datadogprocessor: pick any "datadog" exporter if not ambiguous

### DIFF
--- a/processor/datadogprocessor/config.go
+++ b/processor/datadogprocessor/config.go
@@ -30,6 +30,10 @@ type Config struct {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		MetricsExporter: component.NewID(component.Type("datadog")),
+		MetricsExporter: datadogComponent,
 	}
 }
+
+// datadogComponent defines the default component that will be used for
+// exporting metrics.
+var datadogComponent = component.NewID(component.Type("datadog"))


### PR DESCRIPTION
The processor now chooses any "datadog" type metrics exporter as long as there is only one. Additionally, ensure `go test -race` passes.