### PR TITLE
[receiver/carbonreceiver] fix carbon receiver server start order

### DIFF
--- a/.chloggen/change_carbon_receiver_start_order.yaml
+++ b/.chloggen/change_carbon_receiver_start_order.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: carbonreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Create the carbon receiver server when the `Start` method is called, and only close it if created.
+
+# One or more tracking issues related to the change
+issues: [17404]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** 
Create the carbon receiver server when the `Start` method is called, and only close it if created.

**Link to tracking Issue:** 
#17404 

**Testing:**
Unit tests.