### PR TITLE
[mdatagen] Add ability to specify additional warnings in metadata.yaml

### DIFF
--- a/.chloggen/mdatagen-more-warnings.yaml
+++ b/.chloggen/mdatagen-more-warnings.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ability to specify additional warnings in metadata.yaml
+
+# One or more tracking issues related to the change
+issues: [17180]

--- a/cmd/mdatagen/documentation.md
+++ b/cmd/mdatagen/documentation.md
@@ -16,7 +16,7 @@ metrics:
 
 Monotonic cumulative sum int metric enabled by default.
 
-Additional information.
+The metric will be become optional soon.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -29,6 +29,16 @@ Additional information.
 | string_attr | Attribute with any string value. | Any Str |
 | state | Integer attribute with overridden name. | Any Int |
 | enum_attr | Attribute with a known set of string values. | Str: ``red``, ``green``, ``blue`` |
+
+### default.metric.to_be_removed
+
+[DEPRECATED] Non-monotonic delta sum double metric enabled by default.
+
+The metric will be will be removed soon.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| s | Sum | Double | Delta | false |
 
 ## Optional Metrics
 

--- a/cmd/mdatagen/internal/metadata/testdata/config.yaml
+++ b/cmd/mdatagen/internal/metadata/testdata/config.yaml
@@ -1,0 +1,15 @@
+default:
+all_metrics:
+  default.metric:
+    enabled: true
+  default.metric.to_be_removed:
+    enabled: true
+  optional.metric:
+    enabled: true
+no_metrics:
+  default.metric:
+    enabled: false
+  default.metric.to_be_removed:
+    enabled: false
+  optional.metric:
+    enabled: false

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -175,6 +175,10 @@ func (m metric) Data() MetricData {
 type warnings struct {
 	// A warning that will be displayed if the metric is enabled in user config.
 	IfEnabled string `mapstructure:"if_enabled"`
+	// A warning that will be displayed if `enabled` field is not set explicitly in user config.
+	IfEnabledNotSet string `mapstructure:"if_enabled_not_set"`
+	// A warning that will be displayed if the metrics is configured by user in any way.
+	IfConfigured string `mapstructure:"if_configured"`
 }
 
 type attribute struct {

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -81,8 +81,11 @@ func Test_loadMetadata(t *testing.T) {
 					"default.metric": {
 						Enabled:               true,
 						Description:           "Monotonic cumulative sum int metric enabled by default.",
-						ExtendedDocumentation: "Additional information.",
-						Unit:                  "s",
+						ExtendedDocumentation: "The metric will be become optional soon.",
+						Warnings: warnings{
+							IfEnabledNotSet: "This metric will be disabled by default soon.",
+						},
+						Unit: "s",
 						Sum: &sum{
 							MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeInt},
 							Aggregated:      Aggregated{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -94,13 +97,27 @@ func Test_loadMetadata(t *testing.T) {
 						Enabled:     false,
 						Description: "[DEPRECATED] Gauge double metric disabled by default.",
 						Warnings: warnings{
-							IfEnabled: "This metric is deprecated and will be removed soon.",
+							IfConfigured: "This metric is deprecated and will be removed soon.",
 						},
 						Unit: "1",
 						Gauge: &gauge{
 							MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeDouble},
 						},
 						Attributes: []attributeName{"string_attr", "boolean_attr"},
+					},
+					"default.metric.to_be_removed": {
+						Enabled:               true,
+						Description:           "[DEPRECATED] Non-monotonic delta sum double metric enabled by default.",
+						ExtendedDocumentation: "The metric will be will be removed soon.",
+						Warnings: warnings{
+							IfEnabled: "This metric is deprecated and will be removed soon.",
+						},
+						Unit: "s",
+						Sum: &sum{
+							MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeDouble},
+							Aggregated:      Aggregated{Aggregation: pmetric.AggregationTemporalityDelta},
+							Mono:            Mono{Monotonic: false},
+						},
 					},
 				},
 			},

--- a/cmd/mdatagen/main.go
+++ b/cmd/mdatagen/main.go
@@ -55,11 +55,15 @@ func run(ymlPath string) error {
 	tmplDir := filepath.Join(filepath.Dir(filename), "templates")
 
 	codeDir := filepath.Join(ymlDir, "internal", "metadata")
-	if err = os.MkdirAll(codeDir, 0700); err != nil {
+	if err = os.MkdirAll(filepath.Join(codeDir, "testdata"), 0700); err != nil {
 		return fmt.Errorf("unable to create output directory %q: %w", codeDir, err)
 	}
 	if err = generateFile(filepath.Join(tmplDir, "metrics.go.tmpl"),
 		filepath.Join(codeDir, "generated_metrics.go"), md); err != nil {
+		return err
+	}
+	if err = generateFile(filepath.Join(tmplDir, "testdata", "config.yaml.tmpl"),
+		filepath.Join(codeDir, "testdata", "config.yaml"), md); err != nil {
 		return err
 	}
 	if err = generateFile(filepath.Join(tmplDir, "metrics_test.go.tmpl"),
@@ -99,6 +103,7 @@ func generateFile(tmplFile string, outputFile string, md metadata) error {
 					return false
 				},
 				"stringsJoin": strings.Join,
+				"inc":         func(i int) int { return i + 1 },
 			}).ParseFiles(tmplFile))
 
 	buf := bytes.Buffer{}

--- a/cmd/mdatagen/metadata.yaml
+++ b/cmd/mdatagen/metadata.yaml
@@ -37,13 +37,15 @@ metrics:
   default.metric:
     enabled: true
     description: Monotonic cumulative sum int metric enabled by default.
-    extended_documentation: Additional information.
+    extended_documentation: The metric will be become optional soon.
     unit: s
     sum:
       value_type: int
       monotonic: true
       aggregation: cumulative
     attributes: [string_attr, overridden_int_attr, enum_attr]
+    warnings:
+      if_enabled_not_set: This metric will be disabled by default soon.
 
   optional.metric:
     enabled: false
@@ -52,5 +54,17 @@ metrics:
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr]
+    warnings:
+      if_configured: This metric is deprecated and will be removed soon.
+
+  default.metric.to_be_removed:
+    enabled: true
+    description: "[DEPRECATED] Non-monotonic delta sum double metric enabled by default."
+    extended_documentation: The metric will be will be removed soon.
+    unit: s
+    sum:
+      value_type: double
+      monotonic: false
+      aggregation: delta
     warnings:
       if_enabled: This metric is deprecated and will be removed soon.

--- a/cmd/mdatagen/metric-metadata.yaml
+++ b/cmd/mdatagen/metric-metadata.yaml
@@ -40,7 +40,14 @@ metrics:
     # Optional: warnings that will be shown to user under specified conditions.
     warnings:
       # A warning that will be displayed if the metric is enabled in user config.
+      # Should be used for deprecated default metrics that will be removed soon.
       if_enabled:
+      # A warning that will be displayed if `enabled` field is not set explicitly in user config.
+      # Should be used for metrics that will be turned from default to optional or vice versa.
+      if_enabled_not_set:
+      # A warning that will be displayed if the metrics is configured by user in any way.
+      # Should be used for deprecated optional metrics that will be removed soon.
+      if_configured:
     # Required: metric unit as defined by https://ucum.org/ucum.html.
     unit:
     # Required: metric type with its settings.

