### PR TITLE
[cmd/mdatagen] Ensure templates are built as part of the application

### DIFF
--- a/.chloggen/msg_fix-embed-metadatagen-templates.yaml
+++ b/.chloggen/msg_fix-embed-metadatagen-templates.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/metadata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure template files are downloaded as part of the `go get` and embeded into the application
+
+# One or more tracking issues related to the change
+issues: [17442]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/mdatagen/embeded_templates.go
+++ b/cmd/mdatagen/embeded_templates.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "embed"
+
+// templateFS ensures that the files needed
+// to generate metadata as an embedded filesystem since
+// `go get` doesn't require these files to be downloaded.
+//
+//go:embed templates/*.tmpl templates/testdata/*.tmpl
+var templateFS embed.FS

--- a/cmd/mdatagen/embeded_templates_test.go
+++ b/cmd/mdatagen/embeded_templates_test.go
@@ -31,10 +31,10 @@ func TestEnsureTemplatesLoaded(t *testing.T) {
 
 	var (
 		templateFiles = map[string]struct{}{
-			path.Join(rootDir, "documentation.md.tmpl"):     {},
-			path.Join(rootDir, "metrics_test.go.tmpl"):      {},
-			path.Join(rootDir, "metrics.go.tmpl"):           {},
-			path.Join(rootDir, "testdata/config.yaml.tmpl"): {},
+			path.Join(rootDir, "documentation.md.tmpl"):        {},
+			path.Join(rootDir, "metrics_test.go.tmpl"):         {},
+			path.Join(rootDir, "metrics.go.tmpl"):              {},
+			path.Join(rootDir, "testdata", "config.yaml.tmpl"): {},
 		}
 		count = 0
 	)

--- a/cmd/mdatagen/embeded_templates_test.go
+++ b/cmd/mdatagen/embeded_templates_test.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/fs"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnsureTemplatesLoaded(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rootDir = "templates"
+	)
+
+	var (
+		templateFiles = map[string]struct{}{
+			path.Join(rootDir, "documentation.md.tmpl"):     {},
+			path.Join(rootDir, "metrics_test.go.tmpl"):      {},
+			path.Join(rootDir, "metrics.go.tmpl"):           {},
+			path.Join(rootDir, "testdata/config.yaml.tmpl"): {},
+		}
+		count = 0
+	)
+	assert.NoError(t, fs.WalkDir(templateFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if d != nil && d.IsDir() {
+			return nil
+		}
+		count++
+		assert.Contains(t, templateFiles, path)
+		return nil
+	}))
+	assert.Equal(t, len(templateFiles), count, "Must match the expected number of calls")
+
+}

--- a/cmd/mdatagen/main.go
+++ b/cmd/mdatagen/main.go
@@ -23,7 +23,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"text/template"
 )
@@ -48,11 +47,7 @@ func run(ymlPath string) error {
 		return fmt.Errorf("failed loading %v: %w", ymlPath, err)
 	}
 
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		return errors.New("unable to determine filename")
-	}
-	tmplDir := filepath.Join(filepath.Dir(filename), "templates")
+	tmplDir := "templates"
 
 	codeDir := filepath.Join(ymlDir, "internal", "metadata")
 	if err = os.MkdirAll(filepath.Join(codeDir, "testdata"), 0700); err != nil {
@@ -104,7 +99,7 @@ func generateFile(tmplFile string, outputFile string, md metadata) error {
 				},
 				"stringsJoin": strings.Join,
 				"inc":         func(i int) int { return i + 1 },
-			}).ParseFiles(tmplFile))
+			}).ParseFS(templateFS, tmplFile))
 
 	buf := bytes.Buffer{}
 


### PR DESCRIPTION
**Description:**
Using metadata as part of our CI step internally, I have noticed that the templates directory can be missing causing the app to crash with the following error:

```
mdatagen metadata.yaml
panic: open /go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen@v0.68.0/templates/metrics.go.tmpl: no such file or directory
goroutine 1 [running]:
text/template.Must(...)
	/usr/local/go/src/text/template/helper.go:26
main.generateFile({0xc000176480, 0x74}, {0xc000156a50, 0x26}, {{0xc0001586d8, 0x16}, {0x0, 0x0}, 0x0, 0xc0002054a0, ...})
	/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen@v0.68.0/main.go:73 +0xe25
main.run({0x7fffc6c40ed9, 0xd})
	/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen@v0.68.0/main.go:61 +0x491
main.main()
	/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen@v0.68.0/main.go:34 +0x88
```

**Link to tracking Issue:** 

**Testing:** 

**Documentation:**
N/A