### PR TITLE
[chore] [receiver/solacereceiver] Fix failing windows tests

### DIFF
--- a/receiver/solacereceiver/receiver_test.go
+++ b/receiver/solacereceiver/receiver_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -331,9 +330,6 @@ func TestReceiverUnmarshalVersionFailureExpectingDisable(t *testing.T) {
 }
 
 func TestReceiverFlowControlDelayedRetry(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Failing on windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17197")
-	}
 	someError := consumererror.NewPermanent(fmt.Errorf("some error"))
 	testCases := []struct {
 		name         string
@@ -457,9 +453,6 @@ func TestReceiverFlowControlDelayedRetryInterrupt(t *testing.T) {
 }
 
 func TestReceiverFlowControlDelayedRetryMultipleRetries(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Failing on windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17197")
-	}
 	receiver, messagingService, unmarshaller := newReceiver(t)
 	// we won't wait 10 seconds since we will interrupt well before
 	retryInterval := 2 * time.Millisecond

--- a/receiver/solacereceiver/receiver_test.go
+++ b/receiver/solacereceiver/receiver_test.go
@@ -351,7 +351,7 @@ func TestReceiverFlowControlDelayedRetry(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			receiver, messagingService, unmarshaller := newReceiver(t)
-			delay := 5 * time.Millisecond
+			delay := 50 * time.Millisecond
 			receiver.config.Flow.DelayedRetry.Delay = delay
 			var err error
 			// we want to return an error at first, then set the next consumer to a noop consumer
@@ -455,7 +455,7 @@ func TestReceiverFlowControlDelayedRetryInterrupt(t *testing.T) {
 func TestReceiverFlowControlDelayedRetryMultipleRetries(t *testing.T) {
 	receiver, messagingService, unmarshaller := newReceiver(t)
 	// we won't wait 10 seconds since we will interrupt well before
-	retryInterval := 2 * time.Millisecond
+	retryInterval := 20 * time.Millisecond
 	var retryCount int64 = 5
 	receiver.config.Flow.DelayedRetry.Delay = retryInterval
 	var err error


### PR DESCRIPTION
**Description:** Increases delay on certain tests to allow enough time to pass on windows. Apparently 2ms/5ms is too aggressive for the windows scheduling, so less granularity is required. 

**Link to tracking Issue:** Fixes #17197

**Testing:** N/A

**Documentation:** N/A