### PR TITLE
Mark stable components as beta

### DIFF
--- a/exporter/logzioexporter/README.md
+++ b/exporter/logzioexporter/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |                       |
 | ------------------------ | --------------------- |
-| Stability                | traces [stable]       |
+| Stability                | traces [beta]         |
 |                          | logs [beta]           |
 | Supported pipeline types | traces, logs |
 | Distributions            |  [contrib]   |
@@ -168,5 +168,4 @@ service:
 
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
-[stable]:https://github.com/open-telemetry/opentelemetry-collector#stable
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/mezmoexporter/README.md
+++ b/exporter/mezmoexporter/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |           |
 | ------------------------ |-----------|
-| Stability                | [stable]  |
+| Stability                | [beta]    |
 | Supported pipeline types | logs      |
 | Distributions            | [contrib] |
 
@@ -57,5 +57,5 @@ service:
       exporters: [ mezmo ]
 ```
 
-[stable]: https://github.com/open-telemetry/opentelemetry-collector#stable
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/carbonreceiver/README.md
+++ b/receiver/carbonreceiver/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |            |
 | ------------------------ |------------|
-| Stability                | [stable]   |
+| Stability                | [beta]     |
 | Supported pipeline types | metrics    |
 | Distributions            | [contrib]  |
 
@@ -61,5 +61,5 @@ receivers:
 The full list of settings exposed for this receiver are documented [here](./config.go)
 with detailed sample configurations [here](./testdata/config.yaml).
 
-[stable]: https://github.com/open-telemetry/opentelemetry-collector#stable
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/carbonreceiver/factory.go
+++ b/receiver/carbonreceiver/factory.go
@@ -32,7 +32,7 @@ const (
 	// The value of "type" key in configuration.
 	typeStr = "carbon"
 	// The stability level of the receiver.
-	stability = component.StabilityLevelStable
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for Carbon receiver.

--- a/receiver/signalfxreceiver/README.md
+++ b/receiver/signalfxreceiver/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |               |
 | ------------------------ |---------------|
-| Stability                | [stable]      |
+| Stability                | [beta]        |
 | Supported pipeline types | metrics, logs |
 | Distributions            | [contrib]     |
 
@@ -68,5 +68,5 @@ service:
       exporters: [signalfx]
 ```
 
-[stable]: https://github.com/open-telemetry/opentelemetry-collector#stable
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/signalfxreceiver/factory.go
+++ b/receiver/signalfxreceiver/factory.go
@@ -33,7 +33,7 @@ const (
 	// The value of "type" key in configuration.
 	typeStr = "signalfx"
 	// The stability level of the receiver.
-	stability = component.StabilityLevelStable
+	stability = component.StabilityLevelBeta
 
 	// Default endpoints to bind to.
 	defaultEndpoint = ":9943"


### PR DESCRIPTION
**Description:** 

Mark stable components as beta, since we don't have consensus on what 'stable' entails (see open-telemetry/opentelemetry-collector/issues/5686).

**Link to tracking Issue:** Fixes #17515, fixes #17514
