### PR TITLE
[exporter/humio] deprecate humioexporter

### DIFF
--- a/.chloggen/mark-humio-as-obsolete.yaml
+++ b/.chloggen/mark-humio-as-obsolete.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: humioexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Humio now known as LogScale beginning with version 1.68 supports OTLP using HTTP and no longer requires a product specific exporter.
+
+# One or more tracking issues related to the change
+issues: [17013]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:  See https://library.humio.com/humio-server/endpoints.html

--- a/exporter/humioexporter/README.md
+++ b/exporter/humioexporter/README.md
@@ -1,12 +1,16 @@
-# Humio Exporter
+# Deprecated Humio Exporter
 
-| Status                   |           |
-| ------------------------ |-----------|
-| Stability                | [beta]    |
-| Supported pipeline types | traces    |
-| Distributions            | [contrib] |
+| Status                   |              |
+|--------------------------|--------------|
+| Stability                | [deprecated] |
+| Supported pipeline types | traces       |
+| Distributions            | [contrib]    |
 
 Exports data to Humio using JSON over the HTTP [Ingest API](https://library.humio.com/humio-server/api-ingest.html).
+
+**Humio now known as LogScale beginning with version 1.68 supports OTLP using HTTP and no longer requires a product specific exporter.**
+
+See [#17013](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17013) for more information.
 
 ## Getting Started
 
@@ -145,6 +149,6 @@ curl $YOUR_HUMIO_URL/api/v1/repositories/$REPOSITORY_NAME/taggrouping \
   -d '[ {"field": "trace_id","modulus": 16} ]'
 ```
 
-[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
+[deprecated]:https://github.com/open-telemetry/opentelemetry-collector#deprecated
 
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/humioexporter/factory.go
+++ b/exporter/humioexporter/factory.go
@@ -29,7 +29,7 @@ const (
 	// The key used to refer to this exporter
 	typeStr = "humio"
 	// The stability level of the exporter.
-	stability = component.StabilityLevelBeta
+	stability = component.StabilityLevelDeprecated
 )
 
 // NewFactory creates an exporter factory for Humio

--- a/exporter/humioexporter/go.mod
+++ b/exporter/humioexporter/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: humio exporter is deprecated and will be removed in future versions.
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/humioexporter
 
 go 1.18


### PR DESCRIPTION
**Description:** 
Humio now known as LogScale beginning with version 1.68 supports OTLP using HTTP and no longer requires a product specific exporter. See https://library.humio.com/humio-server/endpoints.html for more information.

**Link to tracking Issue:**
#17013

**Testing:**
N/A

**Documentation:**
Updated README and factory.go.