### PR TITLE
[receiver/purefa] Add relabel and env configs to purefa 

### DIFF
--- a/.chloggen/purefa-receiver-relabel-config.yaml
+++ b/.chloggen/purefa-receiver-relabel-config.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/purefareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a relabel config for important default label names on FlashArray endpoints
+
+# One or more tracking issues related to the change
+issues: [14886]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/purefareceiver/README.md
+++ b/receiver/purefareceiver/README.md
@@ -29,6 +29,7 @@ receivers:
     - address: gse-array01
       auth:
         authenticator: bearertokenauth/array01
+    env: dev
     settings:
       reload_intervals:
         array: 10s

--- a/receiver/purefareceiver/config.go
+++ b/receiver/purefareceiver/config.go
@@ -46,6 +46,9 @@ type Config struct {
 
 	// Volumes represents the list of volumes to query
 	Volumes []internal.ScraperConfig `mapstructure:"volumes"`
+
+	// Env represents the list of environment to query
+	Env string `mapstructure:"env"`
 }
 
 type Settings struct {

--- a/receiver/purefareceiver/config.go
+++ b/receiver/purefareceiver/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	// Volumes represents the list of volumes to query
 	Volumes []internal.ScraperConfig `mapstructure:"volumes"`
 
-	// Env represents the list of environment to query
+	// Env represents the respective environment value valid to scrape
 	Env string `mapstructure:"env"`
 }
 

--- a/receiver/purefareceiver/internal/scraper.go
+++ b/receiver/purefareceiver/internal/scraper.go
@@ -47,6 +47,7 @@ type scraper struct {
 	endpoint       string
 	configs        []ScraperConfig
 	scrapeInterval time.Duration
+	labels         model.LabelSet
 }
 
 func NewScraper(ctx context.Context,
@@ -54,12 +55,14 @@ func NewScraper(ctx context.Context,
 	endpoint string,
 	configs []ScraperConfig,
 	scrapeInterval time.Duration,
+	labels model.LabelSet,
 ) Scraper {
 	return &scraper{
 		scraperType:    scraperType,
 		endpoint:       endpoint,
 		configs:        configs,
 		scrapeInterval: scrapeInterval,
+		labels:         labels,
 	}
 }
 
@@ -98,6 +101,7 @@ func (h *scraper) ToPrometheusReceiverConfig(host component.Host, fact receiver.
 						Targets: []model.LabelSet{
 							{model.AddressLabel: model.LabelValue(u.Host)},
 						},
+						Labels: h.labels,
 					},
 				},
 			},

--- a/receiver/purefareceiver/internal/scraper_test.go
+++ b/receiver/purefareceiver/internal/scraper_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -57,7 +58,7 @@ func TestToPrometheusConfig(t *testing.T) {
 		},
 	}
 
-	scraper := NewScraper(context.Background(), "hosts", endpoint, cfgs, interval)
+	scraper := NewScraper(context.Background(), "hosts", endpoint, cfgs, interval, model.LabelSet{})
 
 	// test
 	scCfgs, err := scraper.ToPrometheusReceiverConfig(host, prFactory)

--- a/receiver/purefareceiver/receiver.go
+++ b/receiver/purefareceiver/receiver.go
@@ -17,6 +17,7 @@ package purefareceiver // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"context"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -48,35 +49,65 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 	fact := prometheusreceiver.NewFactory()
 	scrapeCfgs := []*config.ScrapeConfig{}
 
-	arrScraper := internal.NewScraper(ctx, internal.ScraperTypeArray, r.cfg.Endpoint, r.cfg.Arrays, r.cfg.Settings.ReloadIntervals.Array)
+	arrLabels := model.LabelSet{
+		"env":           model.LabelValue(r.cfg.Env),
+		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
+		"host":          model.LabelValue(r.cfg.Endpoint),
+	}
+
+	arrScraper := internal.NewScraper(ctx, internal.ScraperTypeArray, r.cfg.Endpoint, r.cfg.Arrays, r.cfg.Settings.ReloadIntervals.Array, arrLabels)
 	if scCfgs, err := arrScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
 		return err
 	}
 
-	hostScraper := internal.NewScraper(ctx, internal.ScraperTypeHost, r.cfg.Endpoint, r.cfg.Hosts, r.cfg.Settings.ReloadIntervals.Host)
+	hostLabels := model.LabelSet{
+		"env":           model.LabelValue(r.cfg.Env),
+		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
+		"host":          model.LabelValue(r.cfg.Endpoint),
+	}
+
+	hostScraper := internal.NewScraper(ctx, internal.ScraperTypeHost, r.cfg.Endpoint, r.cfg.Hosts, r.cfg.Settings.ReloadIntervals.Host, hostLabels)
 	if scCfgs, err := hostScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
 		return err
 	}
 
-	directoriesScraper := internal.NewScraper(ctx, internal.ScraperTypeDirectories, r.cfg.Endpoint, r.cfg.Directories, r.cfg.Settings.ReloadIntervals.Directories)
+	dirLabels := model.LabelSet{
+		"env":           model.LabelValue(r.cfg.Env),
+		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
+		"host":          model.LabelValue(r.cfg.Endpoint),
+	}
+
+	directoriesScraper := internal.NewScraper(ctx, internal.ScraperTypeDirectories, r.cfg.Endpoint, r.cfg.Directories, r.cfg.Settings.ReloadIntervals.Directories, dirLabels)
 	if scCfgs, err := directoriesScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
 		return err
 	}
 
