### PR TITLE
[exporter/datadog] Mark unrecoverable errors as permanent

### DIFF
--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -46,7 +46,7 @@ func CreateAPIClient(buildInfo component.BuildInfo, endpoint string, settings ex
 func ValidateAPIKey(ctx context.Context, apiKey string, logger *zap.Logger, apiClient *datadog.APIClient) error {
 	logger.Info("Validating API key.")
 	authAPI := datadogV1.NewAuthenticationApi(apiClient)
-	resp, _, err := authAPI.Validate(GetRequestContext(ctx, apiKey))
+	resp, httpresp, err := authAPI.Validate(GetRequestContext(ctx, apiKey))
 	if err == nil && resp.Valid != nil && *resp.Valid {
 		logger.Info("API key validation successful.")
 		return nil
@@ -56,7 +56,7 @@ func ValidateAPIKey(ctx context.Context, apiKey string, logger *zap.Logger, apiC
 		return nil
 	}
 	logger.Warn(ErrInvalidAPI.Error())
-	return ErrInvalidAPI
+	return WrapError(ErrInvalidAPI, httpresp)
 }
 
 // GetRequestContext creates a new context with API key for DatadogV2 requests

--- a/exporter/datadogexporter/internal/clientutil/error_converter.go
+++ b/exporter/datadogexporter/internal/clientutil/error_converter.go
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/clientutil"
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+// WrapError wraps an error to a permanent consumer error that won't be retried if the http response code is non-retriable.
+func WrapError(err error, resp *http.Response) error {
+	if err == nil || !isNonRetriable(resp) {
+		return err
+	}
+	return consumererror.NewPermanent(err)
+}
+
+func isNonRetriable(resp *http.Response) bool {
+	return resp.StatusCode == 400 || resp.StatusCode == 404 || resp.StatusCode == 413 || resp.StatusCode == 403
+}

--- a/exporter/datadogexporter/internal/clientutil/error_converter_test.go
+++ b/exporter/datadogexporter/internal/clientutil/error_converter_test.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/clientutil"
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+func TestWrapError(t *testing.T) {
+	respOK := http.Response{StatusCode: 200}
+	respRetriable := http.Response{StatusCode: 402}
+	respNonRetriable := http.Response{StatusCode: 404}
+	err := fmt.Errorf("Test error")
+	assert.False(t, consumererror.IsPermanent(WrapError(err, &respOK)))
+	assert.False(t, consumererror.IsPermanent(WrapError(err, &respRetriable)))
+	assert.True(t, consumererror.IsPermanent(WrapError(err, &respNonRetriable)))
+	assert.False(t, consumererror.IsPermanent(WrapError(nil, &respNonRetriable)))
+}

--- a/exporter/datadogexporter/internal/clientutil/retrier_test.go
+++ b/exporter/datadogexporter/internal/clientutil/retrier_test.go
@@ -17,9 +17,12 @@ package clientutil // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
@@ -46,4 +49,18 @@ func TestDoWithRetries(t *testing.T) {
 	)
 	err = retrier.DoWithRetries(ctx, func(context.Context) error { return errors.New("action failed") })
 	require.Error(t, err)
+	assert.Greater(t, retrier.retryNum, int64(0))
+}
+
+func TestNoRetriesOnPermanentError(t *testing.T) {
+	scrubber := scrub.NewScrubber()
+	retrier := NewRetrier(zap.NewNop(), exporterhelper.NewDefaultRetrySettings(), scrubber)
+	ctx := context.Background()
+	respNonRetriable := http.Response{StatusCode: 404}
+
+	err := retrier.DoWithRetries(ctx, func(context.Context) error {
+		return WrapError(fmt.Errorf("test"), &respNonRetriable)
+	})
+	require.Error(t, err)
+	assert.Equal(t, retrier.retryNum, int64(0))
 }

--- a/exporter/datadogexporter/internal/metadata/metadata.go
+++ b/exporter/datadogexporter/internal/metadata/metadata.go
@@ -206,7 +206,7 @@ func pushMetadata(pcfg PusherConfig, params exporter.CreateSettings, metadata *H
 func pushMetadataWithRetry(retrier *clientutil.Retrier, params exporter.CreateSettings, pcfg PusherConfig, hostMetadata *HostMetadata) {
 	params.Logger.Debug("Sending host metadata payload", zap.Any("payload", hostMetadata))
 
-	err := retrier.DoWithRetries(context.Background(), func(context.Context) error {
+	_, err := retrier.DoWithRetries(context.Background(), func(context.Context) error {
 		return pushMetadata(pcfg, params, hostMetadata)
 	})
 

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -223,14 +223,12 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pmetric.Metr
 		err = nil
 		if len(ms) > 0 {
 			exp.params.Logger.Debug("exporting native Datadog payload", zap.Any("metric", ms))
-			err = multierr.Append(
-				err,
-				exp.retrier.DoWithRetries(ctx, func(context.Context) error {
-					ctx = clientutil.GetRequestContext(ctx, string(exp.cfg.API.Key))
-					_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: ms})
-					return clientutil.WrapError(merr, httpresp)
-				}),
-			)
+			_, experr := exp.retrier.DoWithRetries(ctx, func(context.Context) error {
+				ctx = clientutil.GetRequestContext(ctx, string(exp.cfg.API.Key))
+				_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: ms})
+				return clientutil.WrapError(merr, httpresp)
+			})
+			err = multierr.Append(err, experr)
 		}
 	} else {
 		var ms []zorkian.Metric
@@ -240,23 +238,19 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pmetric.Metr
 		err = nil
 		if len(ms) > 0 {
 			exp.params.Logger.Debug("exporting Zorkian Datadog payload", zap.Any("metric", ms))
-			err = multierr.Append(
-				err,
-				exp.retrier.DoWithRetries(ctx, func(context.Context) error {
-					return exp.client.PostMetrics(ms)
-				}),
-			)
+			_, experr := exp.retrier.DoWithRetries(ctx, func(context.Context) error {
+				return exp.client.PostMetrics(ms)
+			})
+			err = multierr.Append(err, experr)
 		}
 	}
 
 	if len(sl) > 0 {
 		exp.params.Logger.Debug("exporting sketches payload", zap.Any("sketches", sl))
-		err = multierr.Append(
-			err,
-			exp.retrier.DoWithRetries(ctx, func(ctx context.Context) error {
-				return exp.pushSketches(ctx, sl)
-			}),
-		)
+		_, experr := exp.retrier.DoWithRetries(ctx, func(ctx context.Context) error {
+			return exp.pushSketches(ctx, sl)
+		})
+		err = multierr.Append(err, experr)
 	}
 
 	if len(sp) > 0 {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Add a helper function that wraps unrecoverable errors with consumererror.Permanent so that they are not retried.

Right now the Datadog metrics exporter retries on all errors, but there are certain response status code that indicates the error is unrecoverable and thus shouldn't be retried: https://github.com/DataDog/datadog-agent/blob/89b27708ab6872a0208fae3b98ccf70a8bac6b79/pkg/forwarder/transaction/transaction.go#L337-L354.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>