### PR TITLE
[receiver/redisreceiver] add scraper shutdown

### DIFF
--- a/.chloggen/receiver-redisreceiver-add-scraper-close.yaml
+++ b/.chloggen/receiver-redisreceiver-add-scraper-close.yaml
@@ -8,7 +8,7 @@ component: redisreceiver
 note: Add scraper shutdown with redis client close function to avoid redis client connection pool leaks
 
 # One or more tracking issues related to the change
-issues: []
+issues: [17491]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/receiver-redisreceiver-add-scraper-close.yaml
+++ b/.chloggen/receiver-redisreceiver-add-scraper-close.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: redisreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add scraper shutdown with redis client close function to avoid redis client connection poll leaks
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/receiver-redisreceiver-add-scraper-close.yaml
+++ b/.chloggen/receiver-redisreceiver-add-scraper-close.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: redisreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add scraper shutdown with redis client close function to avoid redis client connection poll leaks
+note: Add scraper shutdown with redis client close function to avoid redis client connection pool leaks
 
 # One or more tracking issues related to the change
 issues: []

--- a/receiver/redisreceiver/client.go
+++ b/receiver/redisreceiver/client.go
@@ -25,7 +25,7 @@ type client interface {
 	// line delimiter
 	// redis lines are delimited by \r\n, files (for testing) by \n
 	delimiter() string
-	// close
+	// close release redis client connection pool
 	close() error
 }
 
@@ -53,7 +53,7 @@ func (c *redisClient) retrieveInfo() (string, error) {
 	return c.client.Info("all").Result()
 }
 
-// close.
+// close client to release connention pool.
 func (c *redisClient) close() error {
 	return c.client.Close()
 }

--- a/receiver/redisreceiver/client.go
+++ b/receiver/redisreceiver/client.go
@@ -25,6 +25,8 @@ type client interface {
 	// line delimiter
 	// redis lines are delimited by \r\n, files (for testing) by \n
 	delimiter() string
+	// close
+	close() error
 }
 
 // Wraps a real Redis client, implements `client` interface.
@@ -49,4 +51,9 @@ func (c *redisClient) delimiter() string {
 // Retrieve Redis INFO. We retrieve all of the 'sections'.
 func (c *redisClient) retrieveInfo() (string, error) {
 	return c.client.Info("all").Result()
+}
+
+// close.
+func (c *redisClient) close() error {
+	return c.client.Close()
 }

--- a/receiver/redisreceiver/client_test.go
+++ b/receiver/redisreceiver/client_test.go
@@ -44,6 +44,10 @@ func (fakeClient) retrieveInfo() (string, error) {
 	return readFile("info")
 }
 
+func (fakeClient) close() error {
+	return nil
+}
+
 func readFile(fname string) (string, error) {
 	file, err := os.ReadFile(filepath.Join("testdata", fname+".txt"))
 	if err != nil {

--- a/receiver/redisreceiver/redis_scraper.go
+++ b/receiver/redisreceiver/redis_scraper.go
@@ -34,6 +34,7 @@ import (
 // Runs intermittently, fetching info from Redis, creating metrics/datapoints,
 // and feeding them to a metricsConsumer.
 type redisScraper struct {
+	client   client
 	redisSvc *redisSvc
 	settings component.TelemetrySettings
 	mb       *metadata.MetricsBuilder
@@ -58,11 +59,23 @@ func newRedisScraper(cfg *Config, settings receiver.CreateSettings) (scraperhelp
 
 func newRedisScraperWithClient(client client, settings receiver.CreateSettings, cfg *Config) (scraperhelper.Scraper, error) {
 	rs := &redisScraper{
+		client:   client,
 		redisSvc: newRedisSvc(client),
 		settings: settings.TelemetrySettings,
 		mb:       metadata.NewMetricsBuilder(cfg.Metrics, settings),
 	}
-	return scraperhelper.NewScraper(typeStr, rs.Scrape)
+	return scraperhelper.NewScraper(
+		typeStr,
+		rs.Scrape,
+		scraperhelper.WithShutdown(rs.shutdown),
+	)
+}
+
+func (rs *redisScraper) shutdown(context.Context) error {
+	if rs.client != nil {
+		return rs.client.close()
+	}
+	return nil
 }
 
 // Scrape is called periodically, querying Redis and building Metrics to send to


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The redis client has a `connPool`. When using `redisreceiver` with `receiver_creator`, the old client won't be closed. That may lead a memory leak.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
```yaml
receivers:
  nop:
  receiver_creator:
    watch_observers: [host_observer]
    receivers:
      redis/on_host:
        # If this rule matches an instance of this receiver will be started.
        rule: type == "port" && port == 6379 && is_ipv6 == true
      resource_attributes:
        service.name: redis_on_host

processors:
  nop:

exporters:
  nop:

service:
  pipelines:
    extensions: [host_observer]
    metrics/nop:
      receivers: [nop]
      processors: [nop]
      exporters: [nop]
    metrics/redis:
      receivers: [receiver_creator]
      processors: [nop]
      exporters: [nop]
```

**Documentation:** <Describe the documentation added.>

`github.com/go-redis/redis/v7@v7.4.1/redis.go`

```golang
// Close closes the client, releasing any open resources.
//
// It is rare to Close a Client, as the Client is meant to be
// long-lived and shared between many goroutines.
func (c *baseClient) Close() error {
	var firstErr error
	if c.onClose != nil {
		if err := c.onClose(); err != nil {
			firstErr = err
		}
	}
	if err := c.connPool.Close(); err != nil && firstErr == nil {
		firstErr = err
	}
	return firstErr
}
```