### PR TITLE
[chore] [receiver/signalfx] Remove usages of Map.Sort

### DIFF
--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.69.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.69.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/comparetest v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.69.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx v0.69.0
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3
@@ -22,6 +23,7 @@ require (
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
@@ -81,6 +83,8 @@ require (
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter => ../../exporter/signalfxexporter
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/comparetest => ../../internal/comparetest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
 

--- a/receiver/signalfxreceiver/go.sum
+++ b/receiver/signalfxreceiver/go.sum
@@ -166,7 +166,6 @@ github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/comparetest"
 )
 
 func Test_signalfxeceiver_New(t *testing.T) {
@@ -579,7 +580,6 @@ func Test_sfxReceiver_TLS(t *testing.T) {
 	dp.Attributes().PutStr("k0", "v0")
 	dp.Attributes().PutStr("k1", "v1")
 	dp.Attributes().PutStr("k2", "v2")
-	dp.Attributes().Sort()
 
 	t.Log("Sending SignalFx metric data Request")
 
@@ -618,7 +618,7 @@ func Test_sfxReceiver_TLS(t *testing.T) {
 	require.Len(t, mds, 1)
 	got := mds[0]
 	require.Equal(t, 1, got.ResourceMetrics().Len())
-	assert.Equal(t, want, got)
+	require.NoError(t, comparetest.CompareMetrics(want, got))
 }
 
 func Test_sfxReceiver_DatapointAccessTokenPassthrough(t *testing.T) {

--- a/receiver/signalfxreceiver/signalfxv2_event_to_logdata_test.go
+++ b/receiver/signalfxreceiver/signalfxv2_event_to_logdata_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/comparetest"
 )
 
 func TestSignalFxV2EventsToLogData(t *testing.T) {
@@ -66,9 +68,7 @@ func TestSignalFxV2EventsToLogData(t *testing.T) {
 		propMap.PutInt("rack", 5)
 		propMap.PutDouble("temp", 40.5)
 		propMap.PutEmpty("nullProp")
-		propMap.Sort()
 
-		l.Attributes().Sort()
 		return logSlice
 	}
 
@@ -101,10 +101,7 @@ func TestSignalFxV2EventsToLogData(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lrs := plog.NewLogRecordSlice()
 			signalFxV2EventsToLogRecords(tt.sfxEvents, lrs)
-			for i := 0; i < lrs.Len(); i++ {
-				lrs.At(i).Attributes().Sort()
-			}
-			assert.Equal(t, tt.expected, lrs)
+			assert.NoError(t, comparetest.CompareLogRecordSlices(tt.expected, lrs))
 		})
 	}
 }

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -298,3 +298,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/corei
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry => ../pkg/resourcetotelemetry
 
 retract v0.65.0
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/comparetest => ../internal/comparetest


### PR DESCRIPTION
Use comparetest module for logs and metrics equality validation

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/6688