### PR TITLE
processor/resourcedetection: use configopaque for consul token field

### DIFF
--- a/.chloggen/gbbr_opaque_processor_resourcedetection.yaml
+++ b/.chloggen/gbbr_opaque_processor_resourcedetection.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change `Config.Token` to use `configopaque.String` opaque type.
+
+# One or more tracking issues related to the change
+issues: [17314]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/resourcedetectionprocessor/internal/consul/config.go
+++ b/processor/resourcedetectionprocessor/internal/consul/config.go
@@ -14,6 +14,8 @@
 
 package consul // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/consul"
 
+import "go.opentelemetry.io/collector/config/configopaque"
+
 // The struct requires no user-specified fields by default as consul agent's default
 // configuration will be provided to the API client.
 // See `consul.go#NewDetector` for more information.
@@ -29,7 +31,7 @@ type Config struct {
 	// which overrides the agent's default (empty) token.
 	// Token or Tokenfile are only required if [Consul's ACL
 	// System](https://www.consul.io/docs/security/acl/acl-system) is enabled.
-	Token string `mapstructure:"token"`
+	Token configopaque.String `mapstructure:"token"`
 
 	// TokenFile is a file containing the current token to use for this client.
 	// If provided it is read once at startup and never again.

--- a/processor/resourcedetectionprocessor/internal/consul/consul.go
+++ b/processor/resourcedetectionprocessor/internal/consul/consul.go
@@ -56,7 +56,7 @@ func NewDetector(p processor.CreateSettings, dcfg internal.DetectorConfig) (inte
 		cfg.Namespace = userCfg.Namespace
 	}
 	if userCfg.Token != "" {
-		cfg.Token = userCfg.Token
+		cfg.Token = string(userCfg.Token)
 	}
 	if userCfg.TokenFile != "" {
 		cfg.Token = userCfg.TokenFile


### PR DESCRIPTION
Change `Config.Token` to use `configopaque.String` opaque type.

Closes #17314