--- a/cmd/mdatagen/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/templates/metrics.go.tmpl
@@ -23,12 +23,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -39,7 +34,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 
@@ -191,7 +186,17 @@ func NewMetricsBuilder(ms MetricsSettings, settings receiver.CreateSettings, opt
 	if ms.{{ $name.Render }}.Enabled {
 		settings.Logger.Warn("[WARNING] `{{ $name }}` should not be enabled: {{ $metric.Warnings.IfEnabled }}")
 	}
-	{{ end }}
+	{{- end }}
+	{{- if $metric.Warnings.IfEnabledNotSet }}
+	if !ms.{{ $name.Render }}.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `{{ $name }}`: {{ $metric.Warnings.IfEnabledNotSet }}")
+	}
+	{{- end }}
+	{{- if $metric.Warnings.IfConfigured }}
+	if ms.{{ $name.Render }}.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] `{{ $name }}` should not be configured: {{ $metric.Warnings.IfConfigured }}")
+	}
+	{{- end }}
 	{{- end }}
 	mb := &MetricsBuilder{
 		startTime:                pcommon.NewTimestampFromTime(time.Now()),

--- a/cmd/mdatagen/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/templates/metrics_test.go.tmpl
@@ -3,10 +3,14 @@
 package {{ .Package }}
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,24 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	{{ $wantWarnings := 0 }}
+	{{- range $name, $metric := .Metrics }}
+	{{- if and $metric.Enabled $metric.Warnings.IfEnabled }}
+	assert.Equal(t, "[WARNING] `{{ $name }}` should not be enabled: {{ $metric.Warnings.IfEnabled }}", observedLogs.All()[{{ $wantWarnings }}].Message)
+	{{- $wantWarnings = inc $wantWarnings }}
+	{{- end }}
+	{{- if $metric.Warnings.IfEnabledNotSet }}
+	assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `{{ $name }}`: {{ $metric.Warnings.IfEnabledNotSet }}", observedLogs.All()[{{ $wantWarnings }}].Message)
+	{{- $wantWarnings = inc $wantWarnings }}
+	{{- end }}
+	{{- end }}
+	assert.Equal(t, {{ $wantWarnings }}, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 	{{- range $name, $metric := .Metrics }}
 
@@ -46,17 +67,23 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-	{{- range $name, $_ := .Metrics }}
-		{{ $name.Render }}: MetricSettings{Enabled: true},
-	{{- end }}
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
-	assert.Equal(t, 0{{ range $_, $metric := .Metrics }}{{ if $metric.Warnings.IfEnabled }}+1{{ end }}{{ end }}, observedLogs.Len())
+	{{ $wantWarnings = 0 }}
+	{{- range $name, $metric := .Metrics }}
+	{{- if $metric.Warnings.IfEnabled }}
+	assert.Equal(t, "[WARNING] `{{ $name }}` should not be enabled: {{ $metric.Warnings.IfEnabled }}", observedLogs.All()[{{ $wantWarnings }}].Message)
+	{{- $wantWarnings = inc $wantWarnings }}
+	{{- end }}
+	{{- if $metric.Warnings.IfConfigured }}
+	assert.Equal(t, "[WARNING] `{{ $name }}` should not be configured: {{ $metric.Warnings.IfConfigured }}", observedLogs.All()[{{ $wantWarnings }}].Message)
+	{{- $wantWarnings = inc $wantWarnings }}
+	{{- end }}
+	{{- end }}
+	assert.Equal(t, {{ $wantWarnings }}, observedLogs.Len())
 
 	{{ range $name, $metric := .Metrics }}
 	mb.Record{{ $name.Render }}DataPoint(ts, {{ if $metric.Data.HasMetricInputType }}"1"{{ else }}1{{ end }}
@@ -134,19 +161,21 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-	{{- range $name, $_ := .Metrics }}
-		{{ $name.Render }}: MetricSettings{Enabled: false},
-	{{- end }}
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
-	assert.Equal(t, 0, observedLogs.Len())
-
+	{{ $wantWarnings = 0 }}
 	{{- range $name, $metric := .Metrics }}
+	{{- if $metric.Warnings.IfConfigured }}
+	assert.Equal(t, "[WARNING] `{{ $name }}` should not be configured: {{ $metric.Warnings.IfConfigured }}", observedLogs.All()[{{ $wantWarnings }}].Message)
+	{{- $wantWarnings = inc $wantWarnings }}
+	{{- end }}
+	{{- end }}
+	assert.Equal(t, {{ $wantWarnings }}, observedLogs.Len())
+
+	{{ range $name, $metric := .Metrics }}
 	mb.Record{{ $name.Render }}DataPoint(ts, {{ if $metric.Data.HasMetricInputType }}"1"{{ else }}1{{ end }}
 	{{- range $metric.Attributes -}}
 	, {{ if (attributeInfo .).Enum }}Attribute{{ .Render }}(1){{ else }}{{ (attributeInfo .).Type.TestValue }}{{ end }}
@@ -156,4 +185,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/cmd/mdatagen/templates/testdata/config.yaml.tmpl
+++ b/cmd/mdatagen/templates/testdata/config.yaml.tmpl
@@ -1,0 +1,11 @@
+default:
+all_metrics:
+  {{- range $name, $_ := .Metrics }}
+  {{ $name }}:
+    enabled: true
+  {{- end }}
+no_metrics:
+  {{- range $name, $_ := .Metrics }}
+  {{ $name }}:
+    enabled: false
+  {{- end }}

--- a/receiver/activedirectorydsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/activedirectorydsreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/activedirectorydsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/activedirectorydsreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,75 @@
+default:
+all_metrics:
+  active_directory.ds.bind.rate:
+    enabled: true
+  active_directory.ds.ldap.bind.last_successful.time:
+    enabled: true
+  active_directory.ds.ldap.bind.rate:
+    enabled: true
+  active_directory.ds.ldap.client.session.count:
+    enabled: true
+  active_directory.ds.ldap.search.rate:
+    enabled: true
+  active_directory.ds.name_cache.hit_rate:
+    enabled: true
+  active_directory.ds.notification.queued:
+    enabled: true
+  active_directory.ds.operation.rate:
+    enabled: true
+  active_directory.ds.replication.network.io:
+    enabled: true
+  active_directory.ds.replication.object.rate:
+    enabled: true
+  active_directory.ds.replication.operation.pending:
+    enabled: true
+  active_directory.ds.replication.property.rate:
+    enabled: true
+  active_directory.ds.replication.sync.object.pending:
+    enabled: true
+  active_directory.ds.replication.sync.request.count:
+    enabled: true
+  active_directory.ds.replication.value.rate:
+    enabled: true
+  active_directory.ds.security_descriptor_propagations_event.queued:
+    enabled: true
+  active_directory.ds.suboperation.rate:
+    enabled: true
+  active_directory.ds.thread.count:
+    enabled: true
+no_metrics:
+  active_directory.ds.bind.rate:
+    enabled: false
+  active_directory.ds.ldap.bind.last_successful.time:
+    enabled: false
+  active_directory.ds.ldap.bind.rate:
+    enabled: false
+  active_directory.ds.ldap.client.session.count:
+    enabled: false
+  active_directory.ds.ldap.search.rate:
+    enabled: false
+  active_directory.ds.name_cache.hit_rate:
+    enabled: false
+  active_directory.ds.notification.queued:
+    enabled: false
+  active_directory.ds.operation.rate:
+    enabled: false
+  active_directory.ds.replication.network.io:
+    enabled: false
+  active_directory.ds.replication.object.rate:
+    enabled: false
+  active_directory.ds.replication.operation.pending:
+    enabled: false
+  active_directory.ds.replication.property.rate:
+    enabled: false
+  active_directory.ds.replication.sync.object.pending:
+    enabled: false
+  active_directory.ds.replication.sync.request.count:
+    enabled: false
+  active_directory.ds.replication.value.rate:
+    enabled: false
+  active_directory.ds.security_descriptor_propagations_event.queued:
+    enabled: false
+  active_directory.ds.suboperation.rate:
+    enabled: false
+  active_directory.ds.thread.count:
+    enabled: false

--- a/receiver/aerospikereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/aerospikereceiver/internal/metadata/generated_metrics.go
@@ -18,12 +18,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -34,7 +29,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/aerospikereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/aerospikereceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["aerospike.namespace.disk.available"] = true
@@ -80,26 +90,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		AerospikeNamespaceDiskAvailable:                   MetricSettings{Enabled: true},
-		AerospikeNamespaceGeojsonRegionQueryCells:         MetricSettings{Enabled: true},
-		AerospikeNamespaceGeojsonRegionQueryFalsePositive: MetricSettings{Enabled: true},
-		AerospikeNamespaceGeojsonRegionQueryPoints:        MetricSettings{Enabled: true},
-		AerospikeNamespaceGeojsonRegionQueryRequests:      MetricSettings{Enabled: true},
-		AerospikeNamespaceMemoryFree:                      MetricSettings{Enabled: true},
-		AerospikeNamespaceMemoryUsage:                     MetricSettings{Enabled: true},
-		AerospikeNamespaceQueryCount:                      MetricSettings{Enabled: true},
-		AerospikeNamespaceScanCount:                       MetricSettings{Enabled: true},
-		AerospikeNamespaceTransactionCount:                MetricSettings{Enabled: true},
-		AerospikeNodeConnectionCount:                      MetricSettings{Enabled: true},
-		AerospikeNodeConnectionOpen:                       MetricSettings{Enabled: true},
-		AerospikeNodeMemoryFree:                           MetricSettings{Enabled: true},
-		AerospikeNodeQueryTracked:                         MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -357,28 +351,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		AerospikeNamespaceDiskAvailable:                   MetricSettings{Enabled: false},
-		AerospikeNamespaceGeojsonRegionQueryCells:         MetricSettings{Enabled: false},
-		AerospikeNamespaceGeojsonRegionQueryFalsePositive: MetricSettings{Enabled: false},
-		AerospikeNamespaceGeojsonRegionQueryPoints:        MetricSettings{Enabled: false},
-		AerospikeNamespaceGeojsonRegionQueryRequests:      MetricSettings{Enabled: false},
-		AerospikeNamespaceMemoryFree:                      MetricSettings{Enabled: false},
-		AerospikeNamespaceMemoryUsage:                     MetricSettings{Enabled: false},
-		AerospikeNamespaceQueryCount:                      MetricSettings{Enabled: false},
-		AerospikeNamespaceScanCount:                       MetricSettings{Enabled: false},
-		AerospikeNamespaceTransactionCount:                MetricSettings{Enabled: false},
-		AerospikeNodeConnectionCount:                      MetricSettings{Enabled: false},
-		AerospikeNodeConnectionOpen:                       MetricSettings{Enabled: false},
-		AerospikeNodeMemoryFree:                           MetricSettings{Enabled: false},
-		AerospikeNodeQueryTracked:                         MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordAerospikeNamespaceDiskAvailableDataPoint(ts, "1")
 	mb.RecordAerospikeNamespaceGeojsonRegionQueryCellsDataPoint(ts, "1")
 	mb.RecordAerospikeNamespaceGeojsonRegionQueryFalsePositiveDataPoint(ts, "1")
@@ -397,4 +376,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/aerospikereceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/aerospikereceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,59 @@
+default:
+all_metrics:
+  aerospike.namespace.disk.available:
+    enabled: true
+  aerospike.namespace.geojson.region_query_cells:
+    enabled: true
+  aerospike.namespace.geojson.region_query_false_positive:
+    enabled: true
+  aerospike.namespace.geojson.region_query_points:
+    enabled: true
+  aerospike.namespace.geojson.region_query_requests:
+    enabled: true
+  aerospike.namespace.memory.free:
+    enabled: true
+  aerospike.namespace.memory.usage:
+    enabled: true
+  aerospike.namespace.query.count:
+    enabled: true
+  aerospike.namespace.scan.count:
+    enabled: true
+  aerospike.namespace.transaction.count:
+    enabled: true
+  aerospike.node.connection.count:
+    enabled: true
+  aerospike.node.connection.open:
+    enabled: true
+  aerospike.node.memory.free:
+    enabled: true
+  aerospike.node.query.tracked:
+    enabled: true
+no_metrics:
+  aerospike.namespace.disk.available:
+    enabled: false
+  aerospike.namespace.geojson.region_query_cells:
+    enabled: false
+  aerospike.namespace.geojson.region_query_false_positive:
+    enabled: false
+  aerospike.namespace.geojson.region_query_points:
+    enabled: false
+  aerospike.namespace.geojson.region_query_requests:
+    enabled: false
+  aerospike.namespace.memory.free:
+    enabled: false
+  aerospike.namespace.memory.usage:
+    enabled: false
+  aerospike.namespace.query.count:
+    enabled: false
+  aerospike.namespace.scan.count:
+    enabled: false
+  aerospike.namespace.transaction.count:
+    enabled: false
+  aerospike.node.connection.count:
+    enabled: false
+  aerospike.node.connection.open:
+    enabled: false
+  aerospike.node.memory.free:
+    enabled: false
+  aerospike.node.query.tracked:
+    enabled: false

--- a/receiver/apachereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics.go
@@ -18,12 +18,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -34,7 +29,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/apachereceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/apachereceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,51 @@
+default:
+all_metrics:
+  apache.cpu.load:
+    enabled: true
+  apache.cpu.time:
+    enabled: true
+  apache.current_connections:
+    enabled: true
+  apache.load.1:
+    enabled: true
+  apache.load.15:
+    enabled: true
+  apache.load.5:
+    enabled: true
+  apache.request.time:
+    enabled: true
+  apache.requests:
+    enabled: true
+  apache.scoreboard:
+    enabled: true
+  apache.traffic:
+    enabled: true
+  apache.uptime:
+    enabled: true
+  apache.workers:
+    enabled: true
+no_metrics:
+  apache.cpu.load:
+    enabled: false
+  apache.cpu.time:
+    enabled: false
+  apache.current_connections:
+    enabled: false
+  apache.load.1:
+    enabled: false
+  apache.load.15:
+    enabled: false
+  apache.load.5:
+    enabled: false
+  apache.request.time:
+    enabled: false
+  apache.requests:
+    enabled: false
+  apache.scoreboard:
+    enabled: false
+  apache.traffic:
+    enabled: false
+  apache.uptime:
+    enabled: false
+  apache.workers:
+    enabled: false

--- a/receiver/bigipreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/bigipreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/bigipreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/bigipreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["bigip.node.availability"] = true
@@ -119,39 +129,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		BigipNodeAvailability:             MetricSettings{Enabled: true},
-		BigipNodeConnectionCount:          MetricSettings{Enabled: true},
-		BigipNodeDataTransmitted:          MetricSettings{Enabled: true},
-		BigipNodeEnabled:                  MetricSettings{Enabled: true},
-		BigipNodePacketCount:              MetricSettings{Enabled: true},
-		BigipNodeRequestCount:             MetricSettings{Enabled: true},
-		BigipNodeSessionCount:             MetricSettings{Enabled: true},
-		BigipPoolAvailability:             MetricSettings{Enabled: true},
-		BigipPoolConnectionCount:          MetricSettings{Enabled: true},
-		BigipPoolDataTransmitted:          MetricSettings{Enabled: true},
-		BigipPoolEnabled:                  MetricSettings{Enabled: true},
-		BigipPoolMemberCount:              MetricSettings{Enabled: true},
-		BigipPoolPacketCount:              MetricSettings{Enabled: true},
-		BigipPoolRequestCount:             MetricSettings{Enabled: true},
-		BigipPoolMemberAvailability:       MetricSettings{Enabled: true},
-		BigipPoolMemberConnectionCount:    MetricSettings{Enabled: true},
-		BigipPoolMemberDataTransmitted:    MetricSettings{Enabled: true},
-		BigipPoolMemberEnabled:            MetricSettings{Enabled: true},
-		BigipPoolMemberPacketCount:        MetricSettings{Enabled: true},
-		BigipPoolMemberRequestCount:       MetricSettings{Enabled: true},
-		BigipPoolMemberSessionCount:       MetricSettings{Enabled: true},
-		BigipVirtualServerAvailability:    MetricSettings{Enabled: true},
-		BigipVirtualServerConnectionCount: MetricSettings{Enabled: true},
-		BigipVirtualServerDataTransmitted: MetricSettings{Enabled: true},
-		BigipVirtualServerEnabled:         MetricSettings{Enabled: true},
-		BigipVirtualServerPacketCount:     MetricSettings{Enabled: true},
-		BigipVirtualServerRequestCount:    MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -619,41 +600,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		BigipNodeAvailability:             MetricSettings{Enabled: false},
-		BigipNodeConnectionCount:          MetricSettings{Enabled: false},
-		BigipNodeDataTransmitted:          MetricSettings{Enabled: false},
-		BigipNodeEnabled:                  MetricSettings{Enabled: false},
-		BigipNodePacketCount:              MetricSettings{Enabled: false},
-		BigipNodeRequestCount:             MetricSettings{Enabled: false},
-		BigipNodeSessionCount:             MetricSettings{Enabled: false},
-		BigipPoolAvailability:             MetricSettings{Enabled: false},
-		BigipPoolConnectionCount:          MetricSettings{Enabled: false},
-		BigipPoolDataTransmitted:          MetricSettings{Enabled: false},
-		BigipPoolEnabled:                  MetricSettings{Enabled: false},
-		BigipPoolMemberCount:              MetricSettings{Enabled: false},
-		BigipPoolPacketCount:              MetricSettings{Enabled: false},
-		BigipPoolRequestCount:             MetricSettings{Enabled: false},
-		BigipPoolMemberAvailability:       MetricSettings{Enabled: false},
-		BigipPoolMemberConnectionCount:    MetricSettings{Enabled: false},
-		BigipPoolMemberDataTransmitted:    MetricSettings{Enabled: false},
-		BigipPoolMemberEnabled:            MetricSettings{Enabled: false},
-		BigipPoolMemberPacketCount:        MetricSettings{Enabled: false},
-		BigipPoolMemberRequestCount:       MetricSettings{Enabled: false},
-		BigipPoolMemberSessionCount:       MetricSettings{Enabled: false},
-		BigipVirtualServerAvailability:    MetricSettings{Enabled: false},
-		BigipVirtualServerConnectionCount: MetricSettings{Enabled: false},
-		BigipVirtualServerDataTransmitted: MetricSettings{Enabled: false},
-		BigipVirtualServerEnabled:         MetricSettings{Enabled: false},
-		BigipVirtualServerPacketCount:     MetricSettings{Enabled: false},
-		BigipVirtualServerRequestCount:    MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordBigipNodeAvailabilityDataPoint(ts, 1, AttributeAvailabilityStatus(1))
 	mb.RecordBigipNodeConnectionCountDataPoint(ts, 1)
 	mb.RecordBigipNodeDataTransmittedDataPoint(ts, 1, AttributeDirection(1))
@@ -685,4 +638,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/bigipreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/bigipreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,111 @@
+default:
+all_metrics:
+  bigip.node.availability:
+    enabled: true
+  bigip.node.connection.count:
+    enabled: true
+  bigip.node.data.transmitted:
+    enabled: true
+  bigip.node.enabled:
+    enabled: true
+  bigip.node.packet.count:
+    enabled: true
+  bigip.node.request.count:
+    enabled: true
+  bigip.node.session.count:
+    enabled: true
+  bigip.pool.availability:
+    enabled: true
+  bigip.pool.connection.count:
+    enabled: true
+  bigip.pool.data.transmitted:
+    enabled: true
+  bigip.pool.enabled:
+    enabled: true
+  bigip.pool.member.count:
+    enabled: true
+  bigip.pool.packet.count:
+    enabled: true
+  bigip.pool.request.count:
+    enabled: true
+  bigip.pool_member.availability:
+    enabled: true
+  bigip.pool_member.connection.count:
+    enabled: true
+  bigip.pool_member.data.transmitted:
+    enabled: true
+  bigip.pool_member.enabled:
+    enabled: true
+  bigip.pool_member.packet.count:
+    enabled: true
+  bigip.pool_member.request.count:
+    enabled: true
+  bigip.pool_member.session.count:
+    enabled: true
+  bigip.virtual_server.availability:
+    enabled: true
+  bigip.virtual_server.connection.count:
+    enabled: true
+  bigip.virtual_server.data.transmitted:
+    enabled: true
+  bigip.virtual_server.enabled:
+    enabled: true
+  bigip.virtual_server.packet.count:
+    enabled: true
+  bigip.virtual_server.request.count:
+    enabled: true
+no_metrics:
+  bigip.node.availability:
+    enabled: false
+  bigip.node.connection.count:
+    enabled: false
+  bigip.node.data.transmitted:
+    enabled: false
+  bigip.node.enabled:
+    enabled: false
+  bigip.node.packet.count:
+    enabled: false
+  bigip.node.request.count:
+    enabled: false
+  bigip.node.session.count:
+    enabled: false
+  bigip.pool.availability:
+    enabled: false
+  bigip.pool.connection.count:
+    enabled: false
+  bigip.pool.data.transmitted:
+    enabled: false
+  bigip.pool.enabled:
+    enabled: false
+  bigip.pool.member.count:
+    enabled: false
+  bigip.pool.packet.count:
+    enabled: false
+  bigip.pool.request.count:
+    enabled: false
+  bigip.pool_member.availability:
+    enabled: false
+  bigip.pool_member.connection.count:
+    enabled: false
+  bigip.pool_member.data.transmitted:
+    enabled: false
+  bigip.pool_member.enabled:
+    enabled: false
+  bigip.pool_member.packet.count:
+    enabled: false
+  bigip.pool_member.request.count:
+    enabled: false
+  bigip.pool_member.session.count:
+    enabled: false
+  bigip.virtual_server.availability:
+    enabled: false
+  bigip.virtual_server.connection.count:
+    enabled: false
+  bigip.virtual_server.data.transmitted:
+    enabled: false
+  bigip.virtual_server.enabled:
+    enabled: false
+  bigip.virtual_server.packet.count:
+    enabled: false
+  bigip.virtual_server.request.count:
+    enabled: false

--- a/receiver/chronyreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/chronyreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/chronyreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/chronyreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	mb.RecordNtpFrequencyOffsetDataPoint(ts, 1, AttributeLeapStatus(1))
@@ -55,19 +65,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		NtpFrequencyOffset: MetricSettings{Enabled: true},
-		NtpSkew:            MetricSettings{Enabled: true},
-		NtpStratum:         MetricSettings{Enabled: true},
-		NtpTimeCorrection:  MetricSettings{Enabled: true},
-		NtpTimeLastOffset:  MetricSettings{Enabled: true},
-		NtpTimeRmsOffset:   MetricSettings{Enabled: true},
-		NtpTimeRootDelay:   MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -193,21 +194,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		NtpFrequencyOffset: MetricSettings{Enabled: false},
-		NtpSkew:            MetricSettings{Enabled: false},
-		NtpStratum:         MetricSettings{Enabled: false},
-		NtpTimeCorrection:  MetricSettings{Enabled: false},
-		NtpTimeLastOffset:  MetricSettings{Enabled: false},
-		NtpTimeRmsOffset:   MetricSettings{Enabled: false},
-		NtpTimeRootDelay:   MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordNtpFrequencyOffsetDataPoint(ts, 1, AttributeLeapStatus(1))
 	mb.RecordNtpSkewDataPoint(ts, 1)
 	mb.RecordNtpStratumDataPoint(ts, 1)
@@ -219,4 +212,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/chronyreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/chronyreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,31 @@
+default:
+all_metrics:
+  ntp.frequency.offset:
+    enabled: true
+  ntp.skew:
+    enabled: true
+  ntp.stratum:
+    enabled: true
+  ntp.time.correction:
+    enabled: true
+  ntp.time.last_offset:
+    enabled: true
+  ntp.time.rms_offset:
+    enabled: true
+  ntp.time.root_delay:
+    enabled: true
+no_metrics:
+  ntp.frequency.offset:
+    enabled: false
+  ntp.skew:
+    enabled: false
+  ntp.stratum:
+    enabled: false
+  ntp.time.correction:
+    enabled: false
+  ntp.time.last_offset:
+    enabled: false
+  ntp.time.rms_offset:
+    enabled: false
+  ntp.time.root_delay:
+    enabled: false

--- a/receiver/couchdbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/couchdbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/couchdbreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,35 @@
+default:
+all_metrics:
+  couchdb.average_request_time:
+    enabled: true
+  couchdb.database.open:
+    enabled: true
+  couchdb.database.operations:
+    enabled: true
+  couchdb.file_descriptor.open:
+    enabled: true
+  couchdb.httpd.bulk_requests:
+    enabled: true
+  couchdb.httpd.requests:
+    enabled: true
+  couchdb.httpd.responses:
+    enabled: true
+  couchdb.httpd.views:
+    enabled: true
+no_metrics:
+  couchdb.average_request_time:
+    enabled: false
+  couchdb.database.open:
+    enabled: false
+  couchdb.database.operations:
+    enabled: false
+  couchdb.file_descriptor.open:
+    enabled: false
+  couchdb.httpd.bulk_requests:
+    enabled: false
+  couchdb.httpd.requests:
+    enabled: false
+  couchdb.httpd.responses:
+    enabled: false
+  couchdb.httpd.views:
+    enabled: false

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/dockerstatsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/dockerstatsreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,255 @@
+default:
+all_metrics:
+  container.blockio.io_merged_recursive:
+    enabled: true
+  container.blockio.io_queued_recursive:
+    enabled: true
+  container.blockio.io_service_bytes_recursive:
+    enabled: true
+  container.blockio.io_service_time_recursive:
+    enabled: true
+  container.blockio.io_serviced_recursive:
+    enabled: true
+  container.blockio.io_time_recursive:
+    enabled: true
+  container.blockio.io_wait_time_recursive:
+    enabled: true
+  container.blockio.sectors_recursive:
+    enabled: true
+  container.cpu.percent:
+    enabled: true
+  container.cpu.throttling_data.periods:
+    enabled: true
+  container.cpu.throttling_data.throttled_periods:
+    enabled: true
+  container.cpu.throttling_data.throttled_time:
+    enabled: true
+  container.cpu.usage.kernelmode:
+    enabled: true
+  container.cpu.usage.percpu:
+    enabled: true
+  container.cpu.usage.system:
+    enabled: true
+  container.cpu.usage.total:
+    enabled: true
+  container.cpu.usage.usermode:
+    enabled: true
+  container.memory.active_anon:
+    enabled: true
+  container.memory.active_file:
+    enabled: true
+  container.memory.cache:
+    enabled: true
+  container.memory.dirty:
+    enabled: true
+  container.memory.hierarchical_memory_limit:
+    enabled: true
+  container.memory.hierarchical_memsw_limit:
+    enabled: true
+  container.memory.inactive_anon:
+    enabled: true
+  container.memory.inactive_file:
+    enabled: true
+  container.memory.mapped_file:
+    enabled: true
+  container.memory.percent:
+    enabled: true
+  container.memory.pgfault:
+    enabled: true
+  container.memory.pgmajfault:
+    enabled: true
+  container.memory.pgpgin:
+    enabled: true
+  container.memory.pgpgout:
+    enabled: true
+  container.memory.rss:
+    enabled: true
+  container.memory.rss_huge:
+    enabled: true
+  container.memory.swap:
+    enabled: true
+  container.memory.total_active_anon:
+    enabled: true
+  container.memory.total_active_file:
+    enabled: true
+  container.memory.total_cache:
+    enabled: true
+  container.memory.total_dirty:
+    enabled: true
+  container.memory.total_inactive_anon:
+    enabled: true
+  container.memory.total_inactive_file:
+    enabled: true
+  container.memory.total_mapped_file:
+    enabled: true
+  container.memory.total_pgfault:
+    enabled: true
+  container.memory.total_pgmajfault:
+    enabled: true
+  container.memory.total_pgpgin:
+    enabled: true
+  container.memory.total_pgpgout:
+    enabled: true
+  container.memory.total_rss:
+    enabled: true
+  container.memory.total_rss_huge:
+    enabled: true
+  container.memory.total_swap:
+    enabled: true
+  container.memory.total_unevictable:
+    enabled: true
+  container.memory.total_writeback:
+    enabled: true
+  container.memory.unevictable:
+    enabled: true
+  container.memory.usage.limit:
+    enabled: true
+  container.memory.usage.max:
+    enabled: true
+  container.memory.usage.total:
+    enabled: true
+  container.memory.writeback:
+    enabled: true
+  container.network.io.usage.rx_bytes:
+    enabled: true
+  container.network.io.usage.rx_dropped:
+    enabled: true
+  container.network.io.usage.rx_errors:
+    enabled: true
+  container.network.io.usage.rx_packets:
+    enabled: true
+  container.network.io.usage.tx_bytes:
+    enabled: true
+  container.network.io.usage.tx_dropped:
+    enabled: true
+  container.network.io.usage.tx_errors:
+    enabled: true
+  container.network.io.usage.tx_packets:
+    enabled: true
+no_metrics:
+  container.blockio.io_merged_recursive:
+    enabled: false
+  container.blockio.io_queued_recursive:
+    enabled: false
+  container.blockio.io_service_bytes_recursive:
+    enabled: false
+  container.blockio.io_service_time_recursive:
+    enabled: false
+  container.blockio.io_serviced_recursive:
+    enabled: false
+  container.blockio.io_time_recursive:
+    enabled: false
+  container.blockio.io_wait_time_recursive:
+    enabled: false
+  container.blockio.sectors_recursive:
+    enabled: false
+  container.cpu.percent:
+    enabled: false
+  container.cpu.throttling_data.periods:
+    enabled: false
+  container.cpu.throttling_data.throttled_periods:
+    enabled: false
+  container.cpu.throttling_data.throttled_time:
+    enabled: false
+  container.cpu.usage.kernelmode:
+    enabled: false
+  container.cpu.usage.percpu:
+    enabled: false
+  container.cpu.usage.system:
+    enabled: false
+  container.cpu.usage.total:
+    enabled: false
+  container.cpu.usage.usermode:
+    enabled: false
+  container.memory.active_anon:
+    enabled: false
+  container.memory.active_file:
+    enabled: false
+  container.memory.cache:
+    enabled: false
+  container.memory.dirty:
+    enabled: false
+  container.memory.hierarchical_memory_limit:
+    enabled: false
+  container.memory.hierarchical_memsw_limit:
+    enabled: false
+  container.memory.inactive_anon:
+    enabled: false
+  container.memory.inactive_file:
+    enabled: false
+  container.memory.mapped_file:
+    enabled: false
+  container.memory.percent:
+    enabled: false
+  container.memory.pgfault:
+    enabled: false
+  container.memory.pgmajfault:
+    enabled: false
+  container.memory.pgpgin:
+    enabled: false
+  container.memory.pgpgout:
+    enabled: false
+  container.memory.rss:
+    enabled: false
+  container.memory.rss_huge:
+    enabled: false
+  container.memory.swap:
+    enabled: false
+  container.memory.total_active_anon:
+    enabled: false
+  container.memory.total_active_file:
+    enabled: false
+  container.memory.total_cache:
+    enabled: false
+  container.memory.total_dirty:
+    enabled: false
+  container.memory.total_inactive_anon:
+    enabled: false
+  container.memory.total_inactive_file:
+    enabled: false
+  container.memory.total_mapped_file:
+    enabled: false
+  container.memory.total_pgfault:
+    enabled: false
+  container.memory.total_pgmajfault:
+    enabled: false
+  container.memory.total_pgpgin:
+    enabled: false
+  container.memory.total_pgpgout:
+    enabled: false
+  container.memory.total_rss:
+    enabled: false
+  container.memory.total_rss_huge:
+    enabled: false
+  container.memory.total_swap:
+    enabled: false
+  container.memory.total_unevictable:
+    enabled: false
+  container.memory.total_writeback:
+    enabled: false
+  container.memory.unevictable:
+    enabled: false
+  container.memory.usage.limit:
+    enabled: false
+  container.memory.usage.max:
+    enabled: false
+  container.memory.usage.total:
+    enabled: false
+  container.memory.writeback:
+    enabled: false
+  container.network.io.usage.rx_bytes:
+    enabled: false
+  container.network.io.usage.rx_dropped:
+    enabled: false
+  container.network.io.usage.rx_errors:
+    enabled: false
+  container.network.io.usage.rx_packets:
+    enabled: false
+  container.network.io.usage.tx_bytes:
+    enabled: false
+  container.network.io.usage.tx_dropped:
+    enabled: false
+  container.network.io.usage.tx_errors:
+    enabled: false
+  container.network.io.usage.tx_packets:
+    enabled: false

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/elasticsearchreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/elasticsearchreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,367 @@
+default:
+all_metrics:
+  elasticsearch.breaker.memory.estimated:
+    enabled: true
+  elasticsearch.breaker.memory.limit:
+    enabled: true
+  elasticsearch.breaker.tripped:
+    enabled: true
+  elasticsearch.cluster.data_nodes:
+    enabled: true
+  elasticsearch.cluster.health:
+    enabled: true
+  elasticsearch.cluster.in_flight_fetch:
+    enabled: true
+  elasticsearch.cluster.indices.cache.evictions:
+    enabled: true
+  elasticsearch.cluster.nodes:
+    enabled: true
+  elasticsearch.cluster.pending_tasks:
+    enabled: true
+  elasticsearch.cluster.published_states.differences:
+    enabled: true
+  elasticsearch.cluster.published_states.full:
+    enabled: true
+  elasticsearch.cluster.shards:
+    enabled: true
+  elasticsearch.cluster.state_queue:
+    enabled: true
+  elasticsearch.cluster.state_update.count:
+    enabled: true
+  elasticsearch.cluster.state_update.time:
+    enabled: true
+  elasticsearch.index.cache.evictions:
+    enabled: true
+  elasticsearch.index.cache.memory.usage:
+    enabled: true
+  elasticsearch.index.cache.size:
+    enabled: true
+  elasticsearch.index.documents:
+    enabled: true
+  elasticsearch.index.operations.completed:
+    enabled: true
+  elasticsearch.index.operations.merge.docs_count:
+    enabled: true
+  elasticsearch.index.operations.merge.size:
+    enabled: true
+  elasticsearch.index.operations.time:
+    enabled: true
+  elasticsearch.index.segments.count:
+    enabled: true
+  elasticsearch.index.segments.memory:
+    enabled: true
+  elasticsearch.index.segments.size:
+    enabled: true
+  elasticsearch.index.shards.size:
+    enabled: true
+  elasticsearch.index.translog.operations:
+    enabled: true
+  elasticsearch.index.translog.size:
+    enabled: true
+  elasticsearch.indexing_pressure.memory.limit:
+    enabled: true
+  elasticsearch.indexing_pressure.memory.total.primary_rejections:
+    enabled: true
+  elasticsearch.indexing_pressure.memory.total.replica_rejections:
+    enabled: true
+  elasticsearch.memory.indexing_pressure:
+    enabled: true
+  elasticsearch.node.cache.count:
+    enabled: true
+  elasticsearch.node.cache.evictions:
+    enabled: true
+  elasticsearch.node.cache.memory.usage:
+    enabled: true
+  elasticsearch.node.cache.size:
+    enabled: true
+  elasticsearch.node.cluster.connections:
+    enabled: true
+  elasticsearch.node.cluster.io:
+    enabled: true
+  elasticsearch.node.disk.io.read:
+    enabled: true
+  elasticsearch.node.disk.io.write:
+    enabled: true
+  elasticsearch.node.documents:
+    enabled: true
+  elasticsearch.node.fs.disk.available:
+    enabled: true
+  elasticsearch.node.fs.disk.free:
+    enabled: true
+  elasticsearch.node.fs.disk.total:
+    enabled: true
+  elasticsearch.node.http.connections:
+    enabled: true
+  elasticsearch.node.ingest.documents:
+    enabled: true
+  elasticsearch.node.ingest.documents.current:
+    enabled: true
+  elasticsearch.node.ingest.operations.failed:
+    enabled: true
+  elasticsearch.node.open_files:
+    enabled: true
+  elasticsearch.node.operations.completed:
+    enabled: true
+  elasticsearch.node.operations.current:
+    enabled: true
+  elasticsearch.node.operations.get.completed:
+    enabled: true
+  elasticsearch.node.operations.get.time:
+    enabled: true
+  elasticsearch.node.operations.time:
+    enabled: true
+  elasticsearch.node.pipeline.ingest.documents.current:
+    enabled: true
+  elasticsearch.node.pipeline.ingest.documents.preprocessed:
+    enabled: true
+  elasticsearch.node.pipeline.ingest.operations.failed:
+    enabled: true
+  elasticsearch.node.script.cache_evictions:
+    enabled: true
+  elasticsearch.node.script.compilation_limit_triggered:
+    enabled: true
+  elasticsearch.node.script.compilations:
+    enabled: true
+  elasticsearch.node.segments.memory:
+    enabled: true
+  elasticsearch.node.shards.data_set.size:
+    enabled: true
+  elasticsearch.node.shards.reserved.size:
+    enabled: true
+  elasticsearch.node.shards.size:
+    enabled: true
+  elasticsearch.node.thread_pool.tasks.finished:
+    enabled: true
+  elasticsearch.node.thread_pool.tasks.queued:
+    enabled: true
+  elasticsearch.node.thread_pool.threads:
+    enabled: true
+  elasticsearch.node.translog.operations:
+    enabled: true
+  elasticsearch.node.translog.size:
+    enabled: true
+  elasticsearch.node.translog.uncommitted.size:
+    enabled: true
+  elasticsearch.os.cpu.load_avg.15m:
+    enabled: true
+  elasticsearch.os.cpu.load_avg.1m:
+    enabled: true
+  elasticsearch.os.cpu.load_avg.5m:
+    enabled: true
+  elasticsearch.os.cpu.usage:
+    enabled: true
+  elasticsearch.os.memory:
+    enabled: true
+  elasticsearch.process.cpu.time:
+    enabled: true
+  elasticsearch.process.cpu.usage:
+    enabled: true
+  elasticsearch.process.memory.virtual:
+    enabled: true
+  jvm.classes.loaded:
+    enabled: true
+  jvm.gc.collections.count:
+    enabled: true
+  jvm.gc.collections.elapsed:
+    enabled: true
+  jvm.memory.heap.committed:
+    enabled: true
+  jvm.memory.heap.max:
+    enabled: true
+  jvm.memory.heap.used:
+    enabled: true
+  jvm.memory.heap.utilization:
+    enabled: true
+  jvm.memory.nonheap.committed:
+    enabled: true
+  jvm.memory.nonheap.used:
+    enabled: true
+  jvm.memory.pool.max:
+    enabled: true
+  jvm.memory.pool.used:
+    enabled: true
+  jvm.threads.count:
+    enabled: true
+no_metrics:
+  elasticsearch.breaker.memory.estimated:
+    enabled: false
+  elasticsearch.breaker.memory.limit:
+    enabled: false
+  elasticsearch.breaker.tripped:
+    enabled: false
+  elasticsearch.cluster.data_nodes:
+    enabled: false
+  elasticsearch.cluster.health:
+    enabled: false
+  elasticsearch.cluster.in_flight_fetch:
+    enabled: false
+  elasticsearch.cluster.indices.cache.evictions:
+    enabled: false
+  elasticsearch.cluster.nodes:
+    enabled: false
+  elasticsearch.cluster.pending_tasks:
+    enabled: false
+  elasticsearch.cluster.published_states.differences:
+    enabled: false
+  elasticsearch.cluster.published_states.full:
+    enabled: false
+  elasticsearch.cluster.shards:
+    enabled: false
+  elasticsearch.cluster.state_queue:
+    enabled: false
+  elasticsearch.cluster.state_update.count:
+    enabled: false
+  elasticsearch.cluster.state_update.time:
+    enabled: false
+  elasticsearch.index.cache.evictions:
+    enabled: false
+  elasticsearch.index.cache.memory.usage:
+    enabled: false
+  elasticsearch.index.cache.size:
+    enabled: false
+  elasticsearch.index.documents:
+    enabled: false
+  elasticsearch.index.operations.completed:
+    enabled: false
+  elasticsearch.index.operations.merge.docs_count:
+    enabled: false
+  elasticsearch.index.operations.merge.size:
+    enabled: false
+  elasticsearch.index.operations.time:
+    enabled: false
+  elasticsearch.index.segments.count:
+    enabled: false
+  elasticsearch.index.segments.memory:
+    enabled: false
+  elasticsearch.index.segments.size:
+    enabled: false
+  elasticsearch.index.shards.size:
+    enabled: false
+  elasticsearch.index.translog.operations:
+    enabled: false
+  elasticsearch.index.translog.size:
+    enabled: false
+  elasticsearch.indexing_pressure.memory.limit:
+    enabled: false
+  elasticsearch.indexing_pressure.memory.total.primary_rejections:
+    enabled: false
+  elasticsearch.indexing_pressure.memory.total.replica_rejections:
+    enabled: false
+  elasticsearch.memory.indexing_pressure:
+    enabled: false
+  elasticsearch.node.cache.count:
+    enabled: false
+  elasticsearch.node.cache.evictions:
+    enabled: false
+  elasticsearch.node.cache.memory.usage:
+    enabled: false
+  elasticsearch.node.cache.size:
+    enabled: false
+  elasticsearch.node.cluster.connections:
+    enabled: false
+  elasticsearch.node.cluster.io:
+    enabled: false
+  elasticsearch.node.disk.io.read:
+    enabled: false
+  elasticsearch.node.disk.io.write:
+    enabled: false
+  elasticsearch.node.documents:
+    enabled: false
+  elasticsearch.node.fs.disk.available:
+    enabled: false
+  elasticsearch.node.fs.disk.free:
+    enabled: false
+  elasticsearch.node.fs.disk.total:
+    enabled: false
+  elasticsearch.node.http.connections:
+    enabled: false
+  elasticsearch.node.ingest.documents:
+    enabled: false
+  elasticsearch.node.ingest.documents.current:
+    enabled: false
+  elasticsearch.node.ingest.operations.failed:
+    enabled: false
+  elasticsearch.node.open_files:
+    enabled: false
+  elasticsearch.node.operations.completed:
+    enabled: false
+  elasticsearch.node.operations.current:
+    enabled: false
+  elasticsearch.node.operations.get.completed:
+    enabled: false
+  elasticsearch.node.operations.get.time:
+    enabled: false
+  elasticsearch.node.operations.time:
+    enabled: false
+  elasticsearch.node.pipeline.ingest.documents.current:
+    enabled: false
+  elasticsearch.node.pipeline.ingest.documents.preprocessed:
+    enabled: false
+  elasticsearch.node.pipeline.ingest.operations.failed:
+    enabled: false
+  elasticsearch.node.script.cache_evictions:
+    enabled: false
+  elasticsearch.node.script.compilation_limit_triggered:
+    enabled: false
+  elasticsearch.node.script.compilations:
+    enabled: false
+  elasticsearch.node.segments.memory:
+    enabled: false
+  elasticsearch.node.shards.data_set.size:
+    enabled: false
+  elasticsearch.node.shards.reserved.size:
+    enabled: false
+  elasticsearch.node.shards.size:
+    enabled: false
+  elasticsearch.node.thread_pool.tasks.finished:
+    enabled: false
+  elasticsearch.node.thread_pool.tasks.queued:
+    enabled: false
+  elasticsearch.node.thread_pool.threads:
+    enabled: false
+  elasticsearch.node.translog.operations:
+    enabled: false
+  elasticsearch.node.translog.size:
+    enabled: false
+  elasticsearch.node.translog.uncommitted.size:
+    enabled: false
+  elasticsearch.os.cpu.load_avg.15m:
+    enabled: false
+  elasticsearch.os.cpu.load_avg.1m:
+    enabled: false
+  elasticsearch.os.cpu.load_avg.5m:
+    enabled: false
+  elasticsearch.os.cpu.usage:
+    enabled: false
+  elasticsearch.os.memory:
+    enabled: false
+  elasticsearch.process.cpu.time:
+    enabled: false
+  elasticsearch.process.cpu.usage:
+    enabled: false
+  elasticsearch.process.memory.virtual:
+    enabled: false
+  jvm.classes.loaded:
+    enabled: false
+  jvm.gc.collections.count:
+    enabled: false
+  jvm.gc.collections.elapsed:
+    enabled: false
+  jvm.memory.heap.committed:
+    enabled: false
+  jvm.memory.heap.max:
+    enabled: false
+  jvm.memory.heap.used:
+    enabled: false
+  jvm.memory.heap.utilization:
+    enabled: false
+  jvm.memory.nonheap.committed:
+    enabled: false
+  jvm.memory.nonheap.used:
+    enabled: false
+  jvm.memory.pool.max:
+    enabled: false
+  jvm.memory.pool.used:
+    enabled: false
+  jvm.threads.count:
+    enabled: false

--- a/receiver/expvarreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/expvarreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/expvarreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/expvarreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,107 @@
+default:
+all_metrics:
+  process.runtime.memstats.buck_hash_sys:
+    enabled: true
+  process.runtime.memstats.frees:
+    enabled: true
+  process.runtime.memstats.gc_cpu_fraction:
+    enabled: true
+  process.runtime.memstats.gc_sys:
+    enabled: true
+  process.runtime.memstats.heap_alloc:
+    enabled: true
+  process.runtime.memstats.heap_idle:
+    enabled: true
+  process.runtime.memstats.heap_inuse:
+    enabled: true
+  process.runtime.memstats.heap_objects:
+    enabled: true
+  process.runtime.memstats.heap_released:
+    enabled: true
+  process.runtime.memstats.heap_sys:
+    enabled: true
+  process.runtime.memstats.last_pause:
+    enabled: true
+  process.runtime.memstats.lookups:
+    enabled: true
+  process.runtime.memstats.mallocs:
+    enabled: true
+  process.runtime.memstats.mcache_inuse:
+    enabled: true
+  process.runtime.memstats.mcache_sys:
+    enabled: true
+  process.runtime.memstats.mspan_inuse:
+    enabled: true
+  process.runtime.memstats.mspan_sys:
+    enabled: true
+  process.runtime.memstats.next_gc:
+    enabled: true
+  process.runtime.memstats.num_forced_gc:
+    enabled: true
+  process.runtime.memstats.num_gc:
+    enabled: true
+  process.runtime.memstats.other_sys:
+    enabled: true
+  process.runtime.memstats.pause_total:
+    enabled: true
+  process.runtime.memstats.stack_inuse:
+    enabled: true
+  process.runtime.memstats.stack_sys:
+    enabled: true
+  process.runtime.memstats.sys:
+    enabled: true
+  process.runtime.memstats.total_alloc:
+    enabled: true
+no_metrics:
+  process.runtime.memstats.buck_hash_sys:
+    enabled: false
+  process.runtime.memstats.frees:
+    enabled: false
+  process.runtime.memstats.gc_cpu_fraction:
+    enabled: false
+  process.runtime.memstats.gc_sys:
+    enabled: false
+  process.runtime.memstats.heap_alloc:
+    enabled: false
+  process.runtime.memstats.heap_idle:
+    enabled: false
+  process.runtime.memstats.heap_inuse:
+    enabled: false
+  process.runtime.memstats.heap_objects:
+    enabled: false
+  process.runtime.memstats.heap_released:
+    enabled: false
+  process.runtime.memstats.heap_sys:
+    enabled: false
+  process.runtime.memstats.last_pause:
+    enabled: false
+  process.runtime.memstats.lookups:
+    enabled: false
+  process.runtime.memstats.mallocs:
+    enabled: false
+  process.runtime.memstats.mcache_inuse:
+    enabled: false
+  process.runtime.memstats.mcache_sys:
+    enabled: false
+  process.runtime.memstats.mspan_inuse:
+    enabled: false
+  process.runtime.memstats.mspan_sys:
+    enabled: false
+  process.runtime.memstats.next_gc:
+    enabled: false
+  process.runtime.memstats.num_forced_gc:
+    enabled: false
+  process.runtime.memstats.num_gc:
+    enabled: false
+  process.runtime.memstats.other_sys:
+    enabled: false
+  process.runtime.memstats.pause_total:
+    enabled: false
+  process.runtime.memstats.stack_inuse:
+    enabled: false
+  process.runtime.memstats.stack_sys:
+    enabled: false
+  process.runtime.memstats.sys:
+    enabled: false
+  process.runtime.memstats.total_alloc:
+    enabled: false

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
@@ -18,12 +18,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -34,7 +29,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["flink.job.checkpoint.count"] = true
@@ -125,41 +135,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		FlinkJobCheckpointCount:           MetricSettings{Enabled: true},
-		FlinkJobCheckpointInProgress:      MetricSettings{Enabled: true},
-		FlinkJobLastCheckpointSize:        MetricSettings{Enabled: true},
-		FlinkJobLastCheckpointTime:        MetricSettings{Enabled: true},
-		FlinkJobRestartCount:              MetricSettings{Enabled: true},
-		FlinkJvmClassLoaderClassesLoaded:  MetricSettings{Enabled: true},
-		FlinkJvmCPULoad:                   MetricSettings{Enabled: true},
-		FlinkJvmCPUTime:                   MetricSettings{Enabled: true},
-		FlinkJvmGcCollectionsCount:        MetricSettings{Enabled: true},
-		FlinkJvmGcCollectionsTime:         MetricSettings{Enabled: true},
-		FlinkJvmMemoryDirectTotalCapacity: MetricSettings{Enabled: true},
-		FlinkJvmMemoryDirectUsed:          MetricSettings{Enabled: true},
-		FlinkJvmMemoryHeapCommitted:       MetricSettings{Enabled: true},
-		FlinkJvmMemoryHeapMax:             MetricSettings{Enabled: true},
-		FlinkJvmMemoryHeapUsed:            MetricSettings{Enabled: true},
-		FlinkJvmMemoryMappedTotalCapacity: MetricSettings{Enabled: true},
-		FlinkJvmMemoryMappedUsed:          MetricSettings{Enabled: true},
-		FlinkJvmMemoryMetaspaceCommitted:  MetricSettings{Enabled: true},
-		FlinkJvmMemoryMetaspaceMax:        MetricSettings{Enabled: true},
-		FlinkJvmMemoryMetaspaceUsed:       MetricSettings{Enabled: true},
-		FlinkJvmMemoryNonheapCommitted:    MetricSettings{Enabled: true},
-		FlinkJvmMemoryNonheapMax:          MetricSettings{Enabled: true},
-		FlinkJvmMemoryNonheapUsed:         MetricSettings{Enabled: true},
-		FlinkJvmThreadsCount:              MetricSettings{Enabled: true},
-		FlinkMemoryManagedTotal:           MetricSettings{Enabled: true},
-		FlinkMemoryManagedUsed:            MetricSettings{Enabled: true},
-		FlinkOperatorRecordCount:          MetricSettings{Enabled: true},
-		FlinkOperatorWatermarkOutput:      MetricSettings{Enabled: true},
-		FlinkTaskRecordCount:              MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -633,43 +612,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		FlinkJobCheckpointCount:           MetricSettings{Enabled: false},
-		FlinkJobCheckpointInProgress:      MetricSettings{Enabled: false},
-		FlinkJobLastCheckpointSize:        MetricSettings{Enabled: false},
-		FlinkJobLastCheckpointTime:        MetricSettings{Enabled: false},
-		FlinkJobRestartCount:              MetricSettings{Enabled: false},
-		FlinkJvmClassLoaderClassesLoaded:  MetricSettings{Enabled: false},
-		FlinkJvmCPULoad:                   MetricSettings{Enabled: false},
-		FlinkJvmCPUTime:                   MetricSettings{Enabled: false},
-		FlinkJvmGcCollectionsCount:        MetricSettings{Enabled: false},
-		FlinkJvmGcCollectionsTime:         MetricSettings{Enabled: false},
-		FlinkJvmMemoryDirectTotalCapacity: MetricSettings{Enabled: false},
-		FlinkJvmMemoryDirectUsed:          MetricSettings{Enabled: false},
-		FlinkJvmMemoryHeapCommitted:       MetricSettings{Enabled: false},
-		FlinkJvmMemoryHeapMax:             MetricSettings{Enabled: false},
-		FlinkJvmMemoryHeapUsed:            MetricSettings{Enabled: false},
-		FlinkJvmMemoryMappedTotalCapacity: MetricSettings{Enabled: false},
-		FlinkJvmMemoryMappedUsed:          MetricSettings{Enabled: false},
-		FlinkJvmMemoryMetaspaceCommitted:  MetricSettings{Enabled: false},
-		FlinkJvmMemoryMetaspaceMax:        MetricSettings{Enabled: false},
-		FlinkJvmMemoryMetaspaceUsed:       MetricSettings{Enabled: false},
-		FlinkJvmMemoryNonheapCommitted:    MetricSettings{Enabled: false},
-		FlinkJvmMemoryNonheapMax:          MetricSettings{Enabled: false},
-		FlinkJvmMemoryNonheapUsed:         MetricSettings{Enabled: false},
-		FlinkJvmThreadsCount:              MetricSettings{Enabled: false},
-		FlinkMemoryManagedTotal:           MetricSettings{Enabled: false},
-		FlinkMemoryManagedUsed:            MetricSettings{Enabled: false},
-		FlinkOperatorRecordCount:          MetricSettings{Enabled: false},
-		FlinkOperatorWatermarkOutput:      MetricSettings{Enabled: false},
-		FlinkTaskRecordCount:              MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordFlinkJobCheckpointCountDataPoint(ts, "1", AttributeCheckpoint(1))
 	mb.RecordFlinkJobCheckpointInProgressDataPoint(ts, "1")
 	mb.RecordFlinkJobLastCheckpointSizeDataPoint(ts, "1")
@@ -703,4 +652,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/flinkmetricsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/flinkmetricsreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,119 @@
+default:
+all_metrics:
+  flink.job.checkpoint.count:
+    enabled: true
+  flink.job.checkpoint.in_progress:
+    enabled: true
+  flink.job.last_checkpoint.size:
+    enabled: true
+  flink.job.last_checkpoint.time:
+    enabled: true
+  flink.job.restart.count:
+    enabled: true
+  flink.jvm.class_loader.classes_loaded:
+    enabled: true
+  flink.jvm.cpu.load:
+    enabled: true
+  flink.jvm.cpu.time:
+    enabled: true
+  flink.jvm.gc.collections.count:
+    enabled: true
+  flink.jvm.gc.collections.time:
+    enabled: true
+  flink.jvm.memory.direct.total_capacity:
+    enabled: true
+  flink.jvm.memory.direct.used:
+    enabled: true
+  flink.jvm.memory.heap.committed:
+    enabled: true
+  flink.jvm.memory.heap.max:
+    enabled: true
+  flink.jvm.memory.heap.used:
+    enabled: true
+  flink.jvm.memory.mapped.total_capacity:
+    enabled: true
+  flink.jvm.memory.mapped.used:
+    enabled: true
+  flink.jvm.memory.metaspace.committed:
+    enabled: true
+  flink.jvm.memory.metaspace.max:
+    enabled: true
+  flink.jvm.memory.metaspace.used:
+    enabled: true
+  flink.jvm.memory.nonheap.committed:
+    enabled: true
+  flink.jvm.memory.nonheap.max:
+    enabled: true
+  flink.jvm.memory.nonheap.used:
+    enabled: true
+  flink.jvm.threads.count:
+    enabled: true
+  flink.memory.managed.total:
+    enabled: true
+  flink.memory.managed.used:
+    enabled: true
+  flink.operator.record.count:
+    enabled: true
+  flink.operator.watermark.output:
+    enabled: true
+  flink.task.record.count:
+    enabled: true
+no_metrics:
+  flink.job.checkpoint.count:
+    enabled: false
+  flink.job.checkpoint.in_progress:
+    enabled: false
+  flink.job.last_checkpoint.size:
+    enabled: false
+  flink.job.last_checkpoint.time:
+    enabled: false
+  flink.job.restart.count:
+    enabled: false
+  flink.jvm.class_loader.classes_loaded:
+    enabled: false
+  flink.jvm.cpu.load:
+    enabled: false
+  flink.jvm.cpu.time:
+    enabled: false
+  flink.jvm.gc.collections.count:
+    enabled: false
+  flink.jvm.gc.collections.time:
+    enabled: false
+  flink.jvm.memory.direct.total_capacity:
+    enabled: false
+  flink.jvm.memory.direct.used:
+    enabled: false
+  flink.jvm.memory.heap.committed:
+    enabled: false
+  flink.jvm.memory.heap.max:
+    enabled: false
+  flink.jvm.memory.heap.used:
+    enabled: false
+  flink.jvm.memory.mapped.total_capacity:
+    enabled: false
+  flink.jvm.memory.mapped.used:
+    enabled: false
+  flink.jvm.memory.metaspace.committed:
+    enabled: false
+  flink.jvm.memory.metaspace.max:
+    enabled: false
+  flink.jvm.memory.metaspace.used:
+    enabled: false
+  flink.jvm.memory.nonheap.committed:
+    enabled: false
+  flink.jvm.memory.nonheap.max:
+    enabled: false
+  flink.jvm.memory.nonheap.used:
+    enabled: false
+  flink.jvm.threads.count:
+    enabled: false
+  flink.memory.managed.total:
+    enabled: false
+  flink.memory.managed.used:
+    enabled: false
+  flink.operator.record.count:
+    enabled: false
+  flink.operator.watermark.output:
+    enabled: false
+  flink.task.record.count:
+    enabled: false

--- a/receiver/haproxyreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/haproxyreceiver/internal/metadata/generated_metrics.go
@@ -18,12 +18,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -34,7 +29,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/haproxyreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/haproxyreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["haproxy.connection_rate"] = true
@@ -50,16 +60,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		HaproxyConnectionRate: MetricSettings{Enabled: true},
-		HaproxyIdlePercent:    MetricSettings{Enabled: true},
-		HaproxyRequests:       MetricSettings{Enabled: true},
-		HaproxySessionsCount:  MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -172,18 +176,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		HaproxyConnectionRate: MetricSettings{Enabled: false},
-		HaproxyIdlePercent:    MetricSettings{Enabled: false},
-		HaproxyRequests:       MetricSettings{Enabled: false},
-		HaproxySessionsCount:  MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordHaproxyConnectionRateDataPoint(ts, "1")
 	mb.RecordHaproxyIdlePercentDataPoint(ts, "1")
 	mb.RecordHaproxyRequestsDataPoint(ts, "1")
@@ -192,4 +191,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/haproxyreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/haproxyreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,19 @@
+default:
+all_metrics:
+  haproxy.connection_rate:
+    enabled: true
+  haproxy.idle_percent:
+    enabled: true
+  haproxy.requests:
+    enabled: true
+  haproxy.sessions.count:
+    enabled: true
+no_metrics:
+  haproxy.connection_rate:
+    enabled: false
+  haproxy.idle_percent:
+    enabled: false
+  haproxy.requests:
+    enabled: false
+  haproxy.sessions.count:
+    enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["system.cpu.time"] = true
@@ -43,14 +53,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemCPUTime:        MetricSettings{Enabled: true},
-		SystemCPUUtilization: MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -115,20 +121,27 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemCPUTime:        MetricSettings{Enabled: false},
-		SystemCPUUtilization: MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordSystemCPUTimeDataPoint(ts, 1, "attr-val", AttributeState(1))
 	mb.RecordSystemCPUUtilizationDataPoint(ts, 1, "attr-val", AttributeState(1))
 
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/testdata/config.yaml
@@ -1,0 +1,11 @@
+default:
+all_metrics:
+  system.cpu.time:
+    enabled: true
+  system.cpu.utilization:
+    enabled: true
+no_metrics:
+  system.cpu.time:
+    enabled: false
+  system.cpu.utilization:
+    enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["system.disk.io"] = true
@@ -59,19 +69,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemDiskIo:                MetricSettings{Enabled: true},
-		SystemDiskIoTime:            MetricSettings{Enabled: true},
-		SystemDiskMerged:            MetricSettings{Enabled: true},
-		SystemDiskOperationTime:     MetricSettings{Enabled: true},
-		SystemDiskOperations:        MetricSettings{Enabled: true},
-		SystemDiskPendingOperations: MetricSettings{Enabled: true},
-		SystemDiskWeightedIoTime:    MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -229,21 +230,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemDiskIo:                MetricSettings{Enabled: false},
-		SystemDiskIoTime:            MetricSettings{Enabled: false},
-		SystemDiskMerged:            MetricSettings{Enabled: false},
-		SystemDiskOperationTime:     MetricSettings{Enabled: false},
-		SystemDiskOperations:        MetricSettings{Enabled: false},
-		SystemDiskPendingOperations: MetricSettings{Enabled: false},
-		SystemDiskWeightedIoTime:    MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordSystemDiskIoDataPoint(ts, 1, "attr-val", AttributeDirection(1))
 	mb.RecordSystemDiskIoTimeDataPoint(ts, 1, "attr-val")
 	mb.RecordSystemDiskMergedDataPoint(ts, 1, "attr-val", AttributeDirection(1))
@@ -255,4 +248,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/testdata/config.yaml
@@ -1,0 +1,31 @@
+default:
+all_metrics:
+  system.disk.io:
+    enabled: true
+  system.disk.io_time:
+    enabled: true
+  system.disk.merged:
+    enabled: true
+  system.disk.operation_time:
+    enabled: true
+  system.disk.operations:
+    enabled: true
+  system.disk.pending_operations:
+    enabled: true
+  system.disk.weighted_io_time:
+    enabled: true
+no_metrics:
+  system.disk.io:
+    enabled: false
+  system.disk.io_time:
+    enabled: false
+  system.disk.merged:
+    enabled: false
+  system.disk.operation_time:
+    enabled: false
+  system.disk.operations:
+    enabled: false
+  system.disk.pending_operations:
+    enabled: false
+  system.disk.weighted_io_time:
+    enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["system.filesystem.inodes.usage"] = true
@@ -46,15 +56,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemFilesystemInodesUsage: MetricSettings{Enabled: true},
-		SystemFilesystemUsage:       MetricSettings{Enabled: true},
-		SystemFilesystemUtilization: MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -163,17 +168,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemFilesystemInodesUsage: MetricSettings{Enabled: false},
-		SystemFilesystemUsage:       MetricSettings{Enabled: false},
-		SystemFilesystemUtilization: MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordSystemFilesystemInodesUsageDataPoint(ts, 1, "attr-val", "attr-val", "attr-val", "attr-val", AttributeState(1))
 	mb.RecordSystemFilesystemUsageDataPoint(ts, 1, "attr-val", "attr-val", "attr-val", "attr-val", AttributeState(1))
 	mb.RecordSystemFilesystemUtilizationDataPoint(ts, 1, "attr-val", "attr-val", "attr-val", "attr-val")
@@ -181,4 +182,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/testdata/config.yaml
@@ -1,0 +1,15 @@
+default:
+all_metrics:
+  system.filesystem.inodes.usage:
+    enabled: true
+  system.filesystem.usage:
+    enabled: true
+  system.filesystem.utilization:
+    enabled: true
+no_metrics:
+  system.filesystem.inodes.usage:
+    enabled: false
+  system.filesystem.usage:
+    enabled: false
+  system.filesystem.utilization:
+    enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["system.cpu.load_average.15m"] = true
@@ -47,15 +57,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemCPULoadAverage15m: MetricSettings{Enabled: true},
-		SystemCPULoadAverage1m:  MetricSettings{Enabled: true},
-		SystemCPULoadAverage5m:  MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -118,17 +123,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemCPULoadAverage15m: MetricSettings{Enabled: false},
-		SystemCPULoadAverage1m:  MetricSettings{Enabled: false},
-		SystemCPULoadAverage5m:  MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordSystemCPULoadAverage15mDataPoint(ts, 1)
 	mb.RecordSystemCPULoadAverage1mDataPoint(ts, 1)
 	mb.RecordSystemCPULoadAverage5mDataPoint(ts, 1)
@@ -136,4 +137,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/testdata/config.yaml
@@ -1,0 +1,15 @@
+default:
+all_metrics:
+  system.cpu.load_average.15m:
+    enabled: true
+  system.cpu.load_average.1m:
+    enabled: true
+  system.cpu.load_average.5m:
+    enabled: true
+no_metrics:
+  system.cpu.load_average.15m:
+    enabled: false
+  system.cpu.load_average.1m:
+    enabled: false
+  system.cpu.load_average.5m:
+    enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["system.memory.usage"] = true
@@ -43,14 +53,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemMemoryUsage:       MetricSettings{Enabled: true},
-		SystemMemoryUtilization: MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -109,20 +115,27 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemMemoryUsage:       MetricSettings{Enabled: false},
-		SystemMemoryUtilization: MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordSystemMemoryUsageDataPoint(ts, 1, AttributeState(1))
 	mb.RecordSystemMemoryUtilizationDataPoint(ts, 1, AttributeState(1))
 
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/testdata/config.yaml
@@ -1,0 +1,11 @@
+default:
+all_metrics:
+  system.memory.usage:
+    enabled: true
+  system.memory.utilization:
+    enabled: true
+no_metrics:
+  system.memory.usage:
+    enabled: false
+  system.memory.utilization:
+    enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["system.network.connections"] = true
@@ -57,19 +67,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemNetworkConnections:    MetricSettings{Enabled: true},
-		SystemNetworkConntrackCount: MetricSettings{Enabled: true},
-		SystemNetworkConntrackMax:   MetricSettings{Enabled: true},
-		SystemNetworkDropped:        MetricSettings{Enabled: true},
-		SystemNetworkErrors:         MetricSettings{Enabled: true},
-		SystemNetworkIo:             MetricSettings{Enabled: true},
-		SystemNetworkPackets:        MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -224,21 +225,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemNetworkConnections:    MetricSettings{Enabled: false},
-		SystemNetworkConntrackCount: MetricSettings{Enabled: false},
-		SystemNetworkConntrackMax:   MetricSettings{Enabled: false},
-		SystemNetworkDropped:        MetricSettings{Enabled: false},
-		SystemNetworkErrors:         MetricSettings{Enabled: false},
-		SystemNetworkIo:             MetricSettings{Enabled: false},
-		SystemNetworkPackets:        MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordSystemNetworkConnectionsDataPoint(ts, 1, AttributeProtocol(1), "attr-val")
 	mb.RecordSystemNetworkConntrackCountDataPoint(ts, 1)
 	mb.RecordSystemNetworkConntrackMaxDataPoint(ts, 1)
@@ -250,4 +243,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/testdata/config.yaml
@@ -1,0 +1,31 @@
+default:
+all_metrics:
+  system.network.connections:
+    enabled: true
+  system.network.conntrack.count:
+    enabled: true
+  system.network.conntrack.max:
+    enabled: true
+  system.network.dropped:
+    enabled: true
+  system.network.errors:
+    enabled: true
+  system.network.io:
+    enabled: true
+  system.network.packets:
+    enabled: true
+no_metrics:
+  system.network.connections:
+    enabled: false
+  system.network.conntrack.count:
+    enabled: false
+  system.network.conntrack.max:
+    enabled: false
+  system.network.dropped:
+    enabled: false
+  system.network.errors:
+    enabled: false
+  system.network.io:
+    enabled: false
+  system.network.packets:
+    enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["system.paging.faults"] = true
@@ -49,16 +59,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemPagingFaults:      MetricSettings{Enabled: true},
-		SystemPagingOperations:  MetricSettings{Enabled: true},
-		SystemPagingUsage:       MetricSettings{Enabled: true},
-		SystemPagingUtilization: MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -160,18 +164,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemPagingFaults:      MetricSettings{Enabled: false},
-		SystemPagingOperations:  MetricSettings{Enabled: false},
-		SystemPagingUsage:       MetricSettings{Enabled: false},
-		SystemPagingUtilization: MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordSystemPagingFaultsDataPoint(ts, 1, AttributeType(1))
 	mb.RecordSystemPagingOperationsDataPoint(ts, 1, AttributeDirection(1), AttributeType(1))
 	mb.RecordSystemPagingUsageDataPoint(ts, 1, "attr-val", AttributeState(1))
@@ -180,4 +179,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/testdata/config.yaml
@@ -1,0 +1,19 @@
+default:
+all_metrics:
+  system.paging.faults:
+    enabled: true
+  system.paging.operations:
+    enabled: true
+  system.paging.usage:
+    enabled: true
+  system.paging.utilization:
+    enabled: true
+no_metrics:
+  system.paging.faults:
+    enabled: false
+  system.paging.operations:
+    enabled: false
+  system.paging.usage:
+    enabled: false
+  system.paging.utilization:
+    enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["system.processes.count"] = true
@@ -44,14 +54,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemProcessesCount:   MetricSettings{Enabled: true},
-		SystemProcessesCreated: MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -109,20 +115,27 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		SystemProcessesCount:   MetricSettings{Enabled: false},
-		SystemProcessesCreated: MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordSystemProcessesCountDataPoint(ts, 1, AttributeStatus(1))
 	mb.RecordSystemProcessesCreatedDataPoint(ts, 1)
 
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/testdata/config.yaml
@@ -1,0 +1,11 @@
+default:
+all_metrics:
+  system.processes.count:
+    enabled: true
+  system.processes.created:
+    enabled: true
+no_metrics:
+  system.processes.count:
+    enabled: false
+  system.processes.created:
+    enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -17,12 +17,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -33,7 +28,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 
@@ -970,11 +965,9 @@ func NewMetricsBuilder(ms MetricsSettings, settings receiver.CreateSettings, opt
 	if ms.ProcessMemoryPhysicalUsage.Enabled {
 		settings.Logger.Warn("[WARNING] `process.memory.physical_usage` should not be enabled: The metric is deprecated and will be removed in v0.70.0. Please use `process.memory.usage` instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.")
 	}
-
 	if ms.ProcessMemoryVirtualUsage.Enabled {
 		settings.Logger.Warn("[WARNING] `process.memory.virtual_usage` should not be enabled: The metric is deprecated and will be removed in v0.70.0. Please use `process.memory.virtual` metric instead. See  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.")
 	}
-
 	mb := &MetricsBuilder{
 		startTime:                        pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                    pmetric.NewMetrics(),

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/testdata/config.yaml
@@ -1,0 +1,59 @@
+default:
+all_metrics:
+  process.context_switches:
+    enabled: true
+  process.cpu.time:
+    enabled: true
+  process.cpu.utilization:
+    enabled: true
+  process.disk.io:
+    enabled: true
+  process.disk.operations:
+    enabled: true
+  process.memory.physical_usage:
+    enabled: true
+  process.memory.usage:
+    enabled: true
+  process.memory.utilization:
+    enabled: true
+  process.memory.virtual:
+    enabled: true
+  process.memory.virtual_usage:
+    enabled: true
+  process.open_file_descriptors:
+    enabled: true
+  process.paging.faults:
+    enabled: true
+  process.signals_pending:
+    enabled: true
+  process.threads:
+    enabled: true
+no_metrics:
+  process.context_switches:
+    enabled: false
+  process.cpu.time:
+    enabled: false
+  process.cpu.utilization:
+    enabled: false
+  process.disk.io:
+    enabled: false
+  process.disk.operations:
+    enabled: false
+  process.memory.physical_usage:
+    enabled: false
+  process.memory.usage:
+    enabled: false
+  process.memory.utilization:
+    enabled: false
+  process.memory.virtual:
+    enabled: false
+  process.memory.virtual_usage:
+    enabled: false
+  process.open_file_descriptors:
+    enabled: false
+  process.paging.faults:
+    enabled: false
+  process.signals_pending:
+    enabled: false
+  process.threads:
+    enabled: false

--- a/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/httpcheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["httpcheck.duration"] = true
@@ -47,15 +57,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		HttpcheckDuration: MetricSettings{Enabled: true},
-		HttpcheckError:    MetricSettings{Enabled: true},
-		HttpcheckStatus:   MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -143,17 +148,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		HttpcheckDuration: MetricSettings{Enabled: false},
-		HttpcheckError:    MetricSettings{Enabled: false},
-		HttpcheckStatus:   MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordHttpcheckDurationDataPoint(ts, 1, "attr-val")
 	mb.RecordHttpcheckErrorDataPoint(ts, 1, "attr-val", "attr-val")
 	mb.RecordHttpcheckStatusDataPoint(ts, 1, "attr-val", 1, "attr-val", "attr-val")
@@ -161,4 +162,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,15 @@
+default:
+all_metrics:
+  httpcheck.duration:
+    enabled: true
+  httpcheck.error:
+    enabled: true
+  httpcheck.status:
+    enabled: true
+no_metrics:
+  httpcheck.duration:
+    enabled: false
+  httpcheck.error:
+    enabled: false
+  httpcheck.status:
+    enabled: false

--- a/receiver/iisreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/iisreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/iisreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/iisreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["iis.connection.active"] = true
@@ -74,24 +84,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		IisConnectionActive:       MetricSettings{Enabled: true},
-		IisConnectionAnonymous:    MetricSettings{Enabled: true},
-		IisConnectionAttemptCount: MetricSettings{Enabled: true},
-		IisNetworkBlocked:         MetricSettings{Enabled: true},
-		IisNetworkFileCount:       MetricSettings{Enabled: true},
-		IisNetworkIo:              MetricSettings{Enabled: true},
-		IisRequestCount:           MetricSettings{Enabled: true},
-		IisRequestQueueAgeMax:     MetricSettings{Enabled: true},
-		IisRequestQueueCount:      MetricSettings{Enabled: true},
-		IisRequestRejected:        MetricSettings{Enabled: true},
-		IisThreadActive:           MetricSettings{Enabled: true},
-		IisUptime:                 MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -299,26 +295,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		IisConnectionActive:       MetricSettings{Enabled: false},
-		IisConnectionAnonymous:    MetricSettings{Enabled: false},
-		IisConnectionAttemptCount: MetricSettings{Enabled: false},
-		IisNetworkBlocked:         MetricSettings{Enabled: false},
-		IisNetworkFileCount:       MetricSettings{Enabled: false},
-		IisNetworkIo:              MetricSettings{Enabled: false},
-		IisRequestCount:           MetricSettings{Enabled: false},
-		IisRequestQueueAgeMax:     MetricSettings{Enabled: false},
-		IisRequestQueueCount:      MetricSettings{Enabled: false},
-		IisRequestRejected:        MetricSettings{Enabled: false},
-		IisThreadActive:           MetricSettings{Enabled: false},
-		IisUptime:                 MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordIisConnectionActiveDataPoint(ts, 1)
 	mb.RecordIisConnectionAnonymousDataPoint(ts, 1)
 	mb.RecordIisConnectionAttemptCountDataPoint(ts, 1)
@@ -335,4 +318,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/iisreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/iisreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,51 @@
+default:
+all_metrics:
+  iis.connection.active:
+    enabled: true
+  iis.connection.anonymous:
+    enabled: true
+  iis.connection.attempt.count:
+    enabled: true
+  iis.network.blocked:
+    enabled: true
+  iis.network.file.count:
+    enabled: true
+  iis.network.io:
+    enabled: true
+  iis.request.count:
+    enabled: true
+  iis.request.queue.age.max:
+    enabled: true
+  iis.request.queue.count:
+    enabled: true
+  iis.request.rejected:
+    enabled: true
+  iis.thread.active:
+    enabled: true
+  iis.uptime:
+    enabled: true
+no_metrics:
+  iis.connection.active:
+    enabled: false
+  iis.connection.anonymous:
+    enabled: false
+  iis.connection.attempt.count:
+    enabled: false
+  iis.network.blocked:
+    enabled: false
+  iis.network.file.count:
+    enabled: false
+  iis.network.io:
+    enabled: false
+  iis.request.count:
+    enabled: false
+  iis.request.queue.age.max:
+    enabled: false
+  iis.request.queue.count:
+    enabled: false
+  iis.request.rejected:
+    enabled: false
+  iis.thread.active:
+    enabled: false
+  iis.uptime:
+    enabled: false

--- a/receiver/kafkametricsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kafkametricsreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/kafkametricsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/kafkametricsreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["kafka.brokers"] = true
@@ -71,23 +81,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		KafkaBrokers:                 MetricSettings{Enabled: true},
-		KafkaConsumerGroupLag:        MetricSettings{Enabled: true},
-		KafkaConsumerGroupLagSum:     MetricSettings{Enabled: true},
-		KafkaConsumerGroupMembers:    MetricSettings{Enabled: true},
-		KafkaConsumerGroupOffset:     MetricSettings{Enabled: true},
-		KafkaConsumerGroupOffsetSum:  MetricSettings{Enabled: true},
-		KafkaPartitionCurrentOffset:  MetricSettings{Enabled: true},
-		KafkaPartitionOldestOffset:   MetricSettings{Enabled: true},
-		KafkaPartitionReplicas:       MetricSettings{Enabled: true},
-		KafkaPartitionReplicasInSync: MetricSettings{Enabled: true},
-		KafkaTopicPartitions:         MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -306,25 +303,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		KafkaBrokers:                 MetricSettings{Enabled: false},
-		KafkaConsumerGroupLag:        MetricSettings{Enabled: false},
-		KafkaConsumerGroupLagSum:     MetricSettings{Enabled: false},
-		KafkaConsumerGroupMembers:    MetricSettings{Enabled: false},
-		KafkaConsumerGroupOffset:     MetricSettings{Enabled: false},
-		KafkaConsumerGroupOffsetSum:  MetricSettings{Enabled: false},
-		KafkaPartitionCurrentOffset:  MetricSettings{Enabled: false},
-		KafkaPartitionOldestOffset:   MetricSettings{Enabled: false},
-		KafkaPartitionReplicas:       MetricSettings{Enabled: false},
-		KafkaPartitionReplicasInSync: MetricSettings{Enabled: false},
-		KafkaTopicPartitions:         MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordKafkaBrokersDataPoint(ts, 1)
 	mb.RecordKafkaConsumerGroupLagDataPoint(ts, 1, "attr-val", "attr-val", 1)
 	mb.RecordKafkaConsumerGroupLagSumDataPoint(ts, 1, "attr-val", "attr-val")
@@ -340,4 +325,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/kafkametricsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/kafkametricsreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,47 @@
+default:
+all_metrics:
+  kafka.brokers:
+    enabled: true
+  kafka.consumer_group.lag:
+    enabled: true
+  kafka.consumer_group.lag_sum:
+    enabled: true
+  kafka.consumer_group.members:
+    enabled: true
+  kafka.consumer_group.offset:
+    enabled: true
+  kafka.consumer_group.offset_sum:
+    enabled: true
+  kafka.partition.current_offset:
+    enabled: true
+  kafka.partition.oldest_offset:
+    enabled: true
+  kafka.partition.replicas:
+    enabled: true
+  kafka.partition.replicas_in_sync:
+    enabled: true
+  kafka.topic.partitions:
+    enabled: true
+no_metrics:
+  kafka.brokers:
+    enabled: false
+  kafka.consumer_group.lag:
+    enabled: false
+  kafka.consumer_group.lag_sum:
+    enabled: false
+  kafka.consumer_group.members:
+    enabled: false
+  kafka.consumer_group.offset:
+    enabled: false
+  kafka.consumer_group.offset_sum:
+    enabled: false
+  kafka.partition.current_offset:
+    enabled: false
+  kafka.partition.oldest_offset:
+    enabled: false
+  kafka.partition.replicas:
+    enabled: false
+  kafka.partition.replicas_in_sync:
+    enabled: false
+  kafka.topic.partitions:
+    enabled: false

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/kubeletstatsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/kubeletstatsreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,171 @@
+default:
+all_metrics:
+  container.cpu.time:
+    enabled: true
+  container.cpu.utilization:
+    enabled: true
+  container.filesystem.available:
+    enabled: true
+  container.filesystem.capacity:
+    enabled: true
+  container.filesystem.usage:
+    enabled: true
+  container.memory.available:
+    enabled: true
+  container.memory.major_page_faults:
+    enabled: true
+  container.memory.page_faults:
+    enabled: true
+  container.memory.rss:
+    enabled: true
+  container.memory.usage:
+    enabled: true
+  container.memory.working_set:
+    enabled: true
+  k8s.node.cpu.time:
+    enabled: true
+  k8s.node.cpu.utilization:
+    enabled: true
+  k8s.node.filesystem.available:
+    enabled: true
+  k8s.node.filesystem.capacity:
+    enabled: true
+  k8s.node.filesystem.usage:
+    enabled: true
+  k8s.node.memory.available:
+    enabled: true
+  k8s.node.memory.major_page_faults:
+    enabled: true
+  k8s.node.memory.page_faults:
+    enabled: true
+  k8s.node.memory.rss:
+    enabled: true
+  k8s.node.memory.usage:
+    enabled: true
+  k8s.node.memory.working_set:
+    enabled: true
+  k8s.node.network.errors:
+    enabled: true
+  k8s.node.network.io:
+    enabled: true
+  k8s.pod.cpu.time:
+    enabled: true
+  k8s.pod.cpu.utilization:
+    enabled: true
+  k8s.pod.filesystem.available:
+    enabled: true
+  k8s.pod.filesystem.capacity:
+    enabled: true
+  k8s.pod.filesystem.usage:
+    enabled: true
+  k8s.pod.memory.available:
+    enabled: true
+  k8s.pod.memory.major_page_faults:
+    enabled: true
+  k8s.pod.memory.page_faults:
+    enabled: true
+  k8s.pod.memory.rss:
+    enabled: true
+  k8s.pod.memory.usage:
+    enabled: true
+  k8s.pod.memory.working_set:
+    enabled: true
+  k8s.pod.network.errors:
+    enabled: true
+  k8s.pod.network.io:
+    enabled: true
+  k8s.volume.available:
+    enabled: true
+  k8s.volume.capacity:
+    enabled: true
+  k8s.volume.inodes:
+    enabled: true
+  k8s.volume.inodes.free:
+    enabled: true
+  k8s.volume.inodes.used:
+    enabled: true
+no_metrics:
+  container.cpu.time:
+    enabled: false
+  container.cpu.utilization:
+    enabled: false
+  container.filesystem.available:
+    enabled: false
+  container.filesystem.capacity:
+    enabled: false
+  container.filesystem.usage:
+    enabled: false
+  container.memory.available:
+    enabled: false
+  container.memory.major_page_faults:
+    enabled: false
+  container.memory.page_faults:
+    enabled: false
+  container.memory.rss:
+    enabled: false
+  container.memory.usage:
+    enabled: false
+  container.memory.working_set:
+    enabled: false
+  k8s.node.cpu.time:
+    enabled: false
+  k8s.node.cpu.utilization:
+    enabled: false
+  k8s.node.filesystem.available:
+    enabled: false
+  k8s.node.filesystem.capacity:
+    enabled: false
+  k8s.node.filesystem.usage:
+    enabled: false
+  k8s.node.memory.available:
+    enabled: false
+  k8s.node.memory.major_page_faults:
+    enabled: false
+  k8s.node.memory.page_faults:
+    enabled: false
+  k8s.node.memory.rss:
+    enabled: false
+  k8s.node.memory.usage:
+    enabled: false
+  k8s.node.memory.working_set:
+    enabled: false
+  k8s.node.network.errors:
+    enabled: false
+  k8s.node.network.io:
+    enabled: false
+  k8s.pod.cpu.time:
+    enabled: false
+  k8s.pod.cpu.utilization:
+    enabled: false
+  k8s.pod.filesystem.available:
+    enabled: false
+  k8s.pod.filesystem.capacity:
+    enabled: false
+  k8s.pod.filesystem.usage:
+    enabled: false
+  k8s.pod.memory.available:
+    enabled: false
+  k8s.pod.memory.major_page_faults:
+    enabled: false
+  k8s.pod.memory.page_faults:
+    enabled: false
+  k8s.pod.memory.rss:
+    enabled: false
+  k8s.pod.memory.usage:
+    enabled: false
+  k8s.pod.memory.working_set:
+    enabled: false
+  k8s.pod.network.errors:
+    enabled: false
+  k8s.pod.network.io:
+    enabled: false
+  k8s.volume.available:
+    enabled: false
+  k8s.volume.capacity:
+    enabled: false
+  k8s.volume.inodes:
+    enabled: false
+  k8s.volume.inodes.free:
+    enabled: false
+  k8s.volume.inodes.used:
+    enabled: false

--- a/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/memcachedreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["memcached.bytes"] = true
@@ -71,23 +81,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		MemcachedBytes:              MetricSettings{Enabled: true},
-		MemcachedCommands:           MetricSettings{Enabled: true},
-		MemcachedConnectionsCurrent: MetricSettings{Enabled: true},
-		MemcachedConnectionsTotal:   MetricSettings{Enabled: true},
-		MemcachedCPUUsage:           MetricSettings{Enabled: true},
-		MemcachedCurrentItems:       MetricSettings{Enabled: true},
-		MemcachedEvictions:          MetricSettings{Enabled: true},
-		MemcachedNetwork:            MetricSettings{Enabled: true},
-		MemcachedOperationHitRatio:  MetricSettings{Enabled: true},
-		MemcachedOperations:         MetricSettings{Enabled: true},
-		MemcachedThreads:            MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -282,25 +279,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		MemcachedBytes:              MetricSettings{Enabled: false},
-		MemcachedCommands:           MetricSettings{Enabled: false},
-		MemcachedConnectionsCurrent: MetricSettings{Enabled: false},
-		MemcachedConnectionsTotal:   MetricSettings{Enabled: false},
-		MemcachedCPUUsage:           MetricSettings{Enabled: false},
-		MemcachedCurrentItems:       MetricSettings{Enabled: false},
-		MemcachedEvictions:          MetricSettings{Enabled: false},
-		MemcachedNetwork:            MetricSettings{Enabled: false},
-		MemcachedOperationHitRatio:  MetricSettings{Enabled: false},
-		MemcachedOperations:         MetricSettings{Enabled: false},
-		MemcachedThreads:            MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordMemcachedBytesDataPoint(ts, 1)
 	mb.RecordMemcachedCommandsDataPoint(ts, 1, AttributeCommand(1))
 	mb.RecordMemcachedConnectionsCurrentDataPoint(ts, 1)
@@ -316,4 +301,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/memcachedreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/memcachedreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,47 @@
+default:
+all_metrics:
+  memcached.bytes:
+    enabled: true
+  memcached.commands:
+    enabled: true
+  memcached.connections.current:
+    enabled: true
+  memcached.connections.total:
+    enabled: true
+  memcached.cpu.usage:
+    enabled: true
+  memcached.current_items:
+    enabled: true
+  memcached.evictions:
+    enabled: true
+  memcached.network:
+    enabled: true
+  memcached.operation_hit_ratio:
+    enabled: true
+  memcached.operations:
+    enabled: true
+  memcached.threads:
+    enabled: true
+no_metrics:
+  memcached.bytes:
+    enabled: false
+  memcached.commands:
+    enabled: false
+  memcached.connections.current:
+    enabled: false
+  memcached.connections.total:
+    enabled: false
+  memcached.cpu.usage:
+    enabled: false
+  memcached.current_items:
+    enabled: false
+  memcached.evictions:
+    enabled: false
+  memcached.network:
+    enabled: false
+  memcached.operation_hit_ratio:
+    enabled: false
+  memcached.operations:
+    enabled: false
+  memcached.threads:
+    enabled: false

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,255 @@
+default:
+all_metrics:
+  mongodbatlas.db.counts:
+    enabled: true
+  mongodbatlas.db.size:
+    enabled: true
+  mongodbatlas.disk.partition.iops.average:
+    enabled: true
+  mongodbatlas.disk.partition.iops.max:
+    enabled: true
+  mongodbatlas.disk.partition.latency.average:
+    enabled: true
+  mongodbatlas.disk.partition.latency.max:
+    enabled: true
+  mongodbatlas.disk.partition.space.average:
+    enabled: true
+  mongodbatlas.disk.partition.space.max:
+    enabled: true
+  mongodbatlas.disk.partition.usage.average:
+    enabled: true
+  mongodbatlas.disk.partition.usage.max:
+    enabled: true
+  mongodbatlas.disk.partition.utilization.average:
+    enabled: true
+  mongodbatlas.disk.partition.utilization.max:
+    enabled: true
+  mongodbatlas.process.asserts:
+    enabled: true
+  mongodbatlas.process.background_flush:
+    enabled: true
+  mongodbatlas.process.cache.io:
+    enabled: true
+  mongodbatlas.process.cache.size:
+    enabled: true
+  mongodbatlas.process.connections:
+    enabled: true
+  mongodbatlas.process.cpu.children.normalized.usage.average:
+    enabled: true
+  mongodbatlas.process.cpu.children.normalized.usage.max:
+    enabled: true
+  mongodbatlas.process.cpu.children.usage.average:
+    enabled: true
+  mongodbatlas.process.cpu.children.usage.max:
+    enabled: true
+  mongodbatlas.process.cpu.normalized.usage.average:
+    enabled: true
+  mongodbatlas.process.cpu.normalized.usage.max:
+    enabled: true
+  mongodbatlas.process.cpu.usage.average:
+    enabled: true
+  mongodbatlas.process.cpu.usage.max:
+    enabled: true
+  mongodbatlas.process.cursors:
+    enabled: true
+  mongodbatlas.process.db.document.rate:
+    enabled: true
+  mongodbatlas.process.db.operations.rate:
+    enabled: true
+  mongodbatlas.process.db.operations.time:
+    enabled: true
+  mongodbatlas.process.db.query_executor.scanned:
+    enabled: true
+  mongodbatlas.process.db.query_targeting.scanned_per_returned:
+    enabled: true
+  mongodbatlas.process.db.storage:
+    enabled: true
+  mongodbatlas.process.fts.cpu.usage:
+    enabled: true
+  mongodbatlas.process.global_lock:
+    enabled: true
+  mongodbatlas.process.index.btree_miss_ratio:
+    enabled: true
+  mongodbatlas.process.index.counters:
+    enabled: true
+  mongodbatlas.process.journaling.commits:
+    enabled: true
+  mongodbatlas.process.journaling.data_files:
+    enabled: true
+  mongodbatlas.process.journaling.written:
+    enabled: true
+  mongodbatlas.process.memory.usage:
+    enabled: true
+  mongodbatlas.process.network.io:
+    enabled: true
+  mongodbatlas.process.network.requests:
+    enabled: true
+  mongodbatlas.process.oplog.rate:
+    enabled: true
+  mongodbatlas.process.oplog.time:
+    enabled: true
+  mongodbatlas.process.page_faults:
+    enabled: true
+  mongodbatlas.process.restarts:
+    enabled: true
+  mongodbatlas.process.tickets:
+    enabled: true
+  mongodbatlas.system.cpu.normalized.usage.average:
+    enabled: true
+  mongodbatlas.system.cpu.normalized.usage.max:
+    enabled: true
+  mongodbatlas.system.cpu.usage.average:
+    enabled: true
+  mongodbatlas.system.cpu.usage.max:
+    enabled: true
+  mongodbatlas.system.fts.cpu.normalized.usage:
+    enabled: true
+  mongodbatlas.system.fts.cpu.usage:
+    enabled: true
+  mongodbatlas.system.fts.disk.used:
+    enabled: true
+  mongodbatlas.system.fts.memory.usage:
+    enabled: true
+  mongodbatlas.system.memory.usage.average:
+    enabled: true
+  mongodbatlas.system.memory.usage.max:
+    enabled: true
+  mongodbatlas.system.network.io.average:
+    enabled: true
+  mongodbatlas.system.network.io.max:
+    enabled: true
+  mongodbatlas.system.paging.io.average:
+    enabled: true
+  mongodbatlas.system.paging.io.max:
+    enabled: true
+  mongodbatlas.system.paging.usage.average:
+    enabled: true
+  mongodbatlas.system.paging.usage.max:
+    enabled: true
+no_metrics:
+  mongodbatlas.db.counts:
+    enabled: false
+  mongodbatlas.db.size:
+    enabled: false
+  mongodbatlas.disk.partition.iops.average:
+    enabled: false
+  mongodbatlas.disk.partition.iops.max:
+    enabled: false
+  mongodbatlas.disk.partition.latency.average:
+    enabled: false
+  mongodbatlas.disk.partition.latency.max:
+    enabled: false
+  mongodbatlas.disk.partition.space.average:
+    enabled: false
+  mongodbatlas.disk.partition.space.max:
+    enabled: false
+  mongodbatlas.disk.partition.usage.average:
+    enabled: false
+  mongodbatlas.disk.partition.usage.max:
+    enabled: false
+  mongodbatlas.disk.partition.utilization.average:
+    enabled: false
+  mongodbatlas.disk.partition.utilization.max:
+    enabled: false
+  mongodbatlas.process.asserts:
+    enabled: false
+  mongodbatlas.process.background_flush:
+    enabled: false
+  mongodbatlas.process.cache.io:
+    enabled: false
+  mongodbatlas.process.cache.size:
+    enabled: false
+  mongodbatlas.process.connections:
+    enabled: false
+  mongodbatlas.process.cpu.children.normalized.usage.average:
+    enabled: false
+  mongodbatlas.process.cpu.children.normalized.usage.max:
+    enabled: false
+  mongodbatlas.process.cpu.children.usage.average:
+    enabled: false
+  mongodbatlas.process.cpu.children.usage.max:
+    enabled: false
+  mongodbatlas.process.cpu.normalized.usage.average:
+    enabled: false
+  mongodbatlas.process.cpu.normalized.usage.max:
+    enabled: false
+  mongodbatlas.process.cpu.usage.average:
+    enabled: false
+  mongodbatlas.process.cpu.usage.max:
+    enabled: false
+  mongodbatlas.process.cursors:
+    enabled: false
+  mongodbatlas.process.db.document.rate:
+    enabled: false
+  mongodbatlas.process.db.operations.rate:
+    enabled: false
+  mongodbatlas.process.db.operations.time:
+    enabled: false
+  mongodbatlas.process.db.query_executor.scanned:
+    enabled: false
+  mongodbatlas.process.db.query_targeting.scanned_per_returned:
+    enabled: false
+  mongodbatlas.process.db.storage:
+    enabled: false
+  mongodbatlas.process.fts.cpu.usage:
+    enabled: false
+  mongodbatlas.process.global_lock:
+    enabled: false
+  mongodbatlas.process.index.btree_miss_ratio:
+    enabled: false
+  mongodbatlas.process.index.counters:
+    enabled: false
+  mongodbatlas.process.journaling.commits:
+    enabled: false
+  mongodbatlas.process.journaling.data_files:
+    enabled: false
+  mongodbatlas.process.journaling.written:
+    enabled: false
+  mongodbatlas.process.memory.usage:
+    enabled: false
+  mongodbatlas.process.network.io:
+    enabled: false
+  mongodbatlas.process.network.requests:
+    enabled: false
+  mongodbatlas.process.oplog.rate:
+    enabled: false
+  mongodbatlas.process.oplog.time:
+    enabled: false
+  mongodbatlas.process.page_faults:
+    enabled: false
+  mongodbatlas.process.restarts:
+    enabled: false
+  mongodbatlas.process.tickets:
+    enabled: false
+  mongodbatlas.system.cpu.normalized.usage.average:
+    enabled: false
+  mongodbatlas.system.cpu.normalized.usage.max:
+    enabled: false
+  mongodbatlas.system.cpu.usage.average:
+    enabled: false
+  mongodbatlas.system.cpu.usage.max:
+    enabled: false
+  mongodbatlas.system.fts.cpu.normalized.usage:
+    enabled: false
+  mongodbatlas.system.fts.cpu.usage:
+    enabled: false
+  mongodbatlas.system.fts.disk.used:
+    enabled: false
+  mongodbatlas.system.fts.memory.usage:
+    enabled: false
+  mongodbatlas.system.memory.usage.average:
+    enabled: false
+  mongodbatlas.system.memory.usage.max:
+    enabled: false
+  mongodbatlas.system.network.io.average:
+    enabled: false
+  mongodbatlas.system.network.io.max:
+    enabled: false
+  mongodbatlas.system.paging.io.average:
+    enabled: false
+  mongodbatlas.system.paging.io.max:
+    enabled: false
+  mongodbatlas.system.paging.usage.average:
+    enabled: false
+  mongodbatlas.system.paging.usage.max:
+    enabled: false

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["mongodb.cache.operations"] = true
@@ -116,40 +126,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		MongodbCacheOperations:        MetricSettings{Enabled: true},
-		MongodbCollectionCount:        MetricSettings{Enabled: true},
-		MongodbConnectionCount:        MetricSettings{Enabled: true},
-		MongodbCursorCount:            MetricSettings{Enabled: true},
-		MongodbCursorTimeoutCount:     MetricSettings{Enabled: true},
-		MongodbDataSize:               MetricSettings{Enabled: true},
-		MongodbDatabaseCount:          MetricSettings{Enabled: true},
-		MongodbDocumentOperationCount: MetricSettings{Enabled: true},
-		MongodbExtentCount:            MetricSettings{Enabled: true},
-		MongodbGlobalLockTime:         MetricSettings{Enabled: true},
-		MongodbIndexAccessCount:       MetricSettings{Enabled: true},
-		MongodbIndexCount:             MetricSettings{Enabled: true},
-		MongodbIndexSize:              MetricSettings{Enabled: true},
-		MongodbLockAcquireCount:       MetricSettings{Enabled: true},
-		MongodbLockAcquireTime:        MetricSettings{Enabled: true},
-		MongodbLockAcquireWaitCount:   MetricSettings{Enabled: true},
-		MongodbLockDeadlockCount:      MetricSettings{Enabled: true},
-		MongodbMemoryUsage:            MetricSettings{Enabled: true},
-		MongodbNetworkIoReceive:       MetricSettings{Enabled: true},
-		MongodbNetworkIoTransmit:      MetricSettings{Enabled: true},
-		MongodbNetworkRequestCount:    MetricSettings{Enabled: true},
-		MongodbObjectCount:            MetricSettings{Enabled: true},
-		MongodbOperationCount:         MetricSettings{Enabled: true},
-		MongodbOperationLatencyTime:   MetricSettings{Enabled: true},
-		MongodbOperationReplCount:     MetricSettings{Enabled: true},
-		MongodbOperationTime:          MetricSettings{Enabled: true},
-		MongodbSessionCount:           MetricSettings{Enabled: true},
-		MongodbStorageSize:            MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -666,42 +646,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		MongodbCacheOperations:        MetricSettings{Enabled: false},
-		MongodbCollectionCount:        MetricSettings{Enabled: false},
-		MongodbConnectionCount:        MetricSettings{Enabled: false},
-		MongodbCursorCount:            MetricSettings{Enabled: false},
-		MongodbCursorTimeoutCount:     MetricSettings{Enabled: false},
-		MongodbDataSize:               MetricSettings{Enabled: false},
-		MongodbDatabaseCount:          MetricSettings{Enabled: false},
-		MongodbDocumentOperationCount: MetricSettings{Enabled: false},
-		MongodbExtentCount:            MetricSettings{Enabled: false},
-		MongodbGlobalLockTime:         MetricSettings{Enabled: false},
-		MongodbIndexAccessCount:       MetricSettings{Enabled: false},
-		MongodbIndexCount:             MetricSettings{Enabled: false},
-		MongodbIndexSize:              MetricSettings{Enabled: false},
-		MongodbLockAcquireCount:       MetricSettings{Enabled: false},
-		MongodbLockAcquireTime:        MetricSettings{Enabled: false},
-		MongodbLockAcquireWaitCount:   MetricSettings{Enabled: false},
-		MongodbLockDeadlockCount:      MetricSettings{Enabled: false},
-		MongodbMemoryUsage:            MetricSettings{Enabled: false},
-		MongodbNetworkIoReceive:       MetricSettings{Enabled: false},
-		MongodbNetworkIoTransmit:      MetricSettings{Enabled: false},
-		MongodbNetworkRequestCount:    MetricSettings{Enabled: false},
-		MongodbObjectCount:            MetricSettings{Enabled: false},
-		MongodbOperationCount:         MetricSettings{Enabled: false},
-		MongodbOperationLatencyTime:   MetricSettings{Enabled: false},
-		MongodbOperationReplCount:     MetricSettings{Enabled: false},
-		MongodbOperationTime:          MetricSettings{Enabled: false},
-		MongodbSessionCount:           MetricSettings{Enabled: false},
-		MongodbStorageSize:            MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordMongodbCacheOperationsDataPoint(ts, 1, AttributeType(1))
 	mb.RecordMongodbCollectionCountDataPoint(ts, 1, "attr-val")
 	mb.RecordMongodbConnectionCountDataPoint(ts, 1, "attr-val", AttributeConnectionType(1))
@@ -734,4 +685,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,115 @@
+default:
+all_metrics:
+  mongodb.cache.operations:
+    enabled: true
+  mongodb.collection.count:
+    enabled: true
+  mongodb.connection.count:
+    enabled: true
+  mongodb.cursor.count:
+    enabled: true
+  mongodb.cursor.timeout.count:
+    enabled: true
+  mongodb.data.size:
+    enabled: true
+  mongodb.database.count:
+    enabled: true
+  mongodb.document.operation.count:
+    enabled: true
+  mongodb.extent.count:
+    enabled: true
+  mongodb.global_lock.time:
+    enabled: true
+  mongodb.index.access.count:
+    enabled: true
+  mongodb.index.count:
+    enabled: true
+  mongodb.index.size:
+    enabled: true
+  mongodb.lock.acquire.count:
+    enabled: true
+  mongodb.lock.acquire.time:
+    enabled: true
+  mongodb.lock.acquire.wait_count:
+    enabled: true
+  mongodb.lock.deadlock.count:
+    enabled: true
+  mongodb.memory.usage:
+    enabled: true
+  mongodb.network.io.receive:
+    enabled: true
+  mongodb.network.io.transmit:
+    enabled: true
+  mongodb.network.request.count:
+    enabled: true
+  mongodb.object.count:
+    enabled: true
+  mongodb.operation.count:
+    enabled: true
+  mongodb.operation.latency.time:
+    enabled: true
+  mongodb.operation.repl.count:
+    enabled: true
+  mongodb.operation.time:
+    enabled: true
+  mongodb.session.count:
+    enabled: true
+  mongodb.storage.size:
+    enabled: true
+no_metrics:
+  mongodb.cache.operations:
+    enabled: false
+  mongodb.collection.count:
+    enabled: false
+  mongodb.connection.count:
+    enabled: false
+  mongodb.cursor.count:
+    enabled: false
+  mongodb.cursor.timeout.count:
+    enabled: false
+  mongodb.data.size:
+    enabled: false
+  mongodb.database.count:
+    enabled: false
+  mongodb.document.operation.count:
+    enabled: false
+  mongodb.extent.count:
+    enabled: false
+  mongodb.global_lock.time:
+    enabled: false
+  mongodb.index.access.count:
+    enabled: false
+  mongodb.index.count:
+    enabled: false
+  mongodb.index.size:
+    enabled: false
+  mongodb.lock.acquire.count:
+    enabled: false
+  mongodb.lock.acquire.time:
+    enabled: false
+  mongodb.lock.acquire.wait_count:
+    enabled: false
+  mongodb.lock.deadlock.count:
+    enabled: false
+  mongodb.memory.usage:
+    enabled: false
+  mongodb.network.io.receive:
+    enabled: false
+  mongodb.network.io.transmit:
+    enabled: false
+  mongodb.network.request.count:
+    enabled: false
+  mongodb.object.count:
+    enabled: false
+  mongodb.operation.count:
+    enabled: false
+  mongodb.operation.latency.time:
+    enabled: false
+  mongodb.operation.repl.count:
+    enabled: false
+  mongodb.operation.time:
+    enabled: false
+  mongodb.session.count:
+    enabled: false
+  mongodb.storage.size:
+    enabled: false

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -18,12 +18,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -34,7 +29,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,175 @@
+default:
+all_metrics:
+  mysql.buffer_pool.data_pages:
+    enabled: true
+  mysql.buffer_pool.limit:
+    enabled: true
+  mysql.buffer_pool.operations:
+    enabled: true
+  mysql.buffer_pool.page_flushes:
+    enabled: true
+  mysql.buffer_pool.pages:
+    enabled: true
+  mysql.buffer_pool.usage:
+    enabled: true
+  mysql.client.network.io:
+    enabled: true
+  mysql.commands:
+    enabled: true
+  mysql.connection.count:
+    enabled: true
+  mysql.connection.errors:
+    enabled: true
+  mysql.double_writes:
+    enabled: true
+  mysql.handlers:
+    enabled: true
+  mysql.index.io.wait.count:
+    enabled: true
+  mysql.index.io.wait.time:
+    enabled: true
+  mysql.joins:
+    enabled: true
+  mysql.locked_connects:
+    enabled: true
+  mysql.locks:
+    enabled: true
+  mysql.log_operations:
+    enabled: true
+  mysql.mysqlx_connections:
+    enabled: true
+  mysql.mysqlx_worker_threads:
+    enabled: true
+  mysql.opened_resources:
+    enabled: true
+  mysql.operations:
+    enabled: true
+  mysql.page_operations:
+    enabled: true
+  mysql.prepared_statements:
+    enabled: true
+  mysql.query.client.count:
+    enabled: true
+  mysql.query.count:
+    enabled: true
+  mysql.query.slow.count:
+    enabled: true
+  mysql.replica.sql_delay:
+    enabled: true
+  mysql.replica.time_behind_source:
+    enabled: true
+  mysql.row_locks:
+    enabled: true
+  mysql.row_operations:
+    enabled: true
+  mysql.sorts:
+    enabled: true
+  mysql.statement_event.count:
+    enabled: true
+  mysql.statement_event.wait.time:
+    enabled: true
+  mysql.table.io.wait.count:
+    enabled: true
+  mysql.table.io.wait.time:
+    enabled: true
+  mysql.table.lock_wait.read.count:
+    enabled: true
+  mysql.table.lock_wait.read.time:
+    enabled: true
+  mysql.table.lock_wait.write.count:
+    enabled: true
+  mysql.table.lock_wait.write.time:
+    enabled: true
+  mysql.table_open_cache:
+    enabled: true
+  mysql.threads:
+    enabled: true
+  mysql.tmp_resources:
+    enabled: true
+no_metrics:
+  mysql.buffer_pool.data_pages:
+    enabled: false
+  mysql.buffer_pool.limit:
+    enabled: false
+  mysql.buffer_pool.operations:
+    enabled: false
+  mysql.buffer_pool.page_flushes:
+    enabled: false
+  mysql.buffer_pool.pages:
+    enabled: false
+  mysql.buffer_pool.usage:
+    enabled: false
+  mysql.client.network.io:
+    enabled: false
+  mysql.commands:
+    enabled: false
+  mysql.connection.count:
+    enabled: false
+  mysql.connection.errors:
+    enabled: false
+  mysql.double_writes:
+    enabled: false
+  mysql.handlers:
+    enabled: false
+  mysql.index.io.wait.count:
+    enabled: false
+  mysql.index.io.wait.time:
+    enabled: false
+  mysql.joins:
+    enabled: false
+  mysql.locked_connects:
+    enabled: false
+  mysql.locks:
+    enabled: false
+  mysql.log_operations:
+    enabled: false
+  mysql.mysqlx_connections:
+    enabled: false
+  mysql.mysqlx_worker_threads:
+    enabled: false
+  mysql.opened_resources:
+    enabled: false
+  mysql.operations:
+    enabled: false
+  mysql.page_operations:
+    enabled: false
+  mysql.prepared_statements:
+    enabled: false
+  mysql.query.client.count:
+    enabled: false
+  mysql.query.count:
+    enabled: false
+  mysql.query.slow.count:
+    enabled: false
+  mysql.replica.sql_delay:
+    enabled: false
+  mysql.replica.time_behind_source:
+    enabled: false
+  mysql.row_locks:
+    enabled: false
+  mysql.row_operations:
+    enabled: false
+  mysql.sorts:
+    enabled: false
+  mysql.statement_event.count:
+    enabled: false
+  mysql.statement_event.wait.time:
+    enabled: false
+  mysql.table.io.wait.count:
+    enabled: false
+  mysql.table.io.wait.time:
+    enabled: false
+  mysql.table.lock_wait.read.count:
+    enabled: false
+  mysql.table.lock_wait.read.time:
+    enabled: false
+  mysql.table.lock_wait.write.count:
+    enabled: false
+  mysql.table.lock_wait.write.time:
+    enabled: false
+  mysql.table_open_cache:
+    enabled: false
+  mysql.threads:
+    enabled: false
+  mysql.tmp_resources:
+    enabled: false

--- a/receiver/nginxreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/nginxreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["nginx.connections_accepted"] = true
@@ -50,16 +60,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		NginxConnectionsAccepted: MetricSettings{Enabled: true},
-		NginxConnectionsCurrent:  MetricSettings{Enabled: true},
-		NginxConnectionsHandled:  MetricSettings{Enabled: true},
-		NginxRequests:            MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -143,18 +147,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		NginxConnectionsAccepted: MetricSettings{Enabled: false},
-		NginxConnectionsCurrent:  MetricSettings{Enabled: false},
-		NginxConnectionsHandled:  MetricSettings{Enabled: false},
-		NginxRequests:            MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordNginxConnectionsAcceptedDataPoint(ts, 1)
 	mb.RecordNginxConnectionsCurrentDataPoint(ts, 1, AttributeState(1))
 	mb.RecordNginxConnectionsHandledDataPoint(ts, 1)
@@ -163,4 +162,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/nginxreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/nginxreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,19 @@
+default:
+all_metrics:
+  nginx.connections_accepted:
+    enabled: true
+  nginx.connections_current:
+    enabled: true
+  nginx.connections_handled:
+    enabled: true
+  nginx.requests:
+    enabled: true
+no_metrics:
+  nginx.connections_accepted:
+    enabled: false
+  nginx.connections_current:
+    enabled: false
+  nginx.connections_handled:
+    enabled: false
+  nginx.requests:
+    enabled: false

--- a/receiver/nsxtreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/nsxtreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/nsxtreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/nsxtreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["nsxt.node.cpu.utilization"] = true
@@ -59,19 +69,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		NsxtNodeCPUUtilization:        MetricSettings{Enabled: true},
-		NsxtNodeFilesystemUsage:       MetricSettings{Enabled: true},
-		NsxtNodeFilesystemUtilization: MetricSettings{Enabled: true},
-		NsxtNodeMemoryCacheUsage:      MetricSettings{Enabled: true},
-		NsxtNodeMemoryUsage:           MetricSettings{Enabled: true},
-		NsxtNodeNetworkIo:             MetricSettings{Enabled: true},
-		NsxtNodeNetworkPacketCount:    MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -223,21 +224,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		NsxtNodeCPUUtilization:        MetricSettings{Enabled: false},
-		NsxtNodeFilesystemUsage:       MetricSettings{Enabled: false},
-		NsxtNodeFilesystemUtilization: MetricSettings{Enabled: false},
-		NsxtNodeMemoryCacheUsage:      MetricSettings{Enabled: false},
-		NsxtNodeMemoryUsage:           MetricSettings{Enabled: false},
-		NsxtNodeNetworkIo:             MetricSettings{Enabled: false},
-		NsxtNodeNetworkPacketCount:    MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordNsxtNodeCPUUtilizationDataPoint(ts, 1, AttributeClass(1))
 	mb.RecordNsxtNodeFilesystemUsageDataPoint(ts, 1, AttributeDiskState(1))
 	mb.RecordNsxtNodeFilesystemUtilizationDataPoint(ts, 1)
@@ -249,4 +242,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/nsxtreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/nsxtreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,31 @@
+default:
+all_metrics:
+  nsxt.node.cpu.utilization:
+    enabled: true
+  nsxt.node.filesystem.usage:
+    enabled: true
+  nsxt.node.filesystem.utilization:
+    enabled: true
+  nsxt.node.memory.cache.usage:
+    enabled: true
+  nsxt.node.memory.usage:
+    enabled: true
+  nsxt.node.network.io:
+    enabled: true
+  nsxt.node.network.packet.count:
+    enabled: true
+no_metrics:
+  nsxt.node.cpu.utilization:
+    enabled: false
+  nsxt.node.filesystem.usage:
+    enabled: false
+  nsxt.node.filesystem.utilization:
+    enabled: false
+  nsxt.node.memory.cache.usage:
+    enabled: false
+  nsxt.node.memory.usage:
+    enabled: false
+  nsxt.node.network.io:
+    enabled: false
+  nsxt.node.network.packet.count:
+    enabled: false

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -18,12 +18,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -34,7 +29,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["oracledb.cpu_time"] = true
@@ -113,37 +123,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		OracledbCPUTime:               MetricSettings{Enabled: true},
-		OracledbDmlLocksLimit:         MetricSettings{Enabled: true},
-		OracledbDmlLocksUsage:         MetricSettings{Enabled: true},
-		OracledbEnqueueDeadlocks:      MetricSettings{Enabled: true},
-		OracledbEnqueueLocksLimit:     MetricSettings{Enabled: true},
-		OracledbEnqueueLocksUsage:     MetricSettings{Enabled: true},
-		OracledbEnqueueResourcesLimit: MetricSettings{Enabled: true},
-		OracledbEnqueueResourcesUsage: MetricSettings{Enabled: true},
-		OracledbExchangeDeadlocks:     MetricSettings{Enabled: true},
-		OracledbExecutions:            MetricSettings{Enabled: true},
-		OracledbHardParses:            MetricSettings{Enabled: true},
-		OracledbLogicalReads:          MetricSettings{Enabled: true},
-		OracledbParseCalls:            MetricSettings{Enabled: true},
-		OracledbPgaMemory:             MetricSettings{Enabled: true},
-		OracledbPhysicalReads:         MetricSettings{Enabled: true},
-		OracledbProcessesLimit:        MetricSettings{Enabled: true},
-		OracledbProcessesUsage:        MetricSettings{Enabled: true},
-		OracledbSessionsLimit:         MetricSettings{Enabled: true},
-		OracledbSessionsUsage:         MetricSettings{Enabled: true},
-		OracledbTablespaceSizeLimit:   MetricSettings{Enabled: true},
-		OracledbTablespaceSizeUsage:   MetricSettings{Enabled: true},
-		OracledbTransactionsLimit:     MetricSettings{Enabled: true},
-		OracledbTransactionsUsage:     MetricSettings{Enabled: true},
-		OracledbUserCommits:           MetricSettings{Enabled: true},
-		OracledbUserRollbacks:         MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -508,39 +491,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		OracledbCPUTime:               MetricSettings{Enabled: false},
-		OracledbDmlLocksLimit:         MetricSettings{Enabled: false},
-		OracledbDmlLocksUsage:         MetricSettings{Enabled: false},
-		OracledbEnqueueDeadlocks:      MetricSettings{Enabled: false},
-		OracledbEnqueueLocksLimit:     MetricSettings{Enabled: false},
-		OracledbEnqueueLocksUsage:     MetricSettings{Enabled: false},
-		OracledbEnqueueResourcesLimit: MetricSettings{Enabled: false},
-		OracledbEnqueueResourcesUsage: MetricSettings{Enabled: false},
-		OracledbExchangeDeadlocks:     MetricSettings{Enabled: false},
-		OracledbExecutions:            MetricSettings{Enabled: false},
-		OracledbHardParses:            MetricSettings{Enabled: false},
-		OracledbLogicalReads:          MetricSettings{Enabled: false},
-		OracledbParseCalls:            MetricSettings{Enabled: false},
-		OracledbPgaMemory:             MetricSettings{Enabled: false},
-		OracledbPhysicalReads:         MetricSettings{Enabled: false},
-		OracledbProcessesLimit:        MetricSettings{Enabled: false},
-		OracledbProcessesUsage:        MetricSettings{Enabled: false},
-		OracledbSessionsLimit:         MetricSettings{Enabled: false},
-		OracledbSessionsUsage:         MetricSettings{Enabled: false},
-		OracledbTablespaceSizeLimit:   MetricSettings{Enabled: false},
-		OracledbTablespaceSizeUsage:   MetricSettings{Enabled: false},
-		OracledbTransactionsLimit:     MetricSettings{Enabled: false},
-		OracledbTransactionsUsage:     MetricSettings{Enabled: false},
-		OracledbUserCommits:           MetricSettings{Enabled: false},
-		OracledbUserRollbacks:         MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordOracledbCPUTimeDataPoint(ts, 1)
 	mb.RecordOracledbDmlLocksLimitDataPoint(ts, "1")
 	mb.RecordOracledbDmlLocksUsageDataPoint(ts, "1")
@@ -570,4 +527,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,103 @@
+default:
+all_metrics:
+  oracledb.cpu_time:
+    enabled: true
+  oracledb.dml_locks.limit:
+    enabled: true
+  oracledb.dml_locks.usage:
+    enabled: true
+  oracledb.enqueue_deadlocks:
+    enabled: true
+  oracledb.enqueue_locks.limit:
+    enabled: true
+  oracledb.enqueue_locks.usage:
+    enabled: true
+  oracledb.enqueue_resources.limit:
+    enabled: true
+  oracledb.enqueue_resources.usage:
+    enabled: true
+  oracledb.exchange_deadlocks:
+    enabled: true
+  oracledb.executions:
+    enabled: true
+  oracledb.hard_parses:
+    enabled: true
+  oracledb.logical_reads:
+    enabled: true
+  oracledb.parse_calls:
+    enabled: true
+  oracledb.pga_memory:
+    enabled: true
+  oracledb.physical_reads:
+    enabled: true
+  oracledb.processes.limit:
+    enabled: true
+  oracledb.processes.usage:
+    enabled: true
+  oracledb.sessions.limit:
+    enabled: true
+  oracledb.sessions.usage:
+    enabled: true
+  oracledb.tablespace_size.limit:
+    enabled: true
+  oracledb.tablespace_size.usage:
+    enabled: true
+  oracledb.transactions.limit:
+    enabled: true
+  oracledb.transactions.usage:
+    enabled: true
+  oracledb.user_commits:
+    enabled: true
+  oracledb.user_rollbacks:
+    enabled: true
+no_metrics:
+  oracledb.cpu_time:
+    enabled: false
+  oracledb.dml_locks.limit:
+    enabled: false
+  oracledb.dml_locks.usage:
+    enabled: false
+  oracledb.enqueue_deadlocks:
+    enabled: false
+  oracledb.enqueue_locks.limit:
+    enabled: false
+  oracledb.enqueue_locks.usage:
+    enabled: false
+  oracledb.enqueue_resources.limit:
+    enabled: false
+  oracledb.enqueue_resources.usage:
+    enabled: false
+  oracledb.exchange_deadlocks:
+    enabled: false
+  oracledb.executions:
+    enabled: false
+  oracledb.hard_parses:
+    enabled: false
+  oracledb.logical_reads:
+    enabled: false
+  oracledb.parse_calls:
+    enabled: false
+  oracledb.pga_memory:
+    enabled: false
+  oracledb.physical_reads:
+    enabled: false
+  oracledb.processes.limit:
+    enabled: false
+  oracledb.processes.usage:
+    enabled: false
+  oracledb.sessions.limit:
+    enabled: false
+  oracledb.sessions.usage:
+    enabled: false
+  oracledb.tablespace_size.limit:
+    enabled: false
+  oracledb.tablespace_size.usage:
+    enabled: false
+  oracledb.transactions.limit:
+    enabled: false
+  oracledb.transactions.usage:
+    enabled: false
+  oracledb.user_commits:
+    enabled: false
+  oracledb.user_rollbacks:
+    enabled: false

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/postgresqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/postgresqlreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,91 @@
+default:
+all_metrics:
+  postgresql.backends:
+    enabled: true
+  postgresql.bgwriter.buffers.allocated:
+    enabled: true
+  postgresql.bgwriter.buffers.writes:
+    enabled: true
+  postgresql.bgwriter.checkpoint.count:
+    enabled: true
+  postgresql.bgwriter.duration:
+    enabled: true
+  postgresql.bgwriter.maxwritten:
+    enabled: true
+  postgresql.blocks_read:
+    enabled: true
+  postgresql.commits:
+    enabled: true
+  postgresql.connection.max:
+    enabled: true
+  postgresql.database.count:
+    enabled: true
+  postgresql.db_size:
+    enabled: true
+  postgresql.index.scans:
+    enabled: true
+  postgresql.index.size:
+    enabled: true
+  postgresql.operations:
+    enabled: true
+  postgresql.replication.data_delay:
+    enabled: true
+  postgresql.rollbacks:
+    enabled: true
+  postgresql.rows:
+    enabled: true
+  postgresql.table.count:
+    enabled: true
+  postgresql.table.size:
+    enabled: true
+  postgresql.table.vacuum.count:
+    enabled: true
+  postgresql.wal.age:
+    enabled: true
+  postgresql.wal.lag:
+    enabled: true
+no_metrics:
+  postgresql.backends:
+    enabled: false
+  postgresql.bgwriter.buffers.allocated:
+    enabled: false
+  postgresql.bgwriter.buffers.writes:
+    enabled: false
+  postgresql.bgwriter.checkpoint.count:
+    enabled: false
+  postgresql.bgwriter.duration:
+    enabled: false
+  postgresql.bgwriter.maxwritten:
+    enabled: false
+  postgresql.blocks_read:
+    enabled: false
+  postgresql.commits:
+    enabled: false
+  postgresql.connection.max:
+    enabled: false
+  postgresql.database.count:
+    enabled: false
+  postgresql.db_size:
+    enabled: false
+  postgresql.index.scans:
+    enabled: false
+  postgresql.index.size:
+    enabled: false
+  postgresql.operations:
+    enabled: false
+  postgresql.replication.data_delay:
+    enabled: false
+  postgresql.rollbacks:
+    enabled: false
+  postgresql.rows:
+    enabled: false
+  postgresql.table.count:
+    enabled: false
+  postgresql.table.size:
+    enabled: false
+  postgresql.table.vacuum.count:
+    enabled: false
+  postgresql.wal.age:
+    enabled: false
+  postgresql.wal.lag:
+    enabled: false

--- a/receiver/rabbitmqreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/rabbitmqreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/rabbitmqreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/rabbitmqreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,27 @@
+default:
+all_metrics:
+  rabbitmq.consumer.count:
+    enabled: true
+  rabbitmq.message.acknowledged:
+    enabled: true
+  rabbitmq.message.current:
+    enabled: true
+  rabbitmq.message.delivered:
+    enabled: true
+  rabbitmq.message.dropped:
+    enabled: true
+  rabbitmq.message.published:
+    enabled: true
+no_metrics:
+  rabbitmq.consumer.count:
+    enabled: false
+  rabbitmq.message.acknowledged:
+    enabled: false
+  rabbitmq.message.current:
+    enabled: false
+  rabbitmq.message.delivered:
+    enabled: false
+  rabbitmq.message.dropped:
+    enabled: false
+  rabbitmq.message.published:
+    enabled: false

--- a/receiver/redisreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/redisreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/redisreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,135 @@
+default:
+all_metrics:
+  redis.clients.blocked:
+    enabled: true
+  redis.clients.connected:
+    enabled: true
+  redis.clients.max_input_buffer:
+    enabled: true
+  redis.clients.max_output_buffer:
+    enabled: true
+  redis.cmd.calls:
+    enabled: true
+  redis.cmd.usec:
+    enabled: true
+  redis.commands:
+    enabled: true
+  redis.commands.processed:
+    enabled: true
+  redis.connections.received:
+    enabled: true
+  redis.connections.rejected:
+    enabled: true
+  redis.cpu.time:
+    enabled: true
+  redis.db.avg_ttl:
+    enabled: true
+  redis.db.expires:
+    enabled: true
+  redis.db.keys:
+    enabled: true
+  redis.keys.evicted:
+    enabled: true
+  redis.keys.expired:
+    enabled: true
+  redis.keyspace.hits:
+    enabled: true
+  redis.keyspace.misses:
+    enabled: true
+  redis.latest_fork:
+    enabled: true
+  redis.maxmemory:
+    enabled: true
+  redis.memory.fragmentation_ratio:
+    enabled: true
+  redis.memory.lua:
+    enabled: true
+  redis.memory.peak:
+    enabled: true
+  redis.memory.rss:
+    enabled: true
+  redis.memory.used:
+    enabled: true
+  redis.net.input:
+    enabled: true
+  redis.net.output:
+    enabled: true
+  redis.rdb.changes_since_last_save:
+    enabled: true
+  redis.replication.backlog_first_byte_offset:
+    enabled: true
+  redis.replication.offset:
+    enabled: true
+  redis.role:
+    enabled: true
+  redis.slaves.connected:
+    enabled: true
+  redis.uptime:
+    enabled: true
+no_metrics:
+  redis.clients.blocked:
+    enabled: false
+  redis.clients.connected:
+    enabled: false
+  redis.clients.max_input_buffer:
+    enabled: false
+  redis.clients.max_output_buffer:
+    enabled: false
+  redis.cmd.calls:
+    enabled: false
+  redis.cmd.usec:
+    enabled: false
+  redis.commands:
+    enabled: false
+  redis.commands.processed:
+    enabled: false
+  redis.connections.received:
+    enabled: false
+  redis.connections.rejected:
+    enabled: false
+  redis.cpu.time:
+    enabled: false
+  redis.db.avg_ttl:
+    enabled: false
+  redis.db.expires:
+    enabled: false
+  redis.db.keys:
+    enabled: false
+  redis.keys.evicted:
+    enabled: false
+  redis.keys.expired:
+    enabled: false
+  redis.keyspace.hits:
+    enabled: false
+  redis.keyspace.misses:
+    enabled: false
+  redis.latest_fork:
+    enabled: false
+  redis.maxmemory:
+    enabled: false
+  redis.memory.fragmentation_ratio:
+    enabled: false
+  redis.memory.lua:
+    enabled: false
+  redis.memory.peak:
+    enabled: false
+  redis.memory.rss:
+    enabled: false
+  redis.memory.used:
+    enabled: false
+  redis.net.input:
+    enabled: false
+  redis.net.output:
+    enabled: false
+  redis.rdb.changes_since_last_save:
+    enabled: false
+  redis.replication.backlog_first_byte_offset:
+    enabled: false
+  redis.replication.offset:
+    enabled: false
+  redis.role:
+    enabled: false
+  redis.slaves.connected:
+    enabled: false
+  redis.uptime:
+    enabled: false

--- a/receiver/riakreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/riakreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/riakreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/riakreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["riak.memory.limit"] = true
@@ -56,18 +66,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		RiakMemoryLimit:              MetricSettings{Enabled: true},
-		RiakNodeOperationCount:       MetricSettings{Enabled: true},
-		RiakNodeOperationTimeMean:    MetricSettings{Enabled: true},
-		RiakNodeReadRepairCount:      MetricSettings{Enabled: true},
-		RiakVnodeIndexOperationCount: MetricSettings{Enabled: true},
-		RiakVnodeOperationCount:      MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -192,20 +194,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		RiakMemoryLimit:              MetricSettings{Enabled: false},
-		RiakNodeOperationCount:       MetricSettings{Enabled: false},
-		RiakNodeOperationTimeMean:    MetricSettings{Enabled: false},
-		RiakNodeReadRepairCount:      MetricSettings{Enabled: false},
-		RiakVnodeIndexOperationCount: MetricSettings{Enabled: false},
-		RiakVnodeOperationCount:      MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordRiakMemoryLimitDataPoint(ts, 1)
 	mb.RecordRiakNodeOperationCountDataPoint(ts, 1, AttributeRequest(1))
 	mb.RecordRiakNodeOperationTimeMeanDataPoint(ts, 1, AttributeRequest(1))
@@ -216,4 +211,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/riakreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/riakreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,27 @@
+default:
+all_metrics:
+  riak.memory.limit:
+    enabled: true
+  riak.node.operation.count:
+    enabled: true
+  riak.node.operation.time.mean:
+    enabled: true
+  riak.node.read_repair.count:
+    enabled: true
+  riak.vnode.index.operation.count:
+    enabled: true
+  riak.vnode.operation.count:
+    enabled: true
+no_metrics:
+  riak.memory.limit:
+    enabled: false
+  riak.node.operation.count:
+    enabled: false
+  riak.node.operation.time.mean:
+    enabled: false
+  riak.node.read_repair.count:
+    enabled: false
+  riak.vnode.index.operation.count:
+    enabled: false
+  riak.vnode.operation.count:
+    enabled: false

--- a/receiver/saphanareceiver/internal/metadata/generated_metrics.go
+++ b/receiver/saphanareceiver/internal/metadata/generated_metrics.go
@@ -18,12 +18,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -34,7 +29,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/saphanareceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/saphanareceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,183 @@
+default:
+all_metrics:
+  saphana.alert.count:
+    enabled: true
+  saphana.backup.latest:
+    enabled: true
+  saphana.column.memory.used:
+    enabled: true
+  saphana.component.memory.used:
+    enabled: true
+  saphana.connection.count:
+    enabled: true
+  saphana.cpu.used:
+    enabled: true
+  saphana.disk.size.current:
+    enabled: true
+  saphana.host.memory.current:
+    enabled: true
+  saphana.host.swap.current:
+    enabled: true
+  saphana.instance.code_size:
+    enabled: true
+  saphana.instance.memory.current:
+    enabled: true
+  saphana.instance.memory.shared.allocated:
+    enabled: true
+  saphana.instance.memory.used.peak:
+    enabled: true
+  saphana.license.expiration.time:
+    enabled: true
+  saphana.license.limit:
+    enabled: true
+  saphana.license.peak:
+    enabled: true
+  saphana.network.request.average_time:
+    enabled: true
+  saphana.network.request.count:
+    enabled: true
+  saphana.network.request.finished.count:
+    enabled: true
+  saphana.replication.average_time:
+    enabled: true
+  saphana.replication.backlog.size:
+    enabled: true
+  saphana.replication.backlog.time:
+    enabled: true
+  saphana.row_store.memory.used:
+    enabled: true
+  saphana.schema.memory.used.current:
+    enabled: true
+  saphana.schema.memory.used.max:
+    enabled: true
+  saphana.schema.operation.count:
+    enabled: true
+  saphana.schema.record.compressed.count:
+    enabled: true
+  saphana.schema.record.count:
+    enabled: true
+  saphana.service.code_size:
+    enabled: true
+  saphana.service.count:
+    enabled: true
+  saphana.service.memory.compactors.allocated:
+    enabled: true
+  saphana.service.memory.compactors.freeable:
+    enabled: true
+  saphana.service.memory.effective_limit:
+    enabled: true
+  saphana.service.memory.heap.current:
+    enabled: true
+  saphana.service.memory.limit:
+    enabled: true
+  saphana.service.memory.shared.current:
+    enabled: true
+  saphana.service.memory.used:
+    enabled: true
+  saphana.service.stack_size:
+    enabled: true
+  saphana.service.thread.count:
+    enabled: true
+  saphana.transaction.blocked:
+    enabled: true
+  saphana.transaction.count:
+    enabled: true
+  saphana.uptime:
+    enabled: true
+  saphana.volume.operation.count:
+    enabled: true
+  saphana.volume.operation.size:
+    enabled: true
+  saphana.volume.operation.time:
+    enabled: true
+no_metrics:
+  saphana.alert.count:
+    enabled: false
+  saphana.backup.latest:
+    enabled: false
+  saphana.column.memory.used:
+    enabled: false
+  saphana.component.memory.used:
+    enabled: false
+  saphana.connection.count:
+    enabled: false
+  saphana.cpu.used:
+    enabled: false
+  saphana.disk.size.current:
+    enabled: false
+  saphana.host.memory.current:
+    enabled: false
+  saphana.host.swap.current:
+    enabled: false
+  saphana.instance.code_size:
+    enabled: false
+  saphana.instance.memory.current:
+    enabled: false
+  saphana.instance.memory.shared.allocated:
+    enabled: false
+  saphana.instance.memory.used.peak:
+    enabled: false
+  saphana.license.expiration.time:
+    enabled: false
+  saphana.license.limit:
+    enabled: false
+  saphana.license.peak:
+    enabled: false
+  saphana.network.request.average_time:
+    enabled: false
+  saphana.network.request.count:
+    enabled: false
+  saphana.network.request.finished.count:
+    enabled: false
+  saphana.replication.average_time:
+    enabled: false
+  saphana.replication.backlog.size:
+    enabled: false
+  saphana.replication.backlog.time:
+    enabled: false
+  saphana.row_store.memory.used:
+    enabled: false
+  saphana.schema.memory.used.current:
+    enabled: false
+  saphana.schema.memory.used.max:
+    enabled: false
+  saphana.schema.operation.count:
+    enabled: false
+  saphana.schema.record.compressed.count:
+    enabled: false
+  saphana.schema.record.count:
+    enabled: false
+  saphana.service.code_size:
+    enabled: false
+  saphana.service.count:
+    enabled: false
+  saphana.service.memory.compactors.allocated:
+    enabled: false
+  saphana.service.memory.compactors.freeable:
+    enabled: false
+  saphana.service.memory.effective_limit:
+    enabled: false
+  saphana.service.memory.heap.current:
+    enabled: false
+  saphana.service.memory.limit:
+    enabled: false
+  saphana.service.memory.shared.current:
+    enabled: false
+  saphana.service.memory.used:
+    enabled: false
+  saphana.service.stack_size:
+    enabled: false
+  saphana.service.thread.count:
+    enabled: false
+  saphana.transaction.blocked:
+    enabled: false
+  saphana.transaction.count:
+    enabled: false
+  saphana.uptime:
+    enabled: false
+  saphana.volume.operation.count:
+    enabled: false
+  saphana.volume.operation.size:
+    enabled: false
+  saphana.volume.operation.time:
+    enabled: false

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,83 @@
+default:
+all_metrics:
+  sqlserver.batch.request.rate:
+    enabled: true
+  sqlserver.batch.sql_compilation.rate:
+    enabled: true
+  sqlserver.batch.sql_recompilation.rate:
+    enabled: true
+  sqlserver.lock.wait.rate:
+    enabled: true
+  sqlserver.lock.wait_time.avg:
+    enabled: true
+  sqlserver.page.buffer_cache.hit_ratio:
+    enabled: true
+  sqlserver.page.checkpoint.flush.rate:
+    enabled: true
+  sqlserver.page.lazy_write.rate:
+    enabled: true
+  sqlserver.page.life_expectancy:
+    enabled: true
+  sqlserver.page.operation.rate:
+    enabled: true
+  sqlserver.page.split.rate:
+    enabled: true
+  sqlserver.transaction.rate:
+    enabled: true
+  sqlserver.transaction.write.rate:
+    enabled: true
+  sqlserver.transaction_log.flush.data.rate:
+    enabled: true
+  sqlserver.transaction_log.flush.rate:
+    enabled: true
+  sqlserver.transaction_log.flush.wait.rate:
+    enabled: true
+  sqlserver.transaction_log.growth.count:
+    enabled: true
+  sqlserver.transaction_log.shrink.count:
+    enabled: true
+  sqlserver.transaction_log.usage:
+    enabled: true
+  sqlserver.user.connection.count:
+    enabled: true
+no_metrics:
+  sqlserver.batch.request.rate:
+    enabled: false
+  sqlserver.batch.sql_compilation.rate:
+    enabled: false
+  sqlserver.batch.sql_recompilation.rate:
+    enabled: false
+  sqlserver.lock.wait.rate:
+    enabled: false
+  sqlserver.lock.wait_time.avg:
+    enabled: false
+  sqlserver.page.buffer_cache.hit_ratio:
+    enabled: false
+  sqlserver.page.checkpoint.flush.rate:
+    enabled: false
+  sqlserver.page.lazy_write.rate:
+    enabled: false
+  sqlserver.page.life_expectancy:
+    enabled: false
+  sqlserver.page.operation.rate:
+    enabled: false
+  sqlserver.page.split.rate:
+    enabled: false
+  sqlserver.transaction.rate:
+    enabled: false
+  sqlserver.transaction.write.rate:
+    enabled: false
+  sqlserver.transaction_log.flush.data.rate:
+    enabled: false
+  sqlserver.transaction_log.flush.rate:
+    enabled: false
+  sqlserver.transaction_log.flush.wait.rate:
+    enabled: false
+  sqlserver.transaction_log.growth.count:
+    enabled: false
+  sqlserver.transaction_log.shrink.count:
+    enabled: false
+  sqlserver.transaction_log.usage:
+    enabled: false
+  sqlserver.user.connection.count:
+    enabled: false

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["vcenter.cluster.cpu.effective"] = true
@@ -146,48 +156,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		VcenterClusterCPUEffective:      MetricSettings{Enabled: true},
-		VcenterClusterCPULimit:          MetricSettings{Enabled: true},
-		VcenterClusterHostCount:         MetricSettings{Enabled: true},
-		VcenterClusterMemoryEffective:   MetricSettings{Enabled: true},
-		VcenterClusterMemoryLimit:       MetricSettings{Enabled: true},
-		VcenterClusterMemoryUsed:        MetricSettings{Enabled: true},
-		VcenterClusterVMCount:           MetricSettings{Enabled: true},
-		VcenterDatastoreDiskUsage:       MetricSettings{Enabled: true},
-		VcenterDatastoreDiskUtilization: MetricSettings{Enabled: true},
-		VcenterHostCPUUsage:             MetricSettings{Enabled: true},
-		VcenterHostCPUUtilization:       MetricSettings{Enabled: true},
-		VcenterHostDiskLatencyAvg:       MetricSettings{Enabled: true},
-		VcenterHostDiskLatencyMax:       MetricSettings{Enabled: true},
-		VcenterHostDiskThroughput:       MetricSettings{Enabled: true},
-		VcenterHostMemoryUsage:          MetricSettings{Enabled: true},
-		VcenterHostMemoryUtilization:    MetricSettings{Enabled: true},
-		VcenterHostNetworkPacketCount:   MetricSettings{Enabled: true},
-		VcenterHostNetworkPacketErrors:  MetricSettings{Enabled: true},
-		VcenterHostNetworkThroughput:    MetricSettings{Enabled: true},
-		VcenterHostNetworkUsage:         MetricSettings{Enabled: true},
-		VcenterResourcePoolCPUShares:    MetricSettings{Enabled: true},
-		VcenterResourcePoolCPUUsage:     MetricSettings{Enabled: true},
-		VcenterResourcePoolMemoryShares: MetricSettings{Enabled: true},
-		VcenterResourcePoolMemoryUsage:  MetricSettings{Enabled: true},
-		VcenterVMDiskLatencyAvg:         MetricSettings{Enabled: true},
-		VcenterVMDiskLatencyMax:         MetricSettings{Enabled: true},
-		VcenterVMDiskThroughput:         MetricSettings{Enabled: true},
-		VcenterVMDiskUsage:              MetricSettings{Enabled: true},
-		VcenterVMDiskUtilization:        MetricSettings{Enabled: true},
-		VcenterVMMemoryBallooned:        MetricSettings{Enabled: true},
-		VcenterVMMemorySwapped:          MetricSettings{Enabled: true},
-		VcenterVMMemorySwappedSsd:       MetricSettings{Enabled: true},
-		VcenterVMMemoryUsage:            MetricSettings{Enabled: true},
-		VcenterVMNetworkPacketCount:     MetricSettings{Enabled: true},
-		VcenterVMNetworkThroughput:      MetricSettings{Enabled: true},
-		VcenterVMNetworkUsage:           MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -765,50 +737,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		VcenterClusterCPUEffective:      MetricSettings{Enabled: false},
-		VcenterClusterCPULimit:          MetricSettings{Enabled: false},
-		VcenterClusterHostCount:         MetricSettings{Enabled: false},
-		VcenterClusterMemoryEffective:   MetricSettings{Enabled: false},
-		VcenterClusterMemoryLimit:       MetricSettings{Enabled: false},
-		VcenterClusterMemoryUsed:        MetricSettings{Enabled: false},
-		VcenterClusterVMCount:           MetricSettings{Enabled: false},
-		VcenterDatastoreDiskUsage:       MetricSettings{Enabled: false},
-		VcenterDatastoreDiskUtilization: MetricSettings{Enabled: false},
-		VcenterHostCPUUsage:             MetricSettings{Enabled: false},
-		VcenterHostCPUUtilization:       MetricSettings{Enabled: false},
-		VcenterHostDiskLatencyAvg:       MetricSettings{Enabled: false},
-		VcenterHostDiskLatencyMax:       MetricSettings{Enabled: false},
-		VcenterHostDiskThroughput:       MetricSettings{Enabled: false},
-		VcenterHostMemoryUsage:          MetricSettings{Enabled: false},
-		VcenterHostMemoryUtilization:    MetricSettings{Enabled: false},
-		VcenterHostNetworkPacketCount:   MetricSettings{Enabled: false},
-		VcenterHostNetworkPacketErrors:  MetricSettings{Enabled: false},
-		VcenterHostNetworkThroughput:    MetricSettings{Enabled: false},
-		VcenterHostNetworkUsage:         MetricSettings{Enabled: false},
-		VcenterResourcePoolCPUShares:    MetricSettings{Enabled: false},
-		VcenterResourcePoolCPUUsage:     MetricSettings{Enabled: false},
-		VcenterResourcePoolMemoryShares: MetricSettings{Enabled: false},
-		VcenterResourcePoolMemoryUsage:  MetricSettings{Enabled: false},
-		VcenterVMDiskLatencyAvg:         MetricSettings{Enabled: false},
-		VcenterVMDiskLatencyMax:         MetricSettings{Enabled: false},
-		VcenterVMDiskThroughput:         MetricSettings{Enabled: false},
-		VcenterVMDiskUsage:              MetricSettings{Enabled: false},
-		VcenterVMDiskUtilization:        MetricSettings{Enabled: false},
-		VcenterVMMemoryBallooned:        MetricSettings{Enabled: false},
-		VcenterVMMemorySwapped:          MetricSettings{Enabled: false},
-		VcenterVMMemorySwappedSsd:       MetricSettings{Enabled: false},
-		VcenterVMMemoryUsage:            MetricSettings{Enabled: false},
-		VcenterVMNetworkPacketCount:     MetricSettings{Enabled: false},
-		VcenterVMNetworkThroughput:      MetricSettings{Enabled: false},
-		VcenterVMNetworkUsage:           MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordVcenterClusterCPUEffectiveDataPoint(ts, 1)
 	mb.RecordVcenterClusterCPULimitDataPoint(ts, 1)
 	mb.RecordVcenterClusterHostCountDataPoint(ts, 1, true)
@@ -849,4 +784,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/vcenterreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/vcenterreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,147 @@
+default:
+all_metrics:
+  vcenter.cluster.cpu.effective:
+    enabled: true
+  vcenter.cluster.cpu.limit:
+    enabled: true
+  vcenter.cluster.host.count:
+    enabled: true
+  vcenter.cluster.memory.effective:
+    enabled: true
+  vcenter.cluster.memory.limit:
+    enabled: true
+  vcenter.cluster.memory.used:
+    enabled: true
+  vcenter.cluster.vm.count:
+    enabled: true
+  vcenter.datastore.disk.usage:
+    enabled: true
+  vcenter.datastore.disk.utilization:
+    enabled: true
+  vcenter.host.cpu.usage:
+    enabled: true
+  vcenter.host.cpu.utilization:
+    enabled: true
+  vcenter.host.disk.latency.avg:
+    enabled: true
+  vcenter.host.disk.latency.max:
+    enabled: true
+  vcenter.host.disk.throughput:
+    enabled: true
+  vcenter.host.memory.usage:
+    enabled: true
+  vcenter.host.memory.utilization:
+    enabled: true
+  vcenter.host.network.packet.count:
+    enabled: true
+  vcenter.host.network.packet.errors:
+    enabled: true
+  vcenter.host.network.throughput:
+    enabled: true
+  vcenter.host.network.usage:
+    enabled: true
+  vcenter.resource_pool.cpu.shares:
+    enabled: true
+  vcenter.resource_pool.cpu.usage:
+    enabled: true
+  vcenter.resource_pool.memory.shares:
+    enabled: true
+  vcenter.resource_pool.memory.usage:
+    enabled: true
+  vcenter.vm.disk.latency.avg:
+    enabled: true
+  vcenter.vm.disk.latency.max:
+    enabled: true
+  vcenter.vm.disk.throughput:
+    enabled: true
+  vcenter.vm.disk.usage:
+    enabled: true
+  vcenter.vm.disk.utilization:
+    enabled: true
+  vcenter.vm.memory.ballooned:
+    enabled: true
+  vcenter.vm.memory.swapped:
+    enabled: true
+  vcenter.vm.memory.swapped_ssd:
+    enabled: true
+  vcenter.vm.memory.usage:
+    enabled: true
+  vcenter.vm.network.packet.count:
+    enabled: true
+  vcenter.vm.network.throughput:
+    enabled: true
+  vcenter.vm.network.usage:
+    enabled: true
+no_metrics:
+  vcenter.cluster.cpu.effective:
+    enabled: false
+  vcenter.cluster.cpu.limit:
+    enabled: false
+  vcenter.cluster.host.count:
+    enabled: false
+  vcenter.cluster.memory.effective:
+    enabled: false
+  vcenter.cluster.memory.limit:
+    enabled: false
+  vcenter.cluster.memory.used:
+    enabled: false
+  vcenter.cluster.vm.count:
+    enabled: false
+  vcenter.datastore.disk.usage:
+    enabled: false
+  vcenter.datastore.disk.utilization:
+    enabled: false
+  vcenter.host.cpu.usage:
+    enabled: false
+  vcenter.host.cpu.utilization:
+    enabled: false
+  vcenter.host.disk.latency.avg:
+    enabled: false
+  vcenter.host.disk.latency.max:
+    enabled: false
+  vcenter.host.disk.throughput:
+    enabled: false
+  vcenter.host.memory.usage:
+    enabled: false
+  vcenter.host.memory.utilization:
+    enabled: false
+  vcenter.host.network.packet.count:
+    enabled: false
+  vcenter.host.network.packet.errors:
+    enabled: false
+  vcenter.host.network.throughput:
+    enabled: false
+  vcenter.host.network.usage:
+    enabled: false
+  vcenter.resource_pool.cpu.shares:
+    enabled: false
+  vcenter.resource_pool.cpu.usage:
+    enabled: false
+  vcenter.resource_pool.memory.shares:
+    enabled: false
+  vcenter.resource_pool.memory.usage:
+    enabled: false
+  vcenter.vm.disk.latency.avg:
+    enabled: false
+  vcenter.vm.disk.latency.max:
+    enabled: false
+  vcenter.vm.disk.throughput:
+    enabled: false
+  vcenter.vm.disk.usage:
+    enabled: false
+  vcenter.vm.disk.utilization:
+    enabled: false
+  vcenter.vm.memory.ballooned:
+    enabled: false
+  vcenter.vm.memory.swapped:
+    enabled: false
+  vcenter.vm.memory.swapped_ssd:
+    enabled: false
+  vcenter.vm.memory.usage:
+    enabled: false
+  vcenter.vm.network.packet.count:
+    enabled: false
+  vcenter.vm.network.throughput:
+    enabled: false
+  vcenter.vm.network.usage:
+    enabled: false

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics.go
@@ -16,12 +16,7 @@ import (
 type MetricSettings struct {
 	Enabled bool `mapstructure:"enabled"`
 
-	enabledProvidedByUser bool
-}
-
-// IsEnabledProvidedByUser returns true if `enabled` option is explicitly set in user settings to any value.
-func (ms *MetricSettings) IsEnabledProvidedByUser() bool {
-	return ms.enabledProvidedByUser
+	enabledSetByUser bool
 }
 
 func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
@@ -32,7 +27,7 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	ms.enabledProvidedByUser = parser.IsSet("enabled")
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics_test.go
@@ -3,10 +3,14 @@
 package metadata
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -17,7 +21,13 @@ import (
 func TestDefaultMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	mb := NewMetricsBuilder(DefaultMetricsSettings(), receivertest.NewNopCreateSettings(), WithStartTime(start))
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopCreateSettings()
+	settings.Logger = zap.New(observedZapCore)
+	mb := NewMetricsBuilder(loadConfig(t, "default"), settings, WithStartTime(start))
+
+	assert.Equal(t, 0, observedLogs.Len())
+
 	enabledMetrics := make(map[string]bool)
 
 	enabledMetrics["zookeeper.connection.active"] = true
@@ -83,27 +93,10 @@ func TestDefaultMetrics(t *testing.T) {
 func TestAllMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		ZookeeperConnectionActive:            MetricSettings{Enabled: true},
-		ZookeeperDataTreeEphemeralNodeCount:  MetricSettings{Enabled: true},
-		ZookeeperDataTreeSize:                MetricSettings{Enabled: true},
-		ZookeeperFileDescriptorLimit:         MetricSettings{Enabled: true},
-		ZookeeperFileDescriptorOpen:          MetricSettings{Enabled: true},
-		ZookeeperFollowerCount:               MetricSettings{Enabled: true},
-		ZookeeperFsyncExceededThresholdCount: MetricSettings{Enabled: true},
-		ZookeeperLatencyAvg:                  MetricSettings{Enabled: true},
-		ZookeeperLatencyMax:                  MetricSettings{Enabled: true},
-		ZookeeperLatencyMin:                  MetricSettings{Enabled: true},
-		ZookeeperPacketCount:                 MetricSettings{Enabled: true},
-		ZookeeperRequestActive:               MetricSettings{Enabled: true},
-		ZookeeperSyncPending:                 MetricSettings{Enabled: true},
-		ZookeeperWatchCount:                  MetricSettings{Enabled: true},
-		ZookeeperZnodeCount:                  MetricSettings{Enabled: true},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "all_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
 
@@ -346,29 +339,13 @@ func TestAllMetrics(t *testing.T) {
 func TestNoMetrics(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
-	metricsSettings := MetricsSettings{
-		ZookeeperConnectionActive:            MetricSettings{Enabled: false},
-		ZookeeperDataTreeEphemeralNodeCount:  MetricSettings{Enabled: false},
-		ZookeeperDataTreeSize:                MetricSettings{Enabled: false},
-		ZookeeperFileDescriptorLimit:         MetricSettings{Enabled: false},
-		ZookeeperFileDescriptorOpen:          MetricSettings{Enabled: false},
-		ZookeeperFollowerCount:               MetricSettings{Enabled: false},
-		ZookeeperFsyncExceededThresholdCount: MetricSettings{Enabled: false},
-		ZookeeperLatencyAvg:                  MetricSettings{Enabled: false},
-		ZookeeperLatencyMax:                  MetricSettings{Enabled: false},
-		ZookeeperLatencyMin:                  MetricSettings{Enabled: false},
-		ZookeeperPacketCount:                 MetricSettings{Enabled: false},
-		ZookeeperRequestActive:               MetricSettings{Enabled: false},
-		ZookeeperSyncPending:                 MetricSettings{Enabled: false},
-		ZookeeperWatchCount:                  MetricSettings{Enabled: false},
-		ZookeeperZnodeCount:                  MetricSettings{Enabled: false},
-	}
 	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 	settings := receivertest.NewNopCreateSettings()
 	settings.Logger = zap.New(observedZapCore)
-	mb := NewMetricsBuilder(metricsSettings, settings, WithStartTime(start))
+	mb := NewMetricsBuilder(loadConfig(t, "no_metrics"), settings, WithStartTime(start))
 
 	assert.Equal(t, 0, observedLogs.Len())
+
 	mb.RecordZookeeperConnectionActiveDataPoint(ts, 1)
 	mb.RecordZookeeperDataTreeEphemeralNodeCountDataPoint(ts, 1)
 	mb.RecordZookeeperDataTreeSizeDataPoint(ts, 1)
@@ -388,4 +365,14 @@ func TestNoMetrics(t *testing.T) {
 	metrics := mb.Emit()
 
 	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
+}
+
+func loadConfig(t *testing.T, name string) MetricsSettings {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	cfg := DefaultMetricsSettings()
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
+	return cfg
 }

--- a/receiver/zookeeperreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/zookeeperreceiver/internal/metadata/testdata/config.yaml
@@ -1,0 +1,63 @@
+default:
+all_metrics:
+  zookeeper.connection.active:
+    enabled: true
+  zookeeper.data_tree.ephemeral_node.count:
+    enabled: true
+  zookeeper.data_tree.size:
+    enabled: true
+  zookeeper.file_descriptor.limit:
+    enabled: true
+  zookeeper.file_descriptor.open:
+    enabled: true
+  zookeeper.follower.count:
+    enabled: true
+  zookeeper.fsync.exceeded_threshold.count:
+    enabled: true
+  zookeeper.latency.avg:
+    enabled: true
+  zookeeper.latency.max:
+    enabled: true
+  zookeeper.latency.min:
+    enabled: true
+  zookeeper.packet.count:
+    enabled: true
+  zookeeper.request.active:
+    enabled: true
+  zookeeper.sync.pending:
+    enabled: true
+  zookeeper.watch.count:
+    enabled: true
+  zookeeper.znode.count:
+    enabled: true
+no_metrics:
+  zookeeper.connection.active:
+    enabled: false
+  zookeeper.data_tree.ephemeral_node.count:
+    enabled: false
+  zookeeper.data_tree.size:
+    enabled: false
+  zookeeper.file_descriptor.limit:
+    enabled: false
+  zookeeper.file_descriptor.open:
+    enabled: false
+  zookeeper.follower.count:
+    enabled: false
+  zookeeper.fsync.exceeded_threshold.count:
+    enabled: false
+  zookeeper.latency.avg:
+    enabled: false
+  zookeeper.latency.max:
+    enabled: false
+  zookeeper.latency.min:
+    enabled: false
+  zookeeper.packet.count:
+    enabled: false
+  zookeeper.request.active:
+    enabled: false
+  zookeeper.sync.pending:
+    enabled: false
+  zookeeper.watch.count:
+    enabled: false
+  zookeeper.znode.count:
+    enabled: false


### PR DESCRIPTION
This is a follow-up change to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16536 adding the following warnings:

- `if_enabled_not_set`: to require `enabled` field to be explicitly set by users in case if the metric is going to be turned from optional to default and vice versa.

- `if_configured`: to ensure that users do not configure the metric. It should be used for deprecated optional metrics that will be removed soon.

This change also adds more test coverage for the metrics config unmarshaling
