### PR TITLE
[bug]? fix host metrics config test error comparison

### DIFF
--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -109,7 +109,7 @@ func TestLoadInvalidConfig_NoScrapers(t *testing.T) {
 	factories.Receivers[typeStr] = factory
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-noscrapers.yaml"), factories)
 
-	require.Contains(t, err.Error(), "receiver \"hostmetrics\" has invalid configuration: must specify at least one scraper when using hostmetrics receiver")
+	require.Contains(t, err.Error(), "must specify at least one scraper when using hostmetrics receiver")
 }
 
 func TestLoadInvalidConfig_InvalidScraperKey(t *testing.T) {


### PR DESCRIPTION
**Description:** 
Might just be on my machines (ubuntu and arch), but I get the following error when running `make gotest`

```
Running target 'test' in module 'receiver/hostmetricsreceiver' as part of group 'all'
make -C receiver/hostmetricsreceiver test
make[2]: Entering directory '/home/jameshughes/workspace/unison/otel-github/opentelemetry-collector-contrib/receiver/hostmetricsreceiver'
if [ "" = "true" ]; then \
        go test -race -timeout 300s --tags="" -v ./... 2>&1 | tee -a ./foresight-test-report.txt; \
else \
        go test -race -timeout 300s --tags="" ./...; \
fi
--- FAIL: TestLoadInvalidConfig_NoScrapers (0.00s)
    config_test.go:112:
                Error Trace:    /home/jameshughes/workspace/unison/otel-github/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/config_test.go:112
                Error:          "receivers::hostmetrics: must specify at least one scraper when using hostmetrics receiver" does not contain "receiver \"hostmetrics\" has invalid configuration: must specify at least one scraper when using hostmetrics receiver"
                Test:           TestLoadInvalidConfig_NoScrapers
FAIL
FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver  0.921s
```
Note that `receivers::hostmetrics: must...` differs from the expected `receiver "hostmetrics" has invalid configuration: must...`

**Testing:** `make gotest GROUP=receiver-0` clears this particular error, but I'm still getting others (likely because I don't have a swap file on either machine I'm testing on)