### PR TITLE
[exporter/sumologic] Remove Map.Sort calls

### DIFF
--- a/exporter/sumologicexporter/filter.go
+++ b/exporter/sumologicexporter/filter.go
@@ -57,7 +57,6 @@ func (f *filter) mergeAndFilterIn(attrMaps ...pcommon.Map) fields {
 			return true
 		})
 	}
-	returnValue.Sort()
 	return newFields(returnValue)
 }
 
@@ -74,6 +73,5 @@ func (f *filter) filterOut(attributes pcommon.Map) fields {
 		v.CopyTo(returnValue.PutEmpty(k))
 		return true
 	})
-	returnValue.Sort()
 	return newFields(returnValue)
 }


### PR DESCRIPTION
The method will be deprecated soon. Removing the Sort is safe and noop from user's perspective. It also increases the performance of the exporter.

- Result of the `mergeAndFilterIn` is being used to create a string key that is used for grouping and passed as a value of `X-Sumo-Fields` header. The string representation is already sorted in https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/sumologicexporter/fields.go#L52, so sorting the original map is redundant.

- Result of the `filterOut` is used to convert the map into a JSON string which is always sorted by keys OOTB: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/sumologicexporter/sender.go#L181

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/6688