### PR TITLE
Restore feature gate registration for googlecloud exporter

### DIFF
--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -22,15 +22,27 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/featuregate"
 )
 
 const (
 	// The value of "type" key in configuration.
 	typeStr = "googlecloud"
 	// The stability level of the exporter.
-	stability      = component.StabilityLevelBeta
-	defaultTimeout = 12 * time.Second // Consistent with Cloud Monitoring's timeout
+	stability                = component.StabilityLevelBeta
+	defaultTimeout           = 12 * time.Second // Consistent with Cloud Monitoring's timeout
+	pdataExporterFeatureGate = "exporter.googlecloud.OTLPDirect"
 )
+
+func init() {
+	featuregate.GetRegistry().MustRegisterID(
+		pdataExporterFeatureGate,
+		featuregate.StageStable,
+		featuregate.WithRegisterDescription("When enabled, the googlecloud exporter translates pdata directly to google cloud monitoring's types, rather than first translating to opencensus."),
+		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7132"),
+		featuregate.WithRegisterRemovalVersion("v0.69.0"),
+	)
+}
 
 // NewFactory creates a factory for the googlecloud exporter
 func NewFactory() exporter.Factory {

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -8,6 +8,7 @@ require (
 	go.opentelemetry.io/collector v0.68.0
 	go.opentelemetry.io/collector/component v0.68.0
 	go.opentelemetry.io/collector/confmap v0.68.0
+	go.opentelemetry.io/collector/featuregate v0.68.0
 )
 
 require (
@@ -44,7 +45,6 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.68.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.0-rc2 // indirect
 	go.opentelemetry.io/collector/semconv v0.68.0 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect


### PR DESCRIPTION
Addresses https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17191#pullrequestreview-1227465513

The feature gate doesn't do anything, but the error message is more helpful after this change.