### PR TITLE
[exporter/datadog] Fail config validation on empty endpoints

### DIFF
--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -31,8 +31,9 @@ import (
 )
 
 var (
-	errUnsetAPIKey = errors.New("api.key is not set")
-	errNoMetadata  = errors.New("only_metadata can't be enabled when host_metadata::enabled = false or host_metadata::hostname_source != first_resource")
+	errUnsetAPIKey   = errors.New("api.key is not set")
+	errNoMetadata    = errors.New("only_metadata can't be enabled when host_metadata::enabled = false or host_metadata::hostname_source != first_resource")
+	errEmptyEndpoint = errors.New("endpoint cannot be empty")
 )
 
 const (
@@ -498,5 +499,11 @@ func (c *Config) Unmarshal(configMap *confmap.Conf) error {
 	if !configMap.IsSet("logs::endpoint") {
 		c.Logs.TCPAddr.Endpoint = fmt.Sprintf("https://http-intake.logs.%s", c.API.Site)
 	}
+
+	// Return an error if an endpoint is explicitly set to ""
+	if c.Metrics.TCPAddr.Endpoint == "" || c.Traces.TCPAddr.Endpoint == "" || c.Logs.TCPAddr.Endpoint == "" {
+		return errEmptyEndpoint
+	}
+
 	return nil
 }

--- a/exporter/datadogexporter/config_test.go
+++ b/exporter/datadogexporter/config_test.go
@@ -211,6 +211,33 @@ func TestUnmarshal(t *testing.T) {
 			}),
 			err: "\"metrics::instrumentation_library_metadata_as_tags\" was removed in favor of \"metrics::instrumentation_scope_as_tags\". See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11135",
 		},
+		{
+			name: "Empty metric endpoint",
+			configMap: confmap.NewFromStringMap(map[string]interface{}{
+				"metrics": map[string]interface{}{
+					"endpoint": "",
+				},
+			}),
+			err: errEmptyEndpoint.Error(),
+		},
+		{
+			name: "Empty trace endpoint",
+			configMap: confmap.NewFromStringMap(map[string]interface{}{
+				"traces": map[string]interface{}{
+					"endpoint": "",
+				},
+			}),
+			err: errEmptyEndpoint.Error(),
+		},
+		{
+			name: "Empty log endpoint",
+			configMap: confmap.NewFromStringMap(map[string]interface{}{
+				"logs": map[string]interface{}{
+					"endpoint": "",
+				},
+			}),
+			err: errEmptyEndpoint.Error(),
+		},
 	}
 
 	f := NewFactory()

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -32,14 +32,12 @@ func CreateAPIClient(buildInfo component.BuildInfo, endpoint string, settings ex
 	configuration.UserAgent = UserAgent(buildInfo)
 	configuration.HTTPClient = NewHTTPClient(settings, insecureSkipVerify)
 	configuration.Compress = true
-	if endpoint != "" {
-		configuration.Servers = datadog.ServerConfigurations{
-			{
-				URL:         "{site}",
-				Description: "No description provided",
-				Variables:   map[string]datadog.ServerVariable{"site": {DefaultValue: endpoint}},
-			},
-		}
+	configuration.Servers = datadog.ServerConfigurations{
+		{
+			URL:         "{site}",
+			Description: "No description provided",
+			Variables:   map[string]datadog.ServerVariable{"site": {DefaultValue: endpoint}},
+		},
 	}
 	return datadog.NewAPIClient(configuration)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Return an error if an endpoint is explicitly set to empty strings. Follow up of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16545#discussion_r1061344497.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>