### PR TITLE
[chore] deprecate signalfxexporter max_connections warning

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -243,7 +243,7 @@ exporters:
       dot.test: test
     realm: us1
     timeout: 5s
-    max_connections: 80
+    max_idle_conns: 80
 ```
 
 > :warning: When enabling the SignalFx receiver or exporter, configure both the `metrics` and `logs` pipelines.

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -48,6 +48,8 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	defaultCfg.TranslationRules = defaultTranslationRules
 
+	seventy := 70
+
 	tests := []struct {
 		id       component.ID
 		expected component.Config
@@ -59,14 +61,15 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(typeStr, "allsettings"),
 			expected: &Config{
-				AccessToken:    "testToken",
-				Realm:          "us1",
-				MaxConnections: 70,
+				AccessToken: "testToken",
+				Realm:       "us1",
 				HTTPClientSettings: confighttp.HTTPClientSettings{Timeout: 2 * time.Second,
 					Headers: map[string]configopaque.String{
 						"added-entry": "added value",
 						"dot.test":    "test",
 					},
+					MaxIdleConns:        &seventy,
+					MaxIdleConnsPerHost: &seventy,
 				},
 				RetrySettings: exporterhelper.RetrySettings{
 					Enabled:         true,

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -230,10 +230,9 @@ func (se *signalfxExporter) startLogs(_ context.Context, host component.Host) er
 func (se *signalfxExporter) createClient(host component.Host) (*http.Client, error) {
 	se.config.HTTPClientSettings.TLSSetting = se.config.IngestTLSSettings
 
-	if se.config.HTTPClientSettings.MaxIdleConns == nil {
+	if se.config.MaxConnections != 0 {
+		se.logger.Warn("You are using the deprecated `max_connections` option that will be removed in the next release; use `max_idle_conns` and `max_idle_conns_per_host` instead: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#advanced-configuration")
 		se.config.HTTPClientSettings.MaxIdleConns = &se.config.MaxConnections
-	}
-	if se.config.HTTPClientSettings.MaxIdleConnsPerHost == nil {
 		se.config.HTTPClientSettings.MaxIdleConnsPerHost = &se.config.MaxConnections
 	}
 	if se.config.HTTPClientSettings.IdleConnTimeout == nil {

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -230,9 +230,12 @@ func (se *signalfxExporter) startLogs(_ context.Context, host component.Host) er
 func (se *signalfxExporter) createClient(host component.Host) (*http.Client, error) {
 	se.config.HTTPClientSettings.TLSSetting = se.config.IngestTLSSettings
 
-	if se.config.MaxConnections != 0 {
-		se.logger.Warn("You are using the deprecated `max_connections` option that will be removed soon; use `max_idle_conns` and `max_idle_conns_per_host` instead: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#advanced-configuration")
+	if se.config.HTTPClientSettings.MaxIdleConns == nil && se.config.MaxConnections != 0 {
+		se.logger.Warn("You are using the deprecated `max_connections` option that will be removed soon; use `max_idle_conns` instead: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#advanced-configuration")
 		se.config.HTTPClientSettings.MaxIdleConns = &se.config.MaxConnections
+	}
+	if se.config.HTTPClientSettings.MaxIdleConnsPerHost == nil && se.config.MaxConnections != 0 {
+		se.logger.Warn("You are using the deprecated `max_connections` option that will be removed soon; use `max_idle_conns_per_host` instead: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#advanced-configuration")
 		se.config.HTTPClientSettings.MaxIdleConnsPerHost = &se.config.MaxConnections
 	}
 	if se.config.HTTPClientSettings.IdleConnTimeout == nil {

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -231,7 +231,7 @@ func (se *signalfxExporter) createClient(host component.Host) (*http.Client, err
 	se.config.HTTPClientSettings.TLSSetting = se.config.IngestTLSSettings
 
 	if se.config.MaxConnections != 0 {
-		se.logger.Warn("You are using the deprecated `max_connections` option that will be removed in the next release; use `max_idle_conns` and `max_idle_conns_per_host` instead: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#advanced-configuration")
+		se.logger.Warn("You are using the deprecated `max_connections` option that will be removed soon; use `max_idle_conns` and `max_idle_conns_per_host` instead: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#advanced-configuration")
 		se.config.HTTPClientSettings.MaxIdleConns = &se.config.MaxConnections
 		se.config.HTTPClientSettings.MaxIdleConnsPerHost = &se.config.MaxConnections
 	}

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -230,13 +230,14 @@ func (se *signalfxExporter) startLogs(_ context.Context, host component.Host) er
 func (se *signalfxExporter) createClient(host component.Host) (*http.Client, error) {
 	se.config.HTTPClientSettings.TLSSetting = se.config.IngestTLSSettings
 
-	if se.config.HTTPClientSettings.MaxIdleConns == nil && se.config.MaxConnections != 0 {
-		se.logger.Warn("You are using the deprecated `max_connections` option that will be removed soon; use `max_idle_conns` instead: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#advanced-configuration")
-		se.config.HTTPClientSettings.MaxIdleConns = &se.config.MaxConnections
-	}
-	if se.config.HTTPClientSettings.MaxIdleConnsPerHost == nil && se.config.MaxConnections != 0 {
-		se.logger.Warn("You are using the deprecated `max_connections` option that will be removed soon; use `max_idle_conns_per_host` instead: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#advanced-configuration")
-		se.config.HTTPClientSettings.MaxIdleConnsPerHost = &se.config.MaxConnections
+	if se.config.MaxConnections != 0 && (se.config.MaxIdleConns == nil || se.config.HTTPClientSettings.MaxIdleConnsPerHost == nil) {
+		se.logger.Warn("You are using the deprecated `max_connections` option that will be removed soon; use `max_idle_conns` and/or `max_idle_conns_per_host` instead: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#advanced-configuration")
+		if se.config.HTTPClientSettings.MaxIdleConns == nil {
+			se.config.HTTPClientSettings.MaxIdleConns = &se.config.MaxConnections
+		}
+		if se.config.HTTPClientSettings.MaxIdleConnsPerHost == nil {
+			se.config.HTTPClientSettings.MaxIdleConnsPerHost = &se.config.MaxConnections
+		}
 	}
 	if se.config.HTTPClientSettings.IdleConnTimeout == nil {
 		defaultIdleConnTimeout := 30 * time.Second

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -42,6 +42,8 @@ const (
 	stability = component.StabilityLevelBeta
 
 	defaultHTTPTimeout = time.Second * 5
+
+	defaultMaxConns = 100
 )
 
 // NewFactory creates a factory for SignalFx exporter.
@@ -56,17 +58,21 @@ func NewFactory() exporter.Factory {
 }
 
 func createDefaultConfig() component.Config {
+	maxConnCount := defaultMaxConns
 	return &Config{
-		RetrySettings:      exporterhelper.NewDefaultRetrySettings(),
-		QueueSettings:      exporterhelper.NewDefaultQueueSettings(),
-		HTTPClientSettings: confighttp.HTTPClientSettings{Timeout: defaultHTTPTimeout},
+		RetrySettings: exporterhelper.NewDefaultRetrySettings(),
+		QueueSettings: exporterhelper.NewDefaultQueueSettings(),
+		HTTPClientSettings: confighttp.HTTPClientSettings{
+			Timeout:             defaultHTTPTimeout,
+			MaxIdleConns:        &maxConnCount,
+			MaxIdleConnsPerHost: &maxConnCount,
+		},
 		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
 			AccessTokenPassthrough: true,
 		},
 		DeltaTranslationTTL:           3600,
 		Correlation:                   correlation.DefaultConfig(),
 		NonAlphanumericDimensionChars: "_-.",
-		MaxConnections:                100,
 	}
 }
 

--- a/exporter/signalfxexporter/testdata/config.yaml
+++ b/exporter/signalfxexporter/testdata/config.yaml
@@ -4,7 +4,8 @@ signalfx/allsettings:
   access_token: testToken
   realm: "us1"
   timeout: 2s
-  max_connections: 70
+  max_idle_conns: 70
+  max_idle_conns_per_host: 70
   sending_queue:
     enabled: true
     num_consumers: 2


### PR DESCRIPTION
**Description:**
Pendant to #16807, we now have a better way to set up the http client settings, but we need to finish deprecating the max_connections config option. This PR removes use of MaxConnections and adds a warning if it is explicitly used.

**Link to tracking Issue:**
#16807

**Testing:**
Tests pass.

**Documentation:**
No changes.