### PR TITLE
[exporter/coralogixexporter] Improve coralogix exporter batching

### DIFF
--- a/.chloggen/coralogix-batch-export.yaml
+++ b/.chloggen/coralogix-batch-export.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "improve coralogix exporter performance"
+
+# One or more tracking issues related to the change
+issues: [17268]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "improves coralogix exporter to send batched telemetry data to the backend"

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -27,7 +27,9 @@ import (
 const (
 	typeStr = "coralogix"
 	// The stability level of the exporter.
-	stability = component.StabilityLevelBeta
+	stability               = component.StabilityLevelBeta
+	cxAppNameAttrName       = "cx.application.name"
+	cxSubsystemNameAttrName = "cx.subsystem.name"
 )
 
 // Config defines by Coralogix.


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Change exporter to use resource attributes to pass application name and subsystem attributes instead of grpc headers.


**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17268

**Testing:** 
- Tested locally
- passes unit tests

**Documentation:** <Describe the documentation added.>