### PR TITLE
[chore] [pkg/translator/prometheusremotewrite] Replace Map.Sort usage

### DIFF
--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -164,25 +164,25 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, externa
 
 	// Ensure attributes are sorted by key for consistent merging of keys which
 	// collide when sanitized.
-	// Sorting is done on a cloned map, as the original attributes map can read at
-	// the same time in different places.
-	cloneAttributes := pcommon.NewMap()
-	attributes.CopyTo(cloneAttributes)
-	cloneAttributes.Sort()
-	cloneAttributes.Range(func(key string, value pcommon.Value) bool {
-		var finalKey = prometheustranslator.NormalizeLabel(key)
+	labels := make([]prompb.Label, 0, attributes.Len())
+	attributes.Range(func(key string, value pcommon.Value) bool {
+		labels = append(labels, prompb.Label{Name: key, Value: value.AsString()})
+		return true
+	})
+	sort.Stable(ByLabelName(labels))
+
+	for _, label := range labels {
+		var finalKey = prometheustranslator.NormalizeLabel(label.Name)
 		if existingLabel, alreadyExists := l[finalKey]; alreadyExists {
-			existingLabel.Value = existingLabel.Value + ";" + value.AsString()
+			existingLabel.Value = existingLabel.Value + ";" + label.Value
 			l[finalKey] = existingLabel
 		} else {
 			l[finalKey] = prompb.Label{
 				Name:  finalKey,
-				Value: value.AsString(),
+				Value: label.Value,
 			}
 		}
-
-		return true
-	})
+	}
 
 	// Map service.name + service.namespace to job
 	if serviceName, ok := resource.Attributes().Get(conventions.AttributeServiceName); ok {

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -326,6 +326,23 @@ func Test_createLabelSet(t *testing.T) {
 	}
 }
 
+func BenchmarkCreateAttributes(b *testing.B) {
+	r := pcommon.NewResource()
+	ext := map[string]string{}
+
+	m := pcommon.NewMap()
+	m.PutStr("test-string-key2", "test-value-2")
+	m.PutStr("test-string-key1", "test-value-1")
+	m.PutInt("test-int-key", 123)
+	m.PutBool("test-bool-key", true)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		createAttributes(r, m, ext)
+	}
+}
+
 // Test_addExemplars checks addExemplars updates the map it receives correctly based on the exemplars and bucket bounds data it receives.
 func Test_addExemplars(t *testing.T) {
 	type testCase struct {


### PR DESCRIPTION
The Map.Sort method will be removed and deprecated. Replacing its usage with manual keys sorting also improves performance because map cloning is not needed anymore.

Benchmark results:

Before: 

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite
BenchmarkCreateAttributes
BenchmarkCreateAttributes-10    	 1314566	       862.3 ns/op	     579 B/op	      10 allocs/op
PASS
```

After:
```
BenchmarkCreateAttributes
BenchmarkCreateAttributes-10    	 1719690	       694.5 ns/op	     435 B/op	       8 allocs/op
PASS
```

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/6688