### PR TITLE
Set test run parallelization factor to `4`

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -14,8 +14,8 @@ SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
-GOTEST_OPT?= -race -timeout 300s --tags=$(GO_BUILD_TAGS)
-GOTEST_INTEGRATION_OPT?= -race -timeout 360s
+GOTEST_OPT?= -race -timeout 300s -parallel 4 --tags=$(GO_BUILD_TAGS)
+GOTEST_INTEGRATION_OPT?= -race -timeout 360s -parallel 4
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go


### PR DESCRIPTION
**Description:**

Currently, test parallelization factor is not set while running Go tests so number of available CPU cores is used by default. 

Github provides machines with **2-core** CPU for Windows and Linux machines: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

As far as I see in the integration tests, there are some tests running in parallel. But since test parallelization factor is not set and there are **2** available cores, only **2** tests can run simultaneously and others wait in the queue.

I have noticed this behavior with the help of Foresight **"Process Traces"** as shown in the following trace chart. As you can see, only 2 `mongod` containers are running in parallel which means that only 2 MongoDB receivers integration tests are running simultaneously and the other 2 tests wait the first 2 integration tests to complete:
<img width="750" alt="open-telemetry - mongo tests, parallelization 2" src="https://user-images.githubusercontent.com/3143425/210351307-698f50ef-c569-4784-bc6a-777a2f615331.png">

After I have set parallelization factor to **4** for tests with `-parallel 4` option, I have seen in the Foresight that all the **4** `mongod` containers are running in parallel which means that all the 4 MongoDB receivers integration tests running simultaneously without waiting each other:
<img width="703" alt="open-telemetry - mongo tests, parallelization 4" src="https://user-images.githubusercontent.com/3143425/210356262-795e4f08-c9da-4a81-ace3-d69a34e36d23.png">

With this improvement, I was able to decrease integration tests duration to `18:40` minutes from `21:00` minutes.


