### PR TITLE
[chore] Disable foresight reports in tests

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -55,30 +55,18 @@ common: checklicense impi lint misspell
 
 .PHONY: test
 test:
-	if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
-		$(GOTEST) $(GOTEST_OPT) -v ./... 2>&1 | tee -a ./foresight-test-report.txt; \
-	else \
-		$(GOTEST) $(GOTEST_OPT) ./...; \
-	fi
-	
+	$(GOTEST) $(GOTEST_OPT) ./...
+
 .PHONY: do-unit-tests-with-cover
 do-unit-tests-with-cover:
 	@echo "running $(GOCMD) unit test ./... + coverage in `pwd`"
-	@if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
-		$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) -v ./... 2>&1 | tee -a ./foresight-test-report-unit-tests-with-cover.txt; \
-	else \
-		$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./...; \
-	fi
+	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./...
 	$(GOCMD) tool cover -html=coverage.txt -o coverage.html
 
 .PHONY: do-integration-tests-with-cover
 do-integration-tests-with-cover:
 	@echo "running $(GOCMD) integration test ./... + coverage in `pwd`"
-	@if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
-		$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) -v ./... 2>&1 | tee -a ./foresight-test-report-integration-tests-with-cover.txt; \
-	else \
-		$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) ./...; \
-	fi
+	$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) ./...
 	@if [ -e integration-coverage.txt ]; then \
   		$(GOCMD) tool cover -html=integration-coverage.txt -o integration-coverage.html; \
   	fi


### PR DESCRIPTION
This PR is just to uncover all unit tests that have not been reported due to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17037 