### PR TITLE
[chore] separate core modules from places that use them

### DIFF
--- a/.github/workflows/scripts/check-collector-module-version.sh
+++ b/.github/workflows/scripts/check-collector-module-version.sh
@@ -18,6 +18,9 @@
 # verifies if the collector components are using the main core collector version
 # as a dependency.
 #
+
+source ./internal/buildscripts/modules
+
 set -eu -o pipefail
 
 # Return the collector main core version
@@ -80,8 +83,6 @@ PDATA_MOD_VERSION=$(get_collector_version "$PDATA_MODULE" "$MAIN_MOD_FILE")
 
 # Check the collector module version in each of the module files
 check_collector_versions_correct "$COLLECTOR_MODULE" "$COLLECTOR_MOD_VERSION"
-check_collector_versions_correct "go.opentelemetry.io/collector/component" "$COLLECTOR_MOD_VERSION"
-check_collector_versions_correct "go.opentelemetry.io/collector/consumer" "$COLLECTOR_MOD_VERSION"
-check_collector_versions_correct "go.opentelemetry.io/collector/featuregate" "$COLLECTOR_MOD_VERSION"
-check_collector_versions_correct "go.opentelemetry.io/collector/pdata" "$PDATA_MOD_VERSION"
-check_collector_versions_correct "go.opentelemetry.io/collector/semconv" "$COLLECTOR_MOD_VERSION"
+for mod in ${modules[@]}; do
+   check_collector_versions_correct "$mod" "$COLLECTOR_MOD_VERSION"
+done

--- a/.github/workflows/scripts/check-collector-module-version.sh
+++ b/.github/workflows/scripts/check-collector-module-version.sh
@@ -72,17 +72,29 @@ check_collector_versions_correct() {
    fi
 }
 
+MAIN_MOD_FILE="./go.mod"
+
 # Note space at end of string. This is so it filters for the exact string
 # only and does not return string which contains this string as a substring.
-COLLECTOR_MODULE="go.opentelemetry.io/collector "
-PDATA_MODULE="go.opentelemetry.io/collector/pdata "
-
-MAIN_MOD_FILE="./go.mod"
-COLLECTOR_MOD_VERSION=$(get_collector_version "$COLLECTOR_MODULE" "$MAIN_MOD_FILE")
-PDATA_MOD_VERSION=$(get_collector_version "$PDATA_MODULE" "$MAIN_MOD_FILE")
-
-# Check the collector module version in each of the module files
-check_collector_versions_correct "$COLLECTOR_MODULE" "$COLLECTOR_MOD_VERSION"
-for mod in ${modules[@]}; do
-   check_collector_versions_correct "$mod" "$COLLECTOR_MOD_VERSION"
+BETA_MODULE="go.opentelemetry.io/collector "
+BETA_MOD_VERSION=$(get_collector_version "$BETA_MODULE" "$MAIN_MOD_FILE")
+check_collector_versions_correct "$BETA_MODULE" "$BETA_MOD_VERSION"
+for mod in ${beta_modules[@]}; do
+   check_collector_versions_correct "$mod" "$BETA_MOD_VERSION"
 done
+
+# Check RC modules
+RC_MODULE="go.opentelemetry.io/collector/pdata "
+RC_MOD_VERSION=$(get_collector_version "$RC_MODULE" "$MAIN_MOD_FILE")
+check_collector_versions_correct "$RC_MODULE" "$RC_MOD_VERSION"
+for mod in ${rc_modules[@]}; do
+   check_collector_versions_correct "$mod" "$RC_MOD_VERSION"
+done
+
+# Check stable modules, none currently exist, uncomment when pdata is 1.0.0
+# STABLE_MODULE="go.opentelemetry.io/collector/pdata "
+# STABLE_MOD_VERSION=$(get_collector_version "$STABLE_MODULE" "$MAIN_MOD_FILE")
+# check_collector_versions_correct "$STABLE_MODULE" "$STABLE_MOD_VERSION"
+# for mod in ${stable_modules[@]}; do
+#    check_collector_versions_correct "$mod" "$STABLE_MOD_VERSION"
+# done

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -155,5 +155,5 @@ moddownload:
 
 .PHONY: updatedep
 updatedep:
