### PR TITLE
[chore] update makefile to fix update-otel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ include ./Makefile.Common
 RUN_CONFIG?=local/config.yaml
 CMD?=
 OTEL_VERSION=main
+OTEL_RC_VERSION=main
+OTEL_STABLE_VERSION=main
 
 BUILD_INFO_IMPORT_PATH=github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelcontribcore/internal/version
 VERSION=$(shell git describe --always --match "v[0-9]*" HEAD)


### PR DESCRIPTION
Adding the other 2 version variables to main, to ensure update-otel works without additional variables.

Signed-off-by: Alex Boten <aboten@lightstep.com>
