### PR TITLE
[chore] Correct variable name in ping codeowners workflow

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
+++ b/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
@@ -65,7 +65,7 @@ for COMPONENT in ${BODY_COMPONENTS}; do
     fi
 
     PING_LINES+="- ${COMPONENT}: ${CODEOWNERS}\n"
-    PINGED_COMPONENTS["${TITLE_COMPONENT}"]=1
+    PINGED_COMPONENTS["${COMPONENT}"]=1
 
     if (( "${#COMPONENT}" > 50 )); then
       echo "'${COMPONENT}' exceeds GitHub's 50-character limit on labels, skipping adding a label"


### PR DESCRIPTION
**Description:**

Corrects the variable used when checking the components list in the issue body.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17488

**Testing:**

I performed local manual tests on the script to test the script succeeds for all cases where a component name may be present in the title or body.