### PR TITLE
[chore] bump checkout to v3

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [setup-environment]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check Collector Module Version
         run: ./.github/workflows/scripts/check-collector-module-version.sh
   check-codeowners:
@@ -60,7 +60,7 @@ jobs:
     needs: [setup-environment]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check Code Owner Existence
         run: ./.github/workflows/scripts/check-codeowners.sh check_code_owner_existence
       - name: Check Component Existence


### PR DESCRIPTION
This is to address nodejs v12 deprecation notices.

Signed-off-by: Alex Boten <aboten@lightstep.com>
<img width="1425" alt="Screen Shot 2022-12-16 at 9 59 33 AM" src="https://user-images.githubusercontent.com/223565/208160174-5ce9284a-6811-4dec-878f-394e995c9bb6.png">
