### PR TITLE
[chore] [exporter/splunkhec] Refactor client code

### DIFF
--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -1,4 +1,4 @@
-// Copyright 2020, OpenTelemetry Authors
+// Copyright 2022, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -1,0 +1,190 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+)
+
+var (
+	errOverCapacity = errors.New("over capacity")
+)
+
+// Minimum number of bytes to compress. 1500 is the MTU of an ethernet frame.
+const minCompressionLen = 1500
+
+// Composite index of a record.
+type index struct {
+	// Index in orig list (i.e. root parent index).
+	resource int
+	// Index in ScopeLogs/ScopeMetrics list (i.e. immediate parent index).
+	library int
+	// Index in Logs list (i.e. the log record index).
+	record int
+}
+
+// bufferState encapsulates intermediate buffer state when pushing data
+type bufferState struct {
+	compressionAvailable bool
+	compressionEnabled   bool
+	bufferMaxLen         uint
+	writer               io.Writer
+	buf                  *bytes.Buffer
+	bufFront             *index
+	resource             int
+	library              int
+}
+
+func (b *bufferState) reset() {
+	b.buf.Reset()
+	b.compressionEnabled = false
+	b.writer = &cancellableBytesWriter{innerWriter: b.buf, maxCapacity: b.bufferMaxLen}
+}
+
+func (b *bufferState) Read(p []byte) (n int, err error) {
+	return b.buf.Read(p)
+}
+
+func (b *bufferState) Close() error {
+	if _, ok := b.writer.(*cancellableGzipWriter); ok {
+		return b.writer.(*cancellableGzipWriter).close()
+	}
+	return nil
+}
+
+// accept returns true if data is accepted by the buffer
+func (b *bufferState) accept(data []byte) (bool, error) {
+	_, err := b.writer.Write(data)
+	overCapacity := errors.Is(err, errOverCapacity)
+	bufLen := b.buf.Len()
+	if overCapacity {
+		bufLen += len(data)
+	}
+	if b.compressionAvailable && !b.compressionEnabled && bufLen > minCompressionLen {
+		// switch over to a zip buffer.
+		tmpBuf := bytes.NewBuffer(make([]byte, 0, b.bufferMaxLen+bufCapPadding))
+		writer := gzip.NewWriter(tmpBuf)
+		writer.Reset(tmpBuf)
+		zipWriter := &cancellableGzipWriter{
+			innerBuffer: tmpBuf,
+			innerWriter: writer,
+			// 8 bytes required for the zip footer.
+			maxCapacity: b.bufferMaxLen - 8,
+		}
+
+		if b.bufferMaxLen == 0 {
+			zipWriter.maxCapacity = 0
+		}
+
+		// the new data is so big, even with a zip writer, we are over the max limit.
+		// abandon and return false, so we can send what is already in our buffer.
+		if _, err2 := zipWriter.Write(b.buf.Bytes()); err2 != nil {
+			return false, err2
+		}
+		b.writer = zipWriter
+		b.buf = tmpBuf
+		b.compressionEnabled = true
+		// if the byte writer was over capacity, try to write the new entry in the zip writer:
+		if overCapacity {
+			if _, err2 := zipWriter.Write(data); err2 != nil {
+				return false, err2
+			}
+
+		}
+		return true, nil
+	}
+	if overCapacity {
+		return false, nil
+	}
+	return true, err
+}
+
+type cancellableBytesWriter struct {
+	innerWriter *bytes.Buffer
+	maxCapacity uint
+}
+
+func (c *cancellableBytesWriter) Write(b []byte) (int, error) {
+	if c.maxCapacity == 0 {
+		return c.innerWriter.Write(b)
+	}
+	if c.innerWriter.Len()+len(b) > int(c.maxCapacity) {
+		return 0, errOverCapacity
+	}
+	return c.innerWriter.Write(b)
+}
+
+type cancellableGzipWriter struct {
+	innerBuffer *bytes.Buffer
+	innerWriter *gzip.Writer
+	maxCapacity uint
+	len         int
+}
+
+func (c *cancellableGzipWriter) Write(b []byte) (int, error) {
+	if c.maxCapacity == 0 {
+		return c.innerWriter.Write(b)
+	}
+	c.len += len(b)
+	// if we see that at a 50% compression rate, we'd be over max capacity, start flushing.
+	if (c.len / 2) > int(c.maxCapacity) {
+		// we flush so the length of the underlying buffer is accurate.
+		if err := c.innerWriter.Flush(); err != nil {
+			return 0, err
+		}
+	}
+	// we find that the new content uncompressed, added to our buffer, would overflow our max capacity.
+	if c.innerBuffer.Len()+len(b) > int(c.maxCapacity) {
+		// so we create a copy of our content and add this new data, compressed, to check that it fits.
+		copyBuf := bytes.NewBuffer(make([]byte, 0, c.maxCapacity+bufCapPadding))
+		copyBuf.Write(c.innerBuffer.Bytes())
+		writerCopy := gzip.NewWriter(copyBuf)
+		writerCopy.Reset(copyBuf)
+		if _, err := writerCopy.Write(b); err != nil {
+			return 0, err
+		}
+		if err := writerCopy.Flush(); err != nil {
+			return 0, err
+		}
+		// we find that even compressed, the data overflows.
+		if copyBuf.Len() > int(c.maxCapacity) {
+			return 0, errOverCapacity
+		}
+	}
+	return c.innerWriter.Write(b)
+}
+
+func (c *cancellableGzipWriter) close() error {
+	return c.innerWriter.Close()
+}
+
+func makeBlankBufferState(bufCap uint, compressionAvailable bool) *bufferState {
+	// Buffer of JSON encoded Splunk events, last record is expected to overflow bufCap, hence the padding
+	buf := bytes.NewBuffer(make([]byte, 0, bufCap+bufCapPadding))
+
+	return &bufferState{
+		compressionAvailable: compressionAvailable,
+		compressionEnabled:   false,
+		writer:               &cancellableBytesWriter{innerWriter: buf, maxCapacity: bufCap},
+		buf:                  buf,
+		bufferMaxLen:         bufCap,
+		bufFront:             nil, // Index of the log record of the first unsent event in buffer.
+		resource:             0,   // Index of currently processed Resource
+		library:              0,   // Index of currently processed Library
+	}
+}

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -16,13 +16,8 @@ package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"sync"
 
 	jsoniter "github.com/json-iterator/go"
