### PR TITLE
[receiver/filelog] truncate large log entry

### DIFF
--- a/.chloggen/truncate-large-log-entry.yaml
+++ b/.chloggen/truncate-large-log-entry.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: filelogreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: truncate log entry if it is larger than max_log_size
+note: Truncate log entry if it is longer than `max_log_size`
 
 # One or more tracking issues related to the change
 issues: [16487]

--- a/.chloggen/truncate-large-log-entry.yaml
+++ b/.chloggen/truncate-large-log-entry.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: truncate log entry if it is larger than max_log_size
+
+# One or more tracking issues related to the change
+issues: [16487]

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -98,6 +98,64 @@ func TestTokenization(t *testing.T) {
 	}
 }
 
+func TestTokenizationTooLong(t *testing.T) {
+	fileContent := []byte("aaaaaaaaaaaaaaaaaaaaaa\naaa\n")
+	expected := [][]byte{
+		[]byte("aaaaaaaaaa"),
+		[]byte("aaaaaaaaaa"),
+		[]byte("aa"),
+		[]byte("aaa"),
+	}
+
+	f, emitChan := testReaderFactory(t)
+	f.readerConfig.maxLogSize = 10
+
+	temp := openTemp(t, t.TempDir())
+	_, err := temp.Write(fileContent)
+	require.NoError(t, err)
+
+	r, err := f.newReaderBuilder().withFile(temp).build()
+	require.NoError(t, err)
+
+	r.ReadToEnd(context.Background())
+
+	for _, expected := range expected {
+		require.Equal(t, expected, readToken(t, emitChan))
+	}
+}
+
+func TestTokenizationTooLongWithLineStartPattern(t *testing.T) {
+	fileContent := []byte("aaa2023-01-01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 2023-01-01 2 2023-01-01")
+	expected := [][]byte{
+		[]byte("aaa"),
+		[]byte("2023-01-01aaaaa"),
+		[]byte("aaaaaaaaaaaaaaa"),
+		[]byte("aaaaaaaaaaaaaaa"),
+		[]byte("aaaaa"),
+		[]byte("2023-01-01 2"),
+	}
+
+	f, emitChan := testReaderFactory(t)
+
+	mlc := helper.NewMultilineConfig()
+	mlc.LineStartPattern = `\d+-\d+-\d+`
+	f.splitterFactory = newMultilineSplitterFactory(helper.NewEncodingConfig(), helper.NewFlusherConfig(), mlc)
+	f.readerConfig.maxLogSize = 15
+
+	temp := openTemp(t, t.TempDir())
+	_, err := temp.Write(fileContent)
+	require.NoError(t, err)
+
+	r, err := f.newReaderBuilder().withFile(temp).build()
+	require.NoError(t, err)
+
+	r.ReadToEnd(context.Background())
+
+	for _, expected := range expected {
+		require.Equal(t, expected, readToken(t, emitChan))
+	}
+}
+
 func testReaderFactory(t *testing.T) (*readerFactory, chan *emitParams) {
 	emitChan := make(chan *emitParams, 100)
 	return &readerFactory{

--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -24,7 +24,7 @@ Tails and parses logs from files.
 | `include_file_path_resolved` | `false`          | Whether to add the file path after symlinks resolution as the attribute `log.file.path_resolved`. |
 | `poll_interval`              | 200ms            | The duration between filesystem polls                                                                              |
 | `fingerprint_size`           | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time) |
-| `max_log_size`               | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
+| `max_log_size`               | `1MiB`           | The maximum size of a log entry to read. A log entry will be truncated if it is larger than `max_log_size`. Protects against reading large amounts of data into memory |
 | `max_concurrent_files`       | 1024             | The maximum number of log files from which logs will be read concurrently. If the number of files matched in the `include` pattern exceeds this number, then files will be processed in batches. One batch will be processed per `poll_interval` |
 | `attributes`                 | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
 | `resource`                   | {}               | A map of `key: value` pairs to add to the entry's resource                                                    |


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The `PositionalScanner` will return the `bufio.ErrTooLong` error if the log entry is larger than `max(max_log_size, 16384)`.
If `splitFunc` needs more data to produce a valid token but the scanning buffer is already full, truncate the log entry.

This fix use a different strategy to split log entry comparing to #17309.

When scanning this log content with the start line spliter:
```
|<------------- log_max_size --------->|
<log_start_line>...log_content...<log_start_line>...log_content...<log_start_line>
```
#17309 will emit:
```
|<------------- log_max_size --------->|
<log_start_line>...log_content...<log_st
art_line>...log_content...
```

This PR uses a double size (`log_max_size * 2`) buffer to avoid breaking the start line mark and emits:
```
|<------------- log_max_size --------->|
<log_start_line>...log_content...
<log_start_line>...log_content...
```

**Link to tracking Issue:** #16487

**Testing:** <Describe what testing was performed and which tests were added.>
* `TestTokenizationTooLong()`
* `TestTokenizationTooLongWithLineStartPattern()`

**Documentation:** <Describe the documentation added.>
Update the description of `max_log_size` in filelogreceiver's README.md 