### PR TITLE
[chore] clean up validation of SAPM exporter

### DIFF
--- a/exporter/sapmexporter/config.go
+++ b/exporter/sapmexporter/config.go
@@ -16,7 +16,6 @@ package sapmexporter // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 
 	sapmclient "github.com/signalfx/sapm-proto/client"
@@ -67,9 +66,6 @@ func (c *Config) Validate() error {
 	_, err := url.Parse(c.Endpoint)
 	if err != nil {
 		return err
-	}
-	if err := c.QueueSettings.Validate(); err != nil {
-		return fmt.Errorf("sending_queue settings has invalid configuration: %w", err)
 	}
 	return nil
 }

--- a/exporter/sapmexporter/config_test.go
+++ b/exporter/sapmexporter/config_test.go
@@ -115,5 +115,6 @@ func TestInvalidConfig(t *testing.T) {
 			QueueSize: -1,
 		},
 	}
-	require.Error(t, invalid.Validate())
+
+	require.Error(t, component.ValidateConfig(invalid))
 }

--- a/exporter/sapmexporter/config_test.go
+++ b/exporter/sapmexporter/config_test.go
@@ -39,13 +39,17 @@ func TestLoadConfig(t *testing.T) {
 		expected component.Config
 	}{
 		{
-			id:       component.NewIDWithName(typeStr, ""),
-			expected: createDefaultConfig(),
+			id: component.NewIDWithName(typeStr, ""),
+			expected: func() *Config {
+				cfg := createDefaultConfig().(*Config)
+				cfg.Endpoint = "http://example.com"
+				return cfg
+			}(),
 		},
 		{
 			id: component.NewIDWithName(typeStr, "customname"),
 			expected: &Config{
-				Endpoint:            "test-endpoint",
+				Endpoint:            "https://example.com",
 				AccessToken:         "abcd1234",
 				NumWorkers:          3,
 				MaxConnections:      45,
@@ -92,7 +96,7 @@ func TestInvalidConfig(t *testing.T) {
 		NumWorkers:     3,
 		MaxConnections: 45,
 	}
-	noEndpointErr := invalid.validate()
+	noEndpointErr := invalid.Validate()
 	require.Error(t, noEndpointErr)
 
 	invalid = Config{
@@ -101,7 +105,7 @@ func TestInvalidConfig(t *testing.T) {
 		NumWorkers:     3,
 		MaxConnections: 45,
 	}
-	invalidURLErr := invalid.validate()
+	invalidURLErr := invalid.Validate()
 	require.Error(t, invalidURLErr)
 
 	invalid = Config{

--- a/exporter/sapmexporter/exporter.go
+++ b/exporter/sapmexporter/exporter.go
@@ -53,10 +53,6 @@ func (se *sapmExporter) Shutdown(context.Context) error {
 }
 
 func newSAPMExporter(cfg *Config, params exporter.CreateSettings) (sapmExporter, error) {
-	err := cfg.validate()
-	if err != nil {
-		return sapmExporter{}, err
-	}
 
 	client, err := sapmclient.New(cfg.clientOptions()...)
 	if err != nil {

--- a/exporter/sapmexporter/exporter_test.go
+++ b/exporter/sapmexporter/exporter_test.go
@@ -53,14 +53,6 @@ func TestCreateTracesExporter(t *testing.T) {
 	assert.NoError(t, te.Shutdown(context.Background()), "trace exporter shutdown failed")
 }
 
-func TestCreateTracesExporterWithInvalidConfig(t *testing.T) {
-	cfg := &Config{}
-	params := exportertest.NewNopCreateSettings()
-	te, err := newSAPMTracesExporter(cfg, params)
-	require.Error(t, err)
-	assert.Nil(t, te)
-}
-
 func buildTestTraces(setTokenLabel bool) (traces ptrace.Traces) {
 	traces = ptrace.NewTraces()
 	rss := traces.ResourceSpans()

--- a/exporter/sapmexporter/factory.go
+++ b/exporter/sapmexporter/factory.go
@@ -28,7 +28,8 @@ const (
 	// The value of "type" key in configuration.
 	typeStr = "sapm"
 	// The stability level of the exporter.
-	stability = component.StabilityLevelBeta
+	stability         = component.StabilityLevelBeta
+	defaultNumWorkers = 8
 )
 
 // NewFactory creates a factory for SAPM exporter.

--- a/exporter/sapmexporter/testdata/config.yaml
+++ b/exporter/sapmexporter/testdata/config.yaml
@@ -1,9 +1,10 @@
 sapm:
+  endpoint: http://example.com
 sapm/customname:
 
   # Endpoint is the destination to where traces will be sent to in SAPM format.
   # It must be a full URL and include the scheme, port and path e.g, https://ingest.signalfx.com/v2/trace
-  endpoint: test-endpoint
+  endpoint: https://example.com
 
   # AccessToken is the authentication token provided by SignalFx.
   access_token: abcd1234


### PR DESCRIPTION
Clean up of the `validate` and `Validate` functions used by sapmexporter.
This PR merges them, and moves the editing of the endpoint to use https scheme if not explicitly used closer to using the endpoint.