### PR TITLE
[receiver/filelog] truncate large log entry

### DIFF
--- a/.chloggen/truncate-large-log-entry.yaml
+++ b/.chloggen/truncate-large-log-entry.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: truncate log entry if it is larger than max_log_size
+
+# One or more tracking issues related to the change
+issues: [16487]

--- a/pkg/stanza/fileconsumer/scanner.go
+++ b/pkg/stanza/fileconsumer/scanner.go
@@ -22,6 +22,8 @@ import (
 	stanzaerrors "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
 )
 
+const defaultBufSize = 16 * 1024
+
 // PositionalScanner is a scanner that maintains position
 type PositionalScanner struct {
 	pos int64
@@ -35,11 +37,22 @@ func NewPositionalScanner(r io.Reader, maxLogSize int, startOffset int64, splitF
 		Scanner: bufio.NewScanner(r),
 	}
 
-	buf := make([]byte, 0, 16384)
+	bufSize := defaultBufSize
+	if maxLogSize < bufSize {
+		bufSize = maxLogSize
+	}
+
+	buf := make([]byte, 0, bufSize)
 	ps.Scanner.Buffer(buf, maxLogSize)
 
 	scanFunc := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		advance, token, err = splitFunc(data, atEOF)
+		if (advance == 0 && token == nil && err == nil) && len(data) >= maxLogSize {
+			// reference: https://pkg.go.dev/bufio#SplitFunc
+			// splitFunc returns (0, nil, nil) to signal the Scanner to read more data but the buffer is full.
+			// Truncate the log entry.
+			advance, token, err = len(data), data, nil
+		}
 		ps.pos += int64(advance)
 		return
 	}

--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -24,7 +24,7 @@ Tails and parses logs from files.
 | `include_file_path_resolved` | `false`          | Whether to add the file path after symlinks resolution as the attribute `log.file.path_resolved`. |
 | `poll_interval`              | 200ms            | The duration between filesystem polls                                                                              |
 | `fingerprint_size`           | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time) |
-| `max_log_size`               | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
+| `max_log_size`               | `1MiB`           | The maximum size of a log entry to read. A log entry will be truncated if it is larger than `max_log_size`. Protects against reading large amounts of data into memory |
 | `max_concurrent_files`       | 1024             | The maximum number of log files from which logs will be read concurrently. If the number of files matched in the `include` pattern exceeds this number, then files will be processed in batches. One batch will be processed per `poll_interval` |
 | `attributes`                 | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
 | `resource`                   | {}               | A map of `key: value` pairs to add to the entry's resource                                                    |


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The `PositionalScanner` will return the `bufio.ErrTooLong` error if the log entry is larger than `max(max_log_size, 16384)`.
If `splitFunc` needs more data to produce a valid token but the scanning buffer is already full, truncate the log entry.

**Link to tracking Issue:** #16487

**Testing:** <Describe what testing was performed and which tests were added.>
* `TestTokenizationTooLong()` tests `fileconsumer.Reader.ReadToEnd()` with log lines larger than `max_log_size`.

**Documentation:** <Describe the documentation added.>
Update the description of `max_log_size` in filelogreceiver's README.md 