### PR TITLE
[chore] Fix comparetest bugs

### DIFF
--- a/internal/comparetest/compare.go
+++ b/internal/comparetest/compare.go
@@ -34,18 +34,19 @@ func CompareMetrics(expected, actual pmetric.Metrics, options ...CompareOption) 
 	actual.CopyTo(act)
 
 	for _, option := range options {
-		option.apply(expected, actual)
+		option.apply(exp, act)
 	}
 
-	expectedMetrics, actualMetrics := expected.ResourceMetrics(), actual.ResourceMetrics()
+	expectedMetrics, actualMetrics := exp.ResourceMetrics(), act.ResourceMetrics()
 	if expectedMetrics.Len() != actualMetrics.Len() {
 		return fmt.Errorf("number of resources does not match expected: %d, actual: %d", expectedMetrics.Len(),
 			actualMetrics.Len())
 	}
 
 	// sort ResourceMetrics
-	expectedMetrics.Sort(sortResourceMetrics)
-	actualMetrics.Sort(sortResourceMetrics)
+	lessWithSubsort := lessResourceMetrics(true)
+	expectedMetrics.Sort(lessWithSubsort)
+	actualMetrics.Sort(lessWithSubsort)
 
 	numResources := expectedMetrics.Len()
 
@@ -101,8 +102,9 @@ func CompareResourceMetrics(expected, actual pmetric.ResourceMetrics) error {
 			ailms.Len())
 	}
 
-	eilms.Sort(sortInstrumentationLibrary)
-	ailms.Sort(sortInstrumentationLibrary)
+	lessWithSubsort := lessScopeMetrics(true)
+	eilms.Sort(lessWithSubsort)
+	ailms.Sort(lessWithSubsort)
 
 	for i := 0; i < eilms.Len(); i++ {
 		eilm, ailm := eilms.At(i), ailms.At(i)
@@ -131,8 +133,9 @@ func CompareMetricSlices(expected, actual pmetric.MetricSlice) error {
 	}
 
 	// Sort MetricSlices
-	expected.Sort(sortMetricSlice)
-	actual.Sort(sortMetricSlice)
+	lessWithSubsort := lessMetrics(true)
+	expected.Sort(lessWithSubsort)
+	actual.Sort(lessWithSubsort)
 
 	expectedByName, actualByName := metricsByName(expected), metricsByName(actual)
 
@@ -197,6 +200,10 @@ func CompareNumberDataPointSlices(expected, actual pmetric.NumberDataPointSlice)
 	if expected.Len() != actual.Len() {
 		return fmt.Errorf("number of datapoints does not match expected: %d, actual: %d", expected.Len(), actual.Len())
 	}
+
+	// Sort NumberDataPointSlice
+	expected.Sort(lessDataPoints)
+	actual.Sort(lessDataPoints)
 
 	numPoints := expected.Len()
 

--- a/internal/comparetest/compare_test.go
+++ b/internal/comparetest/compare_test.go
@@ -384,8 +384,8 @@ func TestCompareMetrics(t *testing.T) {
 					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
-					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.two:value B hostname:random]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
 				),
 				reason: "An unpredictable attribute value will cause failures if not ignored.",
 			},
@@ -404,8 +404,8 @@ func TestCompareMetrics(t *testing.T) {
 					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
-					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.two:value B hostname:random]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
 				),
 				reason: "An unpredictable attribute will cause failures if not ignored.",
 			},
@@ -472,14 +472,14 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withOptions: expectation{
 				err:    nil,
-				reason: "The underbred resource metrics was properly sorted. The unpredictable resource attribute was ignored on each resource that carried it, but the predictable attributes were preserved.",
+				reason: "The unpredictable resource attribute was ignored on each resource that carried it, but the predictable attributes were preserved.",
 			},
 		},
 		{
 			name: "sort-unordered-metric-slice",
 			withoutOptions: expectation{
 				err:    nil,
-				reason: "the underbred metric slices was properly sorted.",
+				reason: "the unordered metric slices were properly sorted.",
 			},
 		},
 		{
@@ -492,8 +492,8 @@ func TestCompareMetrics(t *testing.T) {
 					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
-					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.two:value B hostname:random]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
 				),
 				reason: "An unpredictable attribute will cause failures if not ignored.",
 			},