-	podsScraper := internal.NewScraper(ctx, internal.ScraperTypePods, r.cfg.Endpoint, r.cfg.Pods, r.cfg.Settings.ReloadIntervals.Pods)
+	podsLabels := model.LabelSet{
+		"env":           model.LabelValue(r.cfg.Env),
+		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
+		"host":          model.LabelValue(r.cfg.Endpoint),
+	}
+
+	podsScraper := internal.NewScraper(ctx, internal.ScraperTypePods, r.cfg.Endpoint, r.cfg.Pods, r.cfg.Settings.ReloadIntervals.Pods, podsLabels)
 	if scCfgs, err := podsScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
 		return err
 	}
 
-	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes)
+	volLabels := model.LabelSet{
+		"env":           model.LabelValue(r.cfg.Env),
+		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
+		"host":          model.LabelValue(r.cfg.Endpoint),
+	}
+
+	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes, volLabels)
 	if scCfgs, err := volumesScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {

--- a/receiver/purefareceiver/receiver.go
+++ b/receiver/purefareceiver/receiver.go
@@ -49,65 +49,41 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 	fact := prometheusreceiver.NewFactory()
 	scrapeCfgs := []*config.ScrapeConfig{}
 
-	arrLabels := model.LabelSet{
+	commomLabel := model.LabelSet{
 		"env":           model.LabelValue(r.cfg.Env),
 		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
 		"host":          model.LabelValue(r.cfg.Endpoint),
 	}
 
-	arrScraper := internal.NewScraper(ctx, internal.ScraperTypeArray, r.cfg.Endpoint, r.cfg.Arrays, r.cfg.Settings.ReloadIntervals.Array, arrLabels)
+	arrScraper := internal.NewScraper(ctx, internal.ScraperTypeArray, r.cfg.Endpoint, r.cfg.Arrays, r.cfg.Settings.ReloadIntervals.Array, commomLabel)
 	if scCfgs, err := arrScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
 		return err
 	}
 
-	hostLabels := model.LabelSet{
-		"env":           model.LabelValue(r.cfg.Env),
-		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
-		"host":          model.LabelValue(r.cfg.Endpoint),
-	}
-
-	hostScraper := internal.NewScraper(ctx, internal.ScraperTypeHost, r.cfg.Endpoint, r.cfg.Hosts, r.cfg.Settings.ReloadIntervals.Host, hostLabels)
+	hostScraper := internal.NewScraper(ctx, internal.ScraperTypeHost, r.cfg.Endpoint, r.cfg.Hosts, r.cfg.Settings.ReloadIntervals.Host, commomLabel)
 	if scCfgs, err := hostScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
 		return err
 	}
 
-	dirLabels := model.LabelSet{
-		"env":           model.LabelValue(r.cfg.Env),
-		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
-		"host":          model.LabelValue(r.cfg.Endpoint),
-	}
-
-	directoriesScraper := internal.NewScraper(ctx, internal.ScraperTypeDirectories, r.cfg.Endpoint, r.cfg.Directories, r.cfg.Settings.ReloadIntervals.Directories, dirLabels)
+	directoriesScraper := internal.NewScraper(ctx, internal.ScraperTypeDirectories, r.cfg.Endpoint, r.cfg.Directories, r.cfg.Settings.ReloadIntervals.Directories, commomLabel)
 	if scCfgs, err := directoriesScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
 		return err
 	}
 
-	podsLabels := model.LabelSet{
-		"env":           model.LabelValue(r.cfg.Env),
-		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
-		"host":          model.LabelValue(r.cfg.Endpoint),
-	}
-
-	podsScraper := internal.NewScraper(ctx, internal.ScraperTypePods, r.cfg.Endpoint, r.cfg.Pods, r.cfg.Settings.ReloadIntervals.Pods, podsLabels)
+	podsScraper := internal.NewScraper(ctx, internal.ScraperTypePods, r.cfg.Endpoint, r.cfg.Pods, r.cfg.Settings.ReloadIntervals.Pods, commomLabel)
 	if scCfgs, err := podsScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
 		return err
 	}
 
-	volLabels := model.LabelSet{
-		"env":           model.LabelValue(r.cfg.Env),
-		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
-		"host":          model.LabelValue(r.cfg.Endpoint),
-	}
-
-	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes, volLabels)
+	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes, model.LabelSet{})
 	if scCfgs, err := volumesScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {

--- a/receiver/purefareceiver/testdata/config.yaml
+++ b/receiver/purefareceiver/testdata/config.yaml
@@ -11,6 +11,7 @@ receivers:
       - address: gse-array02
         auth:
           authenticator: bearertokenauth/array02
+    env: dev
     settings:
       reload_intervals:
         array: 10s


### PR DESCRIPTION
**Description:**
Adds a new **`relabel`** config type to FlashArray receiver array name and the correspondent **`env`**.
eg:  Relabels the `host.name` to the array name on  `array, pods, directory`

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14886

**Testing:**
Just follow the new config var on **`README`**, called **`env`** and check if his value is full filled

**Documentation:**
Still in progress