### PR TITLE
Fix: tracegen example docker-compose and documentation

### DIFF
--- a/examples/tracegen/README.md
+++ b/examples/tracegen/README.md
@@ -7,5 +7,5 @@ To build and run the demo, switch to this directory and run
 `docker-compose up`
 
 There will be an app continuously sending traces, open
-up `http://localhost:9411` or `http://localhost:16686` to search for the traces in the
-Zipkin or Jaeger UIs.
+up `http://localhost:16686` to search for the traces in the
+Jaeger UI.

--- a/examples/tracegen/docker-compose.yml
+++ b/examples/tracegen/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   tracegen:
     build:
-      context: ../../tracegen
+      context: ../../cmd/tracegen
     command:
       - -otlp-endpoint
       - otel-collector:4317


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fix tracegen example demo when running `docker-compose up` which yields error `unable to prepare context: path "../../tracegen" not found`. This works when the build context path is changed to `../../cmd/tracegen`.

**Link to tracking Issue:** <Issue number if applicable>
N/A

**Testing:** <Describe what testing was performed and which tests were added.>
Tested locally with `docker-compose up` like in the tracegen README.

**Documentation:** <Describe the documentation added.>
Documentation README was also updated to reference the missing Zipkin UI at `http://localhost:9411`.