### PR TITLE
[receiver/purefa] Add missing reloadIntervals

### DIFF
--- a/.chloggen/purefa-receiver-missing-scrapers.yaml
+++ b/.chloggen/purefa-receiver-missing-scrapers.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/purefareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Apparently, the non-array metrics are not currently working as expected. 
+
+# One or more tracking issues related to the change
+issues: [16992]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/purefa-receiver-missing-scrapers.yaml
+++ b/.chloggen/purefa-receiver-missing-scrapers.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: receiver/purefareceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: The changes reflect on the solution of non-array scrapers that were not working as expected
+note: Set an explicit reload interval for all scrapers.
 
 # One or more tracking issues related to the change
 issues: [16992]

--- a/.chloggen/purefa-receiver-missing-scrapers.yaml
+++ b/.chloggen/purefa-receiver-missing-scrapers.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: receiver/purefareceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Apparently, the non-array metrics are not currently working as expected. 
+note: The changes reflect on the solution of non-array scrapers that were not working as expected
 
 # One or more tracking issues related to the change
 issues: [16992]

--- a/receiver/purefareceiver/config_test.go
+++ b/receiver/purefareceiver/config_test.go
@@ -40,7 +40,11 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				Settings: &Settings{
 					ReloadIntervals: &ReloadIntervals{
-						Array: 15 * time.Second,
+						Array:       15 * time.Second,
+						Host:        15 * time.Second,
+						Directories: 15 * time.Second,
+						Pods:        15 * time.Second,
+						Volumes:     15 * time.Second,
 					},
 				},
 			},

--- a/receiver/purefareceiver/factory.go
+++ b/receiver/purefareceiver/factory.go
@@ -45,7 +45,7 @@ func createDefaultConfig() component.Config {
 		Settings: &Settings{
 			ReloadIntervals: &ReloadIntervals{
 				Array:       15 * time.Second,
-				Host:        13 * time.Second,
+				Host:        15 * time.Second,
 				Directories: 15 * time.Second,
 				Pods:        15 * time.Second,
 				Volumes:     15 * time.Second,

--- a/receiver/purefareceiver/factory.go
+++ b/receiver/purefareceiver/factory.go
@@ -44,7 +44,11 @@ func createDefaultConfig() component.Config {
 		HTTPClientSettings: confighttp.HTTPClientSettings{},
 		Settings: &Settings{
 			ReloadIntervals: &ReloadIntervals{
-				Array: 15 * time.Second,
+				Array:       15 * time.Second,
+				Host:        13 * time.Second,
+				Directories: 15 * time.Second,
+				Pods:        15 * time.Second,
+				Volumes:     15 * time.Second,
 			},
 		},
 	}


### PR DESCRIPTION
**Description:**
Apparently, the non-array metrics are not currently working as expected. This PR comes to fix this.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14886
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16992

**Documentation:**
Still in progress