### PR TITLE
Add an attribute to specify unknown type before converting to gauge in `prometheusreceiver`

### DIFF
--- a/.chloggen/add-attributes-for-unknown-type-prometheus.yaml
+++ b/.chloggen/add-attributes-for-unknown-type-prometheus.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an attribute to specify unknown type before converting to gauge in `prometheusreceiver`
+
+# One or more tracking issues related to the change
+issues: [17185]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -20,10 +20,9 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs"
 )
 
 const (

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -19,14 +19,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 )
 
 // Test_validateMetrics checks validateMetrics return true if a type and temporality combination is valid, false

--- a/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
@@ -19,11 +19,14 @@ import (
 	"math"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
 )
 
 var staleNaNsPage1 = `
@@ -287,7 +290,7 @@ func verifyNormalNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.Reso
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.PromMetricType: string(textparse.MetricTypeUnknown)}),
 						assertNormalNan(),
 					},
 				},
@@ -371,7 +374,7 @@ func verifyInfValues(t *testing.T, td *testData, resourceMetrics []pmetric.Resou
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.PromMetricType: string(textparse.MetricTypeUnknown)}),
 						compareDoubleValue(math.Inf(-1)),
 					},
 				},

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -20,10 +20,13 @@ import (
 
 	"github.com/prometheus/common/model"
 	promConfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
 )
 
 // Test data and validation functions for all four core metrics for Prometheus Receiver.
@@ -1463,14 +1466,14 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(100),
-						compareAttributes(map[string]string{"method": "post", "code": "200"}),
+						compareAttributes(map[string]string{"method": "post", "code": "200", internal.PromMetricType: string(textparse.MetricTypeUnknown)}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(5),
-						compareAttributes(map[string]string{"method": "post", "code": "400"}),
+						compareAttributes(map[string]string{"method": "post", "code": "400", internal.PromMetricType: string(textparse.MetricTypeUnknown)}),
 					},
 				},
 			}),
@@ -1481,14 +1484,14 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(10),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.PromMetricType: string(textparse.MetricTypeUnknown)}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(12),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6381"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6381", internal.PromMetricType: string(textparse.MetricTypeUnknown)}),
 					},
 				},
 			}),

--- a/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
+++ b/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
@@ -20,9 +20,12 @@ import (
 	"github.com/prometheus/common/model"
 	promcfg "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
 )
 
 var renameMetric = `
@@ -144,7 +147,7 @@ func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.Re
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(15),
-						compareAttributes(map[string]string{"method": "post", "port": "6380"}),
+						compareAttributes(map[string]string{"method": "post", "port": "6380", internal.PromMetricType: string(textparse.MetricTypeUnknown)}),
 					},
 				},
 			}),
@@ -156,14 +159,14 @@ func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.Re
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(10),
-						compareAttributes(map[string]string{"method": "post", "port": "6380"}),
+						compareAttributes(map[string]string{"method": "post", "port": "6380", internal.PromMetricType: string(textparse.MetricTypeUnknown)}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(12),
-						compareAttributes(map[string]string{"method": "post", "port": "6381"}),
+						compareAttributes(map[string]string{"method": "post", "port": "6381", internal.PromMetricType: string(textparse.MetricTypeUnknown)}),
 					},
 				},
 			}),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
As Prometheus Receiver currently, all [untyped prometheus metrics are converted to OTEL Gauge](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/4eaa9f8f8c89492e4df873bda483ea49da8b194f/receiver/prometheusreceiver/internal/util.go#L111-L112) since the whole reason was not to drop untyped prometheus metrics. However, for some of the backend (such as CloudWatch) using with `awsemf` as an exporter/proxy, they [will have limit bound (not supporting +inf or -inf)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html) and combining with some case untyped can be counter, this won't work and will lose metrics. Therefore, there are two options that has been discussed in [this issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16768):
* Dropping all untyped metrics with a flag in config
* Add a metric datapoint's attribute flag specify whether the metric's are unknown. 

After consideration, the latter options would be more straightforward since we can use [filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.68.0/processor/filterprocessor#ottl) to filter/drop untyped metrics and also allow more metrics processing with untyped in exchange for more bytes (more than 16 bytes scaling per datapoint)

**Another thoughts for improvement would be:** if this attribute can also apply to others prometheus metrics type such as StateSet and Info since it has been converted to Otel Counter

Will update [the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#unknown-typed) after everyone agrees on this approach.

**Link to tracking Issue:** <Issue number if applicable>
* https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16768
* https://github.com/open-telemetry/wg-prometheus/issues/69

**Testing:** 
There are two tests I have done:
* `go test ./... with prometheus receiver` with update unit test
```
khanhntd@88665a0eaf54 prometheusreceiver % go test .
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver   219.046s
```

* Using `awsemf` along with `prometheusreceiver` with `prometheus.go`
```
package main

import (
        "log"
        "net/http"

        "github.com/prometheus/client_golang/prometheus"
        "github.com/prometheus/client_golang/prometheus/promhttp"
)

var gaugeFunc = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
        Name: "gaugeFunc",
        Help: "Test for gauge functions",
},
        func() float64 {
                return float64(1.0)
        })

var noneFunc = prometheus.NewUntypedFunc(prometheus.UntypedOpts{
        Name: "noneFunc",
        Help: "Test for none functions",
},
        func() float64 {
                return float64(1.0)
        })
var summaryFunc = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
        Name: "summaryFunc",
        Help: "Test for summary functions",
},
        func() float64 {
                return float64(1.0)
        })

func main() {
        log.Printf("Registering all metrics...")
        prometheus.MustRegister(gaugeFunc)
        prometheus.MustRegister(noneFunc)
        prometheus.MustRegister(summaryFunc)
        log.Printf("Done registering all metrics...")

        http.Handle("/metrics", promhttp.Handler())
        http.ListenAndServe("0.0.0.0:8000", nil)

}
``` 
and have following results:
```
{
    "Version": "1",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "CWAgent-Internal",
                "Dimensions": [
                    [
                        "key1",
                        "key2",
                        "prom_metric_type",
                        "job",
                        "instance",
                        "Version"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "noneFunc"
                    }
                ]
            }
        ],
        "Timestamp": 1671606728349
    },
    "instance": "127.0.0.1:8000",
    "job": "MY_JOB",
    "key1": "value1",
    "key2": "value2",
    "noneFunc": 1,
    "prom_metric_type": "unknown"
}
```
**Documentation:** 
* To understand more about Prometheus Type, please [follow this document](https://docs.google.com/document/d/1KwV0mAXwwbvvifBvDKH_LU1YjyXE_wxCkHNoCGq1GX0/edit#heading=h.1cvzqd4ksd23)
* Understand the conversion between [OTEL and Prometheus ](https://github.com/influxdata/influxdb-observability/blob/main/docs/metrics.md#schema-metricsschematelegrafprometheusv1)

Signed-off-by: Khanh Nguyen [khanhntd@amazon.com](mailto:khanhntd@amazon.com)