### PR TITLE
[receiver/dockerstats] transition featuregate `receiver.dockerstats.useScraperV2` to stable

### DIFF
--- a/.chloggen/dockerstats-featuregate-stable.yaml
+++ b/.chloggen/dockerstats-featuregate-stable.yaml
@@ -1,0 +1,4 @@
+change_type: breaking
+component: dockerstatsreceiver
+note: "Transition the receiver.dockerstats.useScraperV2 featuregate to stable"
+issues: [17509, 9794]

--- a/receiver/dockerstatsreceiver/README.md
+++ b/receiver/dockerstatsreceiver/README.md
@@ -71,13 +71,13 @@ with detailed sample configurations [here](./testdata/config.yaml).
 
 See the [Collector feature gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md#collector-feature-gates) for an overview of feature gates in the collector.
 
-**BETA**: `receiver.dockerstats.useScraperV2`
+**STABLE**: `receiver.dockerstats.useScraperV2`
 
 The feature gate `receiver.dockerstats.useScraperV2` allows collection of selective metrics that is described in [documentation.md](./documentation.md). When the feature gate is disabled, the metrics settings are mostly ignored and not configurable with minor variation in metric name and attributes.
 
 This is considered a breaking change for existing users of this receiver, and it is recommended to migrate to the new implementation when possible. Leave this feature gate enabled to avoid having to migrate any visualisations or alerts.
 
-This feature gate is enabled by default, and eventually the old implementation will be removed.
+This feature gate is enabled by default, and eventually the old implementation will be removed (aiming for 0.71.0).
 
 ### Migrating from ScraperV1 to ScraperV2
 

--- a/receiver/dockerstatsreceiver/factory.go
+++ b/receiver/dockerstatsreceiver/factory.go
@@ -36,9 +36,10 @@ const (
 func init() {
 	featuregate.GetRegistry().MustRegisterID(
 		useScraperV2ID,
-		featuregate.StageBeta,
+		featuregate.StageStable,
 		featuregate.WithRegisterDescription("When enabled, the receiver will use the function ScrapeV2 to collect metrics. This allows each metric to be turned off/on via config. The new metrics are slightly different to the legacy implementation."),
 		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9794"),
+		featuregate.WithRegisterRemovalVersion("0.71.0"),
 	)
 }
 


### PR DESCRIPTION
**Description:** 
The featuregate is now stable, with aim to be completely removed for the 0.71.0 release. 

The featuregate has been in beta since November - this was the PR to make it beta: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16381

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9794

