### PR TITLE
[processor/logstransform] refactor to pass along logs asynchronously

### DIFF
--- a/.chloggen/make-logs-transform-processor-more-reliable.yaml
+++ b/.chloggen/make-logs-transform-processor-more-reliable.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: logstransformprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Lets the logs transform processor directly pass messags to next consumer, avoiding the timing issues it previously exhibited.
+
+# One or more tracking issues related to the change
+issues: [16604, 15378, 9761]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/logstransformprocessor/factory.go
+++ b/processor/logstransformprocessor/factory.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
-	"go.opentelemetry.io/collector/processor/processorhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -68,16 +67,9 @@ func createLogsProcessor(
 	}
 
 	proc := &logsTransformProcessor{
-		logger: set.Logger,
-		config: pCfg,
+		logger:   set.Logger,
+		config:   pCfg,
+		consumer: nextConsumer,
 	}
-	return processorhelper.NewLogsProcessor(
-		ctx,
-		set,
-		cfg,
-		nextConsumer,
-		proc.processLogs,
-		processorhelper.WithStart(proc.Start),
-		processorhelper.WithShutdown(proc.Shutdown),
-		processorhelper.WithCapabilities(processorCapabilities))
+	return proc, nil
 }

--- a/processor/logstransformprocessor/factory.go
+++ b/processor/logstransformprocessor/factory.go
@@ -66,10 +66,5 @@ func createLogsProcessor(
 		return nil, errors.New("no operators were configured for this logs transform processor")
 	}
 
-	proc := &logsTransformProcessor{
-		logger:   set.Logger,
-		config:   pCfg,
-		consumer: nextConsumer,
-	}
-	return proc, nil
+	return newProcessor(pCfg, nextConsumer, set.Logger)
 }

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -17,12 +17,12 @@ package logstransformprocessor // import "github.com/open-telemetry/opentelemetr
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"runtime"
 	"sync"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
@@ -41,13 +41,18 @@ type logsTransformProcessor struct {
 	logger *zap.Logger
 	config *Config
 
+	consumer consumer.Logs
+
 	pipe          *pipeline.DirectedPipeline
 	firstOperator operator.Operator
 	emitter       *adapter.LogEmitter
 	converter     *adapter.Converter
 	fromConverter *adapter.FromPdataConverter
 	wg            sync.WaitGroup
-	outputChannel chan outputType
+}
+
+func (ltp *logsTransformProcessor) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
 }
 
 func (ltp *logsTransformProcessor) Shutdown(ctx context.Context) error {
@@ -93,8 +98,6 @@ func (ltp *logsTransformProcessor) Start(ctx context.Context, host component.Hos
 	ltp.fromConverter = adapter.NewFromPdataConverter(wkrCount, ltp.logger)
 	ltp.fromConverter.Start()
 
-	ltp.outputChannel = make(chan outputType)
-
 	// Below we're starting 3 loops:
 	// * first which reads all the logs translated by the fromConverter and then forwards
 	//   them to pipeline
@@ -110,37 +113,16 @@ func (ltp *logsTransformProcessor) Start(ctx context.Context, host component.Hos
 
 	// ...
 	// * third which reads all the logs produced by the converter
-	//   (aggregated by Resource) and then places them on the outputChannel
+	//   (aggregated by Resource) and then places them on the next consumer
 	ltp.wg.Add(1)
 	go ltp.consumerLoop(ctx)
 
 	return nil
 }
 
-func (ltp *logsTransformProcessor) processLogs(ctx context.Context, ld plog.Logs) (plog.Logs, error) {
+func (ltp *logsTransformProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	// Add the logs to the chain
-	err := ltp.fromConverter.Batch(ld)
-	if err != nil {
-		return ld, err
-	}
-
-	doneChan := ctx.Done()
-	for {
-		select {
-		case <-doneChan:
-			ltp.logger.Debug("loop stopped")
-			return ld, errors.New("processor interrupted")
-		case output, ok := <-ltp.outputChannel:
-			if !ok {
-				return ld, errors.New("processor encountered an issue receiving logs from stanza operators pipeline")
-			}
-			if output.err != nil {
-				return ld, err
-			}
-
-			return output.logs, nil
-		}
-	}
+	return ltp.fromConverter.Batch(ld)
 }
 
 // converterLoop reads the log entries produced by the fromConverter and sends them
@@ -163,7 +145,7 @@ func (ltp *logsTransformProcessor) converterLoop(ctx context.Context) {
 			for _, e := range entries {
 				// Add item to the first operator of the pipeline manually
 				if err := ltp.firstOperator.Process(ctx, e); err != nil {
-					ltp.outputChannel <- outputType{err: fmt.Errorf("processor encountered an issue with the pipeline: %w", err)}
+					ltp.logger.Error("processor encountered an issue with the pipeline", zap.Error(err))
 					break
 				}
 			}
@@ -188,7 +170,7 @@ func (ltp *logsTransformProcessor) emitterLoop(ctx context.Context) {
 			}
 
 			if err := ltp.converter.Batch(e); err != nil {
-				ltp.outputChannel <- outputType{err: fmt.Errorf("processor encountered an issue with the converter: %w", err)}
+				ltp.logger.Error("processor encountered an issue with the converter", zap.Error(err))
 			}
 		}
 	}
@@ -210,7 +192,7 @@ func (ltp *logsTransformProcessor) consumerLoop(ctx context.Context) {
 				return
 			}
 
-			ltp.outputChannel <- outputType{logs: pLogs, err: nil}
+			ltp.consumer.ConsumeLogs(ctx, pLogs)
 		}
 	}
 }

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -76,17 +76,11 @@ type testLogMessage struct {
 	attributes   *map[string]pcommon.Value
 }
 
-// Temporary abstraction to avoid "unused" linter
-var skip = func(t *testing.T, why string) {
-	t.Skip(why)
-}
-
 func TestLogsTransformProcessor(t *testing.T) {
-	skip(t, "Flaky Test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9761")
 	baseMessage := pcommon.NewValueStr("2022-01-01 01:02:03 INFO this is a test message")
 	spanID := pcommon.SpanID([8]byte{0x32, 0xf0, 0xa2, 0x2b, 0x6a, 0x81, 0x2c, 0xff})
 	traceID := pcommon.TraceID([16]byte{0x48, 0x01, 0x40, 0xf3, 0xd7, 0x70, 0xa5, 0xae, 0x32, 0xf0, 0xa2, 0x2b, 0x6a, 0x81, 0x2c, 0xff})
-	infoSeverityText := "Info"
+	infoSeverityText := "INFO"
 
 	tests := []struct {
 		name           string
@@ -163,6 +157,7 @@ func TestLogsTransformProcessor(t *testing.T) {
 			wantLogData := generateLogData(tt.parsedMessages)
 			err = ltp.ConsumeLogs(context.Background(), sourceLogData)
 			require.NoError(t, err)
+			time.Sleep(200 * time.Millisecond)
 			logs := tln.AllLogs()
 			require.Len(t, logs, 1)
 


### PR DESCRIPTION
**Description:** Changed the logs transform processor to asynchronously pass logs along to the next consumer, which should resolve the various timing and deadlocking issues observed in the processor.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16604
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15378
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9761

**Testing:** Some local validation, but more eyes & external validation would be great.

**Documentation:** No documentation changes.