-	$(PWD)/internal/buildscripts/update-dep
+	TOPDIR=$(PWD) $(PWD)/internal/buildscripts/update-dep
 	@$(MAKE) tidy

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.0-rc1.0.20221216200611-892d07dffbb8 // indirect

--- a/exporter/googlemanagedprometheusexporter/go.sum
+++ b/exporter/googlemanagedprometheusexporter/go.sum
@@ -431,8 +431,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/extension/zpagesextension v0.67.0 h1:TRW8vZwE+/h2vJqqMDmyQO9X0sxcYCSXf5MyXozSLas=

--- a/exporter/parquetexporter/go.mod
+++ b/exporter/parquetexporter/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect

--- a/exporter/parquetexporter/go.sum
+++ b/exporter/parquetexporter/go.sum
@@ -282,8 +282,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/exporter/sumologicexporter/go.mod
+++ b/exporter/sumologicexporter/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect

--- a/exporter/sumologicexporter/go.sum
+++ b/exporter/sumologicexporter/go.sum
@@ -301,8 +301,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/exporter/tanzuobservabilityexporter/go.mod
+++ b/exporter/tanzuobservabilityexporter/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect

--- a/exporter/tanzuobservabilityexporter/go.sum
+++ b/exporter/tanzuobservabilityexporter/go.sum
@@ -419,8 +419,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/extension/zpagesextension v0.67.0 h1:TRW8vZwE+/h2vJqqMDmyQO9X0sxcYCSXf5MyXozSLas=

--- a/extension/oidcauthextension/go.mod
+++ b/extension/oidcauthextension/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.0-rc1.0.20221216200611-892d07dffbb8 // indirect

--- a/extension/oidcauthextension/go.sum
+++ b/extension/oidcauthextension/go.sum
@@ -349,8 +349,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/internal/aws/cwlogs/go.mod
+++ b/internal/aws/cwlogs/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.0-rc1.0.20221216200611-892d07dffbb8 // indirect

--- a/internal/aws/cwlogs/go.sum
+++ b/internal/aws/cwlogs/go.sum
@@ -275,8 +275,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/internal/aws/ecsutil/go.mod
+++ b/internal/aws/ecsutil/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/rs/cors v1.8.2 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.0-rc1.0.20221216200611-892d07dffbb8 // indirect

--- a/internal/aws/ecsutil/go.sum
+++ b/internal/aws/ecsutil/go.sum
@@ -283,8 +283,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/internal/buildscripts/modules
+++ b/internal/buildscripts/modules
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+modules=(
+  "go.opentelemetry.io/collector/component"
+  "go.opentelemetry.io/collector/confmap"
+  "go.opentelemetry.io/collector/consumer"
+  "go.opentelemetry.io/collector/exporter/loggingexporter"
+  "go.opentelemetry.io/collector/exporter/otlpexporter"
+  "go.opentelemetry.io/collector/exporter/otlphttpexporter"
+  "go.opentelemetry.io/collector/extension/ballastextension"
+  "go.opentelemetry.io/collector/extension/zpagesextension"
+  "go.opentelemetry.io/collector/featuregate"
+  "go.opentelemetry.io/collector/processor/batchprocessor"
+  "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
+  "go.opentelemetry.io/collector/receiver/otlpreceiver"
+  "go.opentelemetry.io/collector/semconv"
+  "go.opentelemetry.io/collector/pdata"
+)

