### PR TITLE
[chore] make TestReceiveTracesBatches more resilient

### DIFF
--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -454,10 +454,8 @@ func TestReceiveTracesBatches(t *testing.T) {
 				return cfg
 			}(),
 			want: wantType{
-				batches: [][]string{
-					{`"start_time":1`},
-					{`"start_time":99`},
-				},
+				// just test that the test has 2 batches, don't test its contents.
+				batches:    [][]string{{""}, {""}},
 				numBatches: 2,
 				compressed: true,
 			},

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -455,8 +455,8 @@ func TestReceiveTracesBatches(t *testing.T) {
 			}(),
 			want: wantType{
 				batches: [][]string{
-					{`"start_time":1`, `"start_time":2`, `"start_time":3`, `"start_time":4`, `"start_time":7`, `"start_time":8`, `"start_time":9`, `"start_time":20`, `"start_time":40`},
-					{`"start_time":85`, `"start_time":98`, `"start_time":99`},
+					{`"start_time":1`},
+					{`"start_time":99`},
 				},
 				numBatches: 2,
 				compressed: true,


### PR DESCRIPTION
**Description:** 
Fixes #16459, relaxing assertions in a test that makes sure we apply compression when sending traces.

**Link to tracking Issue:**
#16459

**Testing:**
Unit tests

**Documentation:**
N/A