### PR TITLE
[receiver/statsd] Fix statsd server start order

### DIFF
--- a/.chloggen/fix_statsd_start.yaml
+++ b/.chloggen/fix_statsd_start.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the statsdreceiver initialization to only create a server when `Start` is called.
+
+# One or more tracking issues related to the change
+issues: [17402]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -59,11 +59,6 @@ func New(
 		config.NetAddr.Endpoint = "localhost:8125"
 	}
 
-	server, err := buildTransportServer(config)
-	if err != nil {
-		return nil, err
-	}
-
 	rep, err := newReporter(set)
 	if err != nil {
 		return nil, err
@@ -73,7 +68,6 @@ func New(
 		settings:     set,
 		config:       &config,
 		nextConsumer: nextConsumer,
-		server:       server,
 		reporter:     rep,
 		parser:       &protocol.StatsDParser{},
 	}
@@ -93,9 +87,14 @@ func buildTransportServer(config Config) (transport.Server, error) {
 // Start starts a UDP server that can process StatsD messages.
 func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 	ctx, r.cancel = context.WithCancel(ctx)
+	server, err := buildTransportServer(*r.config)
+	if err != nil {
+		return err
+	}
+	r.server = server
 	var transferChan = make(chan string, 10)
 	ticker := time.NewTicker(r.config.AggregationInterval)
-	err := r.parser.Initialize(r.config.EnableMetricType, r.config.IsMonotonicCounter, r.config.TimerHistogramMapping)
+	err = r.parser.Initialize(r.config.EnableMetricType, r.config.IsMonotonicCounter, r.config.TimerHistogramMapping)
 	if err != nil {
 		return err
 	}

--- a/receiver/statsdreceiver/receiver_test.go
+++ b/receiver/statsdreceiver/receiver_test.go
@@ -55,6 +55,25 @@ func Test_statsdreceiver_New(t *testing.T) {
 			},
 			wantErr: component.ErrNilNextConsumer,
 		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(receivertest.NewNopCreateSettings(), tt.args.config, tt.args.nextConsumer)
+			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}
+
+func Test_statsdreceiver_Start(t *testing.T) {
+	type args struct {
+		config       Config
+		nextConsumer consumer.Metrics
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
 		{
 			name: "unsupported transport",
 			args: args{
@@ -71,7 +90,9 @@ func Test_statsdreceiver_New(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := New(receivertest.NewNopCreateSettings(), tt.args.config, tt.args.nextConsumer)
+			receiver, err := New(receivertest.NewNopCreateSettings(), tt.args.config, tt.args.nextConsumer)
+			require.NoError(t, err)
+			err = receiver.Start(context.Background(), componenttest.NewNopHost())
 			assert.Equal(t, tt.wantErr, err)
 		})
 	}


### PR DESCRIPTION
**Description:**
Fix the statsdreceiver initialization to only create a server when `Start` is called.

**Link to tracking Issue:**
#17402 

**Testing:**
Moved unit tests around.
