### PR TITLE
receiver: migrate to configopaque.String

### DIFF
--- a/.chloggen/gbbr_opaque_receivers-awsfirehose.yaml
+++ b/.chloggen/gbbr_opaque_receivers-awsfirehose.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/awsfirehose
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.AccessKey` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-bigip.yaml
+++ b/.chloggen/gbbr_opaque_receivers-bigip.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/bigip
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-cloudfoundry.yaml
+++ b/.chloggen/gbbr_opaque_receivers-cloudfoundry.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/cloudfoundry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.UAA.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-couchdb.yaml
+++ b/.chloggen/gbbr_opaque_receivers-couchdb.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/couchdb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-elasticsearch.yaml
+++ b/.chloggen/gbbr_opaque_receivers-elasticsearch.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-jmx.yaml
+++ b/.chloggen/gbbr_opaque_receivers-jmx.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/jmx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the types of `Config.{Password,KeystorePassword,TruststorePassword}` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-mongodb.yaml
+++ b/.chloggen/gbbr_opaque_receivers-mongodb.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mongodb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-mongodbatlas.yaml
+++ b/.chloggen/gbbr_opaque_receivers-mongodbatlas.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mongodbatlas
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the types of `Config.PrivateKey` and `Config.Alerts.Secret` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-mysql.yaml
+++ b/.chloggen/gbbr_opaque_receivers-mysql.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mysql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-nsxt.yaml
+++ b/.chloggen/gbbr_opaque_receivers-nsxt.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/nsxt
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-podman.yaml
+++ b/.chloggen/gbbr_opaque_receivers-podman.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/podman
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.SSHPassphrase` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-postgresql.yaml
+++ b/.chloggen/gbbr_opaque_receivers-postgresql.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/postgresql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-pulsar.yaml
+++ b/.chloggen/gbbr_opaque_receivers-pulsar.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/pulsar
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the types of `Config.Authentication.Token.Token` and `Config.Authentication.Athenz.PrivateKey` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-rabbitmq.yaml
+++ b/.chloggen/gbbr_opaque_receivers-rabbitmq.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/rabbitmq
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-redis.yaml
+++ b/.chloggen/gbbr_opaque_receivers-redis.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/redis
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-riak.yaml
+++ b/.chloggen/gbbr_opaque_receivers-riak.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/riak
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-saphana.yaml
+++ b/.chloggen/gbbr_opaque_receivers-saphana.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/saphana
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-snmp.yaml
+++ b/.chloggen/gbbr_opaque_receivers-snmp.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/snmp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the types of the `Config.{AuthPassword,PrivacyPassword}` fields to be of `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-snowflake.yaml
+++ b/.chloggen/gbbr_opaque_receivers-snowflake.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/snowflake
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-solace.yaml
+++ b/.chloggen/gbbr_opaque_receivers-solace.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/solace
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Auth.PlainText.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers-vcenter.yaml
+++ b/.chloggen/gbbr_opaque_receivers-vcenter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/vcenter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_receivers.yaml
+++ b/.chloggen/gbbr_opaque_receivers.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/aerospike
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the type of `Config.Password` to be `configopaque.String`
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/aerospikereceiver/config.go
+++ b/receiver/aerospikereceiver/config.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
@@ -45,7 +46,7 @@ type Config struct {
 	Endpoint                                string                      `mapstructure:"endpoint"`
 	TLSName                                 string                      `mapstructure:"tlsname"`
 	Username                                string                      `mapstructure:"username"`
-	Password                                string                      `mapstructure:"password"`
+	Password                                configopaque.String         `mapstructure:"password"`
 	CollectClusterMetrics                   bool                        `mapstructure:"collect_cluster_metrics"`
 	Timeout                                 time.Duration               `mapstructure:"timeout"`
 	Metrics                                 metadata.MetricsSettings    `mapstructure:"metrics"`

--- a/receiver/aerospikereceiver/scraper.go
+++ b/receiver/aerospikereceiver/scraper.go
@@ -82,7 +82,7 @@ func newAerospikeReceiver(params receiver.CreateSettings, cfg *Config, consumer 
 			conf := &clientConfig{
 				host:                  ashost,
 				username:              cfg.Username,
-				password:              cfg.Password,
+				password:              string(cfg.Password),
 				timeout:               cfg.Timeout,
 				logger:                sugaredLogger,
 				collectClusterMetrics: cfg.CollectClusterMetrics,

--- a/receiver/awsfirehosereceiver/config.go
+++ b/receiver/awsfirehosereceiver/config.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 type Config struct {
@@ -31,7 +32,7 @@ type Config struct {
 	// AccessKey is checked against the one received with each request.
 	// This can be set when creating or updating the Firehose delivery
 	// stream.
-	AccessKey string `mapstructure:"access_key"`
+	AccessKey configopaque.String `mapstructure:"access_key"`
 }
 
 // Validate checks that the endpoint and record type exist and

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -243,7 +243,7 @@ func (fmr *firehoseReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // validate checks the Firehose access key in the header against
 // the one passed into the Config
 func (fmr *firehoseReceiver) validate(r *http.Request) (int, error) {
-	if accessKey := r.Header.Get(headerFirehoseAccessKey); accessKey != "" && accessKey != fmr.config.AccessKey {
+	if accessKey := r.Header.Get(headerFirehoseAccessKey); accessKey != "" && accessKey != string(fmr.config.AccessKey) {
 		return http.StatusUnauthorized, errInvalidAccessKey
 	}
 	return http.StatusAccepted, nil

--- a/receiver/bigipreceiver/client.go
+++ b/receiver/bigipreceiver/client.go
@@ -97,7 +97,7 @@ func newClient(cfg *Config, host component.Host, settings component.TelemetrySet
 		hostEndpoint: cfg.Endpoint,
 		creds: bigipCredentials{
 			username: cfg.Username,
-			password: cfg.Password,
+			password: string(cfg.Password),
 		},
 		logger: logger,
 	}, nil

--- a/receiver/bigipreceiver/client_test.go
+++ b/receiver/bigipreceiver/client_test.go
@@ -101,7 +101,7 @@ func TestNewClient(t *testing.T) {
 				require.True(t, ok)
 
 				require.Equal(t, tc.cfg.Username, actualClient.creds.username)
-				require.Equal(t, tc.cfg.Password, actualClient.creds.password)
+				require.EqualValues(t, tc.cfg.Password, actualClient.creds.password)
 				require.Equal(t, tc.cfg.Endpoint, actualClient.hostEndpoint)
 				require.Equal(t, tc.logger, actualClient.logger)
 				require.NotNil(t, actualClient.client)

--- a/receiver/bigipreceiver/config.go
+++ b/receiver/bigipreceiver/config.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
 
@@ -40,7 +41,7 @@ type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	confighttp.HTTPClientSettings           `mapstructure:",squash"`
 	Username                                string                   `mapstructure:"username"`
-	Password                                string                   `mapstructure:"password"`
+	Password                                configopaque.String      `mapstructure:"password"`
 	Metrics                                 metadata.MetricsSettings `mapstructure:"metrics"`
 }
 

--- a/receiver/cloudfoundryreceiver/config.go
+++ b/receiver/cloudfoundryreceiver/config.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 type RLPGatewayConfig struct {
@@ -41,8 +42,8 @@ type LimitedHTTPClientSettings struct {
 
 type UAAConfig struct {
 	LimitedHTTPClientSettings `mapstructure:",squash"`
-	Username                  string `mapstructure:"username"`
-	Password                  string `mapstructure:"password"`
+	Username                  string              `mapstructure:"username"`
+	Password                  configopaque.String `mapstructure:"password"`
 }
 
 // Config defines configuration for Collectd receiver.

--- a/receiver/cloudfoundryreceiver/receiver.go
+++ b/receiver/cloudfoundryreceiver/receiver.go
@@ -77,7 +77,7 @@ func newCloudFoundryReceiver(
 }
 
 func (cfr *cloudFoundryReceiver) Start(ctx context.Context, host component.Host) error {
-	tokenProvider, tokenErr := newUAATokenProvider(cfr.settings.Logger, cfr.config.UAA.LimitedHTTPClientSettings, cfr.config.UAA.Username, cfr.config.UAA.Password)
+	tokenProvider, tokenErr := newUAATokenProvider(cfr.settings.Logger, cfr.config.UAA.LimitedHTTPClientSettings, cfr.config.UAA.Username, string(cfr.config.UAA.Password))
 	if tokenErr != nil {
 		return fmt.Errorf("create cloud foundry UAA token provider: %w", tokenErr)
 	}

--- a/receiver/cloudfoundryreceiver/stream_test.go
+++ b/receiver/cloudfoundryreceiver/stream_test.go
@@ -32,7 +32,7 @@ func TestValidStream(t *testing.T) {
 		zap.NewNop(),
 		cfg.UAA.LimitedHTTPClientSettings,
 		cfg.UAA.Username,
-		cfg.UAA.Password)
+		string(cfg.UAA.Password))
 
 	require.NoError(t, err)
 	require.NotNil(t, uaa)
@@ -68,7 +68,7 @@ func TestInvalidStream(t *testing.T) {
 		zap.NewNop(),
 		cfg.UAA.LimitedHTTPClientSettings,
 		cfg.UAA.Username,
-		cfg.UAA.Password)
+		string(cfg.UAA.Password))
 
 	require.NoError(t, err)
 	require.NotNil(t, uaa)

--- a/receiver/cloudfoundryreceiver/uaa_test.go
+++ b/receiver/cloudfoundryreceiver/uaa_test.go
@@ -30,7 +30,7 @@ func TestValidAuthentication(t *testing.T) {
 		zap.NewNop(),
 		cfg.UAA.LimitedHTTPClientSettings,
 		cfg.UAA.Username,
-		cfg.UAA.Password)
+		string(cfg.UAA.Password))
 
 	require.NoError(t, err)
 	require.NotNil(t, uaa)
@@ -57,7 +57,7 @@ func TestInvalidAuthentication(t *testing.T) {
 		zap.NewNop(),
 		cfg.UAA.LimitedHTTPClientSettings,
 		cfg.UAA.Username,
-		cfg.UAA.Password)
+		string(cfg.UAA.Password))
 
 	require.EqualError(t, err, "client: missing url")
 	require.Nil(t, uaa)

--- a/receiver/couchdbreceiver/client.go
+++ b/receiver/couchdbreceiver/client.go
@@ -110,6 +110,6 @@ func (c *couchDBClient) buildReq(path string) (*http.Request, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(c.cfg.Username, c.cfg.Password)
+	req.SetBasicAuth(c.cfg.Username, string(c.cfg.Password))
 	return req, nil
 }

--- a/receiver/couchdbreceiver/config.go
+++ b/receiver/couchdbreceiver/config.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
 
@@ -43,7 +44,7 @@ type Config struct {
 	confighttp.HTTPClientSettings           `mapstructure:",squash"`
 	Metrics                                 metadata.MetricsSettings `mapstructure:"metrics"`
 	Username                                string                   `mapstructure:"username"`
-	Password                                string                   `mapstructure:"password"`
+	Password                                configopaque.String      `mapstructure:"password"`
 }
 
 // Validate validates missing and invalid configuration fields.

--- a/receiver/elasticsearchreceiver/client_test.go
+++ b/receiver/elasticsearchreceiver/client_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver/internal/model"
 )
@@ -104,7 +105,7 @@ func TestNodeStatsAuthentication(t *testing.T) {
 			Endpoint: elasticsearchMock.URL,
 		},
 		Username: username,
-		Password: password,
+		Password: configopaque.String(password),
 	}, componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -191,7 +192,7 @@ func TestClusterHealthAuthentication(t *testing.T) {
 			Endpoint: elasticsearchMock.URL,
 		},
 		Username: username,
-		Password: password,
+		Password: configopaque.String(password),
 	}, componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -278,7 +279,7 @@ func TestMetadataAuthentication(t *testing.T) {
 			Endpoint: elasticsearchMock.URL,
 		},
 		Username: username,
-		Password: password,
+		Password: configopaque.String(password),
 	}, componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -431,7 +432,7 @@ func TestIndexStatsAuthentication(t *testing.T) {
 			Endpoint: elasticsearchMock.URL,
 		},
 		Username: username,
-		Password: password,
+		Password: configopaque.String(password),
 	}, componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -541,7 +542,7 @@ func TestClusterStatsAuthentication(t *testing.T) {
 			Endpoint: elasticsearchMock.URL,
 		},
 		Username: username,
-		Password: password,
+		Password: configopaque.String(password),
 	}, componenttest.NewNopHost())
 	require.NoError(t, err)
 

--- a/receiver/elasticsearchreceiver/config.go
+++ b/receiver/elasticsearchreceiver/config.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
 
@@ -57,13 +58,13 @@ type Config struct {
 	// Username is the username used when making REST calls to elasticsearch. Must be specified if Password is. Not required.
 	Username string `mapstructure:"username"`
 	// Password is the password used when making REST calls to elasticsearch. Must be specified if Username is. Not required.
-	Password string `mapstructure:"password"`
+	Password configopaque.String `mapstructure:"password"`
 }
 
 // Validate validates the given config, returning an error specifying any issues with the config.
 func (cfg *Config) Validate() error {
 	var combinedErr error
-	if err := invalidCredentials(cfg.Username, cfg.Password); err != nil {
+	if err := invalidCredentials(cfg.Username, string(cfg.Password)); err != nil {
 		combinedErr = multierr.Append(combinedErr, err)
 	}
 

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -45,17 +46,17 @@ type Config struct {
 	// The JMX username
 	Username string `mapstructure:"username"`
 	// The JMX password
-	Password string `mapstructure:"password"`
+	Password configopaque.String `mapstructure:"password"`
 	// The keystore path for SSL
 	KeystorePath string `mapstructure:"keystore_path"`
 	// The keystore password for SSL
-	KeystorePassword string `mapstructure:"keystore_password"`
+	KeystorePassword configopaque.String `mapstructure:"keystore_password"`
 	// The keystore type for SSL
 	KeystoreType string `mapstructure:"keystore_type"`
 	// The truststore path for SSL
 	TruststorePath string `mapstructure:"truststore_path"`
 	// The truststore password for SSL
-	TruststorePassword string `mapstructure:"truststore_password"`
+	TruststorePassword configopaque.String `mapstructure:"truststore_password"`
 	// The truststore type for SSL
 	TruststoreType string `mapstructure:"truststore_type"`
 	// The JMX remote profile.  Should be one of:

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -204,7 +204,7 @@ func (jmx *jmxMetricReceiver) buildJMXMetricGathererConfig() (string, error) {
 	}
 
 	if jmx.config.Password != "" {
-		config["otel.jmx.password"] = jmx.config.Password
+		config["otel.jmx.password"] = string(jmx.config.Password)
 	}
 
 	if jmx.config.RemoteProfile != "" {
@@ -219,7 +219,7 @@ func (jmx *jmxMetricReceiver) buildJMXMetricGathererConfig() (string, error) {
 		config["javax.net.ssl.keyStore"] = jmx.config.KeystorePath
 	}
 	if jmx.config.KeystorePassword != "" {
-		config["javax.net.ssl.keyStorePassword"] = jmx.config.KeystorePassword
+		config["javax.net.ssl.keyStorePassword"] = string(jmx.config.KeystorePassword)
 	}
 	if jmx.config.KeystoreType != "" {
 		config["javax.net.ssl.keyStoreType"] = jmx.config.KeystoreType
@@ -228,7 +228,7 @@ func (jmx *jmxMetricReceiver) buildJMXMetricGathererConfig() (string, error) {
 		config["javax.net.ssl.trustStore"] = jmx.config.TruststorePath
 	}
 	if jmx.config.TruststorePassword != "" {
-		config["javax.net.ssl.trustStorePassword"] = jmx.config.TruststorePassword
+		config["javax.net.ssl.trustStorePassword"] = string(jmx.config.TruststorePassword)
 	}
 	if jmx.config.TruststoreType != "" {
 		config["javax.net.ssl.trustStoreType"] = jmx.config.TruststoreType

--- a/receiver/mongodbatlasreceiver/alerts.go
+++ b/receiver/mongodbatlasreceiver/alerts.go
@@ -115,14 +115,14 @@ func newAlertsReceiver(params rcvr.CreateSettings, baseConfig *Config, consumer 
 
 	recv := &alertsReceiver{
 		addr:          cfg.Endpoint,
-		secret:        cfg.Secret,
+		secret:        string(cfg.Secret),
 		tlsSettings:   cfg.TLS,
 		consumer:      consumer,
 		mode:          cfg.Mode,
 		projects:      cfg.Projects,
 		retrySettings: baseConfig.RetrySettings,
 		publicKey:     baseConfig.PublicKey,
-		privateKey:    baseConfig.PrivateKey,
+		privateKey:    string(baseConfig.PrivateKey),
 		wg:            &sync.WaitGroup{},
 		pollInterval:  baseConfig.Alerts.PollInterval,
 		maxPages:      baseConfig.Alerts.MaxPages,

--- a/receiver/mongodbatlasreceiver/config.go
+++ b/receiver/mongodbatlasreceiver/config.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
@@ -35,7 +36,7 @@ var _ component.Config = (*Config)(nil)
 type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	PublicKey                               string                       `mapstructure:"public_key"`
-	PrivateKey                              string                       `mapstructure:"private_key"`
+	PrivateKey                              configopaque.String          `mapstructure:"private_key"`
 	Granularity                             string                       `mapstructure:"granularity"`
 	Metrics                                 metadata.MetricsSettings     `mapstructure:"metrics"`
 	Alerts                                  AlertConfig                  `mapstructure:"alerts"`
@@ -47,7 +48,7 @@ type Config struct {
 type AlertConfig struct {
 	Enabled  bool                        `mapstructure:"enabled"`
 	Endpoint string                      `mapstructure:"endpoint"`
-	Secret   string                      `mapstructure:"secret"`
+	Secret   configopaque.String         `mapstructure:"secret"`
 	TLS      *configtls.TLSServerSetting `mapstructure:"tls"`
 	Mode     string                      `mapstructure:"mode"`
 

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -55,7 +55,7 @@ type ProjectContext struct {
 const collectionInterval = time.Minute * 5
 
 func newMongoDBAtlasLogsReceiver(settings rcvr.CreateSettings, cfg *Config, consumer consumer.Logs) *logsReceiver {
-	client := internal.NewMongoDBAtlasClient(cfg.PublicKey, cfg.PrivateKey, cfg.RetrySettings, settings.Logger)
+	client := internal.NewMongoDBAtlasClient(cfg.PublicKey, string(cfg.PrivateKey), cfg.RetrySettings, settings.Logger)
 	return &logsReceiver{
 		log:         settings.Logger,
 		cfg:         cfg,

--- a/receiver/mongodbatlasreceiver/receiver.go
+++ b/receiver/mongodbatlasreceiver/receiver.go
@@ -46,7 +46,7 @@ type timeconstraints struct {
 }
 
 func newMongoDBAtlasReceiver(settings rcvr.CreateSettings, cfg *Config) *receiver {
-	client := internal.NewMongoDBAtlasClient(cfg.PublicKey, cfg.PrivateKey, cfg.RetrySettings, settings.Logger)
+	client := internal.NewMongoDBAtlasClient(cfg.PublicKey, string(cfg.PrivateKey), cfg.RetrySettings, settings.Logger)
 	return &receiver{
 		log:         settings.Logger,
 		cfg:         cfg,

--- a/receiver/mongodbreceiver/config.go
+++ b/receiver/mongodbreceiver/config.go
@@ -22,6 +22,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
@@ -36,7 +37,7 @@ type Config struct {
 	Metrics    metadata.MetricsSettings `mapstructure:"metrics"`
 	Hosts      []confignet.NetAddr      `mapstructure:"hosts"`
 	Username   string                   `mapstructure:"username"`
-	Password   string                   `mapstructure:"password"`
+	Password   configopaque.String      `mapstructure:"password"`
 	ReplicaSet string                   `mapstructure:"replica_set,omitempty"`
 	Timeout    time.Duration            `mapstructure:"timeout"`
 }
@@ -87,7 +88,7 @@ func (c *Config) ClientOptions() *options.ClientOptions {
 	if c.Username != "" && c.Password != "" {
 		clientOptions.SetAuth(options.Credential{
 			Username: c.Username,
-			Password: c.Password,
+			Password: string(c.Password),
 		})
 	}
 

--- a/receiver/mongodbreceiver/config_test.go
+++ b/receiver/mongodbreceiver/config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -93,7 +94,7 @@ func TestValidate(t *testing.T) {
 
 			cfg := &Config{
 				Username: tc.username,
-				Password: tc.password,
+				Password: configopaque.String(tc.password),
 				Hosts:    hosts,
 			}
 			err := component.ValidateConfig(cfg)

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -176,7 +176,7 @@ var _ client = (*mySQLClient)(nil)
 func newMySQLClient(conf *Config) client {
 	driverConf := mysql.Config{
 		User:                 conf.Username,
-		Passwd:               conf.Password,
+		Passwd:               string(conf.Password),
 		Net:                  conf.Transport,
 		Addr:                 conf.Endpoint,
 		DBName:               conf.Database,

--- a/receiver/mysqlreceiver/config.go
+++ b/receiver/mysqlreceiver/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver/internal/metadata"
@@ -31,10 +32,10 @@ const (
 
 type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
-	Username                                string `mapstructure:"username,omitempty"`
-	Password                                string `mapstructure:"password,omitempty"`
-	Database                                string `mapstructure:"database,omitempty"`
-	AllowNativePasswords                    bool   `mapstructure:"allow_native_passwords,omitempty"`
+	Username                                string              `mapstructure:"username,omitempty"`
+	Password                                configopaque.String `mapstructure:"password,omitempty"`
+	Database                                string              `mapstructure:"database,omitempty"`
+	AllowNativePasswords                    bool                `mapstructure:"allow_native_passwords,omitempty"`
 	confignet.NetAddr                       `mapstructure:",squash"`
 	Metrics                                 metadata.MetricsSettings `mapstructure:"metrics"`
 	StatementEvents                         StatementEventsConfig    `mapstructure:"statement_events"`

--- a/receiver/nsxtreceiver/client.go
+++ b/receiver/nsxtreceiver/client.go
@@ -164,7 +164,7 @@ func (c *nsxClient) doRequest(ctx context.Context, path string) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(c.config.Username, c.config.Password)
+	req.SetBasicAuth(c.config.Username, string(c.config.Password))
 	h := req.Header
 	h.Add("User-Agent", "opentelemetry-collector")
 	h.Add("Accept", "application/json")

--- a/receiver/nsxtreceiver/config.go
+++ b/receiver/nsxtreceiver/config.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
 
@@ -31,7 +32,7 @@ type Config struct {
 	confighttp.HTTPClientSettings           `mapstructure:",squash"`
 	Metrics                                 metadata.MetricsSettings `mapstructure:"metrics"`
 	Username                                string                   `mapstructure:"username"`
-	Password                                string                   `mapstructure:"password"`
+	Password                                configopaque.String      `mapstructure:"password"`
 }
 
 // Validate returns if the NSX configuration is valid

--- a/receiver/podmanreceiver/config.go
+++ b/receiver/podmanreceiver/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 )
 
@@ -33,9 +34,9 @@ type Config struct {
 	// The maximum amount of time to wait for Podman API responses.  Default is 5s
 	Timeout time.Duration `mapstructure:"timeout"`
 
-	APIVersion    string `mapstructure:"api_version"`
-	SSHKey        string `mapstructure:"ssh_key"`
-	SSHPassphrase string `mapstructure:"ssh_passphrase"`
+	APIVersion    string              `mapstructure:"api_version"`
+	SSHKey        string              `mapstructure:"ssh_key"`
+	SSHPassphrase configopaque.String `mapstructure:"ssh_passphrase"`
 }
 
 func (config Config) Validate() error {

--- a/receiver/podmanreceiver/libpod_client.go
+++ b/receiver/podmanreceiver/libpod_client.go
@@ -39,7 +39,7 @@ type libpodClient struct {
 }
 
 func newLibpodClient(logger *zap.Logger, cfg *Config) (PodmanClient, error) {
-	connection, err := newPodmanConnection(logger, cfg.Endpoint, cfg.SSHKey, cfg.SSHPassphrase)
+	connection, err := newPodmanConnection(logger, cfg.Endpoint, cfg.SSHKey, string(cfg.SSHPassphrase))
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/postgresqlreceiver/config.go
+++ b/receiver/postgresqlreceiver/config.go
@@ -20,6 +20,7 @@ import (
 	"net"
 
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
@@ -39,7 +40,7 @@ const (
 type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	Username                                string                         `mapstructure:"username"`
-	Password                                string                         `mapstructure:"password"`
+	Password                                configopaque.String            `mapstructure:"password"`
 	Databases                               []string                       `mapstructure:"databases"`
 	confignet.NetAddr                       `mapstructure:",squash"`       // provides Endpoint and Transport
 	configtls.TLSClientSetting              `mapstructure:"tls,omitempty"` // provides SSL details

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -77,7 +77,7 @@ type defaultClientFactory struct{}
 func (d *defaultClientFactory) getClient(c *Config, database string) (client, error) {
 	return newPostgreSQLClient(postgreSQLConfig{
 		username: c.Username,
-		password: c.Password,
+		password: string(c.Password),
 		database: database,
 		tls:      c.TLSClientSetting,
 		address:  c.NetAddr,

--- a/receiver/pulsarreceiver/config.go
+++ b/receiver/pulsarreceiver/config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 type Config struct {
@@ -53,17 +54,17 @@ type TLS struct {
 }
 
 type Token struct {
-	Token string `mapstructure:"Token"`
+	Token configopaque.String `mapstructure:"Token"`
 }
 
 type Athenz struct {
-	ProviderDomain  string `mapstructure:"provider_domain"`
-	TenantDomain    string `mapstructure:"tenant_domain"`
-	TenantService   string `mapstructure:"tenant_service"`
-	PrivateKey      string `mapstructure:"private_key"`
-	KeyID           string `mapstructure:"key_id"`
-	PrincipalHeader string `mapstructure:"principal_header"`
-	ZtsURL          string `mapstructure:"zts_url"`
+	ProviderDomain  string              `mapstructure:"provider_domain"`
+	TenantDomain    string              `mapstructure:"tenant_domain"`
+	TenantService   string              `mapstructure:"tenant_service"`
+	PrivateKey      configopaque.String `mapstructure:"private_key"`
+	KeyID           string              `mapstructure:"key_id"`
+	PrincipalHeader string              `mapstructure:"principal_header"`
+	ZtsURL          string              `mapstructure:"zts_url"`
 }
 
 type OAuth2 struct {
@@ -85,7 +86,7 @@ func (cfg *Config) auth() pulsar.Authentication {
 		return pulsar.NewAuthenticationTLS(authentication.TLS.CertFile, authentication.TLS.KeyFile)
 	}
 	if authentication.Token != nil {
-		return pulsar.NewAuthenticationToken(authentication.Token.Token)
+		return pulsar.NewAuthenticationToken(string(authentication.Token.Token))
 	}
 	if authentication.OAuth2 != nil {
 		return pulsar.NewAuthenticationOAuth2(map[string]string{
@@ -99,7 +100,7 @@ func (cfg *Config) auth() pulsar.Authentication {
 			"providerDomain":  authentication.Athenz.ProviderDomain,
 			"tenantDomain":    authentication.Athenz.TenantDomain,
 			"tenantService":   authentication.Athenz.TenantService,
-			"privateKey":      authentication.Athenz.PrivateKey,
+			"privateKey":      string(authentication.Athenz.PrivateKey),
 			"keyId":           authentication.Athenz.KeyID,
 			"principalHeader": authentication.Athenz.PrincipalHeader,
 			"ztsUrl":          authentication.Athenz.ZtsURL,

--- a/receiver/rabbitmqreceiver/client.go
+++ b/receiver/rabbitmqreceiver/client.go
@@ -60,7 +60,7 @@ func newClient(cfg *Config, host component.Host, settings component.TelemetrySet
 		hostEndpoint: cfg.Endpoint,
 		creds: rabbitmqCredentials{
 			username: cfg.Username,
-			password: cfg.Password,
+			password: string(cfg.Password),
 		},
 		logger: logger,
 	}, nil

--- a/receiver/rabbitmqreceiver/client_test.go
+++ b/receiver/rabbitmqreceiver/client_test.go
@@ -92,7 +92,7 @@ func TestNewClient(t *testing.T) {
 				require.True(t, ok)
 
 				require.Equal(t, tc.cfg.Username, actualClient.creds.username)
-				require.Equal(t, tc.cfg.Password, actualClient.creds.password)
+				require.EqualValues(t, tc.cfg.Password, actualClient.creds.password)
 				require.Equal(t, tc.cfg.Endpoint, actualClient.hostEndpoint)
 				require.Equal(t, tc.logger, actualClient.logger)
 				require.NotNil(t, actualClient.client)

--- a/receiver/rabbitmqreceiver/config.go
+++ b/receiver/rabbitmqreceiver/config.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
 
@@ -41,7 +42,7 @@ type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	confighttp.HTTPClientSettings           `mapstructure:",squash"`
 	Username                                string                   `mapstructure:"username"`
-	Password                                string                   `mapstructure:"password"`
+	Password                                configopaque.String      `mapstructure:"password"`
 	Metrics                                 metadata.MetricsSettings `mapstructure:"metrics"`
 }
 

--- a/receiver/redisreceiver/config.go
+++ b/receiver/redisreceiver/config.go
@@ -16,6 +16,7 @@ package redisreceiver // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 
@@ -32,7 +33,7 @@ type Config struct {
 
 	// Optional password. Must match the password specified in the
 	// requirepass server configuration option.
-	Password string `mapstructure:"password"`
+	Password configopaque.String `mapstructure:"password"`
 
 	TLS configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
 

--- a/receiver/redisreceiver/redis_scraper.go
+++ b/receiver/redisreceiver/redis_scraper.go
@@ -45,7 +45,7 @@ const redisMaxDbs = 16 // Maximum possible number of redis databases
 func newRedisScraper(cfg *Config, settings receiver.CreateSettings) (scraperhelper.Scraper, error) {
 	opts := &redis.Options{
 		Addr:     cfg.Endpoint,
-		Password: cfg.Password,
+		Password: string(cfg.Password),
 		Network:  cfg.Transport,
 	}
 

--- a/receiver/riakreceiver/client.go
+++ b/receiver/riakreceiver/client.go
@@ -60,7 +60,7 @@ func newClient(cfg *Config, host component.Host, settings component.TelemetrySet
 		hostEndpoint: cfg.Endpoint,
 		creds: riakCredentials{
 			username: cfg.Username,
-			password: cfg.Password,
+			password: string(cfg.Password),
 		},
 		logger: logger,
 	}, nil

--- a/receiver/riakreceiver/client_test.go
+++ b/receiver/riakreceiver/client_test.go
@@ -82,7 +82,7 @@ func TestNewClient(t *testing.T) {
 				require.True(t, ok)
 
 				require.Equal(t, tc.cfg.Username, actualClient.creds.username)
-				require.Equal(t, tc.cfg.Password, actualClient.creds.password)
+				require.EqualValues(t, tc.cfg.Password, actualClient.creds.password)
 				require.Equal(t, tc.cfg.Endpoint, actualClient.hostEndpoint)
 				require.Equal(t, zap.NewNop(), actualClient.logger)
 				require.NotNil(t, actualClient.client)

--- a/receiver/riakreceiver/config.go
+++ b/receiver/riakreceiver/config.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
 
@@ -41,7 +42,7 @@ type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	confighttp.HTTPClientSettings           `mapstructure:",squash"`
 	Username                                string                   `mapstructure:"username"`
-	Password                                string                   `mapstructure:"password"`
+	Password                                configopaque.String      `mapstructure:"password"`
 	Metrics                                 metadata.MetricsSettings `mapstructure:"metrics"`
 }
 

--- a/receiver/saphanareceiver/config.go
+++ b/receiver/saphanareceiver/config.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
@@ -38,8 +39,8 @@ type Config struct {
 	// Metrics defines which metrics to enable for the scraper
 	Metrics metadata.MetricsSettings `mapstructure:"metrics"`
 
-	Username string `mapstructure:"username"`
-	Password string `mapstructure:"password"`
+	Username string              `mapstructure:"username"`
+	Password configopaque.String `mapstructure:"password"`
 }
 
 func (cfg *Config) Validate() error {

--- a/receiver/snmpreceiver/client.go
+++ b/receiver/snmpreceiver/client.go
@@ -135,17 +135,17 @@ func setV3ClientConfigs(client goSNMPWrapper, cfg *Config) {
 		client.SetMsgFlags(gosnmp.AuthNoPriv)
 		protocol := getAuthProtocol(cfg.AuthType)
 		securityParams.AuthenticationProtocol = protocol
-		securityParams.AuthenticationPassphrase = cfg.AuthPassword
+		securityParams.AuthenticationPassphrase = string(cfg.AuthPassword)
 	case "AUTH_PRIV":
 		client.SetMsgFlags(gosnmp.AuthPriv)
 
 		authProtocol := getAuthProtocol(cfg.AuthType)
 		securityParams.AuthenticationProtocol = authProtocol
-		securityParams.AuthenticationPassphrase = cfg.AuthPassword
+		securityParams.AuthenticationPassphrase = string(cfg.AuthPassword)
 
 		privProtocol := getPrivacyProtocol(cfg.PrivacyType)
 		securityParams.PrivacyProtocol = privProtocol
-		securityParams.PrivacyPassphrase = cfg.PrivacyPassword
+		securityParams.PrivacyPassphrase = string(cfg.PrivacyPassword)
 	default:
 		client.SetMsgFlags(gosnmp.NoAuthNoPriv)
 	}

--- a/receiver/snmpreceiver/client_test.go
+++ b/receiver/snmpreceiver/client_test.go
@@ -114,13 +114,13 @@ func compareConfigToClient(t *testing.T, client *snmpClient, cfg *Config) {
 		case "auth_no_priv":
 			require.Equal(t, gosnmp.AuthNoPriv, client.client.GetMsgFlags())
 			require.Equal(t, cfg.AuthType, securityParams.AuthenticationProtocol)
-			require.Equal(t, cfg.AuthPassword, securityParams.AuthenticationPassphrase)
+			require.EqualValues(t, cfg.AuthPassword, securityParams.AuthenticationPassphrase)
 		case "auth_priv":
 			require.Equal(t, gosnmp.AuthPriv, client.client.GetMsgFlags())
 			require.Equal(t, cfg.AuthType, securityParams.AuthenticationProtocol.String())
-			require.Equal(t, cfg.AuthPassword, securityParams.AuthenticationPassphrase)
+			require.EqualValues(t, cfg.AuthPassword, securityParams.AuthenticationPassphrase)
 			require.Equal(t, cfg.PrivacyType, securityParams.PrivacyProtocol.String())
-			require.Equal(t, cfg.PrivacyPassword, securityParams.PrivacyPassphrase)
+			require.EqualValues(t, cfg.PrivacyPassword, securityParams.PrivacyPassphrase)
 		}
 	}
 }

--- a/receiver/snmpreceiver/config.go
+++ b/receiver/snmpreceiver/config.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
 )
@@ -114,7 +115,7 @@ type Config struct {
 
 	// AuthPassword is the authentication password used for this SNMP connection.
 	// Only valid for version "v3" and if "no_auth_no_priv" is not selected for SecurityLevel
-	AuthPassword string `mapstructure:"auth_password"`
+	AuthPassword configopaque.String `mapstructure:"auth_password"`
 
 	// PrivacyType is the type of privacy protocol to use for this SNMP connection.
 	// Only valid for version “v3” and if "auth_priv" is selected for SecurityLevel
@@ -124,7 +125,7 @@ type Config struct {
 
 	// PrivacyPassword is the authentication password used for this SNMP connection.
 	// Only valid for version “v3” and if "auth_priv" is selected for SecurityLevel
-	PrivacyPassword string `mapstructure:"privacy_password"`
+	PrivacyPassword configopaque.String `mapstructure:"privacy_password"`
 
 	// ResourceAttributes defines what resource attributes will be used for this receiver and is composed
 	// of resource attribute names along with their resource attribute configurations

--- a/receiver/snowflakereceiver/client.go
+++ b/receiver/snowflakereceiver/client.go
@@ -50,7 +50,7 @@ func buildDSN(cfg Config) string {
 	conf := &sf.Config{
 		Account:   cfg.Account,
 		User:      cfg.Username,
-		Password:  cfg.Password,
+		Password:  string(cfg.Password),
 		Database:  cfg.Database,
 		Schema:    cfg.Schema,
 		Role:      cfg.Role,

--- a/receiver/snowflakereceiver/config.go
+++ b/receiver/snowflakereceiver/config.go
@@ -17,6 +17,7 @@ package snowflakereceiver // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"errors"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
 
@@ -34,7 +35,7 @@ type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	Metrics                                 metadata.MetricsSettings `mapstructure:"metrics"`
 	Username                                string                   `mapstructure:"username"`
-	Password                                string                   `mapstructure:"password"`
+	Password                                configopaque.String      `mapstructure:"password"`
 	Account                                 string                   `mapstructure:"account"`
 	Schema                                  string                   `mapstructure:"schema"`
 	Warehouse                               string                   `mapstructure:"warehouse"`

--- a/receiver/solacereceiver/config.go
+++ b/receiver/solacereceiver/config.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
@@ -79,8 +80,8 @@ type Authentication struct {
 
 // SaslPlainTextConfig defines SASL PLAIN authentication.
 type SaslPlainTextConfig struct {
-	Username string `mapstructure:"username"`
-	Password string `mapstructure:"password"`
+	Username string              `mapstructure:"username"`
+	Password configopaque.String `mapstructure:"password"`
 }
 
 // SaslXAuth2Config defines the configuration for the SASL XAUTH2 authentication.

--- a/receiver/solacereceiver/messaging_service.go
+++ b/receiver/solacereceiver/messaging_service.go
@@ -204,7 +204,7 @@ func toAMQPAuthentication(config *Config) (amqp.SASLType, error) {
 		if plaintext.Password == "" || plaintext.Username == "" {
 			return nil, errMissingPlainTextParams
 		}
-		return connSASLPlain(plaintext.Username, plaintext.Password), nil
+		return connSASLPlain(plaintext.Username, string(plaintext.Password)), nil
 	}
 	if config.Auth.XAuth2 != nil {
 		xauth := config.Auth.XAuth2

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -68,7 +68,7 @@ func (vc *vcenterClient) EnsureConnection(ctx context.Context) error {
 	if tlsCfg != nil {
 		client.DefaultTransport().TLSClientConfig = tlsCfg
 	}
-	user := url.UserPassword(vc.cfg.Username, vc.cfg.Password)
+	user := url.UserPassword(vc.cfg.Username, string(vc.cfg.Password))
 	err = client.Login(ctx, user)
 	if err != nil {
 		return fmt.Errorf("unable to login to vcenter sdk: %w", err)

--- a/receiver/vcenterreceiver/client_test.go
+++ b/receiver/vcenterreceiver/client_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
@@ -81,7 +82,7 @@ func TestSessionReestablish(t *testing.T) {
 			vimDriver: c,
 			cfg: &Config{
 				Username: simulator.DefaultLogin.Username(),
-				Password: pw,
+				Password: configopaque.String(pw),
 				Endpoint: fmt.Sprintf("%s://%s", c.URL().Scheme, c.URL().Host),
 				TLSClientSetting: configtls.TLSClientSetting{
 					Insecure: true,

--- a/receiver/vcenterreceiver/config.go
+++ b/receiver/vcenterreceiver/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
@@ -33,7 +34,7 @@ type Config struct {
 	Metrics                                 metadata.MetricsSettings `mapstructure:"metrics"`
 	Endpoint                                string                   `mapstructure:"endpoint"`
 	Username                                string                   `mapstructure:"username"`
-	Password                                string                   `mapstructure:"password"`
+	Password                                configopaque.String      `mapstructure:"password"`
 }
 
 // Validate checks to see if the supplied config will work for the receiver


### PR DESCRIPTION
This change updates sensitive information described in #17273 for all receivers:

- [x] [receiver/aerospike] Use configopaque for password field
- [x] [receiver/awsfirehose] Use configopaque for access_key field
- [x] [receiver/bigip] Use configopaque for password field
- [x] [receiver/cloudfoundry] Use configopaque for password field
- [x] [receiver/couchdb] Use configopaque for password field
- [x] [receiver/elasticsearch] Use configopaque for password field
- [x] [receiver/jmx] Use configopaque for password, keystore_password, truststore_password fields
- [x] [receiver/mongodbatlas] Use configopaque for private_key and secret fields
- [x] [receiver/mongodb] Use configopaque for password field
- [x] [receiver/mysql] Use configopaque for password field
- [x] [receiver/nsxt] Use configopaque for password field
- [x] [receiver/podman] Use configopaque for ssh_passphrase field
- [x] [receiver/postgresql] Use configopaque for password field
- [x] [receiver/pulsar] Use configopaque for auth::Token::Token and auth::athenz::private_key fields
- [x] [receiver/rabbitmq] Use configopaque for password field
- [x] [receiver/redis] Use configopaque for password field
- [x] [receiver/riak] Use configopaque for password field
- [x] [receiver/saphana] Use configopaque for password field
- [x] [receiver/snmp] Use configopaque for auth_password and privacy_password fields
- [x] [receiver/snowflake] Use configopaque for password field
- [x] [receiver/solace] Use configopaque for password field
- [x] [receiver/vcenter] Use configopaque for password field