### PR TITLE
[pkg/translator/prw] Export _created times series if possible.

### DIFF
--- a/.chloggen/create_create-time-series-prw.yaml
+++ b/.chloggen/create_create-time-series-prw.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Export `_created` metric for Summary, Histogram and Monotonic Sum metric points if `StartTimeUnixNano` is set.
+
+# One or more tracking issues related to the change
+issues: [17412, 12426]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/create_create-time-series-prw.yaml
+++ b/.chloggen/create_create-time-series-prw.yaml
@@ -14,3 +14,4 @@ issues: [17412, 12426]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext:
+  The export of tbe `_created` metric is configurable in the Prometheus remote write exporter. It is disabled by default.

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -50,6 +50,10 @@ The following settings can be optionally configured:
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `target_info`: customize `target_info` metric
   - `enabled` (default = true): If `enabled` is `true`, a `target_info` metric will be generated for each resource metric (see https://github.com/open-telemetry/opentelemetry-specification/pull/2381).
+- `export_created_metric`:
+  - `enabled` (default = false): If `enabled` is `true`, a `_created` metric is
+    exported for Summary, Histogram, and Monotonic Sum metric points if
+    `StartTimeUnixNano` is set.
 
 Example:
 

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -50,6 +50,12 @@ type Config struct {
 
 	// TargetInfo allows customizing the target_info metric
 	TargetInfo *TargetInfo `mapstructure:"target_info,omitempty"`
+
+	ExportCreatedMetric *ExportCreatedMetric `mapstructure:"export_created_metric,omitempty"`
+}
+
+type ExportCreatedMetric struct {
+	Enabled bool `mapstructure:"enabled"`
 }
 
 type TargetInfo struct {
@@ -93,6 +99,11 @@ func (cfg *Config) Validate() error {
 	if cfg.TargetInfo == nil {
 		cfg.TargetInfo = &TargetInfo{
 			Enabled: true,
+		}
+	}
+	if cfg.ExportCreatedMetric == nil {
+		cfg.ExportCreatedMetric = &ExportCreatedMetric{
+			Enabled: false,
 		}
 	}
 	return nil

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -51,10 +51,12 @@ type Config struct {
 	// TargetInfo allows customizing the target_info metric
 	TargetInfo *TargetInfo `mapstructure:"target_info,omitempty"`
 
-	ExportCreatedMetric *ExportCreatedMetric `mapstructure:"export_created_metric,omitempty"`
+	// CreatedMetric allows customizing creation of _created metrics
+	CreatedMetric *CreatedMetric `mapstructure:"export_created_metric,omitempty"`
 }
 
-type ExportCreatedMetric struct {
+type CreatedMetric struct {
+	// Enabled if true the _created metrics could be exported
 	Enabled bool `mapstructure:"enabled"`
 }
 
@@ -101,8 +103,8 @@ func (cfg *Config) Validate() error {
 			Enabled: true,
 		}
 	}
-	if cfg.ExportCreatedMetric == nil {
-		cfg.ExportCreatedMetric = &ExportCreatedMetric{
+	if cfg.CreatedMetric == nil {
+		cfg.CreatedMetric = &CreatedMetric{
 			Enabled: false,
 		}
 	}

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -82,7 +82,7 @@ func TestLoadConfig(t *testing.T) {
 				TargetInfo: &TargetInfo{
 					Enabled: true,
 				},
-				ExportCreatedMetric: &ExportCreatedMetric{Enabled: true},
+				CreatedMetric: &CreatedMetric{Enabled: true},
 			},
 		},
 		{

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -82,6 +82,7 @@ func TestLoadConfig(t *testing.T) {
 				TargetInfo: &TargetInfo{
 					Enabled: true,
 				},
+				ExportCreatedMetric: &ExportCreatedMetric{Enabled: true},
 			},
 		},
 		{

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -83,7 +83,7 @@ func newPRWExporter(cfg *Config, set exporter.CreateSettings) (*prwExporter, err
 			Namespace:           cfg.Namespace,
 			ExternalLabels:      sanitizedLabels,
 			DisableTargetInfo:   !cfg.TargetInfo.Enabled,
-			ExportCreatedMetric: cfg.ExportCreatedMetric.Enabled,
+			ExportCreatedMetric: cfg.CreatedMetric.Enabled,
 		},
 	}
 	if cfg.WAL == nil {

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -44,19 +44,17 @@ const maxBatchByteSize = 3000000
 
 // prwExporter converts OTLP metrics to Prometheus remote write TimeSeries and sends them to a remote endpoint.
 type prwExporter struct {
-	namespace         string
-	externalLabels    map[string]string
-	endpointURL       *url.URL
-	client            *http.Client
-	wg                *sync.WaitGroup
-	closeChan         chan struct{}
-	concurrency       int
-	userAgentHeader   string
-	clientSettings    *confighttp.HTTPClientSettings
-	settings          component.TelemetrySettings
-	disableTargetInfo bool
+	endpointURL     *url.URL
+	client          *http.Client
+	wg              *sync.WaitGroup
+	closeChan       chan struct{}
+	concurrency     int
+	userAgentHeader string
+	clientSettings  *confighttp.HTTPClientSettings
+	settings        component.TelemetrySettings
 
-	wal *prweWAL
+	wal              *prweWAL
+	exporterSettings prometheusremotewrite.Settings
 }
 
 // newPRWExporter initializes a new prwExporter instance and sets fields accordingly.
@@ -74,16 +72,19 @@ func newPRWExporter(cfg *Config, set exporter.CreateSettings) (*prwExporter, err
 	userAgentHeader := fmt.Sprintf("%s/%s", strings.ReplaceAll(strings.ToLower(set.BuildInfo.Description), " ", "-"), set.BuildInfo.Version)
 
 	prwe := &prwExporter{
-		namespace:         cfg.Namespace,
-		externalLabels:    sanitizedLabels,
-		endpointURL:       endpointURL,
-		wg:                new(sync.WaitGroup),
-		closeChan:         make(chan struct{}),
-		userAgentHeader:   userAgentHeader,
-		concurrency:       cfg.RemoteWriteQueue.NumConsumers,
-		clientSettings:    &cfg.HTTPClientSettings,
-		settings:          set.TelemetrySettings,
-		disableTargetInfo: !cfg.TargetInfo.Enabled,
+		endpointURL:     endpointURL,
+		wg:              new(sync.WaitGroup),
+		closeChan:       make(chan struct{}),
+		userAgentHeader: userAgentHeader,
+		concurrency:     cfg.RemoteWriteQueue.NumConsumers,
+		clientSettings:  &cfg.HTTPClientSettings,
+		settings:        set.TelemetrySettings,
+		exporterSettings: prometheusremotewrite.Settings{
+			Namespace:           cfg.Namespace,
+			ExternalLabels:      sanitizedLabels,
+			DisableTargetInfo:   !cfg.TargetInfo.Enabled,
+			ExportCreatedMetric: cfg.ExportCreatedMetric.Enabled,
+		},
 	}
 	if cfg.WAL == nil {
 		return prwe, nil
@@ -136,7 +137,7 @@ func (prwe *prwExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) er
 	case <-prwe.closeChan:
 		return errors.New("shutdown has been called")
 	default:
-		tsMap, err := prometheusremotewrite.FromMetrics(md, prometheusremotewrite.Settings{Namespace: prwe.namespace, ExternalLabels: prwe.externalLabels, DisableTargetInfo: prwe.disableTargetInfo})
+		tsMap, err := prometheusremotewrite.FromMetrics(md, prwe.exporterSettings)
 		if err != nil {
 			err = consumererror.NewPermanent(err)
 		}

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -460,7 +460,7 @@ func Test_PushMetrics(t *testing.T) {
 			name:               "intSum_case",
 			metrics:            intSumBatch,
 			reqTestFunc:        checkFunc,
-			expectedTimeSeries: 3,
+			expectedTimeSeries: 5,
 			httpResponseCode:   http.StatusAccepted,
 		},
 		{

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -53,7 +53,7 @@ func Test_NewPRWExporter(t *testing.T) {
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
-		ExportCreatedMetric: &ExportCreatedMetric{
+		CreatedMetric: &CreatedMetric{
 			Enabled: false,
 		},
 	}
@@ -148,7 +148,7 @@ func Test_Start(t *testing.T) {
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
-		ExportCreatedMetric: &ExportCreatedMetric{
+		CreatedMetric: &CreatedMetric{
 			Enabled: false,
 		},
 	}
@@ -657,7 +657,7 @@ func Test_PushMetrics(t *testing.T) {
 						TargetInfo: &TargetInfo{
 							Enabled: true,
 						},
-						ExportCreatedMetric: &ExportCreatedMetric{
+						CreatedMetric: &CreatedMetric{
 							Enabled: true,
 						},
 					}
@@ -844,7 +844,7 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
-		ExportCreatedMetric: &ExportCreatedMetric{
+		CreatedMetric: &CreatedMetric{
 			Enabled: false,
 		},
 	}

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -53,6 +53,9 @@ func Test_NewPRWExporter(t *testing.T) {
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
+		ExportCreatedMetric: &ExportCreatedMetric{
+			Enabled: false,
+		},
 	}
 	buildInfo := component.BuildInfo{
 		Description: "OpenTelemetry Collector",
@@ -125,9 +128,8 @@ func Test_NewPRWExporter(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			require.NotNil(t, prwe)
-			assert.NotNil(t, prwe.namespace)
+			assert.NotNil(t, prwe.exporterSettings)
 			assert.NotNil(t, prwe.endpointURL)
-			assert.NotNil(t, prwe.externalLabels)
 			assert.NotNil(t, prwe.closeChan)
 			assert.NotNil(t, prwe.wg)
 			assert.NotNil(t, prwe.userAgentHeader)
@@ -145,6 +147,9 @@ func Test_Start(t *testing.T) {
 		ExternalLabels:  map[string]string{},
 		TargetInfo: &TargetInfo{
 			Enabled: true,
+		},
+		ExportCreatedMetric: &ExportCreatedMetric{
+			Enabled: false,
 		},
 	}
 	buildInfo := component.BuildInfo{
@@ -652,6 +657,9 @@ func Test_PushMetrics(t *testing.T) {
 						TargetInfo: &TargetInfo{
 							Enabled: true,
 						},
+						ExportCreatedMetric: &ExportCreatedMetric{
+							Enabled: true,
+						},
 					}
 
 					if useWAL {
@@ -835,6 +843,9 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 		},
 		TargetInfo: &TargetInfo{
 			Enabled: true,
+		},
+		ExportCreatedMetric: &ExportCreatedMetric{
+			Enabled: false,
 		},
 	}
 

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -111,5 +111,8 @@ func createDefaultConfig() component.Config {
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
+		ExportCreatedMetric: &ExportCreatedMetric{
+			Enabled: false,
+		},
 	}
 }

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -111,7 +111,7 @@ func createDefaultConfig() component.Config {
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
-		ExportCreatedMetric: &ExportCreatedMetric{
+		CreatedMetric: &CreatedMetric{
 			Enabled: false,
 		},
 	}

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -19,6 +19,8 @@ prometheusremotewrite/2:
     key2: value2
   resource_to_telemetry_conversion:
     enabled: true
+  export_created_metric:
+    enabled: true
   remote_write_queue:
     queue_size: 2000
     num_consumers: 10

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -280,7 +280,7 @@ func addSingleNumberDataPoint(pt pmetric.NumberDataPoint, resource pcommon.Resou
 	addSample(tsMap, sample, labels, metric.Type().String())
 
 	// add _created time series if needed
-	if metric.Type() == pmetric.MetricTypeSum && metric.Sum().IsMonotonic() {
+	if settings.ExportCreatedMetric && isMonotonicSum(metric) {
 		startTimestamp := pt.StartTimestamp()
 		if startTimestamp != 0 {
 			createdLabels := createAttributes(
@@ -293,6 +293,10 @@ func addSingleNumberDataPoint(pt pmetric.NumberDataPoint, resource pcommon.Resou
 			addCreatedTimeSeriesIfNeeded(tsMap, createdLabels, startTimestamp, metric.Type().String())
 		}
 	}
+}
+
+func isMonotonicSum(metric pmetric.Metric) bool {
+	return metric.Type() == pmetric.MetricTypeSum && metric.Sum().IsMonotonic()
 }
 
 // addSingleHistogramDataPoint converts pt to 2 + min(len(ExplicitBounds), len(BucketCount)) + 1 samples. It
@@ -372,7 +376,7 @@ func addSingleHistogramDataPoint(pt pmetric.HistogramDataPoint, resource pcommon
 
 	// add _created time series if needed
 	startTimestamp := pt.StartTimestamp()
-	if startTimestamp != 0 {
+	if settings.ExportCreatedMetric && startTimestamp != 0 {
 		createdLabels := createAttributes(
 			resource,
 			pt.Attributes(),
@@ -520,7 +524,7 @@ func addSingleSummaryDataPoint(pt pmetric.SummaryDataPoint, resource pcommon.Res
 
 	// add _created time series if needed
 	startTimestamp := pt.StartTimestamp()
-	if startTimestamp != 0 {
+	if settings.ExportCreatedMetric && startTimestamp != 0 {
 		createdLabels := createAttributes(
 			resource,
 			pt.Attributes(),

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -44,7 +44,7 @@ const (
 	leStr         = "le"
 	quantileStr   = "quantile"
 	pInfStr       = "+Inf"
-	createdPrefix = "_created"
+	createdSuffix = "_created"
 	// maxExemplarRunes is the maximum number of UTF-8 exemplar characters
 	// according to the prometheus specification
 	// https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars
@@ -288,7 +288,7 @@ func addSingleNumberDataPoint(pt pmetric.NumberDataPoint, resource pcommon.Resou
 				pt.Attributes(),
 				settings.ExternalLabels,
 				nameStr,
-				name+createdPrefix,
+				name+createdSuffix,
 			)
 			addCreatedTimeSeriesIfNeeded(tsMap, createdLabels, startTimestamp, metric.Type().String())
 		}
@@ -382,7 +382,7 @@ func addSingleHistogramDataPoint(pt pmetric.HistogramDataPoint, resource pcommon
 			pt.Attributes(),
 			settings.ExternalLabels,
 			nameStr,
-			baseName+createdPrefix,
+			baseName+createdSuffix,
 		)
 		addCreatedTimeSeriesIfNeeded(tsMap, createdLabels, startTimestamp, metric.Type().String())
 	}
@@ -530,7 +530,7 @@ func addSingleSummaryDataPoint(pt pmetric.SummaryDataPoint, resource pcommon.Res
 			pt.Attributes(),
 			settings.ExternalLabels,
 			nameStr,
-			baseName+createdPrefix,
+			baseName+createdSuffix,
 		)
 		addCreatedTimeSeriesIfNeeded(tsMap, createdLabels, startTimestamp, metric.Type().String())
 	}

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -640,7 +640,7 @@ func TestAddSingleNumberDataPoint(t *testing.T) {
 					{Name: model.MetricNameLabel, Value: "test_sum"},
 				}
 				createdLabels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_sum" + createdPrefix},
+					{Name: model.MetricNameLabel, Value: "test_sum" + createdSuffix},
 				}
 				return map[string]*prompb.TimeSeries{
 					timeSeriesSignature(pmetric.MetricTypeSum.String(), &labels): {
@@ -760,7 +760,7 @@ func TestAddSingleSummaryDataPoint(t *testing.T) {
 					{Name: model.MetricNameLabel, Value: "test_summary" + countStr},
 				}
 				createdLabels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_summary" + createdPrefix},
+					{Name: model.MetricNameLabel, Value: "test_summary" + createdSuffix},
 				}
 				sumLabels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_summary" + sumStr},
@@ -869,7 +869,7 @@ func TestAddSingleHistogramDataPoint(t *testing.T) {
 					{Name: model.MetricNameLabel, Value: "test_hist" + countStr},
 				}
 				createdLabels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_hist" + createdPrefix},
+					{Name: model.MetricNameLabel, Value: "test_hist" + createdSuffix},
 				}
 				infLabels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_hist_bucket"},

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
@@ -608,6 +609,342 @@ func TestMostRecentTimestampInMetric(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			got := mostRecentTimestampInMetric(tc.input)
 			assert.Exactly(t, tc.expected, got)
+		})
+	}
+}
+
+func TestAddSingleNumberDataPoint(t *testing.T) {
+	ts := pcommon.Timestamp(time.Now().UnixNano())
+	tests := []struct {
+		name   string
+		metric func() pmetric.Metric
+		want   func() map[string]*prompb.TimeSeries
+	}{
+		{
+			name: "monotonic cumulative sum with start timestamp",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_sum")
+				metric.SetEmptySum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				metric.SetEmptySum().SetIsMonotonic(true)
+
+				dp := metric.Sum().DataPoints().AppendEmpty()
+				dp.SetDoubleValue(1)
+				dp.SetTimestamp(ts)
+				dp.SetStartTimestamp(ts)
+
+				return metric
+			},
+			want: func() map[string]*prompb.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_sum"},
+				}
+				createdLabels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_sum" + createdPrefix},
+				}
+				return map[string]*prompb.TimeSeries{
+					timeSeriesSignature(pmetric.MetricTypeSum.String(), &labels): {
+						Labels: labels,
+						Samples: []prompb.Sample{
+							{Value: 1, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+					timeSeriesSignature(pmetric.MetricTypeSum.String(), &createdLabels): {
+						Labels: createdLabels,
+						Samples: []prompb.Sample{
+							{Value: float64(convertTimeStamp(ts))},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "monotonic cumulative sum with no start time",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_sum")
+				metric.SetEmptySum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				metric.SetEmptySum().SetIsMonotonic(true)
+
+				dp := metric.Sum().DataPoints().AppendEmpty()
+				dp.SetTimestamp(ts)
+
+				return metric
+			},
+			want: func() map[string]*prompb.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_sum"},
+				}
+				return map[string]*prompb.TimeSeries{
+					timeSeriesSignature(pmetric.MetricTypeSum.String(), &labels): {
+						Labels: labels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "non-monotonic cumulative sum with start time",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_sum")
+				metric.SetEmptySum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				metric.SetEmptySum().SetIsMonotonic(false)
+
+				dp := metric.Sum().DataPoints().AppendEmpty()
+				dp.SetTimestamp(ts)
+
+				return metric
+			},
+			want: func() map[string]*prompb.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_sum"},
+				}
+				return map[string]*prompb.TimeSeries{
+					timeSeriesSignature(pmetric.MetricTypeSum.String(), &labels): {
+						Labels: labels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := tt.metric()
+
+			got := make(map[string]*prompb.TimeSeries)
+			for x := 0; x < metric.Sum().DataPoints().Len(); x++ {
+				addSingleNumberDataPoint(
+					metric.Sum().DataPoints().At(x),
+					pcommon.NewResource(),
+					metric,
+					Settings{},
+					got,
+				)
+			}
+
+			assert.Equal(t, tt.want(), got)
+		})
+	}
+}
+
+func TestAddSingleSummaryDataPoint(t *testing.T) {
+	ts := pcommon.Timestamp(time.Now().UnixNano())
+	tests := []struct {
+		name   string
+		metric func() pmetric.Metric
+		want   func() map[string]*prompb.TimeSeries
+	}{
+		{
+			name: "summary with start time",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_summary")
+				metric.SetEmptySummary()
+
+				dp := metric.Summary().DataPoints().AppendEmpty()
+				dp.SetTimestamp(ts)
+				dp.SetStartTimestamp(ts)
+
+				return metric
+			},
+			want: func() map[string]*prompb.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_summary" + countStr},
+				}
+				createdLabels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_summary" + createdPrefix},
+				}
+				sumLabels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_summary" + sumStr},
+				}
+				return map[string]*prompb.TimeSeries{
+					timeSeriesSignature(pmetric.MetricTypeSummary.String(), &labels): {
+						Labels: labels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+					timeSeriesSignature(pmetric.MetricTypeSummary.String(), &sumLabels): {
+						Labels: sumLabels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+					timeSeriesSignature(pmetric.MetricTypeSummary.String(), &createdLabels): {
+						Labels: createdLabels,
+						Samples: []prompb.Sample{
+							{Value: float64(convertTimeStamp(ts))},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "summary without start time",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_summary")
+				metric.SetEmptySummary()
+
+				dp := metric.Summary().DataPoints().AppendEmpty()
+				dp.SetTimestamp(ts)
+
+				return metric
+			},
+			want: func() map[string]*prompb.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_summary" + countStr},
+				}
+				sumLabels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_summary" + sumStr},
+				}
+				return map[string]*prompb.TimeSeries{
+					timeSeriesSignature(pmetric.MetricTypeSummary.String(), &labels): {
+						Labels: labels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+					timeSeriesSignature(pmetric.MetricTypeSummary.String(), &sumLabels): {
+						Labels: sumLabels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := tt.metric()
+
+			got := make(map[string]*prompb.TimeSeries)
+			for x := 0; x < metric.Summary().DataPoints().Len(); x++ {
+				addSingleSummaryDataPoint(
+					metric.Summary().DataPoints().At(x),
+					pcommon.NewResource(),
+					metric,
+					Settings{},
+					got,
+				)
+			}
+			assert.Equal(t, tt.want(), got)
+		})
+	}
+}
+
+func TestAddSingleHistogramDataPoint(t *testing.T) {
+	ts := pcommon.Timestamp(time.Now().UnixNano())
+	tests := []struct {
+		name   string
+		metric func() pmetric.Metric
+		want   func() map[string]*prompb.TimeSeries
+	}{
+		{
+			name: "histogram with start time",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_hist")
+				metric.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				pt := metric.Histogram().DataPoints().AppendEmpty()
+				pt.SetTimestamp(ts)
+				pt.SetStartTimestamp(ts)
+
+				return metric
+			},
+			want: func() map[string]*prompb.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_hist" + countStr},
+				}
+				createdLabels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_hist" + createdPrefix},
+				}
+				infLabels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_hist_bucket"},
+					{Name: model.BucketLabel, Value: "+Inf"},
+				}
+				return map[string]*prompb.TimeSeries{
+					timeSeriesSignature(pmetric.MetricTypeHistogram.String(), &infLabels): {
+						Labels: infLabels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+					timeSeriesSignature(pmetric.MetricTypeHistogram.String(), &labels): {
+						Labels: labels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+					timeSeriesSignature(pmetric.MetricTypeHistogram.String(), &createdLabels): {
+						Labels: createdLabels,
+						Samples: []prompb.Sample{
+							{Value: float64(convertTimeStamp(ts))},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "histogram without start time",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_hist")
+				metric.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				pt := metric.Histogram().DataPoints().AppendEmpty()
+				pt.SetTimestamp(ts)
+
+				return metric
+			},
+			want: func() map[string]*prompb.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_hist" + countStr},
+				}
+				infLabels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_hist_bucket"},
+					{Name: model.BucketLabel, Value: "+Inf"},
+				}
+				return map[string]*prompb.TimeSeries{
+					timeSeriesSignature(pmetric.MetricTypeHistogram.String(), &infLabels): {
+						Labels: infLabels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+					timeSeriesSignature(pmetric.MetricTypeHistogram.String(), &labels): {
+						Labels: labels,
+						Samples: []prompb.Sample{
+							{Value: 0, Timestamp: convertTimeStamp(ts)},
+						},
+					},
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := tt.metric()
+
+			got := make(map[string]*prompb.TimeSeries)
+			for x := 0; x < metric.Histogram().DataPoints().Len(); x++ {
+				addSingleHistogramDataPoint(
+					metric.Histogram().DataPoints().At(x),
+					pcommon.NewResource(),
+					metric,
+					Settings{},
+					got,
+				)
+			}
+			assert.Equal(t, tt.want(), got)
 		})
 	}
 }

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -723,7 +723,9 @@ func TestAddSingleNumberDataPoint(t *testing.T) {
 					metric.Sum().DataPoints().At(x),
 					pcommon.NewResource(),
 					metric,
-					Settings{},
+					Settings{
+						ExportCreatedMetric: true,
+					},
 					got,
 				)
 			}
@@ -831,7 +833,9 @@ func TestAddSingleSummaryDataPoint(t *testing.T) {
 					metric.Summary().DataPoints().At(x),
 					pcommon.NewResource(),
 					metric,
-					Settings{},
+					Settings{
+						ExportCreatedMetric: true,
+					},
 					got,
 				)
 			}
@@ -940,7 +944,9 @@ func TestAddSingleHistogramDataPoint(t *testing.T) {
 					metric.Histogram().DataPoints().At(x),
 					pcommon.NewResource(),
 					metric,
-					Settings{},
+					Settings{
+						ExportCreatedMetric: true,
+					},
 					got,
 				)
 			}

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -35,9 +35,10 @@ func MetricsToPRW(namespace string, externalLabels map[string]string, md pmetric
 }
 
 type Settings struct {
-	Namespace         string
-	ExternalLabels    map[string]string
-	DisableTargetInfo bool
+	Namespace           string
+	ExternalLabels      map[string]string
+	DisableTargetInfo   bool
+	ExportCreatedMetric bool
 }
 
 // FromMetrics converts pmetric.Metrics to prometheus remote write format.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Export `_created` metric for `Summary`, `Histogram`, and `Monotonic Sum` metric points if `StartTimeUnixNano` is set.

**Link to tracking Issue:** <Issue number if applicable>

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17412
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12426 

**Testing:** <Describe what testing was performed and which tests were added.>

Unit tests.

**Documentation:** <Describe the documentation added.>

It was already documented in the [spec](https://opentelemetry.io/docs/reference/specification/compatibility/prometheus_and_openmetrics/).