### PR TITLE
[processor/servicegraph] Fix cache cleanup to also purge stale series

### DIFF
--- a/.chloggen/servicegraph-cache-cleanup-fix.yaml
+++ b/.chloggen/servicegraph-cache-cleanup-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: servicegraphprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix cache cleanup in servicegraph proccesor to also purge stale series
+
+# One or more tracking issues related to the change
+issues: [ 16262 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/servicegraphprocessor/processor.go
+++ b/processor/servicegraphprocessor/processor.go
@@ -505,6 +505,16 @@ func (p *serviceGraphProcessor) cleanCache() {
 		delete(p.keyToMetric, key)
 	}
 	p.metricMutex.Unlock()
+
+	p.seriesMutex.Lock()
+	for _, key := range staleSeries {
+		delete(p.reqTotal, key)
+		delete(p.reqFailedTotal, key)
+		delete(p.reqDurationSecondsCount, key)
+		delete(p.reqDurationSecondsSum, key)
+		delete(p.reqDurationSecondsBucketCounts, key)
+	}
+	p.seriesMutex.Unlock()
 }
 
 // durationToMillis converts the given duration to the number of milliseconds it represents.


### PR DESCRIPTION
**Description:** Fixes an issue which would cause metric collections to fail in the servicegraph processor after stale metrics were purged.

**Link to tracking Issue:** closes #16262

**Testing:** Added a test that forces a cache cleanup and verifies that no error occurs in the next metric collection.

**Documentation:**