### PR TITLE
[processor/datadog] Mark payloads for which stats have been computed

### DIFF
--- a/processor/datadogprocessor/agent.go
+++ b/processor/datadogprocessor/agent.go
@@ -146,12 +146,13 @@ func (p *traceagent) Ingest(ctx context.Context, traces ptrace.Traces) {
 	rspanss := traces.ResourceSpans()
 	for i := 0; i < rspanss.Len(); i++ {
 		rspans := rspanss.At(i)
-		// Stats will be computed for p. Mark the original resource spans to ensure that they don't
-		// get computed twice in case these spans pass through here again.
-		rspans.Resource().Attributes().PutBool(keyStatsComputed, true)
 		p.OTLPReceiver.ReceiveResourceSpans(ctx, rspans, http.Header{}, "datadogprocessor")
 		// ...the call transforms the OTLP Spans into a Datadog payload and sends the result
 		// down the p.pchan channel
+
+		// Stats will be computed for p. Mark the original resource spans to ensure that they don't
+		// get computed twice in case these spans pass through here again.
+		rspans.Resource().Attributes().PutBool(keyStatsComputed, true)
 	}
 }
 


### PR DESCRIPTION
**Description:** 

Counterpart to DataDog/datadog-agent/pull/14769.

**Link to tracking Issue:** Relates to #17045
