### PR TITLE
[chore] fix zookeeper supported pipeline types

### DIFF
--- a/receiver/zookeeperreceiver/README.md
+++ b/receiver/zookeeperreceiver/README.md
@@ -3,7 +3,7 @@
 | Status                   |               |
 | ------------------------ |---------------|
 | Stability                | [development] |
-| Supported pipeline types | traces        |
+| Supported pipeline types | metrics       |
 | Distributions            | [contrib]     |
 
 The Zookeeper receiver collects metrics from a Zookeeper instance, using the `mntr` command. The `mntr` 4 letter word command needs


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

_tl;dr typo fix_

This PR updates the zookeeper receiver docs to reflect the correct supported pipeline. Currently the zookeeper receiver supports the `metrics` pipeline (see: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/1bf261e29c2d9d088cefc71d595b88ed58668883/receiver/zookeeperreceiver/factory.go#L42) however it's labeled as `traces` in the Readme. this PR fixes this typo.

**Link to tracking Issue:** <Issue number if applicable> n/a

**Testing:** <Describe what testing was performed and which tests were added.> n/a

**Documentation:** <Describe the documentation added.> updated readme