--- a/internal/buildscripts/modules
+++ b/internal/buildscripts/modules
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-modules=(
+beta_modules=(
   "go.opentelemetry.io/collector/component"
   "go.opentelemetry.io/collector/confmap"
   "go.opentelemetry.io/collector/consumer"
@@ -14,5 +14,11 @@ modules=(
   "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
   "go.opentelemetry.io/collector/receiver/otlpreceiver"
   "go.opentelemetry.io/collector/semconv"
+)
+
+rc_modules=(
   "go.opentelemetry.io/collector/pdata"
 )
+
+# No stable modules currently exist, add pdata here once 1.0.0
+stable_modules=()

--- a/internal/buildscripts/update-dep
+++ b/internal/buildscripts/update-dep
@@ -12,7 +12,17 @@ fi
 
 # If MODULE is "go.opentelemetry.io/collector" need to update additional $modules as well
 if [ "$MODULE" == "go.opentelemetry.io/collector" ]; then
-  for mod in ${modules[@]}; do
+  for mod in ${beta_modules[@]}; do
+    if grep -q "$mod " go.mod; then
+      go get -d "$mod"@"$VERSION"
+    fi
+  done
+  for mod in ${rc_modules[@]}; do
+    if grep -q "$mod " go.mod; then
+      go get -d "$mod"@"$VERSION"
+    fi
+  done
+  for mod in ${stable_modules[@]}; do
     if grep -q "$mod " go.mod; then
       go get -d "$mod"@"$VERSION"
     fi

--- a/internal/buildscripts/update-dep
+++ b/internal/buildscripts/update-dep
@@ -4,8 +4,6 @@
 
 source $TOPDIR/internal/buildscripts/modules
 
-echo $modules
-
 set -e
 
 if grep -q "$MODULE " go.mod; then

--- a/internal/buildscripts/update-dep
+++ b/internal/buildscripts/update-dep
@@ -2,27 +2,15 @@
 
 # Updates MODULE inside go.mod if it is already present to version VERSION.
 
+source $TOPDIR/internal/buildscripts/modules
+
+echo $modules
+
 set -e
 
 if grep -q "$MODULE " go.mod; then
   go get "$MODULE"@"$VERSION"
 fi
-
-modules=(
-  "go.opentelemetry.io/collector/component"
-  "go.opentelemetry.io/collector/consumer"
-  "go.opentelemetry.io/collector/exporter/loggingexporter"
-  "go.opentelemetry.io/collector/exporter/otlpexporter"
-  "go.opentelemetry.io/collector/exporter/otlphttpexporter"
-  "go.opentelemetry.io/collector/extension/ballastextension"
-  "go.opentelemetry.io/collector/extension/zpagesextension"
-  "go.opentelemetry.io/collector/featuregate"
-  "go.opentelemetry.io/collector/processor/batchprocessor"
-  "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
-  "go.opentelemetry.io/collector/receiver/otlpreceiver"
-  "go.opentelemetry.io/collector/semconv"
-  "go.opentelemetry.io/collector/pdata"
-)
 
 # If MODULE is "go.opentelemetry.io/collector" need to update additional $modules as well
 if [ "$MODULE" == "go.opentelemetry.io/collector" ]; then

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.0-rc1.0.20221216200611-892d07dffbb8 // indirect

--- a/internal/sharedcomponent/go.sum
+++ b/internal/sharedcomponent/go.sum
@@ -269,8 +269,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/internal/splunk/go.mod
+++ b/internal/splunk/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect

--- a/internal/splunk/go.sum
+++ b/internal/splunk/go.sum
@@ -290,8 +290,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect

--- a/pkg/ottl/go.sum
+++ b/pkg/ottl/go.sum
@@ -272,8 +272,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/pkg/resourcetotelemetry/go.mod
+++ b/pkg/resourcetotelemetry/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect

--- a/pkg/resourcetotelemetry/go.sum
+++ b/pkg/resourcetotelemetry/go.sum
@@ -259,8 +259,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/processor/datadogprocessor/go.mod
+++ b/processor/datadogprocessor/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/semconv v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect

--- a/processor/datadogprocessor/go.sum
+++ b/processor/datadogprocessor/go.sum
@@ -378,8 +378,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/processor/groupbytraceprocessor/go.mod
+++ b/processor/groupbytraceprocessor/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect

--- a/processor/groupbytraceprocessor/go.sum
+++ b/processor/groupbytraceprocessor/go.sum
@@ -288,8 +288,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/processor/servicegraphprocessor/go.mod
+++ b/processor/servicegraphprocessor/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.12.0 // indirect

--- a/processor/servicegraphprocessor/go.sum
+++ b/processor/servicegraphprocessor/go.sum
@@ -430,8 +430,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.67.1-0.20221216200611-892d07dffbb8 h1:45mR0XvW1oS4nYA83nE4lZLr5KVTRXqA6ax7reiTy4Q=

--- a/receiver/azureblobreceiver/go.mod
+++ b/receiver/azureblobreceiver/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/semconv v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.12.0 // indirect

--- a/receiver/azureblobreceiver/go.sum
+++ b/receiver/azureblobreceiver/go.sum
@@ -467,8 +467,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/extension/zpagesextension v0.67.0 h1:TRW8vZwE+/h2vJqqMDmyQO9X0sxcYCSXf5MyXozSLas=

--- a/receiver/influxdbreceiver/go.mod
+++ b/receiver/influxdbreceiver/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/rs/cors v1.8.2 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.0-rc1.0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect

--- a/receiver/influxdbreceiver/go.sum
+++ b/receiver/influxdbreceiver/go.sum
@@ -295,8 +295,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.67.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.67.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver v0.67.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver v0.67.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.67.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.67.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatareceivers/mockawsxrayreceiver v0.67.0

--- a/testbed/mockdatareceivers/mockawsxrayreceiver/go.mod
+++ b/testbed/mockdatareceivers/mockawsxrayreceiver/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 // indirect
+	go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect

--- a/testbed/mockdatareceivers/mockawsxrayreceiver/go.sum
+++ b/testbed/mockdatareceivers/mockawsxrayreceiver/go.sum
@@ -282,8 +282,8 @@ go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8 h1:VcGnEQrjt
 go.opentelemetry.io/collector v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:Qn7kPOb6JCf4PpVt1c2dJdKS0uDC6T78Sqv3CDRuDbw=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8 h1:Y2bxtt7ImtqCGpWBx6opxiTmGztQGqCYjV3g/JraRN8=
 go.opentelemetry.io/collector/component v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:VbvZytUKFYeVzQCpuJ6jxAXl9Rwxz+7sJ8d6uuT1qmM=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3 h1:87+ue6MNDFqbCLo4WnIWxDL3yAOOa8XYa42dylQE64U=
-go.opentelemetry.io/collector/confmap v0.67.1-0.20221216193913-557c077e3cc3/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8 h1:NY1ER0sguSg1WxcAd49hbIuMK1VQE8mQRwU15+qmL8g=
+go.opentelemetry.io/collector/confmap v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:vE14PymmnYeZe+zoOxO5rXCy5BQ1AjUHpr/gDgLl6mw=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8 h1:1R8FOf1aKBpc2qHUHSGxQd1SrCB2oblsshzfjmtWffc=
 go.opentelemetry.io/collector/consumer v0.67.1-0.20221216200611-892d07dffbb8/go.mod h1:maReFNF5y1GcBAM1zBq3ukRg5caMRsoHAK4+5hN3wA0=
 go.opentelemetry.io/collector/featuregate v0.67.1-0.20221216200611-892d07dffbb8 h1:qNeng/2RFFa3k9d+xlohFOPcs6A2q6Fm0VbZe7NnTOw=


### PR DESCRIPTION
There are at least 2 places (updatedep and check-collector-modules) that need the list of all the core modules. This is tedious to update in multiple places. Moving that into its own file, that can be included in other places.

Signed-off-by: Alex Boten <aboten@lightstep.com>
