### PR TITLE
[prometheusremotewriteexporter] Support conversion of OTel Exponential Histogram to Prometheus Native Histogram

### DIFF
--- a/.chloggen/exponetial-to-prom-native-histogram.yaml
+++ b/.chloggen/exponetial-to-prom-native-histogram.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for converting OTLP Exponential Histograms to Prometheus Native Histograms
+
+# One or more tracking issues related to the change
+issues: [16207]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"runtime"
 	"sync"
 	"testing"
 
@@ -832,9 +831,7 @@ func Test_validateAndSanitizeExternalLabels(t *testing.T) {
 // and that we can retrieve those exact requests back from the WAL, when the
 // exporter starts up once again, that it picks up where it left off.
 func TestWALOnExporterRoundTrip(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10142")
-	}
+	t.Skip("skipping test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10142")
 	if testing.Short() {
 		t.Skip("This test could run for long")
 	}

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -384,10 +384,23 @@ func Test_PushMetrics(t *testing.T) {
 
 	doubleGaugeBatch := getMetricsFromMetricList(validMetrics1[validDoubleGauge], validMetrics2[validDoubleGauge])
 
+	expHistogramBatch := getMetricsFromMetricList(
+		getExpHistogramMetric("exponential_hist", lbs1, time1, &floatVal1, uint64(2), 2, []uint64{1, 1}),
+		getExpHistogramMetric("exponential_hist", lbs2, time2, &floatVal2, uint64(2), 0, []uint64{2, 2}),
+	)
+	emptyExponentialHistogramBatch := getMetricsFromMetricList(
+		getExpHistogramMetric("empty_exponential_hist", lbs1, time1, &floatValZero, uint64(0), 0, []uint64{}),
+		getExpHistogramMetric("empty_exponential_hist", lbs1, time1, &floatValZero, uint64(0), 1, []uint64{}),
+		getExpHistogramMetric("empty_exponential_hist", lbs2, time2, &floatValZero, uint64(0), 0, []uint64{}),
+		getExpHistogramMetric("empty_exponential_hist_two", lbs2, time2, &floatValZero, uint64(0), 0, []uint64{}),
+	)
+	exponentialNoSumHistogramBatch := getMetricsFromMetricList(
+		getExpHistogramMetric("no_sum_exponential_hist", lbs1, time1, nil, uint64(2), 0, []uint64{1, 1}),
+		getExpHistogramMetric("no_sum_exponential_hist", lbs1, time2, nil, uint64(2), 0, []uint64{2, 2}),
+	)
+
 	histogramBatch := getMetricsFromMetricList(validMetrics1[validHistogram], validMetrics2[validHistogram])
-
 	emptyDataPointHistogramBatch := getMetricsFromMetricList(validMetrics1[validEmptyHistogram], validMetrics2[validEmptyHistogram])
-
 	histogramNoSumBatch := getMetricsFromMetricList(validMetrics1[validHistogramNoSum], validMetrics2[validHistogramNoSum])
 
 	summaryBatch := getMetricsFromMetricList(validMetrics1[validSummary], validMetrics2[validSummary])
@@ -482,6 +495,27 @@ func Test_PushMetrics(t *testing.T) {
 			metrics:            intGaugeBatch,
 			reqTestFunc:        checkFunc,
 			expectedTimeSeries: 2,
+			httpResponseCode:   http.StatusAccepted,
+		},
+		{
+			name:               "exponential_histogram_case",
+			metrics:            expHistogramBatch,
+			reqTestFunc:        checkFunc,
+			expectedTimeSeries: 2,
+			httpResponseCode:   http.StatusAccepted,
+		},
+		{
+			name:               "valid_empty_exponential_histogram_case",
+			metrics:            emptyExponentialHistogramBatch,
+			reqTestFunc:        checkFunc,
+			expectedTimeSeries: 3,
+			httpResponseCode:   http.StatusAccepted,
+		},
+		{
+			name:               "exponential_histogram_no_sum_case",
+			metrics:            exponentialNoSumHistogramBatch,
+			reqTestFunc:        checkFunc,
+			expectedTimeSeries: 1,
 			httpResponseCode:   http.StatusAccepted,
 		},
 		{

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -302,6 +302,35 @@ func getHistogramMetricEmptyDataPoint(name string, attributes pcommon.Map, ts ui
 	return metric
 }
 
+func getExpHistogramMetric(
+	name string,
+	attributes pcommon.Map,
+	ts uint64,
+	sum *float64,
+	count uint64,
+	offset int32,
+	bucketCounts []uint64,
+) pmetric.Metric {
+	metric := pmetric.NewMetric()
+	metric.SetName(name)
+	metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	dp := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+	if strings.HasPrefix(name, "staleNaN") {
+		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
+	}
+	dp.SetCount(count)
+
+	if sum != nil {
+		dp.SetSum(*sum)
+	}
+	dp.Positive().SetOffset(offset)
+	dp.Positive().BucketCounts().FromRaw(bucketCounts)
+	attributes.CopyTo(dp.Attributes())
+
+	dp.SetTimestamp(pcommon.Timestamp(ts))
+	return metric
+}
+
 func getHistogramMetric(name string, attributes pcommon.Map, ts uint64, sum *float64, count uint64, bounds []float64,
 	buckets []uint64) pmetric.Metric {
 	metric := pmetric.NewMetric()

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -63,6 +63,16 @@ func Test_isValidAggregationTemporality(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "cumulative exponential histogram",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				h := metric.SetEmptyExponentialHistogram()
+				h.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				return metric
+			}(),
+			want: true,
+		},
+		{
 			name:   "missing type",
 			metric: pmetric.NewMetric(),
 			want:   false,
@@ -81,6 +91,16 @@ func Test_isValidAggregationTemporality(t *testing.T) {
 			name: "delta histogram",
 			metric: getHistogramMetric(
 				"", l, pmetric.AggregationTemporalityDelta, 0, 0, 0, []float64{}, []uint64{}),
+			want: false,
+		},
+		{
+			name: "delta exponential histogram",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				h := metric.SetEmptyExponentialHistogram()
+				h.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				return metric
+			}(),
 			want: false,
 		},
 	}

--- a/pkg/translator/prometheusremotewrite/histograms.go
+++ b/pkg/translator/prometheusremotewrite/histograms.go
@@ -140,13 +140,14 @@ func convertBucketsLayout(buckets pmetric.ExponentialHistogramDataPointBuckets) 
 			continue
 		}
 
+		// The offset is adjusted by 1 as described above.
 		bucketIdx := int32(i) + buckets.Offset() + 1
 		delta := bucketIdx - nextBucketIdx
 		if i == 0 || delta > 2 {
 			// We have to create a new span, either because we are
 			// at the very beginning, or because we have found a gap
-			// of more than two buckets. See
-			// https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go#L1296
+			// of more than two buckets. The constant 2 is copied from the logic in
+			// https://github.com/prometheus/client_golang/blob/27f0506d6ebbb117b6b697d0552ee5be2502c5f2/prometheus/histogram.go#L1296
 			spans = append(spans, &prompb.BucketSpan{
 				Offset: delta,
 				Length: 0,

--- a/pkg/translator/prometheusremotewrite/histograms.go
+++ b/pkg/translator/prometheusremotewrite/histograms.go
@@ -1,0 +1,166 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/prompb"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const defaultZeroThreshold = 1e-128
+
+func addSingleExponentialHistogramDataPoint(
+	metric string,
+	pt pmetric.ExponentialHistogramDataPoint,
+	resource pcommon.Resource,
+	settings Settings,
+	series map[string]*prompb.TimeSeries,
+) error {
+	labels := createAttributes(
+		resource,
+		pt.Attributes(),
+		settings.ExternalLabels,
+		model.MetricNameLabel, metric,
+	)
+
+	sig := timeSeriesSignature(
+		pmetric.MetricTypeExponentialHistogram.String(),
+		&labels,
+	)
+	ts, ok := series[sig]
+	if !ok {
+		ts = &prompb.TimeSeries{
+			Labels: labels,
+		}
+		series[sig] = ts
+	}
+
+	histogram, err := exponentialToNativeHistogram(pt)
+	if err != nil {
+		return err
+	}
+	ts.Histograms = append(ts.Histograms, histogram)
+
+	exemplars := getPromExemplars[pmetric.ExponentialHistogramDataPoint](pt)
+	ts.Exemplars = append(ts.Exemplars, exemplars...)
+
+	return nil
+}
+
+// exponentialToNativeHistogram  translates OTel Exponential Histogram data point
+// to Prometheus Native Histogram.
+func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) (prompb.Histogram, error) {
+	scale := p.Scale()
+	if scale < -4 || scale > 8 {
+		return prompb.Histogram{},
+			fmt.Errorf("cannot convert exponential to native histogram."+
+				" Scale must be <= 8 and >= -4, was %d", scale)
+		// TODO: downscale to 8 if scale > 8
+	}
+
+	pSpans, pDeltas := convertBucketsLayout(p.Positive())
+	nSpans, nDeltas := convertBucketsLayout(p.Negative())
+
+	h := prompb.Histogram{
+		Schema: scale,
+
+		ZeroCount: &prompb.Histogram_ZeroCountInt{ZeroCountInt: p.ZeroCount()},
+		// TODO use zero_threshold, if set, see
+		// https://github.com/open-telemetry/opentelemetry-proto/pull/441
+		ZeroThreshold: defaultZeroThreshold,
+
+		PositiveSpans:  pSpans,
+		PositiveDeltas: pDeltas,
+		NegativeSpans:  nSpans,
+		NegativeDeltas: nDeltas,
+
+		Timestamp: convertTimeStamp(p.Timestamp()),
+	}
+
+	if p.Flags().NoRecordedValue() {
+		h.Sum = math.Float64frombits(value.StaleNaN)
+		h.Count = &prompb.Histogram_CountInt{CountInt: value.StaleNaN}
+	} else {
+		if p.HasSum() {
+			h.Sum = p.Sum()
+		}
+		h.Count = &prompb.Histogram_CountInt{CountInt: p.Count()}
+	}
+	return h, nil
+}
+
+// convertBucketsLayout translates OTel Exponential Histogram dense buckets
+// representation to Prometheus Native Histogram sparse bucket representation.
+//
+// The translation logic is taken from the client_golang `histogram.go#makeBuckets`
+// function, see `makeBuckets` https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go
+// The bucket indexes conversion was adjusted, since OTel exp. histogram bucket
+// index 0 corresponds to the range (1, base] while Prometheus bucket index 0
+// to the range (base 1].
+func convertBucketsLayout(buckets pmetric.ExponentialHistogramDataPointBuckets) ([]*prompb.BucketSpan, []int64) {
+	bucketCounts := buckets.BucketCounts()
+	if bucketCounts.Len() == 0 {
+		return nil, nil
+	}
+
+	var (
+		spans         []*prompb.BucketSpan
+		deltas        []int64
+		prevCount     int64
+		nextBucketIdx int32
+	)
+
+	appendDelta := func(count int64) {
+		spans[len(spans)-1].Length++
+		deltas = append(deltas, count-prevCount)
+		prevCount = count
+	}
+
+	for i := 0; i < bucketCounts.Len(); i++ {
+		count := int64(bucketCounts.At(i))
+		if count == 0 {
+			continue
+		}
+
+		bucketIdx := int32(i) + buckets.Offset() + 1
+		delta := bucketIdx - nextBucketIdx
+		if i == 0 || delta > 2 {
+			// We have to create a new span, either because we are
+			// at the very beginning, or because we have found a gap
+			// of more than two buckets. See
+			// https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go#L1296
+			spans = append(spans, &prompb.BucketSpan{
+				Offset: delta,
+				Length: 0,
+			})
+		} else {
+			// We have found a small gap (or no gap at all).
+			// Insert empty buckets as needed.
+			for j := int32(0); j < delta; j++ {
+				appendDelta(0)
+			}
+		}
+		appendDelta(count)
+		nextBucketIdx = bucketIdx + 1
+	}
+
+	return spans, deltas
+}

--- a/pkg/translator/prometheusremotewrite/histograms_test.go
+++ b/pkg/translator/prometheusremotewrite/histograms_test.go
@@ -1,0 +1,398 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusremotewrite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+)
+
+func TestConvertBucketsLayout(t *testing.T) {
+	tests := []struct {
+		name       string
+		buckets    func() pmetric.ExponentialHistogramDataPointBuckets
+		wantSpans  []*prompb.BucketSpan
+		wantDeltas []int64
+	}{
+		{
+			name: "zero offset",
+			buckets: func() pmetric.ExponentialHistogramDataPointBuckets {
+				b := pmetric.NewExponentialHistogramDataPointBuckets()
+				b.SetOffset(0)
+				b.BucketCounts().FromRaw([]uint64{4, 3, 2, 1})
+				return b
+			},
+			wantSpans: []*prompb.BucketSpan{
+				{
+					Offset: 1,
+					Length: 4,
+				},
+			},
+			wantDeltas: []int64{4, -1, -1, -1},
+		},
+		{
+			name: "positive offset",
+			buckets: func() pmetric.ExponentialHistogramDataPointBuckets {
+				b := pmetric.NewExponentialHistogramDataPointBuckets()
+				b.SetOffset(4)
+				b.BucketCounts().FromRaw([]uint64{4, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+				return b
+			},
+			wantSpans: []*prompb.BucketSpan{
+				{
+					Offset: 5,
+					Length: 4,
+				},
+				{
+					Offset: 12,
+					Length: 1,
+				},
+			},
+			wantDeltas: []int64{4, -2, -2, 2, -1},
+		},
+		{
+			name: "negative offset",
+			buckets: func() pmetric.ExponentialHistogramDataPointBuckets {
+				b := pmetric.NewExponentialHistogramDataPointBuckets()
+				b.SetOffset(-2)
+				b.BucketCounts().FromRaw([]uint64{3, 1, 0, 0, 0, 1})
+				return b
+			},
+			wantSpans: []*prompb.BucketSpan{
+				{
+					Offset: -1,
+					Length: 2,
+				},
+				{
+					Offset: 3,
+					Length: 1,
+				},
+			},
+			wantDeltas: []int64{3, -2, 0},
+		},
+		{
+			name: "buckets with gaps of size 1",
+			buckets: func() pmetric.ExponentialHistogramDataPointBuckets {
+				b := pmetric.NewExponentialHistogramDataPointBuckets()
+				b.SetOffset(-2)
+				b.BucketCounts().FromRaw([]uint64{3, 1, 0, 1, 0, 1})
+				return b
+			},
+			wantSpans: []*prompb.BucketSpan{
+				{
+					Offset: -1,
+					Length: 6,
+				},
+			},
+			wantDeltas: []int64{3, -2, -1, 1, -1, 1},
+		},
+		{
+			name: "buckets with gaps of size 2",
+			buckets: func() pmetric.ExponentialHistogramDataPointBuckets {
+				b := pmetric.NewExponentialHistogramDataPointBuckets()
+				b.SetOffset(-2)
+				b.BucketCounts().FromRaw([]uint64{3, 0, 0, 1, 0, 0, 1})
+				return b
+			},
+			wantSpans: []*prompb.BucketSpan{
+				{
+					Offset: -1,
+					Length: 7,
+				},
+			},
+			wantDeltas: []int64{3, -3, 0, 1, -1, 0, 1},
+		},
+		{
+			name:       "zero buckets",
+			buckets:    pmetric.NewExponentialHistogramDataPointBuckets,
+			wantSpans:  nil,
+			wantDeltas: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSpans, gotDeltas := convertBucketsLayout(tt.buckets())
+			assert.Equal(t, tt.wantSpans, gotSpans)
+			assert.Equal(t, tt.wantDeltas, gotDeltas)
+		})
+	}
+}
+
+func TestExponentialToNativeHistogram(t *testing.T) {
+	tests := []struct {
+		name            string
+		exponentialHist func() pmetric.ExponentialHistogramDataPoint
+		wantNativeHist  func() prompb.Histogram
+		wantErrMessage  string
+	}{
+		{
+			name: "convert exp. to native histogram",
+			exponentialHist: func() pmetric.ExponentialHistogramDataPoint {
+				pt := pmetric.NewExponentialHistogramDataPoint()
+				pt.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(100)))
+				pt.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(500)))
+				pt.SetCount(2)
+				pt.SetSum(10.1)
+				pt.SetScale(1)
+				pt.SetZeroCount(1)
+
+				pt.Positive().BucketCounts().FromRaw([]uint64{1, 1})
+				pt.Positive().SetOffset(1)
+
+				pt.Negative().BucketCounts().FromRaw([]uint64{1, 1})
+				pt.Negative().SetOffset(1)
+
+				return pt
+			},
+			wantNativeHist: func() prompb.Histogram {
+				return prompb.Histogram{
+					Count:          &prompb.Histogram_CountInt{CountInt: 2},
+					Sum:            10.1,
+					Schema:         1,
+					ZeroThreshold:  defaultZeroThreshold,
+					ZeroCount:      &prompb.Histogram_ZeroCountInt{ZeroCountInt: 1},
+					NegativeSpans:  []*prompb.BucketSpan{{Offset: 2, Length: 2}},
+					NegativeDeltas: []int64{1, 0},
+					PositiveSpans:  []*prompb.BucketSpan{{Offset: 2, Length: 2}},
+					PositiveDeltas: []int64{1, 0},
+					Timestamp:      500,
+				}
+			},
+		},
+		{
+			name: "convert exp. to native histogram with no sum",
+			exponentialHist: func() pmetric.ExponentialHistogramDataPoint {
+				pt := pmetric.NewExponentialHistogramDataPoint()
+				pt.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(100)))
+				pt.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(500)))
+
+				pt.SetCount(2)
+				pt.SetScale(1)
+				pt.SetZeroCount(1)
+
+				pt.Positive().BucketCounts().FromRaw([]uint64{1, 1})
+				pt.Positive().SetOffset(1)
+
+				pt.Negative().BucketCounts().FromRaw([]uint64{1, 1})
+				pt.Negative().SetOffset(1)
+
+				return pt
+			},
+			wantNativeHist: func() prompb.Histogram {
+				return prompb.Histogram{
+					Count:          &prompb.Histogram_CountInt{CountInt: 2},
+					Schema:         1,
+					ZeroThreshold:  defaultZeroThreshold,
+					ZeroCount:      &prompb.Histogram_ZeroCountInt{ZeroCountInt: 1},
+					NegativeSpans:  []*prompb.BucketSpan{{Offset: 2, Length: 2}},
+					NegativeDeltas: []int64{1, 0},
+					PositiveSpans:  []*prompb.BucketSpan{{Offset: 2, Length: 2}},
+					PositiveDeltas: []int64{1, 0},
+					Timestamp:      500,
+				}
+			},
+		},
+		{
+			name: "invalid scale",
+			exponentialHist: func() pmetric.ExponentialHistogramDataPoint {
+				pt := pmetric.NewExponentialHistogramDataPoint()
+				pt.SetScale(-10)
+				return pt
+			},
+			wantErrMessage: "cannot convert exponential to native histogram." +
+				" Scale must be <= 8 and >= -4, was -10",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := exponentialToNativeHistogram(tt.exponentialHist())
+			if tt.wantErrMessage != "" {
+				assert.ErrorContains(t, err, tt.wantErrMessage)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantNativeHist(), got)
+		})
+	}
+}
+
+func TestAddSingleExponentialHistogramDataPoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		metric     func() pmetric.Metric
+		wantSeries func() map[string]*prompb.TimeSeries
+	}{
+		{
+			name: "histogram data points with same labels",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_hist")
+				metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				pt := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+				pt.SetCount(7)
+				pt.SetScale(1)
+				pt.Positive().SetOffset(-1)
+				pt.Positive().BucketCounts().FromRaw([]uint64{4, 2})
+				pt.Exemplars().AppendEmpty().SetDoubleValue(1)
+				pt.Attributes().PutStr("attr", "test_attr")
+
+				pt = metric.ExponentialHistogram().DataPoints().AppendEmpty()
+				pt.SetCount(4)
+				pt.SetScale(1)
+				pt.Positive().SetOffset(-1)
+				pt.Positive().BucketCounts().FromRaw([]uint64{4, 2, 1})
+				pt.Exemplars().AppendEmpty().SetDoubleValue(2)
+				pt.Attributes().PutStr("attr", "test_attr")
+
+				return metric
+			},
+			wantSeries: func() map[string]*prompb.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_hist"},
+					{Name: "attr", Value: "test_attr"},
+				}
+				return map[string]*prompb.TimeSeries{
+					timeSeriesSignature(pmetric.MetricTypeExponentialHistogram.String(), &labels): {
+						Labels: labels,
+						Histograms: []prompb.Histogram{
+							{
+								Count:          &prompb.Histogram_CountInt{CountInt: 7},
+								Schema:         1,
+								ZeroThreshold:  defaultZeroThreshold,
+								ZeroCount:      &prompb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+								PositiveSpans:  []*prompb.BucketSpan{{Offset: 0, Length: 2}},
+								PositiveDeltas: []int64{4, -2},
+							},
+							{
+								Count:          &prompb.Histogram_CountInt{CountInt: 4},
+								Schema:         1,
+								ZeroThreshold:  defaultZeroThreshold,
+								ZeroCount:      &prompb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+								PositiveSpans:  []*prompb.BucketSpan{{Offset: 0, Length: 3}},
+								PositiveDeltas: []int64{4, -2, -1},
+							},
+						},
+						Exemplars: []prompb.Exemplar{
+							{Value: 1},
+							{Value: 2},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "histogram data points with different labels",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_hist")
+				metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				pt := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+				pt.SetCount(7)
+				pt.SetScale(1)
+				pt.Positive().SetOffset(-1)
+				pt.Positive().BucketCounts().FromRaw([]uint64{4, 2})
+				pt.Exemplars().AppendEmpty().SetDoubleValue(1)
+				pt.Attributes().PutStr("attr", "test_attr")
+
+				pt = metric.ExponentialHistogram().DataPoints().AppendEmpty()
+				pt.SetCount(4)
+				pt.SetScale(1)
+				pt.Negative().SetOffset(-1)
+				pt.Negative().BucketCounts().FromRaw([]uint64{4, 2, 1})
+				pt.Exemplars().AppendEmpty().SetDoubleValue(2)
+				pt.Attributes().PutStr("attr", "test_attr_two")
+
+				return metric
+			},
+			wantSeries: func() map[string]*prompb.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_hist"},
+					{Name: "attr", Value: "test_attr"},
+				}
+				labelsAnother := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_hist"},
+					{Name: "attr", Value: "test_attr_two"},
+				}
+
+				return map[string]*prompb.TimeSeries{
+					timeSeriesSignature(pmetric.MetricTypeExponentialHistogram.String(), &labels): {
+						Labels: labels,
+						Histograms: []prompb.Histogram{
+							{
+								Count:          &prompb.Histogram_CountInt{CountInt: 7},
+								Schema:         1,
+								ZeroThreshold:  defaultZeroThreshold,
+								ZeroCount:      &prompb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+								PositiveSpans:  []*prompb.BucketSpan{{Offset: 0, Length: 2}},
+								PositiveDeltas: []int64{4, -2},
+							},
+						},
+						Exemplars: []prompb.Exemplar{
+							{Value: 1},
+						},
+					},
+					timeSeriesSignature(pmetric.MetricTypeExponentialHistogram.String(), &labelsAnother): {
+						Labels: labelsAnother,
+						Histograms: []prompb.Histogram{
+							{
+								Count:          &prompb.Histogram_CountInt{CountInt: 4},
+								Schema:         1,
+								ZeroThreshold:  defaultZeroThreshold,
+								ZeroCount:      &prompb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+								NegativeSpans:  []*prompb.BucketSpan{{Offset: 0, Length: 3}},
+								NegativeDeltas: []int64{4, -2, -1},
+							},
+						},
+						Exemplars: []prompb.Exemplar{
+							{Value: 2},
+						},
+					},
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := tt.metric()
+
+			gotSeries := make(map[string]*prompb.TimeSeries)
+
+			for x := 0; x < metric.ExponentialHistogram().DataPoints().Len(); x++ {
+				err := addSingleExponentialHistogramDataPoint(
+					prometheustranslator.BuildPromCompliantName(metric, ""),
+					metric.ExponentialHistogram().DataPoints().At(x),
+					pcommon.NewResource(),
+					Settings{},
+					gotSeries,
+				)
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantSeries(), gotSeries)
+		})
+	}
+}

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -22,6 +22,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/multierr"
+
+	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
 )
 
 type Settings struct {
@@ -68,7 +70,6 @@ func FromMetrics(md pmetric.Metrics, settings Settings) (tsMap map[string]*promp
 					if err := addNumberDataPointSlice(dataPoints, resource, metric, settings, tsMap); err != nil {
 						errs = multierr.Append(errs, err)
 					}
-
 				case pmetric.MetricTypeHistogram:
 					dataPoints := metric.Histogram().DataPoints()
 					if dataPoints.Len() == 0 {
@@ -76,6 +77,24 @@ func FromMetrics(md pmetric.Metrics, settings Settings) (tsMap map[string]*promp
 					}
 					for x := 0; x < dataPoints.Len(); x++ {
 						addSingleHistogramDataPoint(dataPoints.At(x), resource, metric, settings, tsMap)
+					}
+				case pmetric.MetricTypeExponentialHistogram:
+					dataPoints := metric.ExponentialHistogram().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+					}
+					name := prometheustranslator.BuildPromCompliantName(metric, settings.Namespace)
+					for x := 0; x < dataPoints.Len(); x++ {
+						errs = multierr.Append(
+							errs,
+							addSingleExponentialHistogramDataPoint(
+								name,
+								dataPoints.At(x),
+								resource,
+								settings,
+								tsMap,
+							),
+						)
 					}
 				case pmetric.MetricTypeSummary:
 					dataPoints := metric.Summary().DataPoints()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Support conversion of OTel Exponential Histogram to Prometheus Native Histogram.

`pmetric.ExponentialHistogramDataPoint` translates to `prompb.Histogram` as follows:

- Exp. `Scale` -> Nat. `Schema`: histogram is dropped if `Scale` -4 < and > 8.
 TODO: We can potentially downscale hist to 8 if `Scale` > 8? (as a separate PR)  
- Exp. `Count` ->  Nat. `Count`: if `Flags().NoRecordedValue()` is false
- Exp. `Sum_` -> Nat. `Sum`: if it `Sum` is set and `Flags().NoRecordedValue()` is false
- Exp. `TimeUnixNano` -> Nat. `Timestamp`:  `TimeUnixNano` ns converted  `Timestamp` ms
- Exp. `ZeroCount` -> Nat. `ZeroCount`
- Nat. `ZeroThreshold` is set to the default value `1e-128`, once https://github.com/open-telemetry/opentelemetry-proto/pull/441 is merged, we can use Exp. `ZeroThreshold` to set the value.
- Exp. `Positive` -> Nat. `PositiveSpans` and Nat. `PositiveDeltas`.
- Exp. `Negative` -> Nat. `NegativeSpans` and Nat. `NegativeDeltas`.
- Exp. `Min_` and `Max_` are not used.
- Exp. `StartTimeUnixNano` is not used.

Exp. `Exemplars`, `Labels`, and `ExponentialHistogramDataPoint` will be translated to native hist data structures and will make up one or more `prompb.TimeSeries`. 

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16207

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests in `pkg/transalator/prometheusremote` and `exporter/prometheusremotewriteexporter `

**Documentation:** <Describe the documentation added.>

https://github.com/open-telemetry/opentelemetry-specification/pull/3079
