### PR TITLE
[internal/filter] Replace usage of deprecated Value.Equal

### DIFF
--- a/internal/filter/filtermatcher/attributematcher.go
+++ b/internal/filter/filtermatcher/attributematcher.go
@@ -21,17 +21,23 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
 )
 
 type AttributesMatcher []AttributeMatcher
 
+type valueIdentifier struct {
+	value     pcommon.Value
+	valueHash [16]byte
+}
+
 // AttributeMatcher is a attribute key/value pair to match to.
 type AttributeMatcher struct {
 	Key string
 	// If both AttributeValue and StringFilter are nil only check for key existence.
-	AttributeValue *pcommon.Value
+	AttributeValue *valueIdentifier
 	// StringFilter is needed to match against a regular expression
 	StringFilter filterset.FilterSet
 }
@@ -72,7 +78,10 @@ func NewAttributesMatcher(config filterset.Config, attributes []filterconfig.Att
 				}
 				entry.StringFilter = filter
 			case filterset.Strict:
-				entry.AttributeValue = &val
+				entry.AttributeValue = &valueIdentifier{
+					value:     val,
+					valueHash: pdatautil.ValueHash(val),
+				}
 			default:
 				return nil, filterset.NewUnrecognizedMatchTypeError(config.MatchType)
 
@@ -110,7 +119,7 @@ func (ma AttributesMatcher) Match(attrs pcommon.Map) bool {
 				return false
 			}
 		} else if property.AttributeValue != nil {
-			if !attr.Equal(*property.AttributeValue) {
+			if !attributeValueMatch(property.AttributeValue, attr) {
 				return false
 			}
 		}
@@ -131,4 +140,22 @@ func attributeStringValue(attr pcommon.Value) (string, error) {
 	default:
 		return "", errUnexpectedAttributeType
 	}
+}
+
+func attributeValueMatch(vi *valueIdentifier, val pcommon.Value) bool {
+	if vi.value.Type() != val.Type() {
+		return false
+	}
+	switch val.Type() {
+	case pcommon.ValueTypeStr:
+		return vi.value.Str() == val.Str()
+	case pcommon.ValueTypeBool:
+		return vi.value.Bool() == val.Bool()
+	case pcommon.ValueTypeDouble:
+		return vi.value.Double() == val.Double()
+	case pcommon.ValueTypeInt:
+		return vi.value.Int() == val.Int()
+	}
+	// Use hash for other complex data types.
+	return vi.valueHash == pdatautil.ValueHash(val)
 }

--- a/internal/filter/filtermatcher/attributematcher_test.go
+++ b/internal/filter/filtermatcher/attributematcher_test.go
@@ -1,0 +1,80 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filtermatcher // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filtermatcher"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterconfig"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
+)
+
+func TestMatchAttributes(t *testing.T) {
+	matchCfg := filterset.Config{MatchType: filterset.Strict}
+	attrsCfg := []filterconfig.Attribute{
+		{Key: "strKey", Value: "strVal"},
+		{Key: "intKey", Value: 1},
+		{Key: "sliceKey", Value: []any{"a", "b"}},
+	}
+	matcher, err := NewAttributesMatcher(matchCfg, attrsCfg)
+	require.NoError(t, err)
+
+	matchingMap := pcommon.NewMap()
+	matchingMap.PutStr("strKey", "strVal")
+	matchingMap.PutInt("intKey", 1)
+	sl := matchingMap.PutEmptySlice("sliceKey")
+	sl.AppendEmpty().SetStr("a")
+	sl.AppendEmpty().SetStr("b")
+	matchingMap.PutStr("anotherKey", "anotherVal")
+
+	notMatchingMap := pcommon.NewMap()
+	notMatchingMap.PutStr("strKey", "strVal")
+	notMatchingMap.PutInt("intKey", 1)
+	notMatchingMap.PutStr("anotherKey", "anotherVal")
+
+	assert.True(t, matcher.Match(matchingMap))
+	assert.False(t, matcher.Match(notMatchingMap))
+}
+
+func BenchmarkMatchAttributes(b *testing.B) {
+	matchCfg := filterset.Config{MatchType: filterset.Strict}
+	attrsCfg := []filterconfig.Attribute{
+		{Key: "strKey", Value: "strVal"},
+		{Key: "intKey", Value: 1},
+	}
+	matcher, err := NewAttributesMatcher(matchCfg, attrsCfg)
+	require.NoError(b, err)
+
+	matchingMap := pcommon.NewMap()
+	matchingMap.PutStr("strKey", "strVal")
+	matchingMap.PutInt("intKey", 1)
+	matchingMap.PutStr("anotherKey", "anotherVal")
+
+	notMatchingMap := pcommon.NewMap()
+	notMatchingMap.PutStr("strKey", "strVal")
+	notMatchingMap.PutBool("boolKey", true)
+	notMatchingMap.PutStr("anotherKey", "anotherVal")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		matcher.Match(matchingMap)
+		matcher.Match(notMatchingMap)
+	}
+}

--- a/internal/filter/go.mod
+++ b/internal/filter/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/alecthomas/participle/v2 v2.0.0-beta.5 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/internal/filter/go.sum
+++ b/internal/filter/go.sum
@@ -35,6 +35,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/processor/attributesprocessor/go.mod
+++ b/processor/attributesprocessor/go.mod
@@ -19,6 +19,7 @@ require (
 require (
 	github.com/alecthomas/participle/v2 v2.0.0-beta.5 // indirect
 	github.com/antonmedv/expr v1.9.0 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/processor/attributesprocessor/go.sum
+++ b/processor/attributesprocessor/go.sum
@@ -35,6 +35,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/processor/filterprocessor/go.mod
+++ b/processor/filterprocessor/go.mod
@@ -19,6 +19,7 @@ require (
 require (
 	github.com/alecthomas/participle/v2 v2.0.0-beta.5 // indirect
 	github.com/antonmedv/expr v1.9.0 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/processor/filterprocessor/go.sum
+++ b/processor/filterprocessor/go.sum
@@ -35,6 +35,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
Value.Equal is deprecated and has to be replaced with another implementation. The following options were considered:

Before:

```
BenchmarkMatchAttributes
BenchmarkMatchAttributes-10    	22528935	        53.61 ns/op	       0 B/op	       0 allocs/op
PASS
```

Using `pdatautil.ValueHash`:

```
BenchmarkMatchAttributes
BenchmarkMatchAttributes-10    	 7497790	       158.8 ns/op	       0 B/op	       0 allocs/op
PASS
```

Using `AsRaw()`:

```
BenchmarkMatchAttributes
BenchmarkMatchAttributes-10    	 9387561	       127.6 ns/op	      64 B/op	       4 allocs/op
PASS
```

Local implementation of the equality function:

```
BenchmarkMatchAttributes
BenchmarkMatchAttributes-10    	22568798	        51.16 ns/op	       0 B/op	       0 allocs/op
```

The last option is implemented in this PR