@@ -510,8 +510,8 @@ func TestCompareMetrics(t *testing.T) {
 			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
-					errors.New("metric missing expected datapoint with attributes: map[attribute.one:one attribute.two:same]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:two attribute.two:same]"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.one:one attribute.two:same]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.one attribute.two:same]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.two attribute.two:same]"),
 				),
@@ -530,10 +530,10 @@ func TestCompareMetrics(t *testing.T) {
 			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
-					errors.New("metric missing expected datapoint with attributes: map[attribute.one:unpredictable.one attribute.two:same]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:unpredictable.two attribute.two:same]"),
-					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.two attribute.two:same]"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.one:unpredictable.one attribute.two:same]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.one attribute.two:same]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.two attribute.two:same]"),
 				),
 				reason: "An unpredictable attribute will cause failures if not ignored.",
 			},

--- a/internal/comparetest/util.go
+++ b/internal/comparetest/util.go
@@ -44,26 +44,133 @@ func getDataPointSlice(metric pmetric.Metric) pmetric.NumberDataPointSlice {
 	return dataPointSlice
 }
 
-func sortInstrumentationLibrary(a, b pmetric.ScopeMetrics) bool {
-	if a.SchemaUrl() < b.SchemaUrl() {
-		return true
+func lessResourceMetrics(subsort bool) func(a, b pmetric.ResourceMetrics) bool {
+	return func(a, b pmetric.ResourceMetrics) bool {
+		if a.SchemaUrl() != b.SchemaUrl() {
+			return a.SchemaUrl() < b.SchemaUrl()
+		}
+		if pdatautil.MapHash(a.Resource().Attributes()) != pdatautil.MapHash(b.Resource().Attributes()) {
+			return pdatautil.MapHash(a.Resource().Attributes()) < pdatautil.MapHash(b.Resource().Attributes())
+		}
+
+		if a.ScopeMetrics().Len() != b.ScopeMetrics().Len() {
+			return a.ScopeMetrics().Len() < b.ScopeMetrics().Len()
+		}
+
+		if subsort {
+			lessWithSubsort := lessScopeMetrics(true)
+			a.ScopeMetrics().Sort(lessWithSubsort)
+			b.ScopeMetrics().Sort(lessWithSubsort)
+		}
+
+		less := lessScopeMetrics(false)
+		for i := 0; i < a.ScopeMetrics().Len(); i++ {
+			aScope := a.ScopeMetrics().At(i)
+			bScope := b.ScopeMetrics().At(i)
+			if less(aScope, bScope) {
+				return true
+			}
+		}
+		return false
 	}
-	if a.Scope().Name() < b.Scope().Name() {
-		return true
+}
+
+func lessScopeMetrics(subsort bool) func(a, b pmetric.ScopeMetrics) bool {
+	return func(a, b pmetric.ScopeMetrics) bool {
+		if a.SchemaUrl() != b.SchemaUrl() {
+			return a.SchemaUrl() < b.SchemaUrl()
+		}
+		if pdatautil.MapHash(a.Scope().Attributes()) != pdatautil.MapHash(b.Scope().Attributes()) {
+			return pdatautil.MapHash(a.Scope().Attributes()) < pdatautil.MapHash(b.Scope().Attributes())
+		}
+
+		if a.Scope().Name() != b.Scope().Name() {
+			return a.Scope().Name() < b.Scope().Name()
+		}
+		if a.Scope().Version() != b.Scope().Version() {
+			return a.Scope().Version() < b.Scope().Version()
+		}
+		if a.Metrics().Len() != b.Metrics().Len() {
+			return a.Metrics().Len() < b.Metrics().Len()
+		}
+
+		if subsort {
+			lessWithSubsort := lessMetrics(true)
+			a.Metrics().Sort(lessWithSubsort)
+			b.Metrics().Sort(lessWithSubsort)
+		}
+
+		less := lessMetrics(false)
+		for i := 0; i < a.Metrics().Len(); i++ {
+			aMetric := a.Metrics().At(i)
+			bMetric := b.Metrics().At(i)
+			if less(aMetric, bMetric) {
+				return true
+			}
+		}
+		return false
 	}
-	if a.Scope().Version() < b.Scope().Version() {
-		return true
+}
+
+func lessMetrics(subsort bool) func(a, b pmetric.Metric) bool {
+	return func(a, b pmetric.Metric) bool {
+		if a.Name() != b.Name() {
+			return a.Name() < b.Name()
+		}
+		if a.Description() != b.Description() {
+			return a.Description() < b.Description()
+		}
+		if a.Unit() != b.Unit() {
+			return a.Unit() < b.Unit()
+		}
+		if a.Type() != b.Type() {
+			return a.Type() < b.Type()
+		}
+
+		var aDataPoints pmetric.NumberDataPointSlice
+		var bDataPoints pmetric.NumberDataPointSlice
+
+		switch a.Type() {
+		case pmetric.MetricTypeGauge:
+			aDataPoints = a.Gauge().DataPoints()
+			bDataPoints = b.Gauge().DataPoints()
+		case pmetric.MetricTypeSum:
+			if a.Sum().AggregationTemporality() != b.Sum().AggregationTemporality() {
+				return a.Sum().AggregationTemporality() < b.Sum().AggregationTemporality()
+			}
+			if a.Sum().IsMonotonic() != b.Sum().IsMonotonic() {
+				return b.Sum().IsMonotonic()
+			}
+			aDataPoints = a.Sum().DataPoints()
+			bDataPoints = b.Sum().DataPoints()
+		}
+
+		if subsort {
+			aDataPoints.Sort(lessDataPoints)
+			bDataPoints.Sort(lessDataPoints)
+		}
+
+		for i := 0; i < aDataPoints.Len(); i++ {
+			aDataPoint := aDataPoints.At(i)
+			bDataPoint := bDataPoints.At(i)
+			if lessDataPoints(aDataPoint, bDataPoint) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func lessDataPoints(a, b pmetric.NumberDataPoint) bool {
+	if pdatautil.MapHash(a.Attributes()) != pdatautil.MapHash(b.Attributes()) {
+		return pdatautil.MapHash(a.Attributes()) < pdatautil.MapHash(b.Attributes())
+	}
+
+	if a.IntValue() != b.IntValue() {
+		return a.IntValue() < b.IntValue()
+	}
+	if a.DoubleValue() != b.DoubleValue() {
+		return a.DoubleValue() < b.DoubleValue()
 	}
 	return false
-}
-
-func sortResourceMetrics(a, b pmetric.ResourceMetrics) bool {
-	if a.SchemaUrl() < b.SchemaUrl() {
-		return true
-	}
-	return pdatautil.MapHash(a.Resource().Attributes()) < pdatautil.MapHash(b.Resource().Attributes())
-}
-
-func sortMetricSlice(a, b pmetric.Metric) bool {
-	return a.Name() < b.Name()
 }


### PR DESCRIPTION
This fixes a bug introduced in [#14702](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14702/files#diff-8d845b9791fa5a63575fae1a11dc596748c55fa68df683bf9101efacec653598), where `CompareOption`s were applied to the wrong set of data (original vs copy).

Fixing this bug caused a failing test due to changes made in [#17179](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17179/files#diff-960aef5f9afcd64ffcfe48d1b3e1dda802f5e0d78bcf86c8debb6818cdb2676b). In the particular case exposed by this change, a `CompareOption` is used to mask a resource attribute, resulting in a loss of uniqueness between sets of resource attributes. In such cases, it is not enough to rely on a hash of the resource attributes. Instead, a deeper comparison must be made in order to guarantee a deterministic sort. This is a testing problem only, but one we must support if `comparetest` is going to be useful in some cases.

Therefore, this PR adds deeper sortation of `pmetric.Metrics` including sortation of all slices in the structure. Changes to the test cases are superficial only.