### PR TITLE
Instead of supply metric metadata and label for aws calculator, supply with aws metric key which consists of metric metadata and label

### DIFF
--- a/.chloggen/use-key-with-aws-calculator.yaml
+++ b/.chloggen/use-key-with-aws-calculator.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: awsemfexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Change to use metric key instead of metric and labels
+note: Instead of supply metric metadata and label for aws calculator, supply with aws metric key which consists of metric metadata and label
 
 # One or more tracking issues related to the change
 issues: [17207]

--- a/.chloggen/use-metric-key-with-aws-calculator.yaml
+++ b/.chloggen/use-metric-key-with-aws-calculator.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change to use metric key instead of metric and labels
+
+# One or more tracking issues related to the change
+issues: [17207]

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -17,10 +17,11 @@ package awsemfexporter // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"time"
 
-	aws "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+
+	aws "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
 )
 
 var deltaMetricCalculator = aws.NewFloat64DeltaCalculator()

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -111,11 +111,9 @@ func (dps numberDataPointSlice) At(i int) (dataPoint, bool) {
 
 	retained := true
 	if dps.adjustToDelta {
-		var (
-			deltaVal interface{}
-			key      = aws.NewKey(dps.deltaMetricMetadata, labels)
-		)
-		deltaVal, retained := deltaMetricCalculator.Calculate(key, metricVal, metric.Timestamp().AsTime())
+		var deltaVal interface{}
+		mKey := aws.NewKey(dps.deltaMetricMetadata, labels)
+		deltaVal, retained = deltaMetricCalculator.Calculate(mKey, metricVal, metric.Timestamp().AsTime())
 		if !retained {
 			return dataPoint{}, retained
 		}
@@ -161,12 +159,10 @@ func (dps summaryDataPointSlice) At(i int) (dataPoint, bool) {
 	count := metric.Count()
 	retained := true
 	if dps.adjustToDelta {
-		var (
-			delta interface{}
-			key   = aws.NewKey(dps.deltaMetricMetadata, labels)
-		)
+		var delta interface{}
+		mKey := aws.NewKey(dps.deltaMetricMetadata, labels)
 
-		delta, retained = summaryMetricCalculator.Calculate(key, summaryMetricEntry{sum, count}, metric.Timestamp().AsTime())
+		delta, retained = summaryMetricCalculator.Calculate(mKey, summaryMetricEntry{sum, count}, metric.Timestamp().AsTime())
 		if !retained {
 			return dataPoint{}, retained
 		}

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -111,9 +111,11 @@ func (dps numberDataPointSlice) At(i int) (dataPoint, bool) {
 
 	retained := true
 	if dps.adjustToDelta {
-		var deltaVal interface{}
-		var metricKey aws.Key = aws.NewKey(dps.deltaMetricMetadata, labels)
-		deltaVal, retained = deltaMetricCalculator.Calculate(metricKey, metricVal, metric.Timestamp().AsTime())
+		var (
+			deltaVal interface{}
+			key      = aws.NewKey(dps.deltaMetricMetadata, labels)
+		)
+		deltaVal, retained := deltaMetricCalculator.Calculate(key, metricVal, metric.Timestamp().AsTime())
 		if !retained {
 			return dataPoint{}, retained
 		}
@@ -159,9 +161,12 @@ func (dps summaryDataPointSlice) At(i int) (dataPoint, bool) {
 	count := metric.Count()
 	retained := true
 	if dps.adjustToDelta {
-		var delta interface{}
-		var metricKey aws.Key = aws.NewKey(dps.deltaMetricMetadata, labels)
-		delta, retained = summaryMetricCalculator.Calculate(metricKey, summaryMetricEntry{sum, count}, metric.Timestamp().AsTime())
+		var (
+			delta interface{}
+			key   = aws.NewKey(dps.deltaMetricMetadata, labels)
+		)
+
+		delta, retained = summaryMetricCalculator.Calculate(key, summaryMetricEntry{sum, count}, metric.Timestamp().AsTime())
 		if !retained {
 			return dataPoint{}, retained
 		}

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -65,7 +65,6 @@ type dataPoints interface {
 type deltaMetricMetadata struct {
 	adjustToDelta bool
 	metricName    string
-	timestampMs   int64
 	namespace     string
 	logGroup      string
 	logStream     string
@@ -209,7 +208,6 @@ func getDataPoints(pmd pmetric.Metric, metadata cWMetricMetadata, logger *zap.Lo
 	adjusterMetadata := deltaMetricMetadata{
 		false,
 		pmd.Name(),
-		metadata.timestampMs,
 		metadata.namespace,
 		metadata.logGroup,
 		metadata.logStream,

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -317,7 +317,6 @@ func TestIntDataPointSliceAt(t *testing.T) {
 				deltaMetricMetadata{
 					tc.adjustToDelta,
 					"foo",
-					0,
 					"namespace",
 					"log-group",
 					"log-stream",
@@ -387,7 +386,6 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 				deltaMetricMetadata{
 					tc.adjustToDelta,
 					"foo",
-					0,
 					"namespace",
 					"log-group",
 					"log-stream",
@@ -507,7 +505,6 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 	setupDataPointCache()
 
 	instrLibName := "cloudwatch-otel"
-	metadataTimeStamp := time.Now().UnixNano() / int64(time.Millisecond)
 
 	testCases := []struct {
 		testName           string
@@ -552,7 +549,6 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 				deltaMetricMetadata{
 					true,
 					"foo",
-					metadataTimeStamp,
 					"namespace",
 					"log-group",
 					"log-stream",
@@ -625,7 +621,6 @@ func TestGetDataPoints(t *testing.T) {
 	dmm := deltaMetricMetadata{
 		false,
 		"foo",
-		metadata.timestampMs,
 		"namespace",
 		"log-group",
 		"log-stream",
@@ -633,7 +628,6 @@ func TestGetDataPoints(t *testing.T) {
 	cumulativeDmm := deltaMetricMetadata{
 		true,
 		"foo",
-		metadata.timestampMs,
 		"namespace",
 		"log-group",
 		"log-stream",

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -18,10 +18,9 @@ import (
 	"encoding/json"
 	"strings"
 
+	aws "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
-
-	aws "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
 )
 
 // groupedMetric defines set of metrics with same namespace, timestamp and labels
@@ -80,7 +79,7 @@ func addToGroupedMetric(pmd pmetric.Metric, groupedMetrics map[interface{}]*grou
 		}
 
 		// Extra params to use when grouping metrics
-		groupKey := groupedMetricKey(metadata.groupedMetricMetadata, labels)
+		groupKey := aws.NewKey(metadata, labels)
 		if _, ok := groupedMetrics[groupKey]; ok {
 			// if MetricName already exists in metrics map, print warning log
 			if _, ok := groupedMetrics[groupKey].metrics[metricName]; ok {
@@ -176,10 +175,6 @@ func mapGetHelper(labels map[string]string, key string) string {
 	}
 
 	return ""
-}
-
-func groupedMetricKey(metadata groupedMetricMetadata, labels map[string]string) aws.Key {
-	return aws.NewKey(metadata, labels)
 }
 
 func translateUnit(metric pmetric.Metric, descriptor map[string]MetricDescriptor) string {

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -18,9 +18,10 @@ import (
 	"encoding/json"
 	"strings"
 
-	aws "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+
+	aws "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
 )
 
 // groupedMetric defines set of metrics with same namespace, timestamp and labels

--- a/internal/aws/metrics/metric_calculator.go
+++ b/internal/aws/metrics/metric_calculator.go
@@ -61,11 +61,11 @@ func NewMetricCalculator(calculateFunc CalculateFunc) MetricCalculator {
 	}
 }
 
-// Calculate accepts a new metric value identified by matricName and labels, and delegates
-// the calculation with value and timestamp back to CalculateFunc for the result. Returns
+// Calculate accepts a new metric value identified by metric Key (consists of metric metadata and labels),
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/eacfde3fcbd46ba60a6db0e9a41977390c4883bd/internal/aws/metrics/metric_calculator.go#L88-L91
+// and delegates the calculation with value and timestamp back to CalculateFunc for the result. Returns
 // true if the calculation is executed successfully.
-func (rm *MetricCalculator) Calculate(metricName string, labels map[string]string, value interface{}, timestamp time.Time) (interface{}, bool) {
-	k := NewKey(metricName, labels)
+func (rm *MetricCalculator) Calculate(metricKey Key, value interface{}, timestamp time.Time) (interface{}, bool) {
 	cacheStore := rm.cache
 
 	var result interface{}
@@ -74,10 +74,10 @@ func (rm *MetricCalculator) Calculate(metricName string, labels map[string]strin
 	rm.lock.Lock()
 	defer rm.lock.Unlock()
 
-	prev, exists := cacheStore.Get(k)
+	prev, exists := cacheStore.Get(metricKey)
 	result, done = rm.calculateFunc(prev, value, timestamp)
 	if !exists || done {
-		cacheStore.Set(k, MetricValue{
+		cacheStore.Set(metricKey, MetricValue{
 			RawValue:  value,
 			Timestamp: timestamp,
 		})

--- a/internal/aws/metrics/metric_calculator.go
+++ b/internal/aws/metrics/metric_calculator.go
@@ -61,11 +61,11 @@ func NewMetricCalculator(calculateFunc CalculateFunc) MetricCalculator {
 	}
 }
 
-// Calculate accepts a new metric value identified by metric Key (consists of metric metadata and labels),
+// Calculate accepts a new metric value identified by metric key (consists of metric metadata and labels),
 // https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/eacfde3fcbd46ba60a6db0e9a41977390c4883bd/internal/aws/metrics/metric_calculator.go#L88-L91
 // and delegates the calculation with value and timestamp back to CalculateFunc for the result. Returns
 // true if the calculation is executed successfully.
-func (rm *MetricCalculator) Calculate(metricKey Key, value interface{}, timestamp time.Time) (interface{}, bool) {
+func (rm *MetricCalculator) Calculate(mKey Key, value interface{}, timestamp time.Time) (interface{}, bool) {
 	cacheStore := rm.cache
 
 	var result interface{}
@@ -74,10 +74,10 @@ func (rm *MetricCalculator) Calculate(metricKey Key, value interface{}, timestam
 	rm.lock.Lock()
 	defer rm.lock.Unlock()
 
-	prev, exists := cacheStore.Get(metricKey)
+	prev, exists := cacheStore.Get(mKey)
 	result, done = rm.calculateFunc(prev, value, timestamp)
 	if !exists || done {
-		cacheStore.Set(metricKey, MetricValue{
+		cacheStore.Set(mKey, MetricValue{
 			RawValue:  value,
 			Timestamp: timestamp,
 		})

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -24,37 +24,37 @@ import (
 )
 
 func TestFloat64RateCalculator(t *testing.T) {
-	MetricMetadata := "rate"
+	metricKey := NewKey("rate", nil)
 	initTime := time.Now()
 	c := newFloat64RateCalculator()
-	r, ok := c.Calculate(MetricMetadata, nil, float64(50), initTime)
+	r, ok := c.Calculate(metricKey, float64(50), initTime)
 	assert.False(t, ok)
 	assert.Equal(t, float64(0), r)
 
 	nextTime := initTime.Add(100 * time.Millisecond)
-	r, ok = c.Calculate(MetricMetadata, nil, float64(100), nextTime)
+	r, ok = c.Calculate(metricKey, float64(100), nextTime)
 	assert.True(t, ok)
 	assert.InDelta(t, 0.5, r, 0.1)
 }
 
 func TestFloat64RateCalculatorWithTooFrequentUpdate(t *testing.T) {
-	MetricMetadata := "rate"
+	metricKey := NewKey("rate", nil)
 	initTime := time.Now()
 	c := newFloat64RateCalculator()
-	r, ok := c.Calculate(MetricMetadata, nil, float64(50), initTime)
+	r, ok := c.Calculate(metricKey, float64(50), initTime)
 	assert.False(t, ok)
 	assert.Equal(t, float64(0), r)
 
 	nextTime := initTime
 	for i := 0; i < 10; i++ {
 		nextTime = nextTime.Add(5 * time.Millisecond)
-		r, ok = c.Calculate(MetricMetadata, nil, float64(105), nextTime)
+		r, ok = c.Calculate(metricKey, float64(105), nextTime)
 		assert.False(t, ok)
 		assert.Equal(t, float64(0), r)
 	}
 
 	nextTime = nextTime.Add(5 * time.Millisecond)
-	r, ok = c.Calculate(MetricMetadata, nil, float64(105), nextTime)
+	r, ok = c.Calculate(metricKey, float64(105), nextTime)
 	assert.True(t, ok)
 	assert.InDelta(t, 1, r, 0.1)
 }
@@ -73,13 +73,13 @@ func newFloat64RateCalculator() MetricCalculator {
 }
 
 func TestFloat64DeltaCalculator(t *testing.T) {
-	MetricMetadata := "delta"
+	metricKey := NewKey("delta", nil)
 	initTime := time.Now()
 	c := NewFloat64DeltaCalculator()
 
 	testCases := []float64{0.1, 0.1, 0.5, 1.3, 1.9, 2.5, 5, 24.2, 103}
 	for i, f := range testCases {
-		r, ok := c.Calculate(MetricMetadata, nil, f, initTime)
+		r, ok := c.Calculate(metricKey, f, initTime)
 		assert.Equal(t, i > 0, ok)
 		if i == 0 {
 			assert.Equal(t, float64(0), r)
@@ -90,13 +90,13 @@ func TestFloat64DeltaCalculator(t *testing.T) {
 }
 
 func TestFloat64DeltaCalculatorWithDecreasingValues(t *testing.T) {
-	MetricMetadata := "delta"
+	metricKey := NewKey("delta", nil)
 	initTime := time.Now()
 	c := NewFloat64DeltaCalculator()
 
 	testCases := []float64{108, 106, 56.2, 28.8, 10, 10, 3, -1, -100}
 	for i, f := range testCases {
-		r, ok := c.Calculate(MetricMetadata, nil, f, initTime)
+		r, ok := c.Calculate(metricKey, f, initTime)
 		assert.Equal(t, i > 0, ok)
 		if ok {
 			assert.Equal(t, testCases[i]-testCases[i-1], r)

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -24,37 +24,37 @@ import (
 )
 
 func TestFloat64RateCalculator(t *testing.T) {
-	metricKey := NewKey("rate", nil)
+	mKey := NewKey("rate", nil)
 	initTime := time.Now()
 	c := newFloat64RateCalculator()
-	r, ok := c.Calculate(metricKey, float64(50), initTime)
+	r, ok := c.Calculate(mKey, float64(50), initTime)
 	assert.False(t, ok)
 	assert.Equal(t, float64(0), r)
 
 	nextTime := initTime.Add(100 * time.Millisecond)
-	r, ok = c.Calculate(metricKey, float64(100), nextTime)
+	r, ok = c.Calculate(mKey, float64(100), nextTime)
 	assert.True(t, ok)
 	assert.InDelta(t, 0.5, r, 0.1)
 }
 
 func TestFloat64RateCalculatorWithTooFrequentUpdate(t *testing.T) {
-	metricKey := NewKey("rate", nil)
+	mKey := NewKey("rate", nil)
 	initTime := time.Now()
 	c := newFloat64RateCalculator()
-	r, ok := c.Calculate(metricKey, float64(50), initTime)
+	r, ok := c.Calculate(mKey, float64(50), initTime)
 	assert.False(t, ok)
 	assert.Equal(t, float64(0), r)
 
 	nextTime := initTime
 	for i := 0; i < 10; i++ {
 		nextTime = nextTime.Add(5 * time.Millisecond)
-		r, ok = c.Calculate(metricKey, float64(105), nextTime)
+		r, ok = c.Calculate(mKey, float64(105), nextTime)
 		assert.False(t, ok)
 		assert.Equal(t, float64(0), r)
 	}
 
 	nextTime = nextTime.Add(5 * time.Millisecond)
-	r, ok = c.Calculate(metricKey, float64(105), nextTime)
+	r, ok = c.Calculate(mKey, float64(105), nextTime)
 	assert.True(t, ok)
 	assert.InDelta(t, 1, r, 0.1)
 }
@@ -73,13 +73,13 @@ func newFloat64RateCalculator() MetricCalculator {
 }
 
 func TestFloat64DeltaCalculator(t *testing.T) {
-	metricKey := NewKey("delta", nil)
+	mKey := NewKey("delta", nil)
 	initTime := time.Now()
 	c := NewFloat64DeltaCalculator()
 
 	testCases := []float64{0.1, 0.1, 0.5, 1.3, 1.9, 2.5, 5, 24.2, 103}
 	for i, f := range testCases {
-		r, ok := c.Calculate(metricKey, f, initTime)
+		r, ok := c.Calculate(mKey, f, initTime)
 		assert.Equal(t, i > 0, ok)
 		if i == 0 {
 			assert.Equal(t, float64(0), r)
@@ -90,13 +90,13 @@ func TestFloat64DeltaCalculator(t *testing.T) {
 }
 
 func TestFloat64DeltaCalculatorWithDecreasingValues(t *testing.T) {
-	metricKey := NewKey("delta", nil)
+	mKey := NewKey("delta", nil)
 	initTime := time.Now()
 	c := NewFloat64DeltaCalculator()
 
 	testCases := []float64{108, 106, 56.2, 28.8, 10, 10, 3, -1, -100}
 	for i, f := range testCases {
-		r, ok := c.Calculate(metricKey, f, initTime)
+		r, ok := c.Calculate(mKey, f, initTime)
 		assert.Equal(t, i > 0, ok)
 		if ok {
 			assert.Equal(t, testCases[i]-testCases[i-1], r)
@@ -186,19 +186,19 @@ func TestMapKeyEquals(t *testing.T) {
 	labelMap2["k2"] = "v2"
 	labelMap2["k1"] = "v1"
 
-	key1 := NewKey("name", labelMap1)
-	key2 := NewKey("name", labelMap2)
-	assert.Equal(t, key1, key2)
+	mKey1 := NewKey("name", labelMap1)
+	mKey2 := NewKey("name", labelMap2)
+	assert.Equal(t, mKey1, mKey2)
 
-	key1 = NewKey(mockKey{
+	mKey1 = NewKey(mockKey{
 		name:  "name",
 		index: 1,
 	}, labelMap1)
-	key2 = NewKey(mockKey{
+	mKey2 = NewKey(mockKey{
 		name:  "name",
 		index: 1,
 	}, labelMap2)
-	assert.Equal(t, key1, key2)
+	assert.Equal(t, mKey1, mKey2)
 }
 
 func TestMapKeyNotEqualOnName(t *testing.T) {
@@ -210,23 +210,23 @@ func TestMapKeyNotEqualOnName(t *testing.T) {
 	labelMap2["k2"] = "v2"
 	labelMap2["k1"] = "v1"
 
-	key1 := NewKey("name1", labelMap1)
-	key2 := NewKey("name2", labelMap2)
-	assert.NotEqual(t, key1, key2)
+	mKey1 := NewKey("name1", labelMap1)
+	mKey2 := NewKey("name2", labelMap2)
+	assert.NotEqual(t, mKey1, mKey2)
 
-	key1 = NewKey(mockKey{
+	mKey1 = NewKey(mockKey{
 		name:  "name",
 		index: 1,
 	}, labelMap1)
-	key2 = NewKey(mockKey{
+	mKey2 = NewKey(mockKey{
 		name:  "name",
 		index: 2,
 	}, labelMap2)
-	assert.NotEqual(t, key1, key2)
+	assert.NotEqual(t, mKey1, mKey2)
 
-	key2 = NewKey(mockKey{
+	mKey2 = NewKey(mockKey{
 		name:  "name0",
 		index: 1,
 	}, labelMap2)
-	assert.NotEqual(t, key1, key2)
+	assert.NotEqual(t, mKey1, mKey2)
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
@@ -139,8 +139,8 @@ func newFloat64RateCalculator() awsmetrics.MetricCalculator {
 
 func assignRateValueToField(rateCalculator *awsmetrics.MetricCalculator, fields map[string]interface{}, metricName string,
 	cinfoName string, curVal interface{}, curTime time.Time, multiplier float64) {
-	metricKey := awsmetrics.NewKey(cinfoName+metricName, nil)
-	if val, ok := rateCalculator.Calculate(metricKey, curVal, curTime); ok {
+	mKey := awsmetrics.NewKey(cinfoName+metricName, nil)
+	if val, ok := rateCalculator.Calculate(mKey, curVal, curTime); ok {
 		fields[metricName] = val.(float64) * multiplier
 	}
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
@@ -19,9 +19,10 @@ import (
 	"time"
 
 	cinfo "github.com/google/cadvisor/info/v1"
+	"go.uber.org/zap"
+
 	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	awsmetrics "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
-	"go.uber.org/zap"
 )
 
 func GetStats(info *cinfo.ContainerInfo) *cinfo.ContainerStats {

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
@@ -19,10 +19,9 @@ import (
 	"time"
 
 	cinfo "github.com/google/cadvisor/info/v1"
-	"go.uber.org/zap"
-
 	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	awsmetrics "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
+	"go.uber.org/zap"
 )
 
 func GetStats(info *cinfo.ContainerInfo) *cinfo.ContainerStats {
@@ -139,8 +138,8 @@ func newFloat64RateCalculator() awsmetrics.MetricCalculator {
 
 func assignRateValueToField(rateCalculator *awsmetrics.MetricCalculator, fields map[string]interface{}, metricName string,
 	cinfoName string, curVal interface{}, curTime time.Time, multiplier float64) {
-	key := cinfoName + metricName
-	if val, ok := rateCalculator.Calculate(key, nil, curVal, curTime); ok {
+	metricKey := awsmetrics.NewKey(cinfoName+metricName, nil)
+	if val, ok := rateCalculator.Calculate(metricKey, curVal, curTime); ok {
 		fields[metricName] = val.(float64) * multiplier
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Instead of passing down metric name and labels and create a new key, we will pass down the Key which [consists of metric metadata and labels](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/eacfde3fcbd46ba60a6db0e9a41977390c4883bd/internal/aws/metrics/metric_calculator.go#L88-L91), which includes metric name. This will provide more flexibility for `awsemfexporter` in constructing the calculation and give easier way to mutate the Key.

**Testing:** 
With new changes, I have tested it by using:
* go test on awsemfexport
```
ok      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter       0.778s
```
* go test on internal/aws/metrics
```
ok      github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics  2.620s
```