### PR TITLE
[chore] remove calls to validate the configuration, now done in the config builder

### DIFF
--- a/exporter/logzioexporter/config_test.go
+++ b/exporter/logzioexporter/config_test.go
@@ -133,3 +133,10 @@ func TestCheckAndWarnDeprecatedOptions(t *testing.T) {
 	expected.QueueSettings.QueueSize = 10
 	assert.Equal(t, expected, actualCfg)
 }
+
+func TestNullTokenConfig(tester *testing.T) {
+	cfg := Config{
+		Region: "eu",
+	}
+	assert.Error(tester, cfg.Validate(), "Empty token should produce error")
+}

--- a/exporter/logzioexporter/exporter.go
+++ b/exporter/logzioexporter/exporter.go
@@ -81,9 +81,6 @@ func newLogzioTracesExporter(config *Config, set exporter.CreateSettings) (expor
 	if err != nil {
 		return nil, err
 	}
-	if err = config.Validate(); err != nil {
-		return nil, err
-	}
 	exporter.config.HTTPClientSettings.Endpoint, err = generateEndpoint(config)
 	if err != nil {
 		return nil, err
@@ -104,9 +101,6 @@ func newLogzioTracesExporter(config *Config, set exporter.CreateSettings) (expor
 func newLogzioLogsExporter(config *Config, set exporter.CreateSettings) (exporter.Logs, error) {
 	exporter, err := newLogzioExporter(config, set)
 	if err != nil {
-		return nil, err
-	}
-	if err = config.Validate(); err != nil {
 		return nil, err
 	}
 	exporter.config.HTTPClientSettings.Endpoint, err = generateEndpoint(config)

--- a/exporter/logzioexporter/exporter_test.go
+++ b/exporter/logzioexporter/exporter_test.go
@@ -232,15 +232,6 @@ func TestNullExporterConfig(tester *testing.T) {
 	assert.Error(tester, err, "Null exporter config should produce error")
 }
 
-func TestNullTokenConfig(tester *testing.T) {
-	cfg := Config{
-		Region: "eu",
-	}
-	params := exportertest.NewNopCreateSettings()
-	_, err := createTracesExporter(context.Background(), params, &cfg)
-	assert.Error(tester, err, "Empty token should produce error")
-}
-
 func gUnzipData(data []byte) (resData []byte, err error) {
 	b := bytes.NewBuffer(data)
 

--- a/exporter/lokiexporter/factory.go
+++ b/exporter/lokiexporter/factory.go
@@ -39,12 +39,6 @@ func NewFactory() exporter.Factory {
 func createLogsExporter(ctx context.Context, set exporter.CreateSettings, config component.Config) (exporter.Logs, error) {
 	expCfg := config.(*Config)
 
-	// this should go away once the legacy code is removed, as the config validation happens during the loading
-	// of the config already, it should not be called explicitly here
-	if err := expCfg.Validate(); err != nil {
-		return nil, err
-	}
-
 	if expCfg.isLegacy() {
 		return createLegacyLogsExporter(ctx, set, expCfg)
 	}

--- a/exporter/mezmoexporter/config_test.go
+++ b/exporter/mezmoexporter/config_test.go
@@ -82,3 +82,23 @@ func TestLoadConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigInvalidEndpoint(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.IngestURL = "urn:something:12345"
+	assert.Error(t, cfg.Validate())
+}
+
+func TestConfig_Validate_Path(t *testing.T) {
+	factory := NewFactory()
+
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.IngestURL = "https://example.com:8088/otel/ingest/rest"
+	cfg.IngestKey = "1234-1234"
+	assert.NoError(t, cfg.Validate())
+
+	// Set values that don't have a valid default.
+	cfg.IngestURL = "https://example.com"
+	cfg.IngestKey = "testToken"
+	assert.Error(t, cfg.Validate())
+}

--- a/exporter/mezmoexporter/factory.go
+++ b/exporter/mezmoexporter/factory.go
@@ -57,10 +57,6 @@ func createLogsExporter(ctx context.Context, settings exporter.CreateSettings, e
 	}
 	expCfg := exporterConfig.(*Config)
 
-	if err := expCfg.Validate(); err != nil {
-		return nil, err
-	}
-
 	exp := newLogsExporter(expCfg, settings.TelemetrySettings, settings.BuildInfo, log)
 
 	return exporterhelper.NewLogsExporter(

--- a/exporter/mezmoexporter/factory_test.go
+++ b/exporter/mezmoexporter/factory_test.go
@@ -55,9 +55,7 @@ func TestIngestUrlMustConform(t *testing.T) {
 	cfg.IngestURL = "https://example.com:8088/services/collector"
 	cfg.IngestKey = "1234-1234"
 
-	params := exportertest.NewNopCreateSettings()
-	_, err := createLogsExporter(context.Background(), params, cfg)
-	assert.Error(t, err, `"ingest_url" must end with "/otel/ingest/rest"`)
+	assert.Error(t, cfg.Validate(), `"ingest_url" must end with "/otel/ingest/rest"`)
 }
 
 func TestCreateLogsExporter(t *testing.T) {
@@ -74,32 +72,4 @@ func TestCreateLogsExporterNoConfig(t *testing.T) {
 	params := exportertest.NewNopCreateSettings()
 	_, err := createLogsExporter(context.Background(), params, nil)
 	assert.Error(t, err)
-}
-
-func TestCreateLogsExporterInvalidEndpoint(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.IngestURL = "urn:something:12345"
-	params := exportertest.NewNopCreateSettings()
-	_, err := createLogsExporter(context.Background(), params, cfg)
-	assert.Error(t, err)
-}
-
-func TestCreateInstanceViaFactory(t *testing.T) {
-	factory := NewFactory()
-
-	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.IngestURL = "https://example.com:8088/otel/ingest/rest"
-	cfg.IngestKey = "1234-1234"
-	params := exportertest.NewNopCreateSettings()
-	exp, err := factory.CreateLogsExporter(context.Background(), params, cfg)
-	assert.NoError(t, err)
-	assert.NotNil(t, exp)
-	assert.NoError(t, exp.Shutdown(context.Background()))
-
-	// Set values that don't have a valid default.
-	cfg.IngestURL = "https://example.com"
-	cfg.IngestKey = "testToken"
-	exp, err = factory.CreateLogsExporter(context.Background(), params, cfg)
-	assert.Error(t, err)
-	assert.Nil(t, exp)
 }

--- a/exporter/sumologicexporter/exporter.go
+++ b/exporter/sumologicexporter/exporter.go
@@ -40,10 +40,6 @@ type sumologicexporter struct {
 }
 
 func initExporter(cfg *Config, settings component.TelemetrySettings) (*sumologicexporter, error) {
-	if err := cfg.Validate(); err != nil {
-		return nil, err
-	}
-
 	sfs := newSourceFormats(cfg)
 
 	f, err := newFilter(cfg.MetadataAttributes)

--- a/exporter/sumologicexporter/exporter_test.go
+++ b/exporter/sumologicexporter/exporter_test.go
@@ -54,20 +54,6 @@ func TestInitExporter(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestInitExporterInvalidConfig(t *testing.T) {
-	_, err := initExporter(&Config{
-		LogFormat:    "json",
-		MetricFormat: "test_format",
-		HTTPClientSettings: confighttp.HTTPClientSettings{
-			Timeout:  defaultTimeout,
-			Endpoint: "test_endpoint",
-		},
-		CompressEncoding: "gzip",
-	}, componenttest.NewNopTelemetrySettings())
-
-	assert.EqualError(t, err, "unexpected metric format: test_format")
-}
-
 func TestAllSuccess(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {

--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -25,7 +25,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"
 	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +40,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"

--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"
 	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -198,6 +199,12 @@ func TestDefaultReceivers(t *testing.T) {
 		{
 			receiver:     "jmx",
 			skipLifecyle: true, // Requires a running instance with JMX
+			getConfigFn: func() component.Config {
+				cfg := jmxreceiver.NewFactory().CreateDefaultConfig().(*jmxreceiver.Config)
+				cfg.Endpoint = "localhost:1234"
+				cfg.TargetSystem = "jvm"
+				return cfg
+			},
 		},
 		{
 			receiver:     "journald",

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -324,6 +324,17 @@ func TestClassPathParse(t *testing.T) {
 	}
 }
 
+func TestWithInvalidConfig(t *testing.T) {
+	f := NewFactory()
+	assert.Equal(t, component.Type("jmx"), f.Type())
+
+	cfg := f.CreateDefaultConfig().(*Config)
+	require.NotNil(t, cfg)
+
+	err := cfg.Validate()
+	assert.Equal(t, "missing required field(s): `endpoint`, `target_system`", err.Error())
+}
+
 func mockJarVersions() {
 	jmxMetricsGathererVersions["5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5"] = supportedJar{
 		jar:     "fake jar",

--- a/receiver/jmxreceiver/factory.go
+++ b/receiver/jmxreceiver/factory.go
@@ -57,8 +57,5 @@ func createReceiver(
 	consumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	jmxConfig := cfg.(*Config)
-	if err := jmxConfig.Validate(); err != nil {
-		return nil, err
-	}
 	return newJMXMetricReceiver(params, jmxConfig, consumer), nil
 }

--- a/receiver/jmxreceiver/factory_test.go
+++ b/receiver/jmxreceiver/factory_test.go
@@ -25,23 +25,6 @@ import (
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
-func TestWithInvalidConfig(t *testing.T) {
-	f := NewFactory()
-	assert.Equal(t, component.Type("jmx"), f.Type())
-
-	cfg := f.CreateDefaultConfig()
-	require.NotNil(t, cfg)
-
-	r, err := f.CreateMetricsReceiver(
-		context.Background(),
-		receivertest.NewNopCreateSettings(),
-		cfg, consumertest.NewNop(),
-	)
-	require.Error(t, err)
-	assert.Equal(t, "missing required field(s): `endpoint`, `target_system`", err.Error())
-	require.Nil(t, r)
-}
-
 func TestWithValidConfig(t *testing.T) {
 	mockJarVersions()
 	defer unmockJarVersions()

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -119,6 +119,9 @@ func (jmx *jmxMetricReceiver) Start(ctx context.Context, host component.Host) er
 }
 
 func (jmx *jmxMetricReceiver) Shutdown(ctx context.Context) error {
+	if jmx.subprocess == nil {
+		return nil
+	}
 	jmx.logger.Debug("Shutting down JMX Receiver")
 	subprocessErr := jmx.subprocess.Shutdown(ctx)
 	otlpErr := jmx.otlpReceiver.Shutdown(ctx)

--- a/receiver/solacereceiver/receiver.go
+++ b/receiver/solacereceiver/receiver.go
@@ -56,11 +56,6 @@ func newTracesReceiver(config *Config, set receiver.CreateSettings, nextConsumer
 		return nil, component.ErrNilNextConsumer
 	}
 
-	if err := config.Validate(); err != nil {
-		set.Logger.Warn("Error validating configuration", zap.Any("error", err))
-		return nil, err
-	}
-
 	factory, err := newAMQPMessagingServiceFactory(config, set.Logger)
 	if err != nil {
 		set.Logger.Warn("Error validating messaging service configuration", zap.Any("error", err))

--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	TimerHistogramMapping []protocol.TimerHistogramMapping `mapstructure:"timer_histogram_mapping"`
 }
 
-func (c *Config) validate() error {
+func (c *Config) Validate() error {
 	var errs error
 
 	if c.AggregationInterval <= 0 {

--- a/receiver/statsdreceiver/config_test.go
+++ b/receiver/statsdreceiver/config_test.go
@@ -21,12 +21,13 @@ import (
 	"time"
 
 	"github.com/lightstep/go-expohisto/structure"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 )
 
 func TestLoadConfig(t *testing.T) {

--- a/receiver/statsdreceiver/config_test.go
+++ b/receiver/statsdreceiver/config_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lightstep/go-expohisto/structure"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -148,11 +148,74 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErr: fmt.Sprintf(observerTypeNotSupportErr, "gauge1"),
 		},
+		{
+			name: "invalidHistogram",
+			cfg: &Config{
+				AggregationInterval: 20 * time.Second,
+				TimerHistogramMapping: []protocol.TimerHistogramMapping{
+					{
+						StatsdType:   "timing",
+						ObserverType: "gauge",
+						Histogram: protocol.HistogramConfig{
+							MaxSize: 100,
+						},
+					},
+				},
+			},
+			expectedErr: "histogram configuration requires observer_type: histogram",
+		},
+		{
+			name: "negativeAggregationInterval",
+			cfg: &Config{
+				AggregationInterval: -1,
+				TimerHistogramMapping: []protocol.TimerHistogramMapping{
+					{StatsdType: "timing", ObserverType: "gauge"},
+				},
+			},
+			expectedErr: "aggregation_interval must be a positive duration",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.EqualError(t, test.cfg.validate(), test.expectedErr)
+			require.EqualError(t, test.cfg.Validate(), test.expectedErr)
 		})
+	}
+}
+func TestConfig_Validate_MaxSize(t *testing.T) {
+	for _, maxSize := range []int32{structure.MaximumMaxSize + 1, -1, -structure.MaximumMaxSize} {
+		cfg := &Config{
+			AggregationInterval: 20 * time.Second,
+			TimerHistogramMapping: []protocol.TimerHistogramMapping{
+				{
+					StatsdType:   "timing",
+					ObserverType: "histogram",
+					Histogram: protocol.HistogramConfig{
+						MaxSize: maxSize,
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "histogram max_size out of range")
+	}
+}
+func TestConfig_Validate_HistogramGoodConfig(t *testing.T) {
+	for _, maxSize := range []int32{structure.MaximumMaxSize, 0, 2} {
+		cfg := &Config{
+			AggregationInterval: 20 * time.Second,
+			TimerHistogramMapping: []protocol.TimerHistogramMapping{
+				{
+					StatsdType:   "timing",
+					ObserverType: "histogram",
+					Histogram: protocol.HistogramConfig{
+						MaxSize: maxSize,
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		assert.NoError(t, err)
 	}
 }

--- a/receiver/statsdreceiver/factory.go
+++ b/receiver/statsdreceiver/factory.go
@@ -70,9 +70,5 @@ func createMetricsReceiver(
 	consumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	c := cfg.(*Config)
-	err := c.validate()
-	if err != nil {
-		return nil, err
-	}
 	return New(params, *c, consumer)
 }

--- a/receiver/statsdreceiver/factory_test.go
+++ b/receiver/statsdreceiver/factory_test.go
@@ -17,16 +17,12 @@ package statsdreceiver
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/lightstep/go-expohisto/structure"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 )
 
 type testHost struct {
@@ -56,101 +52,6 @@ func TestCreateReceiver(t *testing.T) {
 	tReceiver, err := createMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, tReceiver, "receiver creation failed")
-}
-
-func TestCreateReceiverWithConfigErr(t *testing.T) {
-	cfg := &Config{
-		AggregationInterval: -1,
-		TimerHistogramMapping: []protocol.TimerHistogramMapping{
-			{StatsdType: "timing", ObserverType: "gauge"},
-		},
-	}
-	receiver, err := createMetricsReceiver(
-		context.Background(),
-		receivertest.NewNopCreateSettings(),
-		cfg,
-		consumertest.NewNop(),
-	)
-	assert.Error(t, err, "aggregation_interval must be a positive duration")
-	assert.Nil(t, receiver)
-
-}
-
-func TestCreateReceiverWithHistogramConfigError(t *testing.T) {
-	for _, maxSize := range []int32{structure.MaximumMaxSize + 1, -1, -structure.MaximumMaxSize} {
-		cfg := &Config{
-			AggregationInterval: 20 * time.Second,
-			TimerHistogramMapping: []protocol.TimerHistogramMapping{
-				{
-					StatsdType:   "timing",
-					ObserverType: "histogram",
-					Histogram: protocol.HistogramConfig{
-						MaxSize: maxSize,
-					},
-				},
-			},
-		}
-		receiver, err := createMetricsReceiver(
-			context.Background(),
-			receivertest.NewNopCreateSettings(),
-			cfg,
-			consumertest.NewNop(),
-		)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "histogram max_size out of range")
-		assert.Nil(t, receiver)
-	}
-}
-
-func TestCreateReceiverWithHistogramGoodConfig(t *testing.T) {
-	for _, maxSize := range []int32{structure.MaximumMaxSize, 0, 2} {
-		cfg := &Config{
-			AggregationInterval: 20 * time.Second,
-			TimerHistogramMapping: []protocol.TimerHistogramMapping{
-				{
-					StatsdType:   "timing",
-					ObserverType: "histogram",
-					Histogram: protocol.HistogramConfig{
-						MaxSize: maxSize,
-					},
-				},
-			},
-		}
-		receiver, err := createMetricsReceiver(
-			context.Background(),
-			receivertest.NewNopCreateSettings(),
-			cfg,
-			consumertest.NewNop(),
-		)
-		assert.NoError(t, err)
-		assert.NotNil(t, receiver)
-		assert.NoError(t, receiver.Start(context.Background(), &testHost{t: t}))
-		assert.NoError(t, receiver.Shutdown(context.Background()))
-	}
-}
-
-func TestCreateReceiverWithInvalidHistogramConfig(t *testing.T) {
-	cfg := &Config{
-		AggregationInterval: 20 * time.Second,
-		TimerHistogramMapping: []protocol.TimerHistogramMapping{
-			{
-				StatsdType:   "timing",
-				ObserverType: "gauge",
-				Histogram: protocol.HistogramConfig{
-					MaxSize: 100,
-				},
-			},
-		},
-	}
-	receiver, err := createMetricsReceiver(
-		context.Background(),
-		receivertest.NewNopCreateSettings(),
-		cfg,
-		consumertest.NewNop(),
-	)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "histogram configuration requires observer_type: histogram")
-	assert.Nil(t, receiver)
 }
 
 func TestCreateMetricsReceiverWithNilConsumer(t *testing.T) {


### PR DESCRIPTION
**Description:**
As exposed in this [comment](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16839#discussion_r1067636248), there is no longer a need to explicitly call `Validate()` on configuration when creating a component.
This PR removes occurrences of such calls.