### PR TITLE
[internal/pdatautil] Change MapHash result from 64 to 128 bit

### DIFF
--- a/internal/comparetest/util.go
+++ b/internal/comparetest/util.go
@@ -15,6 +15,7 @@
 package comparetest // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/comparetest"
 
 import (
+	"bytes"
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -62,7 +63,9 @@ func sortResourceMetrics(a, b pmetric.ResourceMetrics) bool {
 	if a.SchemaUrl() < b.SchemaUrl() {
 		return true
 	}
-	return pdatautil.MapHash(a.Resource().Attributes()) < pdatautil.MapHash(b.Resource().Attributes())
+	aAttrs := pdatautil.MapHash(a.Resource().Attributes())
+	bAttrs := pdatautil.MapHash(b.Resource().Attributes())
+	return bytes.Compare(aAttrs[:], bAttrs[:]) < 0
 }
 
 func sortMetricSlice(a, b pmetric.Metric) bool {
@@ -73,7 +76,9 @@ func sortResourceLogs(a, b plog.ResourceLogs) bool {
 	if a.SchemaUrl() < b.SchemaUrl() {
 		return true
 	}
-	return pdatautil.MapHash(a.Resource().Attributes()) < pdatautil.MapHash(b.Resource().Attributes())
+	aAttrs := pdatautil.MapHash(a.Resource().Attributes())
+	bAttrs := pdatautil.MapHash(b.Resource().Attributes())
+	return bytes.Compare(aAttrs[:], bAttrs[:]) < 0
 }
 
 func sortLogsInstrumentationLibrary(a, b plog.ScopeLogs) bool {
@@ -90,5 +95,7 @@ func sortLogsInstrumentationLibrary(a, b plog.ScopeLogs) bool {
 }
 
 func sortLogRecordSlice(a, b plog.LogRecord) bool {
-	return pdatautil.MapHash(a.Attributes()) < pdatautil.MapHash(b.Attributes())
+	aAttrs := pdatautil.MapHash(a.Attributes())
+	bAttrs := pdatautil.MapHash(b.Attributes())
+	return bytes.Compare(aAttrs[:], bAttrs[:]) < 0
 }

--- a/internal/coreinternal/pdatautil/map.go
+++ b/internal/coreinternal/pdatautil/map.go
@@ -25,6 +25,7 @@ import (
 )
 
 var (
+	extraByte       = []byte{'\xf3'}
 	keyPrefix       = []byte{'\xf4'}
 	valEmpty        = []byte{'\xf5'}
 	valBytesPrefix  = []byte{'\xf6'}
@@ -41,10 +42,20 @@ var (
 
 // MapHash return a hash for the provided map.
 // Maps with the same underlying key/value pairs in different order produce the same deterministic hash value.
-func MapHash(m pcommon.Map) uint64 {
+func MapHash(m pcommon.Map) [16]byte {
 	h := xxhash.New()
+
 	writeMapHash(h, m)
-	return h.Sum64()
+	b := make([]byte, 0, 16)
+	b = h.Sum(b)
+
+	// Append an extra byte to generate another part of the hash sum
+	_, _ = h.Write(extraByte)
+	b = h.Sum(b)
+
+	res := [16]byte{}
+	copy(res[:], b)
+	return res
 }
 
 func writeMapHash(h hash.Hash, m pcommon.Map) {

--- a/internal/coreinternal/pdatautil/map_test.go
+++ b/internal/coreinternal/pdatautil/map_test.go
@@ -34,7 +34,6 @@ func TestMapHash_Equal(t *testing.T) {
 				for i := 0; i < len(m); i++ {
 					m[i] = pcommon.NewMap()
 				}
-
 				m[1].PutStr("k", "")
 				m[2].PutStr("k", "v")
 				m[3].PutStr("k1", "v1")
@@ -136,5 +135,62 @@ func TestMapHash_Equal(t *testing.T) {
 			}
 		})
 	}
+}
 
+func BenchmarkMapHashFourItems(b *testing.B) {
+	m := pcommon.NewMap()
+	m.PutStr("test-string-key2", "test-value-2")
+	m.PutStr("test-string-key1", "test-value-1")
+	m.PutInt("test-int-key", 123)
+	m.PutBool("test-bool-key", true)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MapHash(m)
+	}
+}
+
+func BenchmarkMapHashEightItems(b *testing.B) {
+	m := pcommon.NewMap()
+	m.PutStr("test-string-key2", "test-value-2")
+	m.PutStr("test-string-key1", "test-value-1")
+	m.PutInt("test-int-key", 123)
+	m.PutBool("test-bool-key", true)
+	m.PutStr("test-string-key3", "test-value-3")
+	m.PutDouble("test-double-key2", 22.123)
+	m.PutDouble("test-double-key1", 11.123)
+	m.PutEmptyBytes("test-bytes-key").FromRaw([]byte("abc"))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MapHash(m)
+	}
+}
+
+func BenchmarkMapHashWithEmbeddedSliceAndMap(b *testing.B) {
+	m := pcommon.NewMap()
+	m.PutStr("test-string-key2", "test-value-2")
+	m.PutStr("test-string-key1", "test-value-1")
+	m.PutInt("test-int-key", 123)
+	m.PutBool("test-bool-key", true)
+	m.PutStr("test-string-key3", "test-value-3")
+	m.PutDouble("test-double-key2", 22.123)
+	m.PutDouble("test-double-key1", 11.123)
+	m.PutEmptyBytes("test-bytes-key").FromRaw([]byte("abc"))
+	m1 := m.PutEmptyMap("test-map-key")
+	m1.PutStr("test-embedded-string-key", "test-embedded-string-value")
+	m1.PutDouble("test-embedded-double-key", 22.123)
+	m1.PutInt("test-embedded-int-key", 234)
+	sl := m.PutEmptySlice("test-slice-key")
+	sl.AppendEmpty().SetStr("test-slice-string-1")
+	sl.AppendEmpty().SetStr("test-slice-string-2")
+	sl.AppendEmpty().SetStr("test-slice-string-3")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MapHash(m)
+	}
 }


### PR DESCRIPTION
For higher collision tolerance

Benchmark results:

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/pdatautil
BenchmarkMapHashFourItems
BenchmarkMapHashFourItems-10                  	 3161750	       377.5 ns/op	     272 B/op	      10 allocs/op
BenchmarkMapHashEightItems
BenchmarkMapHashEightItems-10                 	 1552203	       782.6 ns/op	     440 B/op	      18 allocs/op
BenchmarkMapHashWithEmbeddedSliceAndMap
BenchmarkMapHashWithEmbeddedSliceAndMap-10    	  929382	      1228 ns/op	     768 B/op	      31 allocs/op
PASS
```
