### PR TITLE
[internal/comparetest] Add IgnoreObservedTimespamp option to CompareLogs

### DIFF
--- a/internal/comparetest/compare_test.go
+++ b/internal/comparetest/compare_test.go
@@ -41,7 +41,7 @@ func (e expectation) validate(t *testing.T, err error) {
 func TestCompareMetrics(t *testing.T) {
 	tcs := []struct {
 		name           string
-		compareOptions []CompareOption // when no options are used
+		compareOptions []MetricsCompareOption
 		withoutOptions expectation
 		withOptions    expectation
 	}{
@@ -308,7 +308,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-data-point-value-double-mismatch",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreMetricValues(),
 			},
 			withoutOptions: expectation{
@@ -322,7 +322,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-data-point-value-int-mismatch",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreMetricValues(),
 			},
 			withoutOptions: expectation{
@@ -336,7 +336,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-subsequent-data-points-all",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreSubsequentDataPoints(),
 			},
 			withoutOptions: expectation{
@@ -349,7 +349,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-subsequent-data-points-one",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreSubsequentDataPoints("sum.one"),
 			},
 			withoutOptions: expectation{
@@ -362,7 +362,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-single-metric",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreMetricValues("sum.two"),
 			},
 			withoutOptions: expectation{
@@ -376,7 +376,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-global-attribute-value",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreMetricAttributeValue("hostname"),
 			},
 			withoutOptions: expectation{
@@ -396,7 +396,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-one-attribute-value",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreMetricAttributeValue("hostname", "gauge.one"),
 			},
 			withoutOptions: expectation{
@@ -420,7 +420,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-one-resource-attribute",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreResourceAttributeValue("node_id"),
 			},
 			withoutOptions: expectation{
@@ -437,7 +437,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-one-resource-attribute-multiple-resources",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreResourceAttributeValue("node_id"),
 			},
 			withoutOptions: expectation{
@@ -465,7 +465,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-each-attribute-value",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreMetricAttributeValue("hostname", "gauge.one", "sum.one"),
 			},
 			withoutOptions: expectation{
@@ -485,7 +485,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-attribute-set-collision",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreMetricAttributeValue("attribute.one"),
 			},
 			withoutOptions: expectation{
@@ -505,7 +505,7 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name: "ignore-attribute-set-collision-order",
-			compareOptions: []CompareOption{
+			compareOptions: []MetricsCompareOption{
 				IgnoreMetricAttributeValue("attribute.one"),
 			},
 			withoutOptions: expectation{
@@ -549,22 +549,24 @@ func TestCompareMetrics(t *testing.T) {
 
 func TestCompareLogs(t *testing.T) {
 	tcs := []struct {
-		name    string
-		wantErr expectation
+		name           string
+		compareOptions []LogsCompareOption
+		withoutOptions expectation
+		withOptions    expectation
 	}{
 		{
 			name: "logs-equal",
 		},
 		{
 			name: "logs-missing",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err:    errors.New("amount of ResourceLogs between Logs are not equal expected: 2, actual: 1"),
 				reason: "A missing resource should cause a failure",
 			},
 		},
 		{
 			name: "logs-resource-attributes-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("missing expected resource with attributes: map[testKey2:two]"),
 					errors.New("extra resource with attributes: map[testKey2:one]"),
@@ -574,42 +576,42 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-resource-instrumentation-library-extra",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err:    errors.New("number of instrumentation libraries does not match expected: 1, actual: 2"),
 				reason: "An extra instrumentation library should cause a failure.",
 			},
 		},
 		{
 			name: "logs-resource-instrumentation-library-missing",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err:    errors.New("number of instrumentation libraries does not match expected: 2, actual: 1"),
 				reason: "An missing instrumentation library should cause a failure.",
 			},
 		},
 		{
 			name: "logs-resource-instrumentation-library-name-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err:    errors.New("instrumentation library Name does not match expected: one, actual: two"),
 				reason: "An instrumentation library with a different name is a different library.",
 			},
 		},
 		{
 			name: "logs-resource-instrumentation-library-version-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err:    errors.New("instrumentation library Version does not match expected: 1.0, actual: 2.0"),
 				reason: "An instrumentation library with a different version is a different library.",
 			},
 		},
 		{
 			name: "logs-logrecords-missing",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err:    errors.New("number of log records does not match expected: 1, actual: 0"),
 				reason: "A missing log records should cause a failure",
 			},
 		},
 		{
 			name: "logs-logrecords-attributes-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log missing expected resource with attributes: map[testKey2:teststringvalue2 testKey3:teststringvalue3]"),
 					errors.New("log has extra record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2]"),
@@ -619,7 +621,7 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-logrecords-flag-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2], does not match expected"),
 					errors.New("log record Flags doesn't match expected: 1, actual: 2"),
@@ -629,7 +631,7 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-logrecords-droppedattributescount-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2], does not match expected"),
 					errors.New("log record DroppedAttributesCount doesn't match expected: 0, actual: 10"),
