### PR TITLE
[pkg/ottl] support substring function

### DIFF
--- a/.chloggen/support_substring_func.yaml
+++ b/.chloggen/support_substring_func.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add substring Converter, returns a substring from the given start index to the specified length.
+
+# One or more tracking issues related to the change
+issues: [17038]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -42,6 +42,7 @@ List of available Converters:
 - [SpanID](#spanid)
 - [Split](#split)
 - [TraceID](#traceid)
+- [Substring](#substring)
 
 ### Concat
 
@@ -197,6 +198,20 @@ The `TraceID` factory function returns a `pdata.TraceID` struct from the given b
 Examples:
 
 - `TraceID(0x00000000000000000000000000000000)`
+
+### Substring
+
+`Substring(target, start, length)`
+
+The `Substring` Converter returns a substring from the given start index to the specified length.
+
+`target` is a string. `start` and `length` are `int64`.
+
+The `Substring` Converter will return `nil` if the given parameters are invalid, e.x. `target` is not a string, or the start/length exceed the length of the `target` string.
+
+Examples:
+
+- `Substring("123456789", 0, 3)`
 
 ### delete_key
 

--- a/pkg/ottl/ottlfuncs/func_substring.go
+++ b/pkg/ottl/ottlfuncs/func_substring.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Substring[K any](target ottl.Getter[K], start int64, length int64) (ottl.ExprFunc[K], error) {
+	if start < 0 {
+		return nil, fmt.Errorf("invalid start for substring function, %d cannot be negative", start)
+	}
+	if length <= 0 {
+		return nil, fmt.Errorf("invalid length for substring function, %d cannot be negative or zero", length)
+	}
+
+	return func(ctx context.Context, tCtx K) (interface{}, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		if valStr, ok := val.(string); ok {
+			if (start + length) > int64(len(valStr)) {
+				return nil, fmt.Errorf("invalid range for substring function, %d cannot be greater than the length of target string(%d)", start+length, len(valStr))
+			}
+			return valStr[start : start+length], nil
+		}
+		return nil, nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -1,0 +1,161 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_substring(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   ottl.Getter[interface{}]
+		start    int64
+		length   int64
+		expected interface{}
+	}{
+		{
+			name: "substring",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "123456789", nil
+				},
+			},
+			start:    3,
+			length:   3,
+			expected: "456",
+		},
+		{
+			name: "substring with result of total string",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "123456789", nil
+				},
+			},
+			start:    0,
+			length:   9,
+			expected: "123456789",
+		},
+		{
+			name: "substring non-string",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return 123456789, nil
+				},
+			},
+			start:  3,
+			length: 6,
+		},
+		{
+			name: "substring nil string",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			start:  3,
+			length: 6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := Substring(tt.target, tt.start, tt.length)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_substring_validation(t *testing.T) {
+	tests := []struct {
+		name   string
+		target ottl.Getter[interface{}]
+		start  int64
+		length int64
+	}{
+		{
+			name: "substring with result of empty string",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "123456789", nil
+				},
+			},
+			start:  0,
+			length: 0,
+		},
+		{
+			name: "substring with invalid start index",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "123456789", nil
+				},
+			},
+			start:  -1,
+			length: 6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Substring(tt.target, tt.start, tt.length)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func Test_substring_error(t *testing.T) {
+	tests := []struct {
+		name   string
+		target ottl.Getter[interface{}]
+		start  int64
+		length int64
+	}{
+		{
+			name: "substring empty string",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "", nil
+				},
+			},
+			start:  3,
+			length: 6,
+		},
+		{
+			name: "substring with invalid length index",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "123456789", nil
+				},
+			},
+			start:  3,
+			length: 20,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := Substring(tt.target, tt.start, tt.length)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			assert.Error(t, err)
+			assert.Equal(t, nil, result)
+		})
+	}
+}


### PR DESCRIPTION
**Description:**
Add substring Converter, returns a substring from the given start index to the specified length.

**Link to tracking Issue:** 
#17038 

**Testing:** <Describe what testing was performed and which tests were added.>
Updated unit tests.

**Documentation:** <Describe the documentation added.>
Add the `Substring` function usage in the `README` of `pkg/ottl`