### PR TITLE
[exporter/clickhouse] Fix incorrect yaml keys

### DIFF
--- a/exporter/clickhouseexporter/README.md
+++ b/exporter/clickhouseexporter/README.md
@@ -264,8 +264,8 @@ exporters:
   clickhouse:
     dsn: tcp://127.0.0.1:9000/otel
     ttl_days: 3
-    logs_table: otel_logs
-    traces_table: otel_traces
+    logs_table_name: otel_logs
+    traces_table_name: otel_traces
     timeout: 5s
     retry_on_failure:
       enabled: true


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Change keys for `logs_table` and `traces_table`  to `logs_table_name` and `traces_table_name` as defined in [config.go](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/clickhouseexporter/config.go)
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>
No tracking issue - just a fix

**Testing:** <Describe what testing was performed and which tests were added.>
No testing was performed but you are able to verify `logs_table_name` and `traces_table_name` are both correct keys which should be used in config.go

**Documentation:** <Describe the documentation added.>
No documentation added