### PR TITLE
[extension/httpforwarder] Promote as stable

### DIFF
--- a/.chloggen/promote-httpforwarder-stable.yaml
+++ b/.chloggen/promote-httpforwarder-stable.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: httpforwarder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote extension httpforwarder as a stable component
+
+# One or more tracking issues related to the change
+issues: [17435]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/extension/httpforwarder/README.md
+++ b/extension/httpforwarder/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |           |
 | ------------------------ |-----------|
-| Stability                | [beta]    |
+| Stability                | [stable]  |
 | Distributions            | [contrib] |
 
 This extension accepts HTTP requests, optionally adds headers to them and forwards them.
@@ -39,5 +39,5 @@ The following settings can be optionally configured:
 The full list of settings exposed for this exporter are documented [here](config.go)
 with detailed sample configurations [here](testdata/config.yaml).
 
-[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
+[stable]:https://github.com/open-telemetry/opentelemetry-collector#stable
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
**Description:** 
Promote extension httpforwarder as a stable component

**Link to tracking Issue:**
#17435


**Documentation:**
Updated README.
