### PR TITLE
[exporter/splunkhec] Fix data race when gzip compression is enabled

### DIFF
--- a/.chloggen/splunkhec-gzip-pool-data-race-fix.yaml
+++ b/.chloggen/splunkhec-gzip-pool-data-race-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix data race when gzip compression is enabled
+
+# One or more tracking issues related to the change
+issues: [17083]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Removed gzip writer pool and create a new one when needed.

--- a/exporter/splunkhecexporter/exporter.go
+++ b/exporter/splunkhecexporter/exporter.go
@@ -15,14 +15,12 @@
 package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
 
 import (
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -134,8 +132,5 @@ func buildClient(options *exporterOptions, config *Config, logger *zap.Logger) (
 			"__splunk_app_version": config.SplunkAppVersion,
 		},
 		config: config,
-		gzipWriterPool: &sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
 	}, nil
 }


### PR DESCRIPTION
**Description:** 
When executing the otel agent with a race flag, it detects some data race in gzip package resulting in invalid index access (i.e. index out of the bound access)

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17083

**Testing:** 

Ran the OTel agent for a few hours with the race flag enabled

**Documentation:**