@@ -639,7 +641,7 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-logrecords-timestamp-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2], does not match expected"),
 					errors.New("log record Timestamp doesn't match expected: 11651379494838206464, actual: 11651379494838200000"),
@@ -649,7 +651,7 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-logrecords-observedtimestamp-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2], does not match expected"),
 					errors.New("log record ObservedTimestamp doesn't match expected: 11651379494838206464, actual: 11651379494838200000"),
@@ -659,7 +661,7 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-logrecords-severitynumber-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2], does not match expected"),
 					errors.New("log record SeverityNumber doesn't match expected: 9, actual: 1"),
@@ -669,7 +671,7 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-logrecords-severitytext-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2], does not match expected"),
 					errors.New("log record SeverityText doesn't match expected: TEST, actual: OPEN"),
@@ -679,7 +681,7 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-logrecords-traceid-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2], does not match expected"),
 					errors.New("log record TraceID doesn't match expected: [139 32 209 52 158 249 182 214 249 212 209 212 163 172 46 130], actual: [123 32 209 52 158 249 182 214 249 212 209 212 163 172 46 130]"),
@@ -689,7 +691,7 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-logrecords-spanid-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2], does not match expected"),
 					errors.New("log record SpanID doesn't match expected: [12 42 217 36 225 119 22 64], actual: [12 42 217 36 225 119 22 48]"),
@@ -699,7 +701,7 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "logs-logrecords-body-mismatch",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err: multierr.Combine(
 					errors.New("log record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2], does not match expected"),
 					errors.New("log record Body doesn't match expected: testscopevalue1, actual: testscopevalue2"),
@@ -709,9 +711,26 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name: "sort-unordered-log-slice",
-			wantErr: expectation{
+			withoutOptions: expectation{
 				err:    nil,
 				reason: "A log record body with wrong value should cause a failure",
+			},
+		},
+		{
+			name: "logs-ignore-observed-timestamp",
+			compareOptions: []LogsCompareOption{
+				IgnoreObservedTimestamp(),
+			},
+			withoutOptions: expectation{
+				err: multierr.Combine(
+					errors.New("log record with attributes: map[], does not match expected"),
+					errors.New("log record ObservedTimestamp doesn't match expected: 11651379494838206465, actual: 11651379494838206464"),
+				),
+				reason: "A log record body with wrong ObservedTimestamp should cause a failure",
+			},
+			withOptions: expectation{
+				err:    nil,
+				reason: "Using IgnoreObservedTimestamp option should mute failure caused by wrong ObservedTimestamp.",
 			},
 		},
 	}
@@ -725,7 +744,14 @@ func TestCompareLogs(t *testing.T) {
 			require.NoError(t, err)
 
 			err = CompareLogs(expected, actual)
-			tc.wantErr.validate(t, err)
+			tc.withoutOptions.validate(t, err)
+
+			if tc.compareOptions == nil {
+				return
+			}
+
+			err = CompareLogs(expected, actual, tc.compareOptions...)
+			tc.withOptions.validate(t, err)
 		})
 	}
 }

