### PR TITLE
[pkg/translator/prw] Remove deprecated in 0.45 `MetricsToPRW`.

### DIFF
--- a/.chloggen/prw-remove-deprecated-method.yaml
+++ b/.chloggen/prw-remove-deprecated-method.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/translator/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated in `0.45` `MetricsToPRW` function.
+
+# One or more tracking issues related to the change
+issues: [17446]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/translator/prometheusremotewrite/go.mod
+++ b/pkg/translator/prometheusremotewrite/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/prometheus v0.41.0
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector/consumer v0.69.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rc3.0.20230109164642-7d168dd20efd
 	go.opentelemetry.io/collector/semconv v0.69.0
 	go.uber.org/multierr v1.9.0

--- a/pkg/translator/prometheusremotewrite/go.sum
+++ b/pkg/translator/prometheusremotewrite/go.sum
@@ -40,9 +40,6 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.opentelemetry.io/collector v0.69.0 h1:Uc/bFNtNroTlEPoQywBkngDx0GbHCF+GNPTA1PLV9S8=
-go.opentelemetry.io/collector/consumer v0.69.0 h1:wrj3t+jTZ6kyUk/6lVQ56VslWIWPCri2KoWKv1JcbTw=
-go.opentelemetry.io/collector/consumer v0.69.0/go.mod h1:xpMylJopbVVmQcF7XE0RATW3cC/B6PfAQtXkLIdlJsA=
 go.opentelemetry.io/collector/featuregate v0.69.0 h1:TI6zcWszEbAP1UGyVIWFDKoltaPx4VprjGbd5jsDBj8=
 go.opentelemetry.io/collector/featuregate v0.69.0/go.mod h1:tewuFKJYalWBU0bmNKg++MC1ipINXUr6szYzOw2p1GI=
 go.opentelemetry.io/collector/pdata v1.0.0-rc3.0.20230109164642-7d168dd20efd h1:Mv0AhUDD10YS9620bxXBf0zoTkQjwANcaqWJyxr88ks=

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -19,20 +19,10 @@ import (
 	"fmt"
 
 	"github.com/prometheus/prometheus/prompb"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/multierr"
 )
-
-// Deprecated: [0.45.0] use `prometheusremotewrite.FromMetrics`. It does not wrap the error as `NewPermanent`.
-func MetricsToPRW(namespace string, externalLabels map[string]string, md pmetric.Metrics) (map[string]*prompb.TimeSeries, int, error) {
-	tsMap, err := FromMetrics(md, Settings{Namespace: namespace, ExternalLabels: externalLabels})
-	if err != nil {
-		err = consumererror.NewPermanent(err)
-	}
-	return tsMap, md.MetricCount() - len(tsMap), err
-}
 
 type Settings struct {
 	Namespace         string


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Remove deprecated in `0.45` `MetricsToPRW` function form `pkg/translator/prometheusremotewrite`

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17446