### PR TITLE
[hostmetrics] Add warning on startup if running in docker with no other root defined.

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
@@ -16,7 +16,6 @@ package filesystemscraper // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
-	"errors"
 	"os"
 
 	"go.opentelemetry.io/collector/receiver"
@@ -58,16 +57,20 @@ func (f *Factory) CreateMetricsScraper(
 	cfg := config.(*Config)
 
 	if cfg.RootPath == "" {
+		inContainer := os.Getpid() == 1
 		for _, p := range []string{
 			"/.dockerenv",        // Mounted by dockerd when starting a container by default
 			"/run/.containerenv", // Mounted by podman as described here: https://github.com/containers/podman/blob/ecbb52cb478309cfd59cc061f082702b69f0f4b7/docs/source/markdown/podman-run.1.md.in#L31
 		} {
-			if _, err := os.Stat(p); !errors.Is(err, os.ErrNotExist) {
-				settings.Logger.Warn(
-					"No `root_path` config set when running in docker environment, will report container filesystem stats." +
-						" See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only")
+			if _, err := os.Stat(p); err == nil {
+
 				break
 			}
+		}
+		if inContainer {
+			settings.Logger.Warn(
+				"No `root_path` config set when running in docker environment, will report container filesystem stats." +
+					" See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only")
 		}
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
@@ -57,7 +57,7 @@ func (f *Factory) CreateMetricsScraper(
 	cfg := config.(*Config)
 
 	if _, err := os.Stat("/.dockerenv"); cfg.RootPath == "" && err != nil {
-		settings.Logger.Warn("No root config set when running in docker environment, will report container filesystem stats")
+		settings.Logger.Warn("No `root_path` config set when running in docker environment, will report container filesystem stats. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only")
 	}
 
 	s, err := newFileSystemScraper(ctx, settings, cfg)

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
@@ -16,6 +16,7 @@ package filesystemscraper // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"os"
 
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
@@ -54,6 +55,11 @@ func (f *Factory) CreateMetricsScraper(
 	config internal.Config,
 ) (scraperhelper.Scraper, error) {
 	cfg := config.(*Config)
+
+	if _, err := os.Stat("/.dockerenv"); cfg.RootPath == "" && err != nil {
+		settings.Logger.Warn("No root config set when running in docker environment, will report container filesystem stats")
+	}
+
 	s, err := newFileSystemScraper(ctx, settings, cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description:**

In the event that the container is started in a docker container but doesn't have a root path, it is likely that it will report the container's stats which is misleading and hard to diagnose.

**Link to tracking Issue:** 
NA, came to mind with a discussion in slack

**Testing:** 

**Documentation:** <Describe the documentation added.>