### PR TITLE
[chore] [receiver/solacereceiver] Fixed failing unit test on windows by increasing timeout

### DIFF
--- a/receiver/solacereceiver/receiver_test.go
+++ b/receiver/solacereceiver/receiver_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -351,7 +352,12 @@ func TestReceiverFlowControlDelayedRetry(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			receiver, messagingService, unmarshaller := newReceiver(t)
-			delay := 50 * time.Millisecond
+			delay := 5 * time.Millisecond
+			// Increase delay on windows due to tick granularity
+			// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17197
+			if runtime.GOOS == "windows" {
+				delay = 500 * time.Millisecond
+			}
 			receiver.config.Flow.DelayedRetry.Delay = delay
 			var err error
 			// we want to return an error at first, then set the next consumer to a noop consumer


### PR DESCRIPTION
**Description:** Increase the delay on windows only for unit test `TestReceiverFlowControlDelayedRetry` to 500ms. It seems there are a variety of issues around clock granularity on windows that do not happen on other systems. 500ms should be sufficient to avoid this (10x the previous value which was 10x the original value). This is set only on Windows to improve test time on all other OSs.

**Link to tracking Issue:** Fixes 17197

**Testing:** N/A

**Documentation:** N/A

@dmitryax FYI