### PR TITLE
[receiver/elasticsearch]: change feature gates for cluster health and index operations to beta

### DIFF
--- a/.chloggen/elastic-v0680-feature-gates.yaml
+++ b/.chloggen/elastic-v0680-feature-gates.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: change feature gates for cluster health and index operations to beta
+
+# One or more tracking issues related to the change
+issues: [14635]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -60,18 +60,18 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 See the [Collector feature gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md#collector-feature-gates) for an overview of feature gates in the collector.
 
-**ALPHA**: `receiver.elasticsearch.emitClusterHealthDetailedShardMetrics`
+**BETA**: `receiver.elasticsearch.emitClusterHealthDetailedShardMetrics`
 
 The feature gate `receiver.elasticsearch.emitClusterHealthDetailedShardMetrics` once enabled starts emitting the metric `elasticsearch.cluster.shards`
 with two additional data points - one with `state` equal to `active_primary` and one with `state` equal to `unassigned_delayed`.
 
 This is considered a breaking change for existing users of this receiver, and it is recommended to migrate to the new implementation when possible. Any new users planning to adopt this receiver should enable this feature gate to avoid having to migrate any visualisations or alerts.
 
-This feature gate will eventually be enabled by default, and eventually the old implementation will be removed. It aims
-to give users time to migrate to the new implementation. The target release for this featuregate to be enabled by default
-is 0.68.0.
+This feature gate is enabled by default, and eventually the old implementation will be removed. It aims
+to give users time to migrate to the new implementation. The target release for the old implementation to be removed
+is 0.71.0.
 
-**ALPHA**: `receiver.elasticsearch.emitAllIndexOperationMetrics`
+**BETA**: `receiver.elasticsearch.emitAllIndexOperationMetrics`
 
 The feature gate `receiver.elasticsearch.emitAllIndexOperationMetrics` once enabled starts emitting metrics `elasticsearch.index.operation.count`
 and `elasticsearch.index.operation.time` with all possible data points - for every possible operation type and both shard aggregation types.
@@ -80,9 +80,9 @@ Because of the amount of added data points, this change might affect performance
 It is recommended to migrate to the new implementation when possible.
 Any new users planning to adopt this receiver should enable this feature gate to avoid risking unexpected slowdowns.
 
-This feature gate will eventually be enabled by default, and eventually the old implementation will be removed. It aims
-to give users time to migrate to the new implementation. The target release for this featuregate to be enabled by default
-is 0.68.0.
+This feature gate is enabled by default, and eventually the old implementation will be removed. It aims
+to give users time to migrate to the new implementation. The target release for the old implementation to be removed
+is 0.71.0.
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/elasticsearchreceiver/integration_test.go
+++ b/receiver/elasticsearchreceiver/integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/comparetest"
@@ -57,6 +58,10 @@ var (
 )
 
 func TestElasticsearchIntegration(t *testing.T) {
+	// Let this test check if it works with the features disabled and the unit test will test the feature enabled.
+	err := featuregate.GetRegistry().Apply(map[string]bool{emitClusterHealthDetailedShardMetricsID: false, emitAllIndexOperationMetricsID: false})
+	require.NoError(t, err)
+
 	//Starts an elasticsearch docker container
 	t.Run("Running elasticsearch 7.9", func(t *testing.T) {
 		t.Parallel()

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -52,13 +52,13 @@ const (
 func init() {
 	featuregate.GetRegistry().MustRegisterID(
 		emitClusterHealthDetailedShardMetricsID,
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("When enabled, the elasticsearch.cluster.shards metric will be emitted with two more datapoints."),
 		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14635"),
 	)
 	featuregate.GetRegistry().MustRegisterID(
 		emitAllIndexOperationMetricsID,
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("When enabled, the elasticsearch.index.operation.* metrics will be emitted with all possible datapoints."),
 		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14635"),
 	)

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 
@@ -39,16 +38,6 @@ import (
 const fullExpectedMetricsPath = "./testdata/expected_metrics/full.json"
 const skipClusterExpectedMetricsPath = "./testdata/expected_metrics/clusterSkip.json"
 const noNodesExpectedMetricsPath = "./testdata/expected_metrics/noNodes.json"
-
-func TestMain(m *testing.M) {
-	// Enable the feature gates before all tests to avoid flaky tests.
-	_ = featuregate.GetRegistry().Apply(map[string]bool{
-		emitClusterHealthDetailedShardMetricsID: true,
-		emitAllIndexOperationMetricsID:          true,
-	})
-	code := m.Run()
-	os.Exit(code)
-}
 
 func TestScraper(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
**Description:** 
These feature gates have been introduced in `v0.65` and now should be in beta stage.
Ref PRs: #16170 #14875

**Link to tracking Issue:** #14635

**Testing:** 
unit, integration
I have noted that the integration tests were falsely positive when I tested them locally (ruining the result file by removing datapoints or even resources did not cause them to fail), hopefully this is only my local issue. I do not remember this happening before.

**Documentation:** 
Readme has changed.