### PR TITLE
[exporter/datadogexporter] add option to submit sum as rate

### DIFF
--- a/.chloggen/rong-ddexporter-submit-sum-as-rate.yaml
+++ b/.chloggen/rong-ddexporter-submit-sum-as-rate.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add option to submit OTLP sums as rate to Datadog API
+
+# One or more tracking issues related to the change
+issues: [17483]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -516,9 +516,7 @@ func (c *Config) Unmarshal(configMap *confmap.Conf) error {
 	if c.Metrics.TCPAddr.Endpoint == "" || c.Traces.TCPAddr.Endpoint == "" || c.Logs.TCPAddr.Endpoint == "" {
 		return errEmptyEndpoint
 	}
-
 	if !configMap.IsSet("metrics::sums::sum_to_rate_conversion_interval") {
-		fmt.Println("`sum_to_rate_conversion_interval` is unset. Defaulting it to 10s")
 		c.Metrics.SumConfig.SumToRateConversionInterval = DefaultSumToRateInterval
 	}
 

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -172,8 +172,8 @@ type SumConfig struct {
 	// is false, which means that it will be submitted as a count.
 	SubmitAsRate bool `mapstructure:"submit_as_rate"`
 
-	// Required when SubmitAsRate is set to true
-	// Defaults to 10s for sum to rate conversion interval
+	// SumToRateConversionInterval specifies the interval to use when submitting sums
+	// as rate. To be used in conjunction with SubmitAsRate.
 	SumToRateConversionInterval time.Duration `mapstructure:"sum_to_rate_conversion_interval"`
 }
 

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -41,7 +41,7 @@ var (
 const (
 	// DefaultSite is the default site of the Datadog intake to send data to
 	DefaultSite = "datadoghq.com"
-	// Default interval for sum_to_rate_conversion
+	// DefaultSumToRateInterval specifies the interval to use when converting a sum to a rate.
 	DefaultSumToRateInterval = 10 * time.Second
 )
 

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -168,8 +168,8 @@ type SumConfig struct {
 	// See https://docs.datadoghq.com/metrics/otlp/?tab=sum#mapping for details and examples.
 	CumulativeMonotonicMode CumulativeMonotonicSumMode `mapstructure:"cumulative_monotonic_mode"`
 
-	// The default is false, which submits sum as `count` type
-	// Enabling this changes the submission type from `count` to `rate`
+	// SubmitAsRate reports whether the sum should be submitted as a rate. The default
+	// is false, which means that it will be submitted as a count.
 	SubmitAsRate bool `mapstructure:"submit_as_rate"`
 
 	// Required when SubmitAsRate is set to true

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -119,7 +119,8 @@ func TestLoadConfig(t *testing.T) {
 						SendCountSum: false,
 					},
 					SumConfig: SumConfig{
-						CumulativeMonotonicMode: CumulativeMonotonicSumModeToDelta,
+						CumulativeMonotonicMode:     CumulativeMonotonicSumModeToDelta,
+						SumToRateConversionInterval: DefaultSumToRateInterval,
 					},
 					SummaryConfig: SummaryConfig{
 						Mode: SummaryModeGauges,
@@ -168,7 +169,8 @@ func TestLoadConfig(t *testing.T) {
 						SendCountSum: false,
 					},
 					SumConfig: SumConfig{
-						CumulativeMonotonicMode: CumulativeMonotonicSumModeToDelta,
+						CumulativeMonotonicMode:     CumulativeMonotonicSumModeToDelta,
+						SumToRateConversionInterval: DefaultSumToRateInterval,
 					},
 					SummaryConfig: SummaryConfig{
 						Mode: SummaryModeGauges,
@@ -221,7 +223,8 @@ func TestLoadConfig(t *testing.T) {
 						SendCountSum: false,
 					},
 					SumConfig: SumConfig{
-						CumulativeMonotonicMode: CumulativeMonotonicSumModeToDelta,
+						CumulativeMonotonicMode:     CumulativeMonotonicSumModeToDelta,
+						SumToRateConversionInterval: DefaultSumToRateInterval,
 					},
 					SummaryConfig: SummaryConfig{
 						Mode: SummaryModeGauges,
@@ -247,6 +250,55 @@ func TestLoadConfig(t *testing.T) {
 					HostnameSource: HostnameSourceConfigOrSystem,
 					Tags:           []string{"example:tag"},
 				},
+			},
+		},
+		{
+			id: component.NewIDWithName(typeStr, "sum_as_rate"),
+			expected: &Config{
+				TimeoutSettings: defaulttimeoutSettings(),
+				RetrySettings:   exporterhelper.NewDefaultRetrySettings(),
+				QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
+				API: APIConfig{
+					Key:              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Site:             "datadoghq.com",
+					FailOnInvalidKey: false,
+				},
+
+				Metrics: MetricsConfig{
+					TCPAddr: confignet.TCPAddr{
+						Endpoint: "https://api.datadoghq.com",
+					},
+					DeltaTTL: 3600,
+					HistConfig: HistogramConfig{
+						Mode:         "distributions",
+						SendCountSum: false,
+					},
+					SumConfig: SumConfig{
+						CumulativeMonotonicMode:     CumulativeMonotonicSumModeToDelta,
+						SubmitAsRate:                true,
+						SumToRateConversionInterval: DefaultSumToRateInterval,
+					},
+					SummaryConfig: SummaryConfig{
+						Mode: SummaryModeGauges,
+					},
+				},
+
+				Traces: TracesConfig{
+					TCPAddr: confignet.TCPAddr{
+						Endpoint: "https://trace.agent.datadoghq.com",
+					},
+					IgnoreResources: []string{},
+				},
+				Logs: LogsConfig{
+					TCPAddr: confignet.TCPAddr{
+						Endpoint: "https://http-intake.logs.datadoghq.com",
+					},
+				},
+				HostMetadata: HostMetadataConfig{
+					Enabled:        true,
+					HostnameSource: HostnameSourceConfigOrSystem,
+				},
+				OnlyMetadata: false,
 			},
 		},
 	}

--- a/exporter/datadogexporter/internal/metrics/consumer.go
+++ b/exporter/datadogexporter/internal/metrics/consumer.go
@@ -126,7 +126,7 @@ func (c *Consumer) ConsumeTimeSeries(
 ) {
 	dt := c.toDataType(typ)
 	if dt == datadogV2.METRICINTAKETYPE_RATE {
-		value = value / c.sumToRateConversionInterval.Seconds()
+		value /= c.sumToRateConversionInterval.Seconds()
 	}
 	met := NewMetric(dims.Name(), dt, timestamp, value, dims.Tags())
 	met.SetResources([]datadogV2.MetricResource{

--- a/exporter/datadogexporter/internal/metrics/consumer.go
+++ b/exporter/datadogexporter/internal/metrics/consumer.go
@@ -45,7 +45,7 @@ type Consumer struct {
 	sumToRateConversionInterval time.Duration
 }
 
-// NewConsumer creates a new Datadog consumer. It implements translator.Consumer.
+// NewConsumer creates a new Datadog consumer.
 func NewConsumer(metricsSumAsRate bool, metricsSumToRateConversionInterval time.Duration) *Consumer {
 	return &Consumer{
 		seenHosts:                   make(map[string]struct{}),

--- a/exporter/datadogexporter/internal/metrics/consumer_deprecated.go
+++ b/exporter/datadogexporter/internal/metrics/consumer_deprecated.go
@@ -125,7 +125,7 @@ func (c *ZorkianConsumer) ConsumeTimeSeries(
 ) {
 	dt := c.toDataType(typ)
 	if dt == Rate {
-		value = value / c.sumToRateConversionInterval.Seconds()
+		value /= c.sumToRateConversionInterval.Seconds()
 	}
 	met := NewZorkianMetric(dims.Name(), dt, timestamp, value, dims.Tags())
 	met.SetHost(dims.Host())

--- a/exporter/datadogexporter/internal/metrics/consumer_deprecated_test.go
+++ b/exporter/datadogexporter/internal/metrics/consumer_deprecated_test.go
@@ -52,7 +52,7 @@ func TestZorkianRunningMetrics(t *testing.T) {
 	tr := newTranslator(t, logger)
 
 	ctx := context.Background()
-	consumer := NewZorkianConsumer()
+	consumer := NewZorkianConsumer(false, DefaultSumToRateInterval)
 	assert.NoError(t, tr.MapMetrics(ctx, ms, consumer))
 
 	var runningHostnames []string
@@ -96,7 +96,7 @@ func TestZorkianTagsMetrics(t *testing.T) {
 	tr := newTranslator(t, logger)
 
 	ctx := context.Background()
-	consumer := NewZorkianConsumer()
+	consumer := NewZorkianConsumer(false, DefaultSumToRateInterval)
 	assert.NoError(t, tr.MapMetrics(ctx, ms, consumer))
 
 	runningMetrics := consumer.runningMetrics(0, component.BuildInfo{})
@@ -115,7 +115,7 @@ func TestZorkianTagsMetrics(t *testing.T) {
 }
 
 func TestZorkianConsumeAPMStats(t *testing.T) {
-	c := NewZorkianConsumer()
+	c := NewZorkianConsumer(false, DefaultSumToRateInterval)
 	for _, sp := range testutil.StatsPayloads {
 		c.ConsumeAPMStats(sp)
 	}

--- a/exporter/datadogexporter/internal/metrics/consumer_test.go
+++ b/exporter/datadogexporter/internal/metrics/consumer_test.go
@@ -17,6 +17,7 @@ package metrics
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes"
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/source"
@@ -30,6 +31,10 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/testutil"
+)
+
+const (
+	DefaultSumToRateInterval = 10 * time.Second
 )
 
 type testProvider string
@@ -70,7 +75,7 @@ func TestRunningMetrics(t *testing.T) {
 	tr := newTranslator(t, logger)
 
 	ctx := context.Background()
-	consumer := NewConsumer()
+	consumer := NewConsumer(false, DefaultSumToRateInterval)
 	assert.NoError(t, tr.MapMetrics(ctx, ms, consumer))
 
 	var runningHostnames []string
@@ -113,7 +118,7 @@ func TestTagsMetrics(t *testing.T) {
 	tr := newTranslator(t, logger)
 
 	ctx := context.Background()
-	consumer := NewConsumer()
+	consumer := NewConsumer(false, DefaultSumToRateInterval)
 	assert.NoError(t, tr.MapMetrics(ctx, ms, consumer))
 
 	runningMetrics := consumer.runningMetrics(0, component.BuildInfo{})
@@ -132,7 +137,7 @@ func TestTagsMetrics(t *testing.T) {
 }
 
 func TestConsumeAPMStats(t *testing.T) {
-	c := NewConsumer()
+	c := NewConsumer(false, DefaultSumToRateInterval)
 	for _, sp := range testutil.StatsPayloads {
 		c.ConsumeAPMStats(sp)
 	}

--- a/exporter/datadogexporter/internal/metrics/series_deprecated.go
+++ b/exporter/datadogexporter/internal/metrics/series_deprecated.go
@@ -28,6 +28,8 @@ const (
 	Gauge MetricType = "gauge"
 	// Count is the Datadog Count metric type
 	Count MetricType = "count"
+	// Rate is the Datadog Rate metric type
+	Rate MetricType = "rate"
 )
 
 // newZorkianMetric creates a new Zorkian Datadog metric given a name, a Unix nanoseconds timestamp

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -196,9 +196,11 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pmetric.Metr
 	}
 	var consumer translator.Consumer
 	if isMetricExportV2Enabled() {
-		consumer = metrics.NewConsumer()
+		consumer = metrics.NewConsumer(exp.cfg.Metrics.SumConfig.SubmitAsRate,
+			exp.cfg.Metrics.SumConfig.SumToRateConversionInterval)
 	} else {
-		consumer = metrics.NewZorkianConsumer()
+		consumer = metrics.NewZorkianConsumer(exp.cfg.Metrics.SumConfig.SubmitAsRate,
+			exp.cfg.Metrics.SumConfig.SumToRateConversionInterval)
 	}
 	err := exp.tr.MapMetrics(ctx, md, consumer)
 	if err != nil {

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -388,14 +388,14 @@ func Test_metricsExporter_SumAsRate(t *testing.T) {
 				"series": []interface{}{
 					map[string]interface{}{
 						"metric":    "int.sum",
-						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(11.1)}},
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(1), "value": float64(11.1)}},
 						"type":      float64(datadogV2.METRICINTAKETYPE_RATE),
 						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
 						"tags":      []interface{}{"env:dev"},
 					},
 					map[string]interface{}{
 						"metric":    "double.sum",
-						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(12.345)}},
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(1), "value": float64(12.345)}},
 						"type":      float64(datadogV2.METRICINTAKETYPE_RATE),
 						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
 						"tags":      []interface{}{"env:dev"},
@@ -423,14 +423,14 @@ func Test_metricsExporter_SumAsRate(t *testing.T) {
 				"series": []interface{}{
 					map[string]interface{}{
 						"metric":    "int.sum",
-						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(5.55)}},
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(1), "value": float64(5.55)}},
 						"type":      float64(datadogV2.METRICINTAKETYPE_RATE),
 						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
 						"tags":      []interface{}{"env:dev"},
 					},
 					map[string]interface{}{
 						"metric":    "double.sum",
-						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(6.1725)}},
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(1), "value": float64(6.1725)}},
 						"type":      float64(datadogV2.METRICINTAKETYPE_RATE),
 						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
 						"tags":      []interface{}{"env:dev"},
@@ -457,14 +457,14 @@ func Test_metricsExporter_SumAsRate(t *testing.T) {
 				"series": []interface{}{
 					map[string]interface{}{
 						"metric":    "int.sum",
-						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(111)}},
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(1), "value": float64(111)}},
 						"type":      float64(datadogV2.METRICINTAKETYPE_COUNT),
 						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
 						"tags":      []interface{}{"env:dev", "key1:value1", "key2:value2"},
 					},
 					map[string]interface{}{
 						"metric":    "double.sum",
-						"points":    []interface{}{map[string]interface{}{"timestamp": float64(0), "value": float64(123.45)}},
+						"points":    []interface{}{map[string]interface{}{"timestamp": float64(1), "value": float64(123.45)}},
 						"type":      float64(datadogV2.METRICINTAKETYPE_COUNT),
 						"resources": []interface{}{map[string]interface{}{"name": "test-host", "type": "host"}},
 						"tags":      []interface{}{"env:dev", "key1:value1", "key2:value2"},
@@ -932,14 +932,14 @@ func Test_metricsExporter_SumAsRate_Zorkian(t *testing.T) {
 				"series": []interface{}{
 					map[string]interface{}{
 						"metric": "int.sum",
-						"points": []interface{}{[]interface{}{float64(0), float64(11.1)}},
+						"points": []interface{}{[]interface{}{float64(1), float64(11.1)}},
 						"type":   "rate",
 						"host":   "test-host",
 						"tags":   []interface{}{"env:dev"},
 					},
 					map[string]interface{}{
 						"metric": "double.sum",
-						"points": []interface{}{[]interface{}{float64(0), float64(12.345)}},
+						"points": []interface{}{[]interface{}{float64(1), float64(12.345)}},
 						"type":   "rate",
 						"host":   "test-host",
 						"tags":   []interface{}{"env:dev"},
@@ -967,14 +967,14 @@ func Test_metricsExporter_SumAsRate_Zorkian(t *testing.T) {
 				"series": []interface{}{
 					map[string]interface{}{
 						"metric": "int.sum",
-						"points": []interface{}{[]interface{}{float64(0), float64(5.55)}},
+						"points": []interface{}{[]interface{}{float64(1), float64(5.55)}},
 						"type":   "rate",
 						"host":   "test-host",
 						"tags":   []interface{}{"env:dev"},
 					},
 					map[string]interface{}{
 						"metric": "double.sum",
-						"points": []interface{}{[]interface{}{float64(0), float64(6.1725)}},
+						"points": []interface{}{[]interface{}{float64(1), float64(6.1725)}},
 						"type":   "rate",
 						"host":   "test-host",
 						"tags":   []interface{}{"env:dev"},
@@ -1001,14 +1001,14 @@ func Test_metricsExporter_SumAsRate_Zorkian(t *testing.T) {
 				"series": []interface{}{
 					map[string]interface{}{
 						"metric": "int.sum",
-						"points": []interface{}{[]interface{}{float64(0), float64(111)}},
+						"points": []interface{}{[]interface{}{float64(1), float64(111)}},
 						"type":   "count",
 						"host":   "test-host",
 						"tags":   []interface{}{"env:dev", "key1:value1", "key2:value2"},
 					},
 					map[string]interface{}{
 						"metric": "double.sum",
-						"points": []interface{}{[]interface{}{float64(0), float64(123.45)}},
+						"points": []interface{}{[]interface{}{float64(1), float64(123.45)}},
 						"type":   "count",
 						"host":   "test-host",
 						"tags":   []interface{}{"env:dev", "key1:value1", "key2:value2"},
@@ -1190,7 +1190,7 @@ func createTestSums(additionalAttributes map[string]string) pmetric.Metrics {
 	dpsInt := met.SetEmptySum().DataPoints()
 	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 	dpInt := dpsInt.AppendEmpty()
-	dpInt.SetTimestamp(seconds(0))
+	dpInt.SetTimestamp(seconds(1))
 	dpInt.SetIntValue(111)
 
 	// DoubleSum
@@ -1199,7 +1199,7 @@ func createTestSums(additionalAttributes map[string]string) pmetric.Metrics {
 	dpsDbl := met.SetEmptySum().DataPoints()
 	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 	dpDbl := dpsDbl.AppendEmpty()
-	dpDbl.SetTimestamp(seconds(0))
+	dpDbl.SetTimestamp(seconds(1))
 	dpDbl.SetDoubleValue(123.45)
 
 	return md

--- a/exporter/datadogexporter/testdata/config.yaml
+++ b/exporter/datadogexporter/testdata/config.yaml
@@ -37,3 +37,10 @@ datadog/default:
   api:
     key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
+datadog/sum_as_rate:
+  api:
+    key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+  metrics:
+    sums:
+      submit_as_rate: true


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add an option to datadogexporter to submit sums as rate (to match the behavior of datadog-agent)

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17483

**Testing:**
- added unit tests to metric_exporter_test.go to test submission of sums as rate using different conversion intervals.

**Documentation:**
N/A (datadogexporter README.md links to external site)

@KSerrania @mx-psi @gbbr @knusbaum @amenasria @dineshg13 @aallawala