--- a/internal/comparetest/testdata/logs-ignore-observed-timestamp/actual.json
+++ b/internal/comparetest/testdata/logs-ignore-observed-timestamp/actual.json
@@ -1,0 +1,36 @@
+{
+    "resourceLogs": [
+        {
+            "resource": {
+                "attributes": [],
+                "droppedAttributesCount": 0
+            },
+            "scopeLogs": [
+                {
+                    "logRecords": [
+                        {
+                            "attributes": [],
+                            "body": {
+                                "stringValue": "test"
+                            },
+                            "droppedAttributesCount": 0,
+                            "observedTimeUnixNano": "11651379494838206465",
+                            "timeUnixNano": "11651379494838206464",
+                            "severityNumber": 9,
+                            "severityText": "TEST",
+                            "flags": 1,
+                            "spanId": "",
+                            "traceId": ""
+                        }
+                    ],
+                    "scope": {
+                        "name": "collector",
+                        "version": "v0.1.0"
+                    },
+                    "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
+        }
+    ]
+}

--- a/internal/comparetest/testdata/logs-ignore-observed-timestamp/expected.json
+++ b/internal/comparetest/testdata/logs-ignore-observed-timestamp/expected.json
@@ -1,0 +1,36 @@
+{
+    "resourceLogs": [
+        {
+            "resource": {
+                "attributes": [],
+                "droppedAttributesCount": 0
+            },
+            "scopeLogs": [
+                {
+                    "logRecords": [
+                        {
+                            "attributes": [],
+                            "body": {
+                                "stringValue": "test"
+                            },
+                            "droppedAttributesCount": 0,
+                            "observedTimeUnixNano": "11651379494838206464",
+                            "timeUnixNano": "11651379494838206464",
+                            "severityNumber": 9,
+                            "severityText": "TEST",
+                            "flags": 1,
+                            "spanId": "",
+                            "traceId": ""
+                        }
+                    ],
+                    "scope": {
+                        "name": "collector",
+                        "version": "v0.1.0"
+                    },
+                    "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
+        }
+    ]
+}

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -99,7 +99,7 @@ func TestScaperScrape(t *testing.T) {
 		expectedMetricGen func(t *testing.T) pmetric.Metrics
 		expectedErr       error
 		endpoint          string
-		compareOptions    []comparetest.CompareOption
+		compareOptions    []comparetest.MetricsCompareOption
 	}{
 		{
 			desc:             "Successful Collection",
@@ -111,7 +111,7 @@ func TestScaperScrape(t *testing.T) {
 				return expectedMetrics
 			},
 			expectedErr: nil,
-			compareOptions: []comparetest.CompareOption{
+			compareOptions: []comparetest.MetricsCompareOption{
 				comparetest.IgnoreMetricAttributeValue("http.url"),
 				comparetest.IgnoreMetricValues("httpcheck.duration"),
 			},
@@ -126,7 +126,7 @@ func TestScaperScrape(t *testing.T) {
 				return expectedMetrics
 			},
 			expectedErr: nil,
-			compareOptions: []comparetest.CompareOption{
+			compareOptions: []comparetest.MetricsCompareOption{
 				comparetest.IgnoreMetricAttributeValue("http.url"),
 				comparetest.IgnoreMetricValues("httpcheck.duration"),
 			},
@@ -141,7 +141,7 @@ func TestScaperScrape(t *testing.T) {
 				return expectedMetrics
 			},
 			expectedErr: nil,
-			compareOptions: []comparetest.CompareOption{
+			compareOptions: []comparetest.MetricsCompareOption{
 				comparetest.IgnoreMetricValues("httpcheck.duration"),
 				comparetest.IgnoreMetricAttributeValue("error.message"),
 			},


### PR DESCRIPTION
This PR adds the ability to provide compare option for logs. The first option is to ignore the observed timestamp that is needed in AWS Cloud Watch Receiver tests.