### PR TITLE
[chore] fix unittests in exporter/loadbalancing

### DIFF
--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -102,8 +102,7 @@ func (e *logExporterImp) consumeLog(ctx context.Context, ld plog.Logs) error {
 
 	le, ok := exp.(exporter.Logs)
 	if !ok {
-		expectType := (*exporter.Logs)(nil)
-		return fmt.Errorf("unable to export logs, unexpected exporter type: expected %T but got %T", expectType, exp)
+		return fmt.Errorf("unable to export logs, unexpected exporter type: expected exporter.Logs but got %T", exp)
 	}
 
 	start := time.Now()

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -195,7 +195,7 @@ func TestConsumeLogsUnexpectedExporterType(t *testing.T) {
 
 	// verify
 	assert.Error(t, res)
-	assert.EqualError(t, res, fmt.Sprintf("unable to export logs, unexpected exporter type: expected *exporter.Logs but got %T", newNopMockExporter()))
+	assert.EqualError(t, res, fmt.Sprintf("unable to export logs, unexpected exporter type: expected exporter.Logs but got %T", newNopMockExporter()))
 }
 
 func TestLogBatchWithTwoTraces(t *testing.T) {

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -114,8 +114,7 @@ func (e *traceExporterImp) consumeTrace(ctx context.Context, td ptrace.Traces) e
 
 		te, ok := exp.(exporter.Traces)
 		if !ok {
-			expectType := (*exporter.Traces)(nil)
-			return fmt.Errorf("expected %T but got %T", expectType, exp)
+			return fmt.Errorf("unable to export traces, unexpected exporter type: expected exporter.Traces but got %T", exp)
 		}
 
 		start := time.Now()

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -297,7 +297,7 @@ func TestConsumeTracesUnexpectedExporterType(t *testing.T) {
 
 	// verify
 	assert.Error(t, res)
-	assert.EqualError(t, res, fmt.Sprintf("expected *exporter.Traces but got %T", newNopMockExporter()))
+	assert.EqualError(t, res, fmt.Sprintf("unable to export traces, unexpected exporter type: expected exporter.Traces but got %T", newNopMockExporter()))
 }
 
 func TestBuildExporterConfig(t *testing.T) {


### PR DESCRIPTION
Alternative to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17049 since this is future proof. The other solution will break again when we remove the alias to the deprecated `component.TracesExporter`.

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17037