### PR TITLE
[pkg/stanza/adapter] Deprecate Convert helper

### DIFF
--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -288,6 +288,9 @@ func convert(ent *entry.Entry) plog.LogRecord {
 // Convert converts one entry.Entry into plog.Logs.
 // To be used in a stateless setting like tests where ease of use is more
 // important than performance or throughput.
+// Deprecated: [v0.68.0] Unnecessary exported API.
+// Please add a comment in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17429
+// if you use it.
 func Convert(ent *entry.Entry) plog.Logs {
 	pLogs := plog.NewLogs()
 	logs := pLogs.ResourceLogs()


### PR DESCRIPTION
Convert helper was introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3125, but was never used.

Now we have pkg/stanza/adapter exposed as a public API, it's important to limit its scope.