### PR TITLE
exporters: migrate remaining sensitive config fields to configopaque.String

### DIFF
--- a/.chloggen/gbbr_opaque_exporters-azuredataexplorer.yaml
+++ b/.chloggen/gbbr_opaque_exporters-azuredataexplorer.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/azuredataexplorer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.ApplicationKey` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-azuremonitor.yaml
+++ b/.chloggen/gbbr_opaque_exporters-azuremonitor.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.InstrumentationKey` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-coralogix.yaml
+++ b/.chloggen/gbbr_opaque_exporters-coralogix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/coralogix
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.PrivateKey` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-elasticsearch.yaml
+++ b/.chloggen/gbbr_opaque_exporters-elasticsearch.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the types of the `Config.{Password,APIKey}` fields to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-influxdb.yaml
+++ b/.chloggen/gbbr_opaque_exporters-influxdb.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/influxdb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the types of the `Config.Token` and `Config.V1Compatibility.Password` fields to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-instana.yaml
+++ b/.chloggen/gbbr_opaque_exporters-instana.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/instana
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.AgentKey` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-logicmonitor.yaml
+++ b/.chloggen/gbbr_opaque_exporters-logicmonitor.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/logicmonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.APIToken.AccessKey` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-logzio.yaml
+++ b/.chloggen/gbbr_opaque_exporters-logzio.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/logzio
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.Token` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-mezmo.yaml
+++ b/.chloggen/gbbr_opaque_exporters-mezmo.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/mezmo
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.IngestKey` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-pulsar.yaml
+++ b/.chloggen/gbbr_opaque_exporters-pulsar.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/pulsar
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the types of the `Config.Authentication.Token.Token` and `Config.Authentication.Athenz.PrivateKey` fields to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-sapm.yaml
+++ b/.chloggen/gbbr_opaque_exporters-sapm.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/sapm
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.AccessToken` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters-tencentcloudlogservice.yaml
+++ b/.chloggen/gbbr_opaque_exporters-tencentcloudlogservice.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/tencentcloudlogservice
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.SecretKey` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/gbbr_opaque_exporters.yaml
+++ b/.chloggen/gbbr_opaque_exporters.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/alibabacloudlogservice
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed the type of `Config.AccessKeySecret` to `configopaque.String`.
+
+# One or more tracking issues related to the change
+issues: [17273]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/alibabacloudlogserviceexporter/config.go
+++ b/exporter/alibabacloudlogserviceexporter/config.go
@@ -14,7 +14,8 @@
 
 package alibabacloudlogserviceexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter"
 
-// Config defines configuration for AlibabaCloud Log Service exporter.
+import "go.opentelemetry.io/collector/config/configopaque" // Config defines configuration for AlibabaCloud Log Service exporter.
+
 type Config struct {
 	// LogService's Endpoint, https://www.alibabacloud.com/help/doc-detail/29008.htm
 	// for AlibabaCloud Kubernetes(or ECS), set {region-id}-intranet.log.aliyuncs.com, eg cn-hangzhou-intranet.log.aliyuncs.com;
@@ -27,7 +28,7 @@ type Config struct {
 	// AlibabaCloud access key id
 	AccessKeyID string `mapstructure:"access_key_id"`
 	// AlibabaCloud access key secret
-	AccessKeySecret string `mapstructure:"access_key_secret"`
+	AccessKeySecret configopaque.String `mapstructure:"access_key_secret"`
 	// Set AlibabaCLoud ECS ram role if you are using ACK
 	ECSRamRole string `mapstructure:"ecs_ram_role"`
 	// Set Token File Path if you are using ACK

--- a/exporter/alibabacloudlogserviceexporter/uploader.go
+++ b/exporter/alibabacloudlogserviceexporter/uploader.go
@@ -61,7 +61,7 @@ func NewLogServiceClient(config *Config, logger *zap.Logger) (LogServiceClient, 
 	producerConfig := producer.GetDefaultProducerConfig()
 	producerConfig.Endpoint = config.Endpoint
 	producerConfig.AccessKeyID = config.AccessKeyID
-	producerConfig.AccessKeySecret = config.AccessKeySecret
+	producerConfig.AccessKeySecret = string(config.AccessKeySecret)
 	if config.ECSRamRole != "" || config.TokenFilePath != "" {
 		tokenUpdateFunc, _ := slsutil.NewTokenUpdateFunc(config.ECSRamRole, config.TokenFilePath)
 		producerConfig.UpdateStsToken = tokenUpdateFunc

--- a/exporter/azuredataexplorerexporter/adx_exporter.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter.go
@@ -219,7 +219,7 @@ func getMappingRef(config *Config, telemetryDataType int) ingest.FileOption {
 func buildAdxClient(config *Config) (*kusto.Client, error) {
 	authorizer := kusto.Authorization{
 		Config: auth.NewClientCredentialsConfig(config.ApplicationID,
-			config.ApplicationKey, config.TenantID),
+			string(config.ApplicationKey), config.TenantID),
 	}
 	client, err := kusto.New(config.ClusterURI, authorizer)
 	return client, err

--- a/exporter/azuredataexplorerexporter/config.go
+++ b/exporter/azuredataexplorerexporter/config.go
@@ -18,22 +18,24 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 // Config defines configuration for Azure Data Explorer Exporter
 type Config struct {
-	ClusterURI         string `mapstructure:"cluster_uri"`
-	ApplicationID      string `mapstructure:"application_id"`
-	ApplicationKey     string `mapstructure:"application_key"`
-	TenantID           string `mapstructure:"tenant_id"`
-	Database           string `mapstructure:"db_name"`
-	MetricTable        string `mapstructure:"metrics_table_name"`
-	LogTable           string `mapstructure:"logs_table_name"`
-	TraceTable         string `mapstructure:"traces_table_name"`
-	MetricTableMapping string `mapstructure:"metrics_table_json_mapping"`
-	LogTableMapping    string `mapstructure:"logs_table_json_mapping"`
-	TraceTableMapping  string `mapstructure:"traces_table_json_mapping"`
-	IngestionType      string `mapstructure:"ingestion_type"`
+	ClusterURI         string              `mapstructure:"cluster_uri"`
+	ApplicationID      string              `mapstructure:"application_id"`
+	ApplicationKey     configopaque.String `mapstructure:"application_key"`
+	TenantID           string              `mapstructure:"tenant_id"`
+	Database           string              `mapstructure:"db_name"`
+	MetricTable        string              `mapstructure:"metrics_table_name"`
+	LogTable           string              `mapstructure:"logs_table_name"`
+	TraceTable         string              `mapstructure:"traces_table_name"`
+	MetricTableMapping string              `mapstructure:"metrics_table_json_mapping"`
+	LogTableMapping    string              `mapstructure:"logs_table_json_mapping"`
+	TraceTableMapping  string              `mapstructure:"traces_table_json_mapping"`
+	IngestionType      string              `mapstructure:"ingestion_type"`
 }
 
 // Validate checks if the exporter configuration is valid
@@ -42,7 +44,7 @@ func (adxCfg *Config) Validate() error {
 		return errors.New("ADX config is nil / not provided")
 	}
 
-	if isEmpty(adxCfg.ClusterURI) || isEmpty(adxCfg.ApplicationID) || isEmpty(adxCfg.ApplicationKey) || isEmpty(adxCfg.TenantID) {
+	if isEmpty(adxCfg.ClusterURI) || isEmpty(adxCfg.ApplicationID) || isEmpty(string(adxCfg.ApplicationKey)) || isEmpty(adxCfg.TenantID) {
 		return errors.New(`mandatory configurations "cluster_uri" ,"application_id" , "application_key" and "tenant_id" are missing or empty `)
 	}
 

--- a/exporter/azuremonitorexporter/config.go
+++ b/exporter/azuremonitorexporter/config.go
@@ -16,13 +16,15 @@ package azuremonitorexporter // import "github.com/open-telemetry/opentelemetry-
 
 import (
 	"time"
+
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 // Config defines configuration for Azure Monitor
 type Config struct {
-	Endpoint           string        `mapstructure:"endpoint"`
-	InstrumentationKey string        `mapstructure:"instrumentation_key"`
-	MaxBatchSize       int           `mapstructure:"maxbatchsize"`
-	MaxBatchInterval   time.Duration `mapstructure:"maxbatchinterval"`
-	SpanEventsEnabled  bool          `mapstructure:"spaneventsenabled"`
+	Endpoint           string              `mapstructure:"endpoint"`
+	InstrumentationKey configopaque.String `mapstructure:"instrumentation_key"`
+	MaxBatchSize       int                 `mapstructure:"maxbatchsize"`
+	MaxBatchInterval   time.Duration       `mapstructure:"maxbatchinterval"`
+	SpanEventsEnabled  bool                `mapstructure:"spaneventsenabled"`
 }

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -98,7 +98,7 @@ func (f *factory) getTransportChannel(exporterConfig *Config, logger *zap.Logger
 	// The default transport channel uses the default send mechanism from the AppInsights telemetry client.
 	// This default channel handles batching, appropriate retries, and is backed by memory.
 	if f.tChannel == nil {
-		telemetryConfiguration := appinsights.NewTelemetryConfiguration(exporterConfig.InstrumentationKey)
+		telemetryConfiguration := appinsights.NewTelemetryConfiguration(string(exporterConfig.InstrumentationKey))
 		telemetryConfiguration.EndpointUrl = exporterConfig.Endpoint
 		telemetryConfiguration.MaxBatchSize = exporterConfig.MaxBatchSize
 		telemetryConfiguration.MaxBatchInterval = exporterConfig.MaxBatchInterval

--- a/exporter/azuremonitorexporter/logexporter.go
+++ b/exporter/azuremonitorexporter/logexporter.go
@@ -39,7 +39,7 @@ func (exporter *logExporter) onLogData(context context.Context, logData plog.Log
 			logs := scopeLogs.At(j).LogRecords()
 			for k := 0; k < logs.Len(); k++ {
 				envelope := logPacker.LogRecordToEnvelope(logs.At(k))
-				envelope.IKey = exporter.config.InstrumentationKey
+				envelope.IKey = string(exporter.config.InstrumentationKey)
 				exporter.transportChannel.Send(envelope)
 			}
 		}

--- a/exporter/azuremonitorexporter/traceexporter.go
+++ b/exporter/azuremonitorexporter/traceexporter.go
@@ -51,7 +51,7 @@ func (v *traceVisitor) visit(
 	}
 
 	for _, envelope := range envelopes {
-		envelope.IKey = v.exporter.config.InstrumentationKey
+		envelope.IKey = string(v.exporter.config.InstrumentationKey)
 
 		// This is a fire and forget operation
 		v.exporter.transportChannel.Send(envelope)

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
@@ -49,7 +50,7 @@ type Config struct {
 	Logs configgrpc.GRPCClientSettings `mapstructure:"logs"`
 
 	// Your Coralogix private key (sensitive) for authentication
-	PrivateKey string `mapstructure:"private_key"`
+	PrivateKey configopaque.String `mapstructure:"private_key"`
 
 	// Ordered list of Resource attributes that are used for Coralogix
 	// AppName and SubSystem values. The first non-empty Resource attribute is used.
@@ -87,7 +88,7 @@ func (c *Config) Validate() error {
 	if len(c.GRPCClientSettings.Headers) == 0 {
 		c.GRPCClientSettings.Headers = map[string]string{}
 	}
-	c.GRPCClientSettings.Headers["ACCESS_TOKEN"] = c.PrivateKey
+	c.GRPCClientSettings.Headers["ACCESS_TOKEN"] = string(c.PrivateKey)
 	c.GRPCClientSettings.Headers["appName"] = c.AppName
 	return nil
 }

--- a/exporter/coralogixexporter/logs_client.go
+++ b/exporter/coralogixexporter/logs_client.go
@@ -63,7 +63,7 @@ func (e *logsExporter) start(ctx context.Context, host component.Host) (err erro
 	if e.config.Logs.Headers == nil {
 		e.config.Logs.Headers = make(map[string]string)
 	}
-	e.config.Logs.Headers["Authorization"] = "Bearer " + e.config.PrivateKey
+	e.config.Logs.Headers["Authorization"] = "Bearer " + string(e.config.PrivateKey)
 
 	e.callOptions = []grpc.CallOption{
 		grpc.WaitForReady(e.config.Logs.WaitForReady),

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -69,7 +69,7 @@ func (e *exporter) start(ctx context.Context, host component.Host) (err error) {
 	if e.config.Metrics.Headers == nil {
 		e.config.Metrics.Headers = make(map[string]string)
 	}
-	e.config.Metrics.Headers["Authorization"] = "Bearer " + e.config.PrivateKey
+	e.config.Metrics.Headers["Authorization"] = "Bearer " + string(e.config.PrivateKey)
 
 	e.callOptions = []grpc.CallOption{
 		grpc.WaitForReady(e.config.Metrics.WaitForReady),

--- a/exporter/coralogixexporter/traces_client.go
+++ b/exporter/coralogixexporter/traces_client.go
@@ -66,7 +66,7 @@ func (e *tracesExporter) start(ctx context.Context, host component.Host) (err er
 	if e.config.Traces.Headers == nil {
 		e.config.Traces.Headers = make(map[string]string)
 	}
-	e.config.Traces.Headers["Authorization"] = "Bearer " + e.config.PrivateKey
+	e.config.Traces.Headers["Authorization"] = "Bearer " + string(e.config.PrivateKey)
 
 	e.callOptions = []grpc.CallOption{
 		grpc.WaitForReady(e.config.Traces.WaitForReady),

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
@@ -94,12 +95,12 @@ type AuthenticationSettings struct {
 	User string `mapstructure:"user"`
 
 	// Password is used to configure HTTP Basic Authentication.
-	Password string `mapstructure:"password"`
+	Password configopaque.String `mapstructure:"password"`
 
 	// APIKey is used to configure ApiKey based Authentication.
 	//
 	// https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
-	APIKey string `mapstructure:"api_key"`
+	APIKey configopaque.String `mapstructure:"api_key"`
 }
 
 // DiscoverySettings defines Elasticsearch node discovery related settings.

--- a/exporter/elasticsearchexporter/elasticsearch_bulk.go
+++ b/exporter/elasticsearchexporter/elasticsearch_bulk.go
@@ -111,8 +111,8 @@ func newElasticsearchClient(logger *zap.Logger, config *Config) (*esClientCurren
 		Addresses: config.Endpoints,
 		CloudID:   config.CloudID,
 		Username:  config.Authentication.User,
-		Password:  config.Authentication.Password,
-		APIKey:    config.Authentication.APIKey,
+		Password:  string(config.Authentication.Password),
+		APIKey:    string(config.Authentication.APIKey),
 		Header:    headers,
 
 		// configure retry behavior

--- a/exporter/influxdbexporter/config.go
+++ b/exporter/influxdbexporter/config.go
@@ -17,6 +17,7 @@ package influxdbexporter // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
@@ -36,7 +37,7 @@ type V1Compatibility struct {
 	// Username is used to optionally specify the basic auth username
 	Username string `mapstructure:"username"`
 	// Password is used to optionally specify the basic auth password
-	Password string `mapstructure:"password"`
+	Password configopaque.String `mapstructure:"password"`
 }
 
 // Config defines configuration for the InfluxDB exporter.
@@ -50,7 +51,7 @@ type Config struct {
 	// Bucket is the InfluxDB bucket name that telemetry will be written to.
 	Bucket string `mapstructure:"bucket"`
 	// Token is used to identify InfluxDB permissions within the organization.
-	Token string `mapstructure:"token"`
+	Token configopaque.String `mapstructure:"token"`
 	// V1Compatibility is used to specify if the exporter should use the v1.X InfluxDB API schema.
 	V1Compatibility V1Compatibility `mapstructure:"v1_compatibility"`
 

--- a/exporter/influxdbexporter/writer.go
+++ b/exporter/influxdbexporter/writer.go
@@ -75,7 +75,7 @@ func newInfluxHTTPWriter(logger common.Logger, config *Config, host component.Ho
 		queryValues.Set("bucket", config.Bucket)
 
 		if config.Token != "" {
-			config.HTTPClientSettings.Headers["Authorization"] = configopaque.String("Token " + config.Token)
+			config.HTTPClientSettings.Headers["Authorization"] = "Token " + config.Token
 		}
 	}
 

--- a/exporter/influxdbexporter/writer.go
+++ b/exporter/influxdbexporter/writer.go
@@ -67,7 +67,7 @@ func newInfluxHTTPWriter(logger common.Logger, config *Config, host component.Ho
 
 		if config.V1Compatibility.Username != "" && config.V1Compatibility.Password != "" {
 			var basicAuth []byte
-			base64.StdEncoding.Encode(basicAuth, []byte(config.V1Compatibility.Username+":"+config.V1Compatibility.Password))
+			base64.StdEncoding.Encode(basicAuth, []byte(config.V1Compatibility.Username+":"+string(config.V1Compatibility.Password)))
 			config.HTTPClientSettings.Headers["Authorization"] = configopaque.String("Basic " + string(basicAuth))
 		}
 	} else {

--- a/exporter/instanaexporter/config.go
+++ b/exporter/instanaexporter/config.go
@@ -21,13 +21,14 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 // Config defines configuration for the Instana exporter
 type Config struct {
 	Endpoint string `mapstructure:"endpoint"`
 
-	AgentKey string `mapstructure:"agent_key"`
+	AgentKey configopaque.String `mapstructure:"agent_key"`
 
 	confighttp.HTTPClientSettings `mapstructure:",squash"`
 }

--- a/exporter/instanaexporter/exporter.go
+++ b/exporter/instanaexporter/exporter.go
@@ -85,7 +85,7 @@ func (e *instanaExporter) pushConvertedTraces(ctx context.Context, td ptrace.Tra
 	}
 
 	headers := map[string]string{
-		backend.HeaderKey:  e.config.AgentKey,
+		backend.HeaderKey:  string(e.config.AgentKey),
 		backend.HeaderHost: hostID,
 		// Used only by the Instana agent and can be set to "0" for the exporter
 		backend.HeaderTime: "0",

--- a/exporter/logicmonitorexporter/config.go
+++ b/exporter/logicmonitorexporter/config.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry"
@@ -37,8 +38,8 @@ type Config struct {
 }
 
 type APIToken struct {
-	AccessID  string `mapstructure:"access_id"`
-	AccessKey string `mapstructure:"access_key"`
+	AccessID  string              `mapstructure:"access_id"`
+	AccessKey configopaque.String `mapstructure:"access_key"`
 }
 
 func (c *Config) Validate() error {

--- a/exporter/logzioexporter/config.go
+++ b/exporter/logzioexporter/config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
@@ -27,7 +28,7 @@ type Config struct {
 	confighttp.HTTPClientSettings `mapstructure:",squash"`          // confighttp client settings https://pkg.go.dev/go.opentelemetry.io/collector/config/confighttp#HTTPClientSettings
 	exporterhelper.QueueSettings  `mapstructure:"sending_queue"`    // exporter helper queue settings https://pkg.go.dev/go.opentelemetry.io/collector/exporter/exporterhelper#QueueSettings
 	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"` // exporter helper retry settings https://pkg.go.dev/go.opentelemetry.io/collector/exporter/exporterhelper#RetrySettings
