### PR TITLE
[receiver/prometheusreceiver] Use `_created` metric, if present, to set StartTimeUnixNano on Sum, Histogram, Summaries

### DIFF
--- a/.chloggen/prw-receiver-use-created-metric.yaml
+++ b/.chloggen/prw-receiver-use-created-metric.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: breaking
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: receiver/prometheusreceiver
@@ -18,3 +18,5 @@ subtext: |
   metric family, only then its values is used to set `StartTimeUnixNano` on the
   relevant OTLP metric and dropped afterwards. Otherwise, it is converted to the
   monotonic OTLP Sum metric.
+  This behaviour is disabled by default. Use the `receiver.prometheusreceiver.UseCreatedMetric`
+  to enable it.

--- a/.chloggen/prw-receiver-use-created-metric.yaml
+++ b/.chloggen/prw-receiver-use-created-metric.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use `_created` metrics, if present, to set `StartTimeUnixNano` for Sum, Histogram and Summary metrics.
+
+# One or more tracking issues related to the change
+issues: [12428]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  If the `_created` metric was present in the Histogram, Summary or Counter
+  metric family, only then its values is used to set `StartTimeUnixNano` on the
+  relevant OTLP metric and dropped afterwards. Otherwise, it is converted to the
+  monotonic OTLP Sum metric.

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -50,6 +50,16 @@ you must escape them using `$$`.
 prometheus --config.file=prom.yaml
 ```
 
+**Feature gates**:
+
+- `receiver.prometheusreceiver.UseCreatedMetric`: Start time for Summary, Histogram 
+  and Sum metrics can be retrieved from `_created` metrics. Currently, this behaviour
+  is disabled by default. To enable it, use the following feature gate option:
+
+```shell
+"--feature-gates=receiver.prometheusreceiver.UseCreatedMetric"
+```
+
 You can copy and paste that same configuration under:
 
 ```yaml

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -28,9 +28,19 @@ import (
 // This file implements config for Prometheus receiver.
 
 const (
-	typeStr   = "prometheus"
-	stability = component.StabilityLevelBeta
+	typeStr                = "prometheus"
+	stability              = component.StabilityLevelBeta
+	useCreatedMetricGateID = "receiver.prometheusreceiver.UseCreatedMetric"
 )
+
+func init() {
+	featuregate.GetRegistry().MustRegisterID(
+		useCreatedMetricGateID,
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("When enabled, the Prometheus receiver will"+
+			" retrieve the start time for Summary, Histogram and Sum metrics from _created metric"),
+	)
+}
 
 var errRenamingDisallowed = errors.New("metric renaming using metric_relabel_configs is disallowed")
 

--- a/receiver/prometheusreceiver/internal/appendable.go
+++ b/receiver/prometheusreceiver/internal/appendable.go
@@ -47,11 +47,12 @@ func NewAppendable(
 	gcInterval time.Duration,
 	useStartTimeMetric bool,
 	startTimeMetricRegex *regexp.Regexp,
+	useCreatedMetric bool,
 	externalLabels labels.Labels,
 	registry *featuregate.Registry) (storage.Appendable, error) {
 	var metricAdjuster MetricsAdjuster
 	if !useStartTimeMetric {
-		metricAdjuster = NewInitialPointAdjuster(set.Logger, gcInterval)
+		metricAdjuster = NewInitialPointAdjuster(set.Logger, gcInterval, useCreatedMetric)
 	} else {
 		metricAdjuster = NewStartTimeMetricAdjuster(set.Logger, startTimeMetricRegex)
 	}

--- a/receiver/prometheusreceiver/internal/metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/metricfamily_test.go
@@ -72,6 +72,12 @@ var mc = testMetadataStore{
 		Help:   "This is some help for a histogram",
 		Unit:   "ms",
 	},
+	"histogram_with_created": scrape.MetricMetadata{
+		Metric: "hg",
+		Type:   textparse.MetricTypeHistogram,
+		Help:   "This is some help for a histogram",
+		Unit:   "ms",
+	},
 	"histogram_stale": scrape.MetricMetadata{
 		Metric: "hg_stale",
 		Type:   textparse.MetricTypeHistogram,
@@ -79,6 +85,12 @@ var mc = testMetadataStore{
 		Unit:   "ms",
 	},
 	"summary": scrape.MetricMetadata{
+		Metric: "s",
+		Type:   textparse.MetricTypeSummary,
+		Help:   "This is some help for a summary",
+		Unit:   "ms",
+	},
+	"summary_with_created": scrape.MetricMetadata{
 		Metric: "s",
 		Type:   textparse.MetricTypeSummary,
 		Help:   "This is some help for a summary",
@@ -137,6 +149,49 @@ func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 				attributes := point.Attributes()
 				attributes.PutStr("a", "A")
 				attributes.PutStr("b", "B")
+				return point
+			},
+		},
+		{
+			name:                "histogram with startTimestamp from _created",
+			metricName:          "histogram_with_created",
+			intervalStartTimeMs: 11,
+			labels:              labels.FromMap(map[string]string{"a": "A"}),
+			scrapes: []*scrape{
+				{at: 11, value: 66, metric: "histogram_with_created_count"},
+				{at: 11, value: 1004.78, metric: "histogram_with_created_sum"},
+				{at: 11, value: 600.78, metric: "histogram_with_created_created"},
+				{
+					at:         11,
+					value:      33,
+					metric:     "histogram_with_created_bucket",
+					extraLabel: labels.Label{Name: "le", Value: "0.75"},
+				},
+				{
+					at:         11,
+					value:      55,
+					metric:     "histogram_with_created_bucket",
+					extraLabel: labels.Label{Name: "le", Value: "2.75"},
+				},
+				{
+					at:         11,
+					value:      66,
+					metric:     "histogram_with_created_bucket",
+					extraLabel: labels.Label{Name: "le", Value: "+Inf"}},
+			},
+			want: func() pmetric.HistogramDataPoint {
+				point := pmetric.NewHistogramDataPoint()
+				point.SetCount(66)
+				point.SetSum(1004.78)
+
+				// the time in milliseconds -> nanoseconds.
+				point.SetTimestamp(pcommon.Timestamp(11 * time.Millisecond))
+				point.SetStartTimestamp(timestampFromFloat64(600.78))
+
+				point.ExplicitBounds().FromRaw([]float64{0.75, 2.75})
+				point.BucketCounts().FromRaw([]uint64{33, 22, 11})
+				attributes := point.Attributes()
+				attributes.PutStr("a", "A")
 				return point
 			},
 		},
@@ -311,6 +366,79 @@ func TestMetricGroupData_toSummaryUnitTest(t *testing.T) {
 			},
 		},
 		{
+			name: "summary_with_created",
+			labelsScrapes: []*labelsScrapes{
+				{
+					labels: labels.FromMap(map[string]string{"a": "A", "b": "B"}),
+					scrapes: []*scrape{
+						{at: 14, value: 10, metric: "summary_with_created_count"},
+						{at: 14, value: 15, metric: "summary_with_created_sum"},
+						{at: 14, value: 150, metric: "summary_with_created_created"},
+					},
+				},
+				{
+					labels: labels.FromMap(map[string]string{"a": "A", "quantile": "0.0", "b": "B"}),
+					scrapes: []*scrape{
+						{at: 14, value: 8, metric: "value"},
+					},
+				},
+				{
+					labels: labels.FromMap(map[string]string{"a": "A", "quantile": "0.75", "b": "B"}),
+					scrapes: []*scrape{
+						{at: 14, value: 33.7, metric: "value"},
+					},
+				},
+				{
+					labels: labels.FromMap(map[string]string{"a": "A", "quantile": "0.50", "b": "B"}),
+					scrapes: []*scrape{
+						{at: 14, value: 27, metric: "value"},
+					},
+				},
+				{
+					labels: labels.FromMap(map[string]string{"a": "A", "quantile": "0.90", "b": "B"}),
+					scrapes: []*scrape{
+						{at: 14, value: 56, metric: "value"},
+					},
+				},
+				{
+					labels: labels.FromMap(map[string]string{"a": "A", "quantile": "0.99", "b": "B"}),
+					scrapes: []*scrape{
+						{at: 14, value: 82, metric: "value"},
+					},
+				},
+			},
+			want: func() pmetric.SummaryDataPoint {
+				point := pmetric.NewSummaryDataPoint()
+				point.SetCount(10)
+				point.SetSum(15)
+				qtL := point.QuantileValues()
+				qn0 := qtL.AppendEmpty()
+				qn0.SetQuantile(0)
+				qn0.SetValue(8)
+				qn50 := qtL.AppendEmpty()
+				qn50.SetQuantile(.5)
+				qn50.SetValue(27)
+				qn75 := qtL.AppendEmpty()
+				qn75.SetQuantile(.75)
+				qn75.SetValue(33.7)
+				qn90 := qtL.AppendEmpty()
+				qn90.SetQuantile(.9)
+				qn90.SetValue(56)
+				qn99 := qtL.AppendEmpty()
+				qn99.SetQuantile(.99)
+				qn99.SetValue(82)
+
+				// the time in milliseconds -> nanoseconds.
+				point.SetTimestamp(pcommon.Timestamp(14 * time.Millisecond))
+				point.SetStartTimestamp(timestampFromFloat64(150))
+
+				attributes := point.Attributes()
+				attributes.PutStr("a", "A")
+				attributes.PutStr("b", "B")
+				return point
+			},
+		},
+		{
 			name: "summary_stale",
 			labelsScrapes: []*labelsScrapes{
 				{
@@ -453,6 +581,29 @@ func TestMetricGroupData_toNumberDataUnitTest(t *testing.T) {
 		intervalStartTimestampMs int64
 		want                     func() pmetric.NumberDataPoint
 	}{
+		{
+			metricKind:               "counter",
+			name:                     "counter:: startTimestampMs from _created",
+			intervalStartTimestampMs: 11,
+			labels:                   labels.FromMap(map[string]string{"a": "A", "b": "B"}),
+			scrapes: []*scrape{
+				{at: 13, value: 33.7, metric: "value"},
+				{at: 13, value: 150, metric: "value_created"},
+			},
+			want: func() pmetric.NumberDataPoint {
+				point := pmetric.NewNumberDataPoint()
+				point.SetDoubleValue(33.7)
+
+				// the time in milliseconds -> nanoseconds.
+				point.SetTimestamp(pcommon.Timestamp(13 * time.Millisecond))
+				point.SetStartTimestamp(timestampFromFloat64(150))
+
+				attributes := point.Attributes()
+				attributes.PutStr("a", "A")
+				attributes.PutStr("b", "B")
+				return point
+			},
+		},
 		{
 			metricKind:               "counter",
 			name:                     "counter:: startTimestampMs of 11",

--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -244,21 +244,23 @@ type MetricsAdjuster interface {
 // and provides AdjustMetricSlice, which takes a sequence of metrics and adjust their start times based on
 // the initial points.
 type initialPointAdjuster struct {
-	jobsMap *JobsMap
-	logger  *zap.Logger
+	jobsMap          *JobsMap
+	logger           *zap.Logger
+	useCreatedMetric bool
 }
 
 // NewInitialPointAdjuster returns a new MetricsAdjuster that adjust metrics' start times based on the initial received points.
-func NewInitialPointAdjuster(logger *zap.Logger, gcInterval time.Duration) MetricsAdjuster {
+func NewInitialPointAdjuster(logger *zap.Logger, gcInterval time.Duration, useCreatedMetric bool) MetricsAdjuster {
 	return &initialPointAdjuster{
-		jobsMap: NewJobsMap(gcInterval),
-		logger:  logger,
+		jobsMap:          NewJobsMap(gcInterval),
+		logger:           logger,
+		useCreatedMetric: useCreatedMetric,
 	}
 }
 
 // AdjustMetrics takes a sequence of metrics and adjust their start times based on the initial and
 // previous points in the timeseriesMap.
-func (ma *initialPointAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
+func (a *initialPointAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
 	// By contract metrics will have at least 1 data point, so for sure will have at least one ResourceMetrics.
 
 	job, found := metrics.ResourceMetrics().At(0).Resource().Attributes().Get(semconv.AttributeServiceName)
@@ -270,7 +272,7 @@ func (ma *initialPointAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
 	if !found {
 		return errors.New("adjusting metrics without instance")
 	}
-	tsm := ma.jobsMap.get(job.Str(), instance.Str())
+	tsm := a.jobsMap.get(job.Str(), instance.Str())
 
 	// The lock on the relevant timeseriesMap is held throughout the adjustment process to ensure that
 	// nothing else can modify the data used for adjustment.
@@ -287,17 +289,17 @@ func (ma *initialPointAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
 					// gauges don't need to be adjusted so no additional processing is necessary
 
 				case pmetric.MetricTypeHistogram:
-					adjustMetricHistogram(tsm, metric)
+					a.adjustMetricHistogram(tsm, metric)
 
 				case pmetric.MetricTypeSummary:
-					adjustMetricSummary(tsm, metric)
+					a.adjustMetricSummary(tsm, metric)
 
 				case pmetric.MetricTypeSum:
-					adjustMetricSum(tsm, metric)
+					a.adjustMetricSum(tsm, metric)
 
 				default:
 					// this shouldn't happen
-					ma.logger.Info("Adjust - skipping unexpected point", zap.String("type", dataType.String()))
+					a.logger.Info("Adjust - skipping unexpected point", zap.String("type", dataType.String()))
 				}
 			}
 		}
@@ -305,7 +307,7 @@ func (ma *initialPointAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
 	return nil
 }
 
-func adjustMetricHistogram(tsm *timeseriesMap, current pmetric.Metric) {
+func (a *initialPointAdjuster) adjustMetricHistogram(tsm *timeseriesMap, current pmetric.Metric) {
 	histogram := current.Histogram()
 	if histogram.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
 		// Only dealing with CumulativeDistributions.
@@ -317,7 +319,8 @@ func adjustMetricHistogram(tsm *timeseriesMap, current pmetric.Metric) {
 		currentDist := currentPoints.At(i)
 
 		// start timestamp was set from _created
-		if !currentDist.Flags().NoRecordedValue() &&
+		if a.useCreatedMetric &&
+			!currentDist.Flags().NoRecordedValue() &&
 			currentDist.StartTimestamp() < currentDist.Timestamp() {
 			continue
 		}
@@ -352,13 +355,14 @@ func adjustMetricHistogram(tsm *timeseriesMap, current pmetric.Metric) {
 	}
 }
 
-func adjustMetricSum(tsm *timeseriesMap, current pmetric.Metric) {
+func (a *initialPointAdjuster) adjustMetricSum(tsm *timeseriesMap, current pmetric.Metric) {
 	currentPoints := current.Sum().DataPoints()
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentSum := currentPoints.At(i)
 
 		// start timestamp was set from _created
-		if !currentSum.Flags().NoRecordedValue() &&
+		if a.useCreatedMetric &&
+			!currentSum.Flags().NoRecordedValue() &&
 			currentSum.StartTimestamp() < currentSum.Timestamp() {
 			continue
 		}
@@ -390,14 +394,15 @@ func adjustMetricSum(tsm *timeseriesMap, current pmetric.Metric) {
 	}
 }
 
-func adjustMetricSummary(tsm *timeseriesMap, current pmetric.Metric) {
+func (a *initialPointAdjuster) adjustMetricSummary(tsm *timeseriesMap, current pmetric.Metric) {
 	currentPoints := current.Summary().DataPoints()
 
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentSummary := currentPoints.At(i)
 
 		// start timestamp was set from _created
-		if !currentSummary.Flags().NoRecordedValue() &&
+		if a.useCreatedMetric &&
+			!currentSummary.Flags().NoRecordedValue() &&
 			currentSummary.StartTimestamp() < currentSummary.Timestamp() {
 			continue
 		}

--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -315,6 +315,13 @@ func adjustMetricHistogram(tsm *timeseriesMap, current pmetric.Metric) {
 	currentPoints := histogram.DataPoints()
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentDist := currentPoints.At(i)
+
+		// start timestamp was set from _created
+		if !currentDist.Flags().NoRecordedValue() &&
+			currentDist.StartTimestamp() < currentDist.Timestamp() {
+			continue
+		}
+
 		tsi, found := tsm.get(current, currentDist.Attributes())
 		if !found {
 			// initialize everything.
@@ -349,6 +356,13 @@ func adjustMetricSum(tsm *timeseriesMap, current pmetric.Metric) {
 	currentPoints := current.Sum().DataPoints()
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentSum := currentPoints.At(i)
+
+		// start timestamp was set from _created
+		if !currentSum.Flags().NoRecordedValue() &&
+			currentSum.StartTimestamp() < currentSum.Timestamp() {
+			continue
+		}
+
 		tsi, found := tsm.get(current, currentSum.Attributes())
 		if !found {
 			// initialize everything.
@@ -381,6 +395,13 @@ func adjustMetricSummary(tsm *timeseriesMap, current pmetric.Metric) {
 
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentSummary := currentPoints.At(i)
+
+		// start timestamp was set from _created
+		if !currentSummary.Flags().NoRecordedValue() &&
+			currentSummary.StartTimestamp() < currentSummary.Timestamp() {
+			continue
+		}
+
 		tsi, found := tsm.get(current, currentSummary.Attributes())
 		if !found {
 			// initialize everything.

--- a/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
@@ -78,7 +78,7 @@ func TestGauge(t *testing.T) {
 			adjusted:    metrics(gaugeMetric(gauge1, doublePoint(k1v1k2v2, t3, t3, 55))),
 		},
 	}
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestSum(t *testing.T) {
@@ -109,7 +109,7 @@ func TestSum(t *testing.T) {
 			adjusted:    metrics(sumMetric(sum1, doublePoint(k1v1k2v2, t3, t5, 72))),
 		},
 	}
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestSummaryNoCount(t *testing.T) {
@@ -136,7 +136,7 @@ func TestSummaryNoCount(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestSummaryFlagNoRecordedValue(t *testing.T) {
@@ -153,7 +153,7 @@ func TestSummaryFlagNoRecordedValue(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestSummary(t *testing.T) {
@@ -196,7 +196,7 @@ func TestSummary(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestHistogram(t *testing.T) {
@@ -219,7 +219,7 @@ func TestHistogram(t *testing.T) {
 			adjusted:    metrics(histogramMetric(histogram1, histogramPoint(k1v1k2v2, t3, t4, bounds0, []uint64{7, 4, 2, 12}))),
 		},
 	}
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestHistogramFlagNoRecordedValue(t *testing.T) {
@@ -236,7 +236,7 @@ func TestHistogramFlagNoRecordedValue(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestHistogramFlagNoRecordedValueFirstObservation(t *testing.T) {
@@ -253,7 +253,7 @@ func TestHistogramFlagNoRecordedValueFirstObservation(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestSummaryFlagNoRecordedValueFirstObservation(t *testing.T) {
@@ -270,7 +270,7 @@ func TestSummaryFlagNoRecordedValueFirstObservation(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestGaugeFlagNoRecordedValueFirstObservation(t *testing.T) {
@@ -287,7 +287,7 @@ func TestGaugeFlagNoRecordedValueFirstObservation(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestSumFlagNoRecordedValueFirstObservation(t *testing.T) {
@@ -304,7 +304,7 @@ func TestSumFlagNoRecordedValueFirstObservation(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestMultiMetrics(t *testing.T) {
@@ -368,7 +368,7 @@ func TestMultiMetrics(t *testing.T) {
 			),
 		},
 	}
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestNewDataPointsAdded(t *testing.T) {
@@ -430,7 +430,7 @@ func TestNewDataPointsAdded(t *testing.T) {
 			),
 		},
 	}
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestMultiTimeseries(t *testing.T) {
@@ -489,7 +489,7 @@ func TestMultiTimeseries(t *testing.T) {
 			),
 		},
 	}
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestEmptyLabels(t *testing.T) {
@@ -515,7 +515,7 @@ func TestEmptyLabels(t *testing.T) {
 			adjusted:    metrics(sumMetric(sum1, doublePoint(k1vEmptyk2vEmptyk3vEmpty, t1, t3, 88))),
 		},
 	}
-	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute), "job", "0", script)
+	runScript(t, NewInitialPointAdjuster(zap.NewNop(), time.Minute, true), "job", "0", script)
 }
 
 func TestTsGC(t *testing.T) {
@@ -569,7 +569,7 @@ func TestTsGC(t *testing.T) {
 		},
 	}
 
-	ma := NewInitialPointAdjuster(zap.NewNop(), time.Minute)
+	ma := NewInitialPointAdjuster(zap.NewNop(), time.Minute, true)
 
 	// run round 1
 	runScript(t, ma, "job", "0", script1)
@@ -629,7 +629,7 @@ func TestJobGC(t *testing.T) {
 	}
 
 	gcInterval := 10 * time.Millisecond
-	ma := NewInitialPointAdjuster(zap.NewNop(), gcInterval)
+	ma := NewInitialPointAdjuster(zap.NewNop(), gcInterval, true)
 
 	// run job 1, round 1 - all entries marked
 	runScript(t, ma, "job1", "0", job1Script1)

--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -33,6 +33,7 @@ const (
 	metricsSuffixSum    = "_sum"
 	metricSuffixTotal   = "_total"
 	metricSuffixInfo    = "_info"
+	metricSuffixCreated = "_created"
 	startTimeMetricName = "process_start_time_seconds"
 	scrapeUpMetricName  = "up"
 
@@ -41,7 +42,7 @@ const (
 )
 
 var (
-	trimmableSuffixes     = []string{metricsSuffixBucket, metricsSuffixCount, metricsSuffixSum, metricSuffixTotal, metricSuffixInfo}
+	trimmableSuffixes     = []string{metricsSuffixBucket, metricsSuffixCount, metricsSuffixSum, metricSuffixTotal, metricSuffixInfo, metricSuffixCreated}
 	errNoDataToBuild      = errors.New("there's no data to build")
 	errNoBoundaryLabel    = errors.New("given metricType has no 'le' or 'quantile' label")
 	errEmptyQuantileLabel = errors.New("'quantile' label on summary metric missing is empty")

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -274,6 +274,7 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, host component
 		gcInterval(r.cfg.PrometheusConfig),
 		r.cfg.UseStartTimeMetric,
 		startTimeMetricRegex,
+		featuregate.GetRegistry().IsEnabled(useCreatedMetricGateID),
 		r.cfg.PrometheusConfig.GlobalConfig.ExternalLabels,
 		r.registry,
 	)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Use `_created` metric, if present, to set StartTimeUnixNano on Sum, Histogram, Summary metrics.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12428

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests.

**Documentation:** <Describe the documentation added.>
It is a part of the [specification](https://opentelemetry.io/docs/reference/specification/compatibility/prometheus_and_openmetrics/#start-time).
