### PR TITLE
[internal/coreinternal/pdatautil] Write key prefix in MapHash function

### DIFF
--- a/internal/comparetest/metrics_test.go
+++ b/internal/comparetest/metrics_test.go
@@ -429,12 +429,12 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: expectation{
 				err: multierr.Combine(
-					errors.New("missing expected resource with attributes: map[namespace:BB903-test node_id:BB903-expected]"),
 					errors.New("missing expected resource with attributes: map[namespace:BB904-test node_id:BB904-expected]"),
 					errors.New("missing expected resource with attributes: map[namespace:BB902-test node_id:BB902-expected]"),
+					errors.New("missing expected resource with attributes: map[namespace:BB903-test node_id:BB903-expected]"),
+					errors.New("extra resource with attributes: map[namespace:BB904-test node_id:BB904-actual]"),
 					errors.New("extra resource with attributes: map[namespace:BB903-test node_id:BB903-actual]"),
 					errors.New("extra resource with attributes: map[namespace:BB902-test node_id:BB902-actual]"),
-					errors.New("extra resource with attributes: map[namespace:BB904-test node_id:BB904-actual]"),
 				),
 				reason: "An unpredictable resource attribute will cause failures if not ignored.",
 			},

--- a/internal/coreinternal/pdatautil/map.go
+++ b/internal/coreinternal/pdatautil/map.go
@@ -25,6 +25,7 @@ import (
 )
 
 var (
+	keyPrefix       = []byte{'\xf4'}
 	valEmpty        = []byte{'\xf5'}
 	valBytesPrefix  = []byte{'\xf6'}
 	valStrPrefix    = []byte{'\xf7'}
@@ -55,6 +56,7 @@ func writeMapHash(h hash.Hash, m pcommon.Map) {
 	sort.Strings(keys)
 	for _, k := range keys {
 		v, _ := m.Get(k)
+		h.Write(keyPrefix)
 		h.Write([]byte(k))
 		writeValueHash(h, v)
 	}

--- a/internal/coreinternal/pdatautil/map_test.go
+++ b/internal/coreinternal/pdatautil/map_test.go
@@ -28,58 +28,54 @@ func TestMapHash_Equal(t *testing.T) {
 		equal bool
 	}{
 		{
-			name: "different_keys",
+			name: "different_maps",
 			maps: func() []pcommon.Map {
-				m := []pcommon.Map{pcommon.NewMap(), pcommon.NewMap()}
-				m[0].PutStr("k", "v1")
-				m[1].PutStr("k1", "v1")
-				return m
-			}(),
-			equal: false,
-		},
-		{
-			name: "different_values",
-			maps: func() []pcommon.Map {
-				m := make([]pcommon.Map, 26)
+				m := make([]pcommon.Map, 29)
 				for i := 0; i < len(m); i++ {
 					m[i] = pcommon.NewMap()
 				}
 
 				m[1].PutStr("k", "")
 				m[2].PutStr("k", "v")
-				m[3].PutBool("k", false)
-				m[4].PutBool("k", true)
-				m[5].PutInt("k", 0)
-				m[6].PutInt("k", 1)
-				m[7].PutDouble("k", 0)
-				m[8].PutDouble("k", 1)
-				m[9].PutEmpty("k")
+				m[3].PutStr("k1", "v1")
+				m[4].PutBool("k", false)
+				m[5].PutBool("k", true)
+				m[6].PutInt("k", 0)
+				m[7].PutInt("k", 1)
+				m[8].PutDouble("k", 0)
+				m[9].PutDouble("k", 1)
+				m[10].PutEmpty("k")
 
-				m[10].PutEmptySlice("k")
-				m[11].PutEmptySlice("k").AppendEmpty()
-				m[12].PutEmptySlice("k").AppendEmpty().SetStr("")
-				m[13].PutEmptySlice("k").AppendEmpty().SetStr("v")
-				sl1 := m[14].PutEmptySlice("k")
+				m[11].PutStr("k1", "val")
+				m[11].PutStr("k2", "val")
+				m[12].PutStr("k1", "va")
+				m[12].PutStr("lk2", "val")
+
+				m[13].PutEmptySlice("k")
+				m[14].PutEmptySlice("k").AppendEmpty()
+				m[15].PutEmptySlice("k").AppendEmpty().SetStr("")
+				m[16].PutEmptySlice("k").AppendEmpty().SetStr("v")
+				sl1 := m[17].PutEmptySlice("k")
 				sl1.AppendEmpty().SetStr("v1")
 				sl1.AppendEmpty().SetStr("v2")
-				sl2 := m[15].PutEmptySlice("k")
+				sl2 := m[18].PutEmptySlice("k")
 				sl2.AppendEmpty().SetStr("v2")
 				sl2.AppendEmpty().SetStr("v1")
 
-				m[16].PutEmptyBytes("k")
-				m[17].PutEmptyBytes("k").FromRaw([]byte{0})
-				m[18].PutEmptyBytes("k").FromRaw([]byte{1})
+				m[19].PutEmptyBytes("k")
+				m[20].PutEmptyBytes("k").FromRaw([]byte{0})
+				m[21].PutEmptyBytes("k").FromRaw([]byte{1})
 
-				m[19].PutEmptyMap("k")
-				m[20].PutEmptyMap("k").PutStr("k", "")
-				m[21].PutEmptyMap("k").PutBool("k", false)
-				m[22].PutEmptyMap("k").PutEmptyMap("")
-				m[23].PutEmptyMap("k").PutEmptyMap("k")
+				m[22].PutEmptyMap("k")
+				m[23].PutEmptyMap("k").PutStr("k", "")
+				m[24].PutEmptyMap("k").PutBool("k", false)
+				m[25].PutEmptyMap("k").PutEmptyMap("")
+				m[26].PutEmptyMap("k").PutEmptyMap("k")
 
-				m[24].PutStr("k1", "v1")
-				m[24].PutStr("k2", "v2")
-				m[25].PutEmptyMap("k0").PutStr("k1", "v1")
-				m[25].PutStr("k2", "v2")
+				m[27].PutStr("k1", "v1")
+				m[27].PutStr("k2", "v2")
+				m[28].PutEmptyMap("k0").PutStr("k1", "v1")
+				m[28].PutStr("k2", "v2")
 
 				return m
 			}(),


### PR DESCRIPTION
Write a key prefix to avoid collisions with embedded maps and slices in some rare cases

This is taken from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17169 but unrelated to the PR comments.