### PR TITLE
[exporter/loki] Add instrumentation scope to log object

### DIFF
--- a/.chloggen/loki-instrumentation-scope.yaml
+++ b/.chloggen/loki-instrumentation-scope.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/loki
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Added `InstrumentationScope` to log object"
+
+# One or more tracking issues related to the change
+issues: [16485]

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -142,8 +142,8 @@ func removeAttributes(attrs pcommon.Map, labels model.LabelSet) {
 	})
 }
 
-func convertLogToJSONEntry(lr plog.LogRecord, res pcommon.Resource) (*logproto.Entry, error) {
-	line, err := Encode(lr, res)
+func convertLogToJSONEntry(lr plog.LogRecord, res pcommon.Resource, scope pcommon.InstrumentationScope) (*logproto.Entry, error) {
+	line, err := Encode(lr, res, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +153,8 @@ func convertLogToJSONEntry(lr plog.LogRecord, res pcommon.Resource) (*logproto.E
 	}, nil
 }
 
-func convertLogToLogfmtEntry(lr plog.LogRecord, res pcommon.Resource) (*logproto.Entry, error) {
-	line, err := EncodeLogfmt(lr, res)
+func convertLogToLogfmtEntry(lr plog.LogRecord, res pcommon.Resource, scope pcommon.InstrumentationScope) (*logproto.Entry, error) {
+	line, err := EncodeLogfmt(lr, res, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -164,12 +164,12 @@ func convertLogToLogfmtEntry(lr plog.LogRecord, res pcommon.Resource) (*logproto
 	}, nil
 }
 
-func convertLogToLokiEntry(lr plog.LogRecord, res pcommon.Resource, format string) (*logproto.Entry, error) {
+func convertLogToLokiEntry(lr plog.LogRecord, res pcommon.Resource, format string, scope pcommon.InstrumentationScope) (*logproto.Entry, error) {
 	switch format {
 	case formatJSON:
-		return convertLogToJSONEntry(lr, res)
+		return convertLogToJSONEntry(lr, res, scope)
 	case formatLogfmt:
-		return convertLogToLogfmtEntry(lr, res)
+		return convertLogToLogfmtEntry(lr, res, scope)
 	default:
 		return nil, fmt.Errorf("invalid format %s. Expected one of: %s, %s", format, formatJSON, formatLogfmt)
 	}

--- a/pkg/translator/loki/encode_test.go
+++ b/pkg/translator/loki/encode_test.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-func exampleLog() (plog.LogRecord, pcommon.Resource) {
+func exampleLog() (plog.LogRecord, pcommon.Resource, pcommon.InstrumentationScope) {
 
 	buffer := plog.NewLogRecord()
 	buffer.Body().SetStr("Example log")
@@ -36,27 +36,32 @@ func exampleLog() (plog.LogRecord, pcommon.Resource) {
 	resource := pcommon.NewResource()
 	resource.Attributes().PutStr("host.name", "something")
 
-	return buffer, resource
+	scope := pcommon.NewInstrumentationScope()
+	scope.SetName("example-logger-name")
+	scope.SetVersion("v1")
+
+	return buffer, resource, scope
 }
 
 func TestEncodeJsonWithStringBody(t *testing.T) {
-	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"}}`
+	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+	log, resource, scope := exampleLog()
 
-	out, err := Encode(exampleLog())
+	out, err := Encode(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)
 }
 
 func TestEncodeJsonWithMapBody(t *testing.T) {
-	in := `{"body":{"key1":"value","key2":"value"},"traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"}}`
+	in := `{"body":{"key1":"value","key2":"value"},"traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
 
-	log, resource := exampleLog()
+	log, resource, scope := exampleLog()
 	mapVal := pcommon.NewValueMap()
 	mapVal.Map().PutStr("key1", "value")
 	mapVal.Map().PutStr("key2", "value")
 	mapVal.CopyTo(log.Body())
 
-	out, err := Encode(log, resource)
+	out, err := Encode(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)
 }
@@ -148,42 +153,42 @@ func TestSerializeComplexBody(t *testing.T) {
 }
 
 func TestEncodeLogfmtWithStringBody(t *testing.T) {
-	in := `msg="hello world" traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 resource_host.name=something`
-	log, resource := exampleLog()
+	in := `msg="hello world" traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 resource_host.name=something instrumentation_scope_name=example-logger-name instrumentation_scope_version=v1`
+	log, resource, scope := exampleLog()
 	log.Body().SetStr("msg=\"hello world\"")
-	out, err := EncodeLogfmt(log, resource)
+	out, err := EncodeLogfmt(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)
 }
 
 func TestEncodeLogfmtWithMapBody(t *testing.T) {
-	in := `key1=value key2=value traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 resource_host.name=something`
-	log, resource := exampleLog()
+	in := `key1=value key2=value traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 resource_host.name=something instrumentation_scope_name=example-logger-name instrumentation_scope_version=v1`
+	log, resource, scope := exampleLog()
 	mapVal := pcommon.NewValueMap()
 	mapVal.Map().PutStr("key1", "value")
 	mapVal.Map().PutStr("key2", "value")
 	mapVal.CopyTo(log.Body())
-	out, err := EncodeLogfmt(log, resource)
+	out, err := EncodeLogfmt(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)
 }
 
 func TestEncodeLogfmtWithSliceBody(t *testing.T) {
-	in := `body_0=value body_1=true body_2=123 traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 resource_host.name=something`
-	log, resource := exampleLog()
+	in := `body_0=value body_1=true body_2=123 traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 resource_host.name=something instrumentation_scope_name=example-logger-name instrumentation_scope_version=v1`
+	log, resource, scope := exampleLog()
 	sliceVal := pcommon.NewValueSlice()
 	sliceVal.Slice().AppendEmpty().SetStr("value")
 	sliceVal.Slice().AppendEmpty().SetBool(true)
 	sliceVal.Slice().AppendEmpty().SetInt(123)
 	sliceVal.CopyTo(log.Body())
-	out, err := EncodeLogfmt(log, resource)
+	out, err := EncodeLogfmt(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)
 }
 
 func TestEncodeLogfmtWithComplexAttributes(t *testing.T) {
-	in := `Example= log= traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 attribute_aslice_0=fooo attribute_aslice_1_slice_0=true attribute_aslice_1_foo=bar attribute_aslice_2_nested="deeply nested" attribute_aslice_2_uint=123 resource_host.name=something resource_bslice_0=fooo resource_bslice_1_slice_0=true resource_bslice_1_foo=bar resource_bslice_2_nested="deeply nested" resource_bslice_2_uint=123`
-	log, resource := exampleLog()
+	in := `Example= log= traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 attribute_aslice_0=fooo attribute_aslice_1_slice_0=true attribute_aslice_1_foo=bar attribute_aslice_2_nested="deeply nested" attribute_aslice_2_uint=123 resource_host.name=something resource_bslice_0=fooo resource_bslice_1_slice_0=true resource_bslice_1_foo=bar resource_bslice_2_nested="deeply nested" resource_bslice_2_uint=123 instrumentation_scope_name=example-logger-name instrumentation_scope_version=v1`
+	log, resource, scope := exampleLog()
 	sliceVal := pcommon.NewValueSlice()
 	sliceVal.Slice().AppendEmpty().SetStr("fooo")
 	map1 := pcommon.NewValueMap()
@@ -197,7 +202,7 @@ func TestEncodeLogfmtWithComplexAttributes(t *testing.T) {
 	sliceVal.CopyTo(log.Attributes().PutEmpty("aslice"))
 	sliceVal.CopyTo(resource.Attributes().PutEmpty("bslice"))
 
-	out, err := EncodeLogfmt(log, resource)
+	out, err := EncodeLogfmt(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)
 }

--- a/pkg/translator/loki/logs_to_loki.go
+++ b/pkg/translator/loki/logs_to_loki.go
@@ -66,6 +66,7 @@ func LogsToLokiRequests(ld plog.Logs) map[string]PushRequest {
 
 		for j := 0; j < ills.Len(); j++ {
 			logs := ills.At(j).LogRecords()
+			scope := ills.At(j).Scope()
 			for k := 0; k < logs.Len(); k++ {
 
 				// similarly, we may remove attributes, so change only our version
@@ -99,7 +100,7 @@ func LogsToLokiRequests(ld plog.Logs) map[string]PushRequest {
 
 				// create the stream name based on the labels
 				labels := mergedLabels.String()
-				entry, err := convertLogToLokiEntry(log, resource, format)
+				entry, err := convertLogToLokiEntry(log, resource, format, scope)
 				if err != nil {
 					// Couldn't convert so dropping log.
 					group.report.Errors = append(group.report.Errors, fmt.Errorf("failed to convert, dropping log: %w", err))
@@ -205,6 +206,7 @@ func LogsToLoki(ld plog.Logs) (*logproto.PushRequest, *PushReport) {
 		ills := rls.At(i).ScopeLogs()
 
 		for j := 0; j < ills.Len(); j++ {
+			scope := ills.At(j).Scope()
 			logs := ills.At(j).LogRecords()
 			for k := 0; k < logs.Len(); k++ {
 
@@ -229,7 +231,7 @@ func LogsToLoki(ld plog.Logs) (*logproto.PushRequest, *PushReport) {
 				// create the stream name based on the labels
 				labels := mergedLabels.String()
 
-				entry, err := convertLogToLokiEntry(log, resource, format)
+				entry, err := convertLogToLokiEntry(log, resource, format, scope)
 				if err != nil {
 					// Couldn't convert so dropping log.
 					report.Errors = append(report.Errors, fmt.Errorf("failed to convert, dropping log: %w", err))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Added `InstrumentationScope` to loki log object. `InstrumentationScope` is provided by opentelemetry https://opentelemetry.io/docs/reference/specification/logs/data-model/#field-instrumentationscope, it would be a good user experience to have it supported by loki exporter

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16485

**Testing:** Added unit tests