### PR TITLE
[receiver/hostmetrics] Disable deprecated process memory metrics

### DIFF
--- a/.chloggen/hostmetricsreceiver-disable-deprecated-process-memory-metrics.yaml
+++ b/.chloggen/hostmetricsreceiver-disable-deprecated-process-memory-metrics.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable deprecated process memory metrics
+
+# One or more tracking issues related to the change
+issues: [14327]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The metrics `process.memory.physical_usage` and `process.memory.virtual_usage` are now disabled by default and will be removed in v0.72.0.
+  As a replacement, the following metrics are now enabled by default: `process.memory.usage`, `process.memory.virtual`.
+  For details, see the [docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.68.0/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification).
+

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -194,7 +194,7 @@ the following process will be followed to phase out the old metrics:
 
 - Until and including `v0.63.0`, only the old metrics `process.memory.physical_usage` and `process.memory.virtual_usage` are emitted.
   You can use the [Metrics Transform processor][metricstransformprocessor_docs] to rename them.
-- Between `v0.64.0` and `v0.69.0`, the new metrics are introduced as optional (disabled by default) and the old metrics are marked as deprecated.
+- Between `v0.64.0` and `v0.68.0`, the new metrics are introduced as optional (disabled by default) and the old metrics are marked as deprecated.
   Only the old metrics are emitted by default.
 - Between `v0.69.0` and `v0.71.0`, the new metrics are enabled and the old metrics are disabled by default.
 - In `v0.72.0` and up, the old metrics are removed.

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -69,8 +69,8 @@ var standardMetrics = []string{
 
 var resourceMetrics = []string{
 	"process.cpu.time",
-	"process.memory.physical_usage",
-	"process.memory.virtual_usage",
+	"process.memory.usage",
+	"process.memory.virtual",
 	"process.disk.io",
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
@@ -40,17 +40,17 @@ Disk bytes transferred.
 | ---- | ----------- | ------ |
 | direction | Direction of flow of bytes (read or write). | Str: ``read``, ``write`` |
 
-### process.memory.physical_usage
+### process.memory.usage
 
-Deprecated: use `process.memory.usage` metric instead. The amount of physical memory in use.
+The amount of physical memory in use.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | By | Sum | Int | Cumulative | false |
 
-### process.memory.virtual_usage
+### process.memory.virtual
 
-Deprecated: Use `process.memory.virtual` metric instead. Virtual memory size.
+Virtual memory size.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -108,9 +108,9 @@ Number of disk operations performed by the process.
 | ---- | ----------- | ------ |
 | direction | Direction of flow of bytes (read or write). | Str: ``read``, ``write`` |
 
-### process.memory.usage
+### process.memory.physical_usage
 
-The amount of physical memory in use.
+[DEPRECATED] Use `process.memory.usage` metric instead. The amount of physical memory in use.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -124,9 +124,9 @@ Percentage of total physical memory that is used by the process.
 | ---- | ----------- | ---------- |
 | 1 | Gauge | Double |
 
-### process.memory.virtual
+### process.memory.virtual_usage
 
-Virtual memory size.
+[DEPRECATED] Use `process.memory.virtual` metric instead. Virtual memory size.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -68,19 +68,19 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: false,
 		},
 		ProcessMemoryPhysicalUsage: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ProcessMemoryUsage: MetricSettings{
-			Enabled: false,
+			Enabled: true,
 		},
 		ProcessMemoryUtilization: MetricSettings{
 			Enabled: false,
 		},
 		ProcessMemoryVirtual: MetricSettings{
-			Enabled: false,
+			Enabled: true,
 		},
 		ProcessMemoryVirtualUsage: MetricSettings{
-			Enabled: true,
+			Enabled: false,
 		},
 		ProcessOpenFileDescriptors: MetricSettings{
 			Enabled: false,
@@ -477,7 +477,7 @@ type metricProcessMemoryPhysicalUsage struct {
 // init fills process.memory.physical_usage metric with initial data.
 func (m *metricProcessMemoryPhysicalUsage) init() {
 	m.data.SetName("process.memory.physical_usage")
-	m.data.SetDescription("Deprecated: use `process.memory.usage` metric instead. The amount of physical memory in use.")
+	m.data.SetDescription("[DEPRECATED] Use `process.memory.usage` metric instead. The amount of physical memory in use.")
 	m.data.SetUnit("By")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
@@ -679,7 +679,7 @@ type metricProcessMemoryVirtualUsage struct {
 // init fills process.memory.virtual_usage metric with initial data.
 func (m *metricProcessMemoryVirtualUsage) init() {
 	m.data.SetName("process.memory.virtual_usage")
-	m.data.SetDescription("Deprecated: Use `process.memory.virtual` metric instead. Virtual memory size.")
+	m.data.SetDescription("[DEPRECATED] Use `process.memory.virtual` metric instead. Virtual memory size.")
 	m.data.SetUnit("By")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
@@ -962,11 +962,11 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 }
 
 func NewMetricsBuilder(ms MetricsSettings, settings receiver.CreateSettings, options ...metricBuilderOption) *MetricsBuilder {
-	if ms.ProcessMemoryPhysicalUsage.Enabled {
-		settings.Logger.Warn("[WARNING] `process.memory.physical_usage` should not be enabled: The metric is deprecated and will be removed in v0.70.0. Please use `process.memory.usage` instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.")
+	if ms.ProcessMemoryPhysicalUsage.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] `process.memory.physical_usage` should not be configured: The metric is deprecated and will be removed in v0.72.0. Please use `process.memory.usage` instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.")
 	}
-	if ms.ProcessMemoryVirtualUsage.Enabled {
-		settings.Logger.Warn("[WARNING] `process.memory.virtual_usage` should not be enabled: The metric is deprecated and will be removed in v0.70.0. Please use `process.memory.virtual` metric instead. See  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.")
+	if ms.ProcessMemoryVirtualUsage.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] `process.memory.virtual_usage` should not be configured: The metric is deprecated and will be removed in v0.72.0. Please use `process.memory.virtual` metric instead. See  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.")
 	}
 	mb := &MetricsBuilder{
 		startTime:                        pcommon.NewTimestampFromTime(time.Now()),

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
@@ -53,12 +53,12 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadConfig(t, test.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
-			if test.metricsSet == testMetricsSetDefault || test.metricsSet == testMetricsSetAll {
-				assert.Equal(t, "[WARNING] `process.memory.physical_usage` should not be enabled: The metric is deprecated and will be removed in v0.70.0. Please use `process.memory.usage` instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.", observedLogs.All()[expectedWarnings].Message)
+			if test.metricsSet == testMetricsSetAll || test.metricsSet == testMetricsSetNo {
+				assert.Equal(t, "[WARNING] `process.memory.physical_usage` should not be configured: The metric is deprecated and will be removed in v0.72.0. Please use `process.memory.usage` instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.", observedLogs.All()[expectedWarnings].Message)
 				expectedWarnings++
 			}
-			if test.metricsSet == testMetricsSetDefault || test.metricsSet == testMetricsSetAll {
-				assert.Equal(t, "[WARNING] `process.memory.virtual_usage` should not be enabled: The metric is deprecated and will be removed in v0.70.0. Please use `process.memory.virtual` metric instead. See  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.", observedLogs.All()[expectedWarnings].Message)
+			if test.metricsSet == testMetricsSetAll || test.metricsSet == testMetricsSetNo {
+				assert.Equal(t, "[WARNING] `process.memory.virtual_usage` should not be configured: The metric is deprecated and will be removed in v0.72.0. Please use `process.memory.virtual` metric instead. See  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification for more details.", observedLogs.All()[expectedWarnings].Message)
 				expectedWarnings++
 			}
 			assert.Equal(t, expectedWarnings, observedLogs.Len())
@@ -83,20 +83,20 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordProcessDiskOperationsDataPoint(ts, 1, AttributeDirection(1))
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordProcessMemoryPhysicalUsageDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordProcessMemoryUsageDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordProcessMemoryUtilizationDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordProcessMemoryVirtualDataPoint(ts, 1)
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordProcessMemoryVirtualUsageDataPoint(ts, 1)
 
@@ -251,7 +251,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["process.memory.physical_usage"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Deprecated: use `process.memory.usage` metric instead. The amount of physical memory in use.", ms.At(i).Description())
+					assert.Equal(t, "[DEPRECATED] Use `process.memory.usage` metric instead. The amount of physical memory in use.", ms.At(i).Description())
 					assert.Equal(t, "By", ms.At(i).Unit())
 					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
@@ -305,7 +305,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["process.memory.virtual_usage"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Deprecated: Use `process.memory.virtual` metric instead. Virtual memory size.", ms.At(i).Description())
+					assert.Equal(t, "[DEPRECATED] Use `process.memory.virtual` metric instead. Virtual memory size.", ms.At(i).Description())
 					assert.Equal(t, "By", ms.At(i).Unit())
 					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -84,11 +84,11 @@ metrics:
     attributes: [state]
 
   process.memory.physical_usage:
-    enabled: true
-    description: "Deprecated: use `process.memory.usage` metric instead. The amount of physical memory in use."
+    enabled: false
+    description: "[DEPRECATED] Use `process.memory.usage` metric instead. The amount of physical memory in use."
     warnings:
-      if_enabled: >-
-        The metric is deprecated and will be removed in v0.70.0. Please use `process.memory.usage` instead. See
+      if_configured: >-
+        The metric is deprecated and will be removed in v0.72.0. Please use `process.memory.usage` instead. See
         https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification
         for more details.
     unit: By
@@ -98,7 +98,7 @@ metrics:
       monotonic: false
 
   process.memory.usage:
-    enabled: false
+    enabled: true
     description: The amount of physical memory in use.
     unit: By
     sum:
@@ -107,11 +107,11 @@ metrics:
       monotonic: false
 
   process.memory.virtual_usage:
-    enabled: true
-    description: "Deprecated: Use `process.memory.virtual` metric instead. Virtual memory size."
+    enabled: false
+    description: "[DEPRECATED] Use `process.memory.virtual` metric instead. Virtual memory size."
     warnings:
-      if_enabled: >-
-        The metric is deprecated and will be removed in v0.70.0. Please use `process.memory.virtual` metric instead. See 
+      if_configured: >-
+        The metric is deprecated and will be removed in v0.72.0. Please use `process.memory.virtual` metric instead. See 
         https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification
         for more details.
     unit: By
@@ -121,7 +121,7 @@ metrics:
       monotonic: false
 
   process.memory.virtual:
-    enabled: false
+    enabled: true
     description: Virtual memory size.
     unit: By
     sum:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -243,7 +243,7 @@ func (s *scraper) scrapeAndAppendCPUTimeMetric(now pcommon.Timestamp, handle pro
 }
 
 func (s *scraper) scrapeAndAppendMemoryUsageMetrics(now pcommon.Timestamp, handle processHandle) error {
-	if !(s.config.Metrics.ProcessMemoryPhysicalUsage.Enabled || s.config.Metrics.ProcessMemoryVirtualUsage.Enabled) {
+	if !(s.config.Metrics.ProcessMemoryUsage.Enabled || s.config.Metrics.ProcessMemoryVirtual.Enabled || s.config.Metrics.ProcessMemoryPhysicalUsage.Enabled || s.config.Metrics.ProcessMemoryVirtualUsage.Enabled) {
 		return nil
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -207,10 +207,10 @@ func assertCPUUtilizationMetricValid(t *testing.T, resourceMetrics pmetric.Resou
 }
 
 func assertMemoryUsageMetricValid(t *testing.T, resourceMetrics pmetric.ResourceMetricsSlice, startTime pcommon.Timestamp) {
-	physicalMemUsageMetric := getMetric(t, "process.memory.physical_usage", resourceMetrics)
-	assert.Equal(t, "process.memory.physical_usage", physicalMemUsageMetric.Name())
-	virtualMemUsageMetric := getMetric(t, "process.memory.virtual_usage", resourceMetrics)
-	assert.Equal(t, "process.memory.virtual_usage", virtualMemUsageMetric.Name())
+	physicalMemUsageMetric := getMetric(t, "process.memory.usage", resourceMetrics)
+	assert.Equal(t, "process.memory.usage", physicalMemUsageMetric.Name())
+	virtualMemUsageMetric := getMetric(t, "process.memory.virtual", resourceMetrics)
+	assert.Equal(t, "process.memory.virtual", virtualMemUsageMetric.Name())
 
 	if startTime != 0 {
 		internal.AssertSumMetricStartTimeEquals(t, physicalMemUsageMetric, startTime)
@@ -962,8 +962,8 @@ func TestScrapeMetrics_DontCheckDisabledMetrics(t *testing.T) {
 	metricSettings.ProcessCPUTime.Enabled = false
 	metricSettings.ProcessDiskIo.Enabled = false
 	metricSettings.ProcessDiskOperations.Enabled = false
-	metricSettings.ProcessMemoryPhysicalUsage.Enabled = false
-	metricSettings.ProcessMemoryVirtualUsage.Enabled = false
+	metricSettings.ProcessMemoryUsage.Enabled = false
+	metricSettings.ProcessMemoryVirtual.Enabled = false
 
 	t.Run("Metrics don't log errors when disabled", func(t *testing.T) {
 		config := &Config{Metrics: metricSettings}


### PR DESCRIPTION
As described in the [docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.68.0/receiver/hostmetricsreceiver#transition-to-process-memory-metric-names-aligned-with-opentelemetry-specification), starting with v0.69.0 the new metrics are now enabled and the old ones are disabled.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14327