@@ -37,193 +32,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
-var (
-	errOverCapacity = errors.New("over capacity")
-)
-
-// Minimum number of bytes to compress. 1500 is the MTU of an ethernet frame.
-const minCompressionLen = 1500
-
 // client sends the data to the splunk backend.
 type client struct {
-	config         *Config
-	url            *url.URL
-	healthCheckURL *url.URL
-	client         *http.Client
-	logger         *zap.Logger
-	wg             sync.WaitGroup
-	headers        map[string]string
-}
-
-// bufferState encapsulates intermediate buffer state when pushing data
-type bufferState struct {
-	compressionAvailable bool
-	compressionEnabled   bool
-	bufferMaxLen         uint
-	writer               io.Writer
-	buf                  *bytes.Buffer
-	bufFront             *index
-	resource             int
-	library              int
-}
-
-func (b *bufferState) reset() {
-	b.buf.Reset()
-	b.compressionEnabled = false
-	b.writer = &cancellableBytesWriter{innerWriter: b.buf, maxCapacity: b.bufferMaxLen}
-}
-
-func (b *bufferState) Read(p []byte) (n int, err error) {
-	return b.buf.Read(p)
-}
-
-func (b *bufferState) Close() error {
-	if _, ok := b.writer.(*cancellableGzipWriter); ok {
-		return b.writer.(*cancellableGzipWriter).close()
-	}
-	return nil
-}
-
-// accept returns true if data is accepted by the buffer
-func (b *bufferState) accept(data []byte) (bool, error) {
-	_, err := b.writer.Write(data)
-	overCapacity := errors.Is(err, errOverCapacity)
-	bufLen := b.buf.Len()
-	if overCapacity {
-		bufLen += len(data)
-	}
-	if b.compressionAvailable && !b.compressionEnabled && bufLen > minCompressionLen {
-		// switch over to a zip buffer.
-		tmpBuf := bytes.NewBuffer(make([]byte, 0, b.bufferMaxLen+bufCapPadding))
-		writer := gzip.NewWriter(tmpBuf)
-		writer.Reset(tmpBuf)
-		zipWriter := &cancellableGzipWriter{
-			innerBuffer: tmpBuf,
-			innerWriter: writer,
-			// 8 bytes required for the zip footer.
-			maxCapacity: b.bufferMaxLen - 8,
-		}
-
-		if b.bufferMaxLen == 0 {
-			zipWriter.maxCapacity = 0
-		}
-
-		// the new data is so big, even with a zip writer, we are over the max limit.
-		// abandon and return false, so we can send what is already in our buffer.
-		if _, err2 := zipWriter.Write(b.buf.Bytes()); err2 != nil {
-			return false, err2
-		}
-		b.writer = zipWriter
-		b.buf = tmpBuf
-		b.compressionEnabled = true
-		// if the byte writer was over capacity, try to write the new entry in the zip writer:
-		if overCapacity {
-			if _, err2 := zipWriter.Write(data); err2 != nil {
-				return false, err2
-			}
-
-		}
-		return true, nil
-	}
-	if overCapacity {
-		return false, nil
-	}
-	return true, err
-}
-
-type cancellableBytesWriter struct {
-	innerWriter *bytes.Buffer
-	maxCapacity uint
-}
-
-func (c *cancellableBytesWriter) Write(b []byte) (int, error) {
-	if c.maxCapacity == 0 {
-		return c.innerWriter.Write(b)
-	}
-	if c.innerWriter.Len()+len(b) > int(c.maxCapacity) {
-		return 0, errOverCapacity
-	}
-	return c.innerWriter.Write(b)
-}
-
-type cancellableGzipWriter struct {
-	innerBuffer *bytes.Buffer
-	innerWriter *gzip.Writer
-	maxCapacity uint
-	len         int
-}
-
-func (c *cancellableGzipWriter) Write(b []byte) (int, error) {
-	if c.maxCapacity == 0 {
-		return c.innerWriter.Write(b)
-	}
-	c.len += len(b)
-	// if we see that at a 50% compression rate, we'd be over max capacity, start flushing.
-	if (c.len / 2) > int(c.maxCapacity) {
-		// we flush so the length of the underlying buffer is accurate.
-		if err := c.innerWriter.Flush(); err != nil {
-			return 0, err
-		}
-	}
-	// we find that the new content uncompressed, added to our buffer, would overflow our max capacity.
-	if c.innerBuffer.Len()+len(b) > int(c.maxCapacity) {
-		// so we create a copy of our content and add this new data, compressed, to check that it fits.
-		copyBuf := bytes.NewBuffer(make([]byte, 0, c.maxCapacity+bufCapPadding))
-		copyBuf.Write(c.innerBuffer.Bytes())
-		writerCopy := gzip.NewWriter(copyBuf)
-		writerCopy.Reset(copyBuf)
-		if _, err := writerCopy.Write(b); err != nil {
-			return 0, err
-		}
-		if err := writerCopy.Flush(); err != nil {
-			return 0, err
-		}
-		// we find that even compressed, the data overflows.
-		if copyBuf.Len() > int(c.maxCapacity) {
-			return 0, errOverCapacity
-		}
-	}
-	return c.innerWriter.Write(b)
-}
-
-func (c *cancellableGzipWriter) close() error {
-	return c.innerWriter.Close()
-}
-
-// Composite index of a record.
-type index struct {
-	// Index in orig list (i.e. root parent index).
-	resource int
-	// Index in ScopeLogs/ScopeMetrics list (i.e. immediate parent index).
-	library int
-	// Index in Logs list (i.e. the log record index).
-	record int
-}
-
-func (c *client) checkHecHealth() error {
-
-	req, err := http.NewRequest("GET", c.healthCheckURL.String(), nil)
-	if err != nil {
-		return consumererror.NewPermanent(err)
-	}
-
-	// Set the headers configured for the client
-	for k, v := range c.headers {
-		req.Header.Set(k, v)
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	err = splunk.HandleHTTPCode(resp)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	config    *Config
+	logger    *zap.Logger
+	wg        sync.WaitGroup
+	hecWorker hecWorker
 }
 
 func (c *client) pushMetricsData(
@@ -233,22 +47,15 @@ func (c *client) pushMetricsData(
 	c.wg.Add(1)
 	defer c.wg.Done()
 
-	// Callback when each batch is to be sent.
-	send := func(ctx context.Context, bufState *bufferState) (err error) {
-		localHeaders := map[string]string{}
-		if md.ResourceMetrics().Len() != 0 {
-			accessToken, found := md.ResourceMetrics().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
-			if found {
-				localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
-			}
+	localHeaders := map[string]string{}
+	if md.ResourceMetrics().Len() != 0 {
+		accessToken, found := md.ResourceMetrics().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
+		if found {
+			localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
 		}
-		if err := bufState.Close(); err != nil {
-			return err
-		}
-		return c.postEvents(ctx, bufState, localHeaders, bufState.compressionEnabled, bufState.buf.Len())
 	}
 
-	return c.pushMetricsDataInBatches(ctx, md, send)
+	return c.pushMetricsDataInBatches(ctx, md, localHeaders)
 }
 
 func (c *client) pushTraceData(
@@ -258,48 +65,30 @@ func (c *client) pushTraceData(
 	c.wg.Add(1)
 	defer c.wg.Done()
 
-	// Callback when each batch is to be sent.
-	send := func(ctx context.Context, bufState *bufferState) (err error) {
-		localHeaders := map[string]string{}
-		if td.ResourceSpans().Len() != 0 {
-			accessToken, found := td.ResourceSpans().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
-			if found {
-				localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
-			}
+	localHeaders := map[string]string{}
+	if td.ResourceSpans().Len() != 0 {
+		accessToken, found := td.ResourceSpans().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
+		if found {
+			localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
 		}
-		if err := bufState.Close(); err != nil {
-			return err
-		}
-		return c.postEvents(ctx, bufState, localHeaders, bufState.compressionEnabled, bufState.buf.Len())
 	}
 
-	return c.pushTracesDataInBatches(ctx, td, send)
+	return c.pushTracesDataInBatches(ctx, td, localHeaders)
 }
 
 func (c *client) pushLogData(ctx context.Context, ld plog.Logs) error {
 	c.wg.Add(1)
 	defer c.wg.Done()
 
-	// Callback when each batch is to be sent.
-	send := func(ctx context.Context, bufState *bufferState, headers map[string]string) (err error) {
-		localHeaders := headers
-		if ld.ResourceLogs().Len() != 0 {
-			accessToken, found := ld.ResourceLogs().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
-			if found {
-				localHeaders = map[string]string{}
-				for k, v := range headers {
-					localHeaders[k] = v
-				}
-				localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
-			}
+	localHeaders := map[string]string{}
+	if ld.ResourceLogs().Len() != 0 {
+		accessToken, found := ld.ResourceLogs().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
+		if found {
+			localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
 		}
-		if err := bufState.Close(); err != nil {
-			return err
-		}
-		return c.postEvents(ctx, bufState, localHeaders, bufState.compressionEnabled, bufState.buf.Len())
 	}
 
-	return c.pushLogDataInBatches(ctx, ld, send)
+	return c.pushLogDataInBatches(ctx, ld, localHeaders)
 }
 
 // A guesstimated value > length of bytes of a single event.
@@ -316,28 +105,21 @@ func isProfilingData(sl plog.ScopeLogs) bool {
 	return sl.Scope().Name() == profilingLibraryName
 }
 
-func makeBlankBufferState(bufCap uint, compressionAvailable bool) *bufferState {
-	// Buffer of JSON encoded Splunk events, last record is expected to overflow bufCap, hence the padding
-	buf := bytes.NewBuffer(make([]byte, 0, bufCap+bufCapPadding))
-
-	return &bufferState{
-		compressionAvailable: compressionAvailable,
-		compressionEnabled:   false,
-		writer:               &cancellableBytesWriter{innerWriter: buf, maxCapacity: bufCap},
-		buf:                  buf,
-		bufferMaxLen:         bufCap,
-		bufFront:             nil, // Index of the log record of the first unsent event in buffer.
-		resource:             0,   // Index of currently processed Resource
-		library:              0,   // Index of currently processed Library
-	}
-}
-
 // pushLogDataInBatches sends batches of Splunk events in JSON format.
 // The batch content length is restricted to MaxContentLengthLogs.
 // ld log records are parsed to Splunk events.
 // The input data may contain both logs and profiling data.
 // They are batched separately and sent with different HTTP headers
-func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, send func(context.Context, *bufferState, map[string]string) error) error {
+func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, headers map[string]string) error {
+	profilingLocalHeaders := map[string]string{}
+	for k, v := range profilingHeaders {
+		profilingLocalHeaders[k] = v
+	}
+
+	for k, v := range headers {
+		profilingLocalHeaders[k] = v
+	}
+
 	var bufState = makeBlankBufferState(c.config.MaxContentLengthLogs, !c.config.DisableCompression)
 	var profilingBufState = makeBlankBufferState(c.config.MaxContentLengthLogs, !c.config.DisableCompression)
 	var permanentErrors []error
@@ -356,14 +138,14 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, send fu
 					continue
 				}
 				profilingBufState.resource, profilingBufState.library = i, j
-				newPermanentErrors, err = c.pushLogRecords(ctx, rls, profilingBufState, profilingHeaders, send)
+				newPermanentErrors, err = c.pushLogRecords(ctx, rls, profilingBufState, profilingLocalHeaders)
 			} else {
 				if !c.config.LogDataEnabled {
 					droppedLogRecords += ills.At(j).LogRecords().Len()
 					continue
 				}
 				bufState.resource, bufState.library = i, j
-				newPermanentErrors, err = c.pushLogRecords(ctx, rls, bufState, nil, send)
+				newPermanentErrors, err = c.pushLogRecords(ctx, rls, bufState, headers)
 			}
 
 			if err != nil {
@@ -384,14 +166,14 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, send fu
 	// There's some leftover unsent non-profiling data
 	if bufState.buf.Len() > 0 {
 
-		if err := send(ctx, bufState, nil); err != nil {
+		if err := c.postEvents(ctx, bufState, headers); err != nil {
 			return consumererror.NewLogs(err, c.subLogs(ld, bufState.bufFront, profilingBufState.bufFront))
 		}
 	}
 
 	// There's some leftover unsent profiling data
 	if profilingBufState.buf.Len() > 0 {
-		if err := send(ctx, profilingBufState, profilingHeaders); err != nil {
+		if err := c.postEvents(ctx, profilingBufState, profilingLocalHeaders); err != nil {
 			// Non-profiling bufFront is set to nil because all non-profiling data was flushed successfully above.
 			return consumererror.NewLogs(err, c.subLogs(ld, nil, profilingBufState.bufFront))
 		}
@@ -400,7 +182,7 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, send fu
 	return multierr.Combine(permanentErrors...)
 }
 
-func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice, state *bufferState, headers map[string]string, send func(context.Context, *bufferState, map[string]string) error) (permanentErrors []error, sendingError error) {
+func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice, state *bufferState, headers map[string]string) (permanentErrors []error, sendingError error) {
 	res := lds.At(state.resource)
 	logs := res.ScopeLogs().At(state.library).LogRecords()
 
@@ -430,7 +212,7 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 		}
 
 		if state.buf.Len() > 0 {
-			if err = send(ctx, state, headers); err != nil {
+			if err = c.postEvents(ctx, state, headers); err != nil {
 				return permanentErrors, err
 			}
 		}
@@ -461,7 +243,7 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 	return permanentErrors, nil
 }
 
-func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMetricsSlice, state *bufferState, send func(context.Context, *bufferState) error) (permanentErrors []error, sendingError error) {
+func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMetricsSlice, state *bufferState, headers map[string]string) (permanentErrors []error, sendingError error) {
 	res := mds.At(state.resource)
 	metrics := res.ScopeMetrics().At(state.library).Metrics()
 
@@ -496,7 +278,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 		}
 
 		if state.buf.Len() > 0 {
-			if err := send(ctx, state); err != nil {
+			if err := c.postEvents(ctx, state, headers); err != nil {
 				return permanentErrors, err
 			}
 		}
@@ -528,7 +310,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 	return permanentErrors, nil
 }
 
-func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSlice, state *bufferState, send func(context.Context, *bufferState) error) (permanentErrors []error, sendingError error) {
+func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSlice, state *bufferState, headers map[string]string) (permanentErrors []error, sendingError error) {
 	res := tds.At(state.resource)
 	spans := res.ScopeSpans().At(state.library).Spans()
 
@@ -558,7 +340,7 @@ func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSli
 		}
 
 		if state.buf.Len() > 0 {
-			if err = send(ctx, state); err != nil {
+			if err = c.postEvents(ctx, state, headers); err != nil {
 				return permanentErrors, err
 			}
 		}
@@ -593,7 +375,7 @@ func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSli
 // pushMetricsDataInBatches sends batches of Splunk events in JSON format.
 // The batch content length is restricted to MaxContentLengthMetrics.
 // md metrics are parsed to Splunk events.
-func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metrics, send func(context.Context, *bufferState) error) error {
+func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metrics, headers map[string]string) error {
 	var bufState = makeBlankBufferState(c.config.MaxContentLengthMetrics, !c.config.DisableCompression)
 	var permanentErrors []error
 
@@ -605,7 +387,7 @@ func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metric
 			var newPermanentErrors []error
 
 			bufState.resource, bufState.library = i, j
-			newPermanentErrors, err = c.pushMetricsRecords(ctx, rms, bufState, send)
+			newPermanentErrors, err = c.pushMetricsRecords(ctx, rms, bufState, headers)
 
 			if err != nil {
 				return consumererror.NewMetrics(err, subMetrics(md, bufState.bufFront))
@@ -617,7 +399,7 @@ func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metric
 
 	// There's some leftover unsent metrics
 	if bufState.buf.Len() > 0 {
-		if err := send(ctx, bufState); err != nil {
+		if err := c.postEvents(ctx, bufState, headers); err != nil {
 			return consumererror.NewMetrics(err, subMetrics(md, bufState.bufFront))
 		}
 	}
@@ -628,7 +410,7 @@ func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metric
 // pushTracesDataInBatches sends batches of Splunk events in JSON format.
 // The batch content length is restricted to MaxContentLengthMetrics.
 // td traces are parsed to Splunk events.
-func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, send func(context.Context, *bufferState) error) error {
+func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, headers map[string]string) error {
 	bufState := makeBlankBufferState(c.config.MaxContentLengthTraces, !c.config.DisableCompression)
 	var permanentErrors []error
 
@@ -640,7 +422,7 @@ func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, 
 			var newPermanentErrors []error
 
 			bufState.resource, bufState.library = i, j
-			newPermanentErrors, err = c.pushTracesData(ctx, rts, bufState, send)
+			newPermanentErrors, err = c.pushTracesData(ctx, rts, bufState, headers)
 
 			if err != nil {
 				return consumererror.NewTraces(err, subTraces(td, bufState.bufFront))
@@ -652,7 +434,7 @@ func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, 
 
 	// There's some leftover unsent traces
 	if bufState.buf.Len() > 0 {
-		if err := send(ctx, bufState); err != nil {
+		if err := c.postEvents(ctx, bufState, headers); err != nil {
 			return consumererror.NewTraces(err, subTraces(td, bufState.bufFront))
 		}
 	}
@@ -660,40 +442,11 @@ func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, 
 	return multierr.Combine(permanentErrors...)
 }
 
-func (c *client) postEvents(ctx context.Context, events io.Reader, headers map[string]string, compressed bool, contentLength int) error {
-	req, err := http.NewRequestWithContext(ctx, "POST", c.url.String(), events)
-	if err != nil {
-		return consumererror.NewPermanent(err)
-	}
-	req.ContentLength = int64(contentLength)
-
-	// Set the headers configured for the client
-	for k, v := range c.headers {
-		req.Header.Set(k, v)
-	}
-
-	// Set extra headers passed by the caller
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-
-	if compressed {
-		req.Header.Set("Content-Encoding", "gzip")
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
+func (c *client) postEvents(ctx context.Context, bufState *bufferState, headers map[string]string) error {
+	if err := bufState.Close(); err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-
-	err = splunk.HandleHTTPCode(resp)
-	if err != nil {
-		return err
-	}
-
-	_, errCopy := io.Copy(io.Discard, resp.Body)
-	return multierr.Combine(err, errCopy)
+	return c.hecWorker.Send(ctx, bufState, headers)
 }
 
 // subLogs returns a subset of `ld` starting from `profilingBufFront` for profiling data

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -446,7 +446,7 @@ func (c *client) postEvents(ctx context.Context, bufState *bufferState, headers 
 	if err := bufState.Close(); err != nil {
 		return err
 	}
-	return c.hecWorker.Send(ctx, bufState, headers)
+	return c.hecWorker.send(ctx, bufState, headers)
 }
 
 // subLogs returns a subset of `ld` starting from `profilingBufFront` for profiling data

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -827,16 +827,12 @@ func Test_PushMetricsData_Histogram_NaN_Sum(t *testing.T) {
 	dp.SetSum(math.NaN())
 
 	c := client{
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
-		config: NewFactory().CreateDefaultConfig().(*Config),
-		logger: zap.NewNop(),
+		config:    NewFactory().CreateDefaultConfig().(*Config),
+		logger:    zap.NewNop(),
+		hecWorker: &mockHecWorker{},
 	}
 
-	sender := func(ctx context.Context, state *bufferState) error {
-		return nil
-	}
-
-	permanentErrors := c.pushMetricsDataInBatches(context.Background(), metrics, sender)
+	permanentErrors := c.pushMetricsDataInBatches(context.Background(), metrics, map[string]string{})
 	assert.NoError(t, permanentErrors)
 }
 
@@ -850,16 +846,12 @@ func Test_PushMetricsData_Summary_NaN_Sum(t *testing.T) {
 	dp.SetSum(math.NaN())
 
 	c := client{
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
-		config: NewFactory().CreateDefaultConfig().(*Config),
-		logger: zap.NewNop(),
+		config:    NewFactory().CreateDefaultConfig().(*Config),
+		logger:    zap.NewNop(),
+		hecWorker: &mockHecWorker{},
 	}
 
-	sender := func(ctx context.Context, state *bufferState) error {
-		return nil
-	}
-
-	permanentErrors := c.pushMetricsDataInBatches(context.Background(), metrics, sender)
+	permanentErrors := c.pushMetricsDataInBatches(context.Background(), metrics, map[string]string{})
 	assert.NoError(t, permanentErrors)
 }
 
@@ -1054,9 +1046,9 @@ func Test_pushLogData_InvalidLog(t *testing.T) {
 
 func Test_pushLogData_PostError(t *testing.T) {
 	c := client{
-		url:    &url.URL{Host: "in va lid"},
-		config: NewFactory().CreateDefaultConfig().(*Config),
-		logger: zaptest.NewLogger(t),
+		config:    NewFactory().CreateDefaultConfig().(*Config),
+		logger:    zaptest.NewLogger(t),
+		hecWorker: &hecWorkerWithoutAck{url: &url.URL{Host: "in va lid"}},
 	}
 
 	// 2000 log records -> ~371888 bytes when JSON encoded.
@@ -1093,9 +1085,10 @@ func Test_pushLogData_PostError(t *testing.T) {
 }
 
 func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
+	config := NewFactory().CreateDefaultConfig().(*Config)
+	url := &url.URL{Scheme: "http", Host: "splunk"}
 	splunkClient := client{
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
-		config: NewFactory().CreateDefaultConfig().(*Config),
+		config: config,
 		logger: zaptest.NewLogger(t),
 	}
 	logs := createLogData(1, 1, 1)
@@ -1103,7 +1096,8 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	responseBody := `some error occurred`
 
 	// An HTTP client that returns status code 400 and response body responseBody.
-	splunkClient.client, _ = newTestClient(400, responseBody)
+	httpClient, _ := newTestClient(400, responseBody)
+	splunkClient.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
 	// Sending logs using the client.
 	err := splunkClient.pushLogData(context.Background(), logs)
 	// TODO: Uncomment after consumererror.Logs implements method Unwrap.
@@ -1113,7 +1107,8 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	assert.Contains(t, err.Error(), responseBody)
 
 	// An HTTP client that returns some other status code other than 400 and response body responseBody.
-	splunkClient.client, _ = newTestClient(500, responseBody)
+	httpClient, _ = newTestClient(500, responseBody)
+	splunkClient.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
 	// Sending logs using the client.
 	err = splunkClient.pushLogData(context.Background(), logs)
 	// TODO: Uncomment after consumererror.Logs implements method Unwrap.
@@ -1125,8 +1120,8 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 
 func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
+	url := &url.URL{Scheme: "http", Host: "splunk"}
 	c := client{
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
 		config: config,
 		logger: zaptest.NewLogger(t),
 	}
@@ -1138,7 +1133,8 @@ func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 	c.config.MaxContentLengthLogs, c.config.DisableCompression = 250, true
 
 	// The first record is to be sent successfully, the second one should not
-	c.client, _ = newTestClientWithPresetResponses([]int{200, 400}, []string{"OK", "NOK"})
+	httpClient, _ := newTestClientWithPresetResponses([]int{200, 400}, []string{"OK", "NOK"})
+	c.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
 
 	err := c.pushLogData(context.Background(), logs)
 	require.Error(t, err)
@@ -1152,16 +1148,19 @@ func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 }
 
 func Test_pushLogData_ShouldAddHeadersForProfilingData(t *testing.T) {
+	config := NewFactory().CreateDefaultConfig().(*Config)
+	url := &url.URL{Scheme: "http", Host: "splunk"}
 	c := client{
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
-		config: NewFactory().CreateDefaultConfig().(*Config),
+		config: config,
 		logger: zaptest.NewLogger(t),
 	}
 
 	logs := createLogDataWithCustomLibraries(1, []string{"otel.logs", "otel.profiling"}, []int{10, 20})
 	var headers *[]http.Header
 
-	c.client, headers = newTestClient(200, "OK")
+	httpClient, headers := newTestClient(200, "OK")
+	c.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
+
 	// A 300-byte buffer only fits one record (around 200 bytes), so each record will be sent separately
 	c.config.MaxContentLengthLogs, c.config.DisableCompression = 300, true
 
@@ -1218,13 +1217,16 @@ func Benchmark_pushLogData_10_1_1_1024(b *testing.B) {
 }
 
 func benchPushLogData(b *testing.B, numResources int, numProfiling int, numNonProfiling int, bufSize uint) {
+	config := NewFactory().CreateDefaultConfig().(*Config)
+	url := &url.URL{Scheme: "http", Host: "splunk"}
 	c := client{
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
-		config: NewFactory().CreateDefaultConfig().(*Config),
+		config: config,
 		logger: zaptest.NewLogger(b),
 	}
 
-	c.client, _ = newTestClient(200, "OK")
+	httpClient, _ := newTestClient(200, "OK")
+	c.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
+
 	c.config.MaxContentLengthLogs = bufSize
 	logs := createLogDataWithCustomLibraries(numResources, []string{"otel.logs", "otel.profiling"}, []int{numNonProfiling, numProfiling})
 
@@ -1237,11 +1239,11 @@ func benchPushLogData(b *testing.B, numResources int, numProfiling int, numNonPr
 }
 
 func Test_pushLogData_Small_MaxContentLength(t *testing.T) {
+	config := NewFactory().CreateDefaultConfig().(*Config)
 	c := client{
-		config: NewFactory().CreateDefaultConfig().(*Config),
-		logger: zaptest.NewLogger(t),
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
-		client: http.DefaultClient,
+		config:    config,
+		logger:    zaptest.NewLogger(t),
+		hecWorker: &hecWorkerWithoutAck{&url.URL{Scheme: "http", Host: "splunk"}, http.DefaultClient, buildHTTPHeaders(config)},
 	}
 	c.config.MaxContentLengthLogs = 1
 
@@ -1383,33 +1385,6 @@ func TestSubLogs(t *testing.T) {
 	assert.Equal(t, "1_1_9", val.AsString())
 }
 
-func TestHecHealthCheckFailed(t *testing.T) {
-	c := client{
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
-		config: NewFactory().CreateDefaultConfig().(*Config),
-		logger: zaptest.NewLogger(t),
-
-		healthCheckURL: &url.URL{Scheme: "http", Host: "splunk", Path: "/services/collector/health"},
-	}
-	c.client, _ = newTestClient(503, "NOK")
-	err := c.checkHecHealth()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "503")
-}
-
-func TestHecHealthCheckSucceded(t *testing.T) {
-	c := client{
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
-		config: NewFactory().CreateDefaultConfig().(*Config),
-		logger: zaptest.NewLogger(t),
-
-		healthCheckURL: &url.URL{Scheme: "http", Host: "splunk", Path: "/services/collector/health"},
-	}
-	c.client, _ = newTestClient(200, "OK")
-	err := c.checkHecHealth()
-	assert.NoError(t, err)
-}
-
 // validateCompressedEqual validates that GZipped `got` contains `expected` strings
 func validateCompressedContains(t *testing.T, expected []string, got []byte) {
 	z, err := gzip.NewReader(bytes.NewReader(got))
@@ -1427,16 +1402,14 @@ func validateCompressedContains(t *testing.T, expected []string, got []byte) {
 func BenchmarkPushLogRecords(b *testing.B) {
 	logs := createLogData(1, 1, 1)
 	c := client{
-		url:    &url.URL{Scheme: "http", Host: "splunk"},
-		config: NewFactory().CreateDefaultConfig().(*Config),
-		logger: zap.NewNop(),
+		config:    NewFactory().CreateDefaultConfig().(*Config),
+		logger:    zap.NewNop(),
+		hecWorker: &mockHecWorker{},
 	}
-	sender := func(ctx context.Context, state *bufferState, headers map[string]string) error {
-		return nil
-	}
+
 	state := makeBlankBufferState(4096, true)
 	for n := 0; n < b.N; n++ {
-		permanentErrs, sendingErr := c.pushLogRecords(context.Background(), logs.ResourceLogs(), state, map[string]string{}, sender)
+		permanentErrs, sendingErr := c.pushLogRecords(context.Background(), logs.ResourceLogs(), state, map[string]string{})
 		assert.NoError(b, sendingErr)
 		for _, permanentErr := range permanentErrs {
 			assert.NoError(b, permanentErr)

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -1048,7 +1048,7 @@ func Test_pushLogData_PostError(t *testing.T) {
 	c := client{
 		config:    NewFactory().CreateDefaultConfig().(*Config),
 		logger:    zaptest.NewLogger(t),
-		hecWorker: &hecWorkerWithoutAck{url: &url.URL{Host: "in va lid"}},
+		hecWorker: &defaultHecWorker{url: &url.URL{Host: "in va lid"}},
 	}
 
 	// 2000 log records -> ~371888 bytes when JSON encoded.
@@ -1097,7 +1097,7 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 
 	// An HTTP client that returns status code 400 and response body responseBody.
 	httpClient, _ := newTestClient(400, responseBody)
-	splunkClient.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
+	splunkClient.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config)}
 	// Sending logs using the client.
 	err := splunkClient.pushLogData(context.Background(), logs)
 	// TODO: Uncomment after consumererror.Logs implements method Unwrap.
@@ -1108,7 +1108,7 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 
 	// An HTTP client that returns some other status code other than 400 and response body responseBody.
 	httpClient, _ = newTestClient(500, responseBody)
-	splunkClient.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
+	splunkClient.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config)}
 	// Sending logs using the client.
 	err = splunkClient.pushLogData(context.Background(), logs)
 	// TODO: Uncomment after consumererror.Logs implements method Unwrap.
@@ -1134,7 +1134,7 @@ func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 
 	// The first record is to be sent successfully, the second one should not
 	httpClient, _ := newTestClientWithPresetResponses([]int{200, 400}, []string{"OK", "NOK"})
-	c.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
+	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config)}
 
 	err := c.pushLogData(context.Background(), logs)
 	require.Error(t, err)
@@ -1159,7 +1159,7 @@ func Test_pushLogData_ShouldAddHeadersForProfilingData(t *testing.T) {
 	var headers *[]http.Header
 
 	httpClient, headers := newTestClient(200, "OK")
-	c.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
+	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config)}
 
 	// A 300-byte buffer only fits one record (around 200 bytes), so each record will be sent separately
 	c.config.MaxContentLengthLogs, c.config.DisableCompression = 300, true
@@ -1225,7 +1225,7 @@ func benchPushLogData(b *testing.B, numResources int, numProfiling int, numNonPr
 	}
 
 	httpClient, _ := newTestClient(200, "OK")
-	c.hecWorker = &hecWorkerWithoutAck{url, httpClient, buildHTTPHeaders(config)}
+	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config)}
 
 	c.config.MaxContentLengthLogs = bufSize
 	logs := createLogDataWithCustomLibraries(numResources, []string{"otel.logs", "otel.profiling"}, []int{numNonProfiling, numProfiling})
@@ -1243,7 +1243,7 @@ func Test_pushLogData_Small_MaxContentLength(t *testing.T) {
 	c := client{
 		config:    config,
 		logger:    zaptest.NewLogger(t),
-		hecWorker: &hecWorkerWithoutAck{&url.URL{Scheme: "http", Host: "splunk"}, http.DefaultClient, buildHTTPHeaders(config)},
+		hecWorker: &defaultHecWorker{&url.URL{Scheme: "http", Host: "splunk"}, http.DefaultClient, buildHTTPHeaders(config)},
 	}
 	c.config.MaxContentLengthLogs = 1
 

--- a/exporter/splunkhecexporter/exporter.go
+++ b/exporter/splunkhecexporter/exporter.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -76,14 +77,17 @@ func createExporter(
 		return nil, err
 	}
 
-	client, err := buildClient(options, config, logger)
+	httpClient, err := buildHTTPClient(config)
 	if err != nil {
 		return nil, err
 	}
 
+	client := buildClient(options, config, httpClient, logger)
+
 	if config.HecHealthCheckEnabled {
-		err = client.checkHecHealth()
-		if err != nil {
+		healthCheckURL := options.url
+		healthCheckURL.Path = config.HealthPath
+		if err := checkHecHealth(httpClient, healthCheckURL); err != nil {
 			return nil, fmt.Errorf("health check failed: %w", err)
 		}
 	}
@@ -97,40 +101,62 @@ func createExporter(
 	}, nil
 }
 
-func buildClient(options *exporterOptions, config *Config, logger *zap.Logger) (*client, error) {
+func checkHecHealth(client *http.Client, healthCheckURL *url.URL) error {
+
+	req, err := http.NewRequest("GET", healthCheckURL.String(), nil)
+	if err != nil {
+		return consumererror.NewPermanent(err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	err = splunk.HandleHTTPCode(resp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildClient(options *exporterOptions, config *Config, httpClient *http.Client, logger *zap.Logger) *client {
+	return &client{
+		logger:    logger,
+		config:    config,
+		hecWorker: &hecWorkerWithoutAck{options.url, httpClient, buildHTTPHeaders(config)},
+	}
+}
+
+func buildHTTPClient(config *Config) (*http.Client, error) {
 	tlsCfg, err := config.TLSSetting.LoadTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve TLS config for Splunk HEC Exporter: %w", err)
 	}
-	healthCheckURLPath := *options.url
-	healthCheckURLPath.Path = config.HealthPath
-	return &client{
-		url:            options.url,
-		healthCheckURL: &healthCheckURLPath,
-		client: &http.Client{
-			Timeout: config.Timeout,
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				DialContext: (&net.Dialer{
-					Timeout:   dialerTimeout,
-					KeepAlive: dialerKeepAlive,
-				}).DialContext,
-				MaxIdleConns:        int(config.MaxConnections),
-				MaxIdleConnsPerHost: int(config.MaxConnections),
-				IdleConnTimeout:     idleConnTimeout,
-				TLSHandshakeTimeout: tlsHandshakeTimeout,
-				TLSClientConfig:     tlsCfg,
-			},
-		},
-		logger: logger,
-		headers: map[string]string{
-			"Connection":           "keep-alive",
-			"Content-Type":         "application/json",
-			"User-Agent":           config.SplunkAppName + "/" + config.SplunkAppVersion,
-			"Authorization":        splunk.HECTokenHeader + " " + config.Token,
-			"__splunk_app_name":    config.SplunkAppName,
-			"__splunk_app_version": config.SplunkAppVersion,
-		},
-		config: config,
-	}, nil
+	return &http.Client{
+		Timeout: config.Timeout,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   dialerTimeout,
+				KeepAlive: dialerKeepAlive,
+			}).DialContext,
+			MaxIdleConns:        int(config.MaxConnections),
+			MaxIdleConnsPerHost: int(config.MaxConnections),
+			IdleConnTimeout:     idleConnTimeout,
+			TLSHandshakeTimeout: tlsHandshakeTimeout,
+			TLSClientConfig:     tlsCfg,
+		}}, nil
+}
+func buildHTTPHeaders(config *Config) map[string]string {
+	return map[string]string{
+		"Connection":           "keep-alive",
+		"Content-Type":         "application/json",
+		"User-Agent":           config.SplunkAppName + "/" + config.SplunkAppVersion,
+		"Authorization":        splunk.HECTokenHeader + " " + config.Token,
+		"__splunk_app_name":    config.SplunkAppName,
+		"__splunk_app_version": config.SplunkAppVersion,
+	}
 }

--- a/exporter/splunkhecexporter/exporter.go
+++ b/exporter/splunkhecexporter/exporter.go
@@ -126,7 +126,7 @@ func buildClient(options *exporterOptions, config *Config, httpClient *http.Clie
 	return &client{
 		logger:    logger,
 		config:    config,
-		hecWorker: &hecWorkerWithoutAck{options.url, httpClient, buildHTTPHeaders(config)},
+		hecWorker: &defaultHecWorker{options.url, httpClient, buildHTTPHeaders(config)},
 	}
 }
 

--- a/exporter/splunkhecexporter/hec_worker.go
+++ b/exporter/splunkhecexporter/hec_worker.go
@@ -1,4 +1,4 @@
-// Copyright 2020, OpenTelemetry Authors
+// Copyright 2022, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/splunkhecexporter/hec_worker.go
+++ b/exporter/splunkhecexporter/hec_worker.go
@@ -1,0 +1,75 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/multierr"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
+)
+
+type hecWorker interface {
+	Send(context.Context, *bufferState, map[string]string) error
+}
+
+type hecWorkerWithoutAck struct {
+	url     *url.URL
+	client  *http.Client
+	headers map[string]string
+}
+
+func (hec *hecWorkerWithoutAck) Send(ctx context.Context, bufferState *bufferState, headers map[string]string) error {
+	req, err := http.NewRequestWithContext(ctx, "POST", hec.url.String(), bufferState)
+	if err != nil {
+		return consumererror.NewPermanent(err)
+	}
+	req.ContentLength = int64(bufferState.buf.Len())
+
+	// Set the headers configured for the client
+	for k, v := range hec.headers {
+		req.Header.Set(k, v)
+	}
+
+	// Set extra headers passed by the caller
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	if bufferState.compressionEnabled {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
+
+	resp, err := hec.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	err = splunk.HandleHTTPCode(resp)
+	if err != nil {
+		return err
+	}
+
+	_, errCopy := io.Copy(io.Discard, resp.Body)
+	return multierr.Combine(err, errCopy)
+}
+
+var _ hecWorker = &hecWorkerWithoutAck{}

--- a/exporter/splunkhecexporter/hec_worker.go
+++ b/exporter/splunkhecexporter/hec_worker.go
@@ -27,16 +27,16 @@ import (
 )
 
 type hecWorker interface {
-	Send(context.Context, *bufferState, map[string]string) error
+	send(context.Context, *bufferState, map[string]string) error
 }
 
-type hecWorkerWithoutAck struct {
+type defaultHecWorker struct {
 	url     *url.URL
 	client  *http.Client
 	headers map[string]string
 }
 
-func (hec *hecWorkerWithoutAck) Send(ctx context.Context, bufferState *bufferState, headers map[string]string) error {
+func (hec *defaultHecWorker) send(ctx context.Context, bufferState *bufferState, headers map[string]string) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", hec.url.String(), bufferState)
 	if err != nil {
 		return consumererror.NewPermanent(err)
@@ -72,4 +72,4 @@ func (hec *hecWorkerWithoutAck) Send(ctx context.Context, bufferState *bufferSta
 	return multierr.Combine(err, errCopy)
 }
 
-var _ hecWorker = &hecWorkerWithoutAck{}
+var _ hecWorker = &defaultHecWorker{}

--- a/exporter/splunkhecexporter/hec_worker_test.go
+++ b/exporter/splunkhecexporter/hec_worker_test.go
@@ -20,7 +20,7 @@ import (
 
 type mockHecWorker struct{}
 
-func (m *mockHecWorker) Send(ctx context.Context, bufferState *bufferState, headers map[string]string) error {
+func (m *mockHecWorker) send(ctx context.Context, bufferState *bufferState, headers map[string]string) error {
 	return nil
 }
 

--- a/exporter/splunkhecexporter/hec_worker_test.go
+++ b/exporter/splunkhecexporter/hec_worker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020, OpenTelemetry Authors
+// Copyright 2022, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/splunkhecexporter/hec_worker_test.go
+++ b/exporter/splunkhecexporter/hec_worker_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunkhecexporter
+
+import (
+	"context"
+)
+
+type mockHecWorker struct{}
+
+func (m *mockHecWorker) Send(ctx context.Context, bufferState *bufferState, headers map[string]string) error {
+	return nil
+}
+
+var _ hecWorker = &mockHecWorker{}


### PR DESCRIPTION
### Description
`client.go` file is very large. So, I have:
- Extracted `send` method from `client.go` and moved it into `defaultHecWorker` struct that implements `hecWorker` interface
- Extracted `bufferState`, `cancellableBytesWriter` and `cancellableGzipWriter` from `client.go` and moved them to `buffer.go` file