### PR TITLE
[processor/filter] docs: fix configuration example

### DIFF
--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -90,34 +90,39 @@ processors:
         resource_attributes:
           - Key: host.name
             Value: just_this_one_hostname
-    logs/regexp:
+  filter/regexp:
+    logs:
       include:
         match_type: regexp
         resource_attributes:
           - Key: host.name
             Value: prefix.*
-    logs/regexp_record:
+  filter/regexp_record:
+    logs:
       include:
         match_type: regexp
         record_attributes:
           - Key: record_attr
             Value: prefix_.*
-    # Filter on severity text field
-    logs/severity_text:
+  # Filter on severity text field
+  filter/severity_text:
+    logs:
       include:
         match_type: regexp
         severity_texts:
         - INFO[2-4]?
         - WARN[2-4]?
         - ERROR[2-4]?
-    # Filter out logs below INFO (no DEBUG or TRACE level logs),
-    # retaining logs with undefined severity
-    logs/severity_number:
+  # Filter out logs below INFO (no DEBUG or TRACE level logs),
+  # retaining logs with undefined severity
+  filter/severity_number:
+    logs:
       include:
         severity_number:
           min: "INFO"
           match_undefined: true
-    logs/bodies:
+  filter/bodies:
+    logs:
       include:
         match_type: regexp
         bodies:


### PR DESCRIPTION
Suffixing signal type with a name like "logs/regexp" doesn't work, collector fails with error:

```console
2023/01/12 14:53:06 collector server run finished with error: failed to get config: cannot unmarshal the configuration: 1 error(s) decoding:
* error decoding 'processors': error reading configuration for "filter": 1 error(s) decoding:
* '' has invalid keys: logs/regexp
```