-	Token                         string                            `mapstructure:"account_token"`    // Your Logz.io Account Token, can be found at https://app.logz.io/#/dashboard/settings/general
+	Token                         configopaque.String               `mapstructure:"account_token"`    // Your Logz.io Account Token, can be found at https://app.logz.io/#/dashboard/settings/general
 	Region                        string                            `mapstructure:"region"`           // Your Logz.io 2-letter region code, can be found at https://docs.logz.io/user-guide/accounts/account-region.html#available-regions
 	CustomEndpoint                string                            `mapstructure:"custom_endpoint"`  // **Deprecation** Custom endpoint to ship traces to. Use only for dev and tests.
 	DrainInterval                 int                               `mapstructure:"drain_interval"`   // **Deprecation** Queue drain interval in seconds. Defaults to `3`.

--- a/exporter/mezmoexporter/config.go
+++ b/exporter/mezmoexporter/config.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
@@ -51,7 +52,7 @@ type Config struct {
 	IngestURL string `mapstructure:"ingest_url"`
 
 	// Token is the authentication token provided by Mezmo.
-	IngestKey string `mapstructure:"ingest_key"`
+	IngestKey configopaque.String `mapstructure:"ingest_key"`
 }
 
 // returns default http client settings

--- a/exporter/mezmoexporter/exporter.go
+++ b/exporter/mezmoexporter/exporter.go
@@ -182,7 +182,7 @@ func (m *mezmoExporter) sendLinesToMezmo(post string) (errs error) {
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("User-Agent", m.userAgentString)
-	req.Header.Add("apikey", m.config.IngestKey)
+	req.Header.Add("apikey", string(m.config.IngestKey))
 
 	var res *http.Response
 	if res, errs = m.client.Do(req); errs != nil {

--- a/exporter/pulsarexporter/config.go
+++ b/exporter/pulsarexporter/config.go
@@ -17,6 +17,7 @@ package pulsarexporter // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"github.com/apache/pulsar-client-go/pulsar"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
@@ -52,17 +53,17 @@ type TLS struct {
 }
 
 type Token struct {
-	Token string `mapstructure:"Token"`
+	Token configopaque.String `mapstructure:"Token"`
 }
 
 type Athenz struct {
-	ProviderDomain  string `mapstructure:"provider_domain"`
-	TenantDomain    string `mapstructure:"tenant_domain"`
-	TenantService   string `mapstructure:"tenant_service"`
-	PrivateKey      string `mapstructure:"private_key"`
-	KeyID           string `mapstructure:"key_id"`
-	PrincipalHeader string `mapstructure:"principal_header"`
-	ZtsURL          string `mapstructure:"zts_url"`
+	ProviderDomain  string              `mapstructure:"provider_domain"`
+	TenantDomain    string              `mapstructure:"tenant_domain"`
+	TenantService   string              `mapstructure:"tenant_service"`
+	PrivateKey      configopaque.String `mapstructure:"private_key"`
+	KeyID           string              `mapstructure:"key_id"`
+	PrincipalHeader string              `mapstructure:"principal_header"`
+	ZtsURL          string              `mapstructure:"zts_url"`
 }
 
 type OAuth2 struct {
@@ -85,7 +86,7 @@ func (cfg *Config) auth() pulsar.Authentication {
 		return pulsar.NewAuthenticationTLS(authentication.TLS.CertFile, authentication.TLS.KeyFile)
 	}
 	if authentication.Token != nil {
-		return pulsar.NewAuthenticationToken(authentication.Token.Token)
+		return pulsar.NewAuthenticationToken(string(authentication.Token.Token))
 	}
 	if authentication.OAuth2 != nil {
 		return pulsar.NewAuthenticationOAuth2(map[string]string{
@@ -99,7 +100,7 @@ func (cfg *Config) auth() pulsar.Authentication {
 			"providerDomain":  authentication.Athenz.ProviderDomain,
 			"tenantDomain":    authentication.Athenz.TenantDomain,
 			"tenantService":   authentication.Athenz.TenantService,
-			"privateKey":      authentication.Athenz.PrivateKey,
+			"privateKey":      string(authentication.Athenz.PrivateKey),
 			"keyId":           authentication.Athenz.KeyID,
 			"principalHeader": authentication.Athenz.PrincipalHeader,
 			"ztsUrl":          authentication.Athenz.ZtsURL,

--- a/exporter/sapmexporter/config.go
+++ b/exporter/sapmexporter/config.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 
 	sapmclient "github.com/signalfx/sapm-proto/client"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
@@ -38,7 +39,7 @@ type Config struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// AccessToken is the authentication token provided by SignalFx.
-	AccessToken string `mapstructure:"access_token"`
+	AccessToken configopaque.String `mapstructure:"access_token"`
 
 	// NumWorkers is the number of workers that should be used to export traces.
 	// Exporter can make as many requests in parallel as the number of workers. Defaults to 8.
@@ -97,7 +98,7 @@ func (c *Config) clientOptions() []sapmclient.Option {
 	}
 
 	if c.AccessToken != "" {
-		opts = append(opts, sapmclient.WithAccessToken(c.AccessToken))
+		opts = append(opts, sapmclient.WithAccessToken(string(c.AccessToken)))
 	}
 
 	if c.DisableCompression {

--- a/exporter/tencentcloudlogserviceexporter/config.go
+++ b/exporter/tencentcloudlogserviceexporter/config.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 // Config defines configuration for TencentCloud Log Service exporter.
@@ -33,7 +34,7 @@ type Config struct {
 	// TencentCloud access key id
 	SecretID string `mapstructure:"secret_id"`
 	// TencentCloud access key secret
-	SecretKey string `mapstructure:"secret_key"`
+	SecretKey configopaque.String `mapstructure:"secret_key"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/exporter/tencentcloudlogserviceexporter/uploader.go
+++ b/exporter/tencentcloudlogserviceexporter/uploader.go
@@ -41,7 +41,7 @@ type logServiceClientImpl struct {
 
 // newLogServiceClient Create Log Service client
 func newLogServiceClient(config *Config, logger *zap.Logger) logServiceClient {
-	credential := common.NewCredential(config.SecretID, config.SecretKey)
+	credential := common.NewCredential(config.SecretID, string(config.SecretKey))
 
 	c := &logServiceClientImpl{
 		clientInstance: common.NewCommonClient(credential, config.Region, profile.NewClientProfile()),


### PR DESCRIPTION
This change migrates the remaining exporters from #17273 to use configopaque.String:

- [x] [exporter/alibabacloudlogservice] Use configopaque for access_key_secret field
- [x] [exporter/azuredataexplorer] Use configopaque for application_key field
- [x] [exporter/azuremonitor] Use configopaque for instrumentation_key field
- [x] [exporter/coralogix] Use configopaque for private_key field
- [x] [exporter/elasticsearch] Use configopaque for api_key and password fields
- [x] [exporter/influxdb] Use configopaque for token and password fields
- [x] [exporter/instana] Use configopaque for agent_key field
- [x] [exporter/logicmonitor] Use configopaque for apitoken::access_key fields
- [x] [exporter/logzio] Use configopaque for account_token field
- [x] [exporter/mezmo] Use configopaque for ingest_key field
- [x] [exporter/pulsar] Use configopaque for auth::Token::Token and auth::athenz::private_key fields
- [x] [exporter/sapm] Use configopaque for access_token field
- [x] [exporter/tencentcloudlogservice] Use configopaque for secret_key field
