### PR TITLE
[receiver/otljsonfilereceiver] disregard empty resources when reading from files

### DIFF
--- a/.chloggen/otlpjsonfilereceiver-no-error-on-mixed-signals.yaml
+++ b/.chloggen/otlpjsonfilereceiver-no-error-on-mixed-signals.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: otlpjsonfilereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disregard empty resource logs, metrics or traces when reading from files.
+
+# One or more tracking issues related to the change
+issues: [12603]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -92,7 +92,9 @@ func createLogsReceiver(_ context.Context, settings rcvr.CreateSettings, configu
 		if err != nil {
 			obsrecv.EndLogsOp(ctx, typeStr, 0, err)
 		} else {
-			err = logs.ConsumeLogs(ctx, l)
+			if l.ResourceLogs().Len() != 0 {
+				err = logs.ConsumeLogs(ctx, l)
+			}
 			obsrecv.EndLogsOp(ctx, typeStr, l.LogRecordCount(), err)
 		}
 	})
@@ -121,7 +123,9 @@ func createMetricsReceiver(_ context.Context, settings rcvr.CreateSettings, conf
 		if err != nil {
 			obsrecv.EndMetricsOp(ctx, typeStr, 0, err)
 		} else {
-			err = metrics.ConsumeMetrics(ctx, m)
+			if m.ResourceMetrics().Len() != 0 {
+				err = metrics.ConsumeMetrics(ctx, m)
+			}
 			obsrecv.EndMetricsOp(ctx, typeStr, m.MetricCount(), err)
 		}
 	})
@@ -150,7 +154,9 @@ func createTracesReceiver(ctx context.Context, settings rcvr.CreateSettings, con
 		if err != nil {
 			obsrecv.EndTracesOp(ctx, typeStr, 0, err)
 		} else {
-			err = traces.ConsumeTraces(ctx, t)
+			if t.ResourceSpans().Len() != 0 {
+				err = traces.ConsumeTraces(ctx, t)
+			}
 			obsrecv.EndTracesOp(ctx, typeStr, t.SpanCount(), err)
 		}
 	})

--- a/receiver/otlpjsonfilereceiver/file_test.go
+++ b/receiver/otlpjsonfilereceiver/file_test.go
@@ -155,3 +155,60 @@ func TestLoadConfig(t *testing.T) {
 
 	assert.Equal(t, testdataConfigYamlAsMap(), cfg)
 }
+
+func TestFileMixedSignals(t *testing.T) {
+	tempFolder := t.TempDir()
+	factory := NewFactory()
+	cfg := createDefaultConfig().(*Config)
+	cfg.Config.Include = []string{filepath.Join(tempFolder, "*")}
+	cfg.Config.StartAt = "beginning"
+	cs := receivertest.NewNopCreateSettings()
+	ms := new(consumertest.MetricsSink)
+	mr, err := factory.CreateMetricsReceiver(context.Background(), cs, cfg, ms)
+	assert.NoError(t, err)
+	err = mr.Start(context.Background(), nil)
+	assert.NoError(t, err)
+	ts := new(consumertest.TracesSink)
+	tr, err := factory.CreateTracesReceiver(context.Background(), cs, cfg, ts)
+	assert.NoError(t, err)
+	err = tr.Start(context.Background(), nil)
+	assert.NoError(t, err)
+	ls := new(consumertest.LogsSink)
+	lr, err := factory.CreateLogsReceiver(context.Background(), cs, cfg, ls)
+	assert.NoError(t, err)
+	err = lr.Start(context.Background(), nil)
+	assert.NoError(t, err)
+
+	md := testdata.GenerateMetricsManyMetricsSameResource(5)
+	marshaler := &pmetric.JSONMarshaler{}
+	b, err := marshaler.MarshalMetrics(md)
+	assert.NoError(t, err)
+	td := testdata.GenerateTracesTwoSpansSameResource()
+	tmarshaler := &ptrace.JSONMarshaler{}
+	b2, err := tmarshaler.MarshalTraces(td)
+	assert.NoError(t, err)
+	ld := testdata.GenerateLogsManyLogRecordsSameResource(5)
+	lmarshaler := &plog.JSONMarshaler{}
+	b3, err := lmarshaler.MarshalLogs(ld)
+	assert.NoError(t, err)
+	b = append(b, '\n')
+	b = append(b, b2...)
+	b = append(b, '\n')
+	b = append(b, b3...)
+	err = os.WriteFile(filepath.Join(tempFolder, "metrics.json"), b, 0600)
+	assert.NoError(t, err)
+	time.Sleep(1 * time.Second)
+
+	require.Len(t, ms.AllMetrics(), 1)
+	assert.EqualValues(t, md, ms.AllMetrics()[0])
+	require.Len(t, ts.AllTraces(), 1)
+	assert.EqualValues(t, td, ts.AllTraces()[0])
+	require.Len(t, ls.AllLogs(), 1)
+	assert.EqualValues(t, ld, ls.AllLogs()[0])
+	err = mr.Shutdown(context.Background())
+	assert.NoError(t, err)
+	err = tr.Shutdown(context.Background())
+	assert.NoError(t, err)
+	err = lr.Shutdown(context.Background())
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
**Description:** 
Disregard empty resource logs, metrics or traces when reading from files.

**Link to tracking Issue:**
#12603

**Testing:**
Unit tests.

**Documentation:**
N/A