### PR TITLE
[pkg/stanza/adapter] Deprecate ConvertFrom

### DIFF
--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -288,7 +288,7 @@ func convert(ent *entry.Entry) plog.LogRecord {
 // Convert converts one entry.Entry into plog.Logs.
 // To be used in a stateless setting like tests where ease of use is more
 // important than performance or throughput.
-// Deprecated: [v0.68.0] Unnecessary exported API.
+// Deprecated: [v0.68.0] Unnecessarily exported API.
 // Please add a comment in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17429
 // if you use it.
 func Convert(ent *entry.Entry) plog.Logs {

--- a/pkg/stanza/adapter/frompdataconverter.go
+++ b/pkg/stanza/adapter/frompdataconverter.go
@@ -176,6 +176,9 @@ func convertFromLogs(workerItem fromConverterWorkerItem) []*entry.Entry {
 // ConvertFrom converts plog.Logs into a slice of entry.Entry
 // To be used in a stateless setting like tests where ease of use is more
 // important than performance or throughput.
+// Deprecated: [v0.69.0] Unnecessarily exported API.
+// Please add a comment in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17429
+// if you use it.
 func ConvertFrom(pLogs plog.Logs) []*entry.Entry {
 	result := make([]*entry.Entry, 0, pLogs.LogRecordCount())
 	for i := 0; i < pLogs.ResourceLogs().Len(); i++ {


### PR DESCRIPTION
Similar to Convert, the API is not being used and shouldn't be exported.

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17429
