### PR TITLE
[chore] [receiver/snmp] fix typo in a README link

### DIFF
--- a/receiver/snmpreceiver/README.md
+++ b/receiver/snmpreceiver/README.md
@@ -241,5 +241,5 @@ receivers:
 
 The full list of settings exposed for this receiver are documented [here](./config.go) with detailed sample configurations [here](./testdata/config.yaml).
 
-[alpha]: https://github.com/open-telemetry/opentelemetry-collector#development
+[alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
Fix typo in README link.