### PR TITLE
[exporter/file] Improving write performance speed

### DIFF
--- a/exporter/fileexporter/buffered_writer.go
+++ b/exporter/fileexporter/buffered_writer.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fileexporter
 
 import (
@@ -8,7 +22,7 @@ import (
 )
 
 // bufferedWriteCloser is intended to use more memory
-// in order to optimise writing to disk to help improve performance.
+// in order to optimize writing to disk to help improve performance.
 type bufferedWriteCloser struct {
 	wraped   io.Closer
 	buffered *bufio.Writer

--- a/exporter/fileexporter/buffered_writer.go
+++ b/exporter/fileexporter/buffered_writer.go
@@ -32,7 +32,7 @@ var (
 	_ io.WriteCloser = (*bufferedWriteCloser)(nil)
 )
 
-func newBufferedWriterCloser(f io.WriteCloser) io.WriteCloser {
+func newBufferedWriteCloser(f io.WriteCloser) io.WriteCloser {
 	return &bufferedWriteCloser{
 		wrapped:  f,
 		buffered: bufio.NewWriter(f),

--- a/exporter/fileexporter/buffered_writer.go
+++ b/exporter/fileexporter/buffered_writer.go
@@ -24,7 +24,7 @@ import (
 // bufferedWriteCloser is intended to use more memory
 // in order to optimize writing to disk to help improve performance.
 type bufferedWriteCloser struct {
-	wraped   io.Closer
+	wrapped   io.Closer
 	buffered *bufio.Writer
 }
 

--- a/exporter/fileexporter/buffered_writer.go
+++ b/exporter/fileexporter/buffered_writer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fileexporter
+package fileexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
 
 import (
 	"bufio"

--- a/exporter/fileexporter/buffered_writer.go
+++ b/exporter/fileexporter/buffered_writer.go
@@ -1,0 +1,37 @@
+package fileexporter
+
+import (
+	"bufio"
+	"io"
+
+	"go.uber.org/multierr"
+)
+
+// bufferedWriteCloser is intended to use more memory
+// in order to optimise writing to disk to help improve performance.
+type bufferedWriteCloser struct {
+	wraped   io.Closer
+	buffered *bufio.Writer
+}
+
+var (
+	_ io.WriteCloser = (*bufferedWriteCloser)(nil)
+)
+
+func newBufferedWriterCloser(f io.WriteCloser) io.WriteCloser {
+	return &bufferedWriteCloser{
+		wraped:   f,
+		buffered: bufio.NewWriter(f),
+	}
+}
+
+func (bwc *bufferedWriteCloser) Write(p []byte) (n int, err error) {
+	return bwc.buffered.Write(p)
+}
+
+func (bwc *bufferedWriteCloser) Close() error {
+	return multierr.Combine(
+		bwc.buffered.Flush(),
+		bwc.wraped.Close(),
+	)
+}

--- a/exporter/fileexporter/buffered_writer.go
+++ b/exporter/fileexporter/buffered_writer.go
@@ -24,7 +24,7 @@ import (
 // bufferedWriteCloser is intended to use more memory
 // in order to optimize writing to disk to help improve performance.
 type bufferedWriteCloser struct {
-	wrapped   io.Closer
+	wrapped  io.Closer
 	buffered *bufio.Writer
 }
 
@@ -34,7 +34,7 @@ var (
 
 func newBufferedWriterCloser(f io.WriteCloser) io.WriteCloser {
 	return &bufferedWriteCloser{
-		wraped:   f,
+		wrapped:  f,
 		buffered: bufio.NewWriter(f),
 	}
 }
@@ -46,6 +46,6 @@ func (bwc *bufferedWriteCloser) Write(p []byte) (n int, err error) {
 func (bwc *bufferedWriteCloser) Close() error {
 	return multierr.Combine(
 		bwc.buffered.Flush(),
-		bwc.wraped.Close(),
+		bwc.wrapped.Close(),
 	)
 }

--- a/exporter/fileexporter/buffered_writer_test.go
+++ b/exporter/fileexporter/buffered_writer_test.go
@@ -46,7 +46,7 @@ func TestBufferedWrites(t *testing.T) {
 	t.Parallel()
 
 	b := bytes.NewBuffer(nil)
-	w := newBufferedWriterCloser(&NopWriteCloser{b})
+	w := newBufferedWriteCloser(&NopWriteCloser{b})
 
 	_, err := w.Write([]byte(msg))
 	require.NoError(t, err, "Must not error when writing data")
@@ -81,9 +81,9 @@ func BenchmarkWriter(b *testing.B) {
 		}
 		for name, w := range map[string]io.WriteCloser{
 			"discard":          &NopWriteCloser{io.Discard},
-			"buffered-discard": newBufferedWriterCloser(&NopWriteCloser{io.Discard}),
+			"buffered-discard": newBufferedWriteCloser(&NopWriteCloser{io.Discard}),
 			"raw-file":         tempfile(b),
-			"buffered-file":    newBufferedWriterCloser(tempfile(b)),
+			"buffered-file":    newBufferedWriteCloser(tempfile(b)),
 		} {
 			w := w
 			b.Run(fmt.Sprintf("%s_%d_bytes", name, payloadSize), func(b *testing.B) {

--- a/exporter/fileexporter/buffered_writer_test.go
+++ b/exporter/fileexporter/buffered_writer_test.go
@@ -1,0 +1,72 @@
+package fileexporter
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
+)
+
+const (
+	msg = "it is a beautiful world"
+)
+
+type NopWriteCloser struct {
+	w io.Writer
+}
+
+func (NopWriteCloser) Close() error                    { return nil }
+func (wc *NopWriteCloser) Write(p []byte) (int, error) { return wc.w.Write(p) }
+
+func TestBufferedWrites(t *testing.T) {
+	t.Parallel()
+
+	b := bytes.NewBuffer(nil)
+	w := newBufferedWriterCloser(&NopWriteCloser{b})
+
+	_, err := w.Write([]byte(msg))
+	require.NoError(t, err, "Must not error when writing data")
+	assert.NoError(t, w.Close(), "Must not error when closing writer")
+
+	assert.Equal(t, msg, b.String(), "Must match the expected string")
+}
+
+var (
+	benchmarkErr error
+)
+
+func BenchmarkWriter(b *testing.B) {
+	tempfile := func(tb testing.TB) io.WriteCloser {
+		f, err := ioutil.TempFile(tb.TempDir(), tb.Name())
+		require.NoError(tb, err, "Must not error when creating benchmark temp file")
+		tb.Cleanup(func() {
+			assert.NoError(tb, os.RemoveAll(path.Dir(f.Name())), "Must clean up files after being writen")
+		})
+		return f
+	}
+
+	for name, w := range map[string]io.WriteCloser{
+		"discard":          &NopWriteCloser{io.Discard},
+		"buffered-discard": newBufferedWriterCloser(&NopWriteCloser{io.Discard}),
+		"raw-file":         tempfile(b),
+		"buffered-file":    newBufferedWriterCloser(tempfile(b)),
+	} {
+		w := w
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			var err error
+			for i := 0; i < b.N; i++ {
+				_, err = w.Write([]byte(msg))
+			}
+			benchmarkErr = multierr.Combine(err, w.Close())
+		})
+	}
+}

--- a/exporter/fileexporter/buffered_writer_test.go
+++ b/exporter/fileexporter/buffered_writer_test.go
@@ -1,9 +1,22 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fileexporter
 
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -43,10 +56,10 @@ var (
 
 func BenchmarkWriter(b *testing.B) {
 	tempfile := func(tb testing.TB) io.WriteCloser {
-		f, err := ioutil.TempFile(tb.TempDir(), tb.Name())
+		f, err := os.CreateTemp(tb.TempDir(), tb.Name())
 		require.NoError(tb, err, "Must not error when creating benchmark temp file")
 		tb.Cleanup(func() {
-			assert.NoError(tb, os.RemoveAll(path.Dir(f.Name())), "Must clean up files after being writen")
+			assert.NoError(tb, os.RemoveAll(path.Dir(f.Name())), "Must clean up files after being written")
 		})
 		return f
 	}

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -150,7 +150,7 @@ func buildFileWriter(cfg *Config) (io.WriteCloser, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newBufferedWriterCloser(f), nil
+		return newBufferedWriteCloser(f), nil
 	}
 	return &lumberjack.Logger{
 		Filename:   cfg.Path,

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -146,7 +146,11 @@ func newFileExporter(conf *Config, writer io.WriteCloser) *fileExporter {
 
 func buildFileWriter(cfg *Config) (io.WriteCloser, error) {
 	if cfg.Rotation == nil {
-		return os.OpenFile(cfg.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+		f, err := os.OpenFile(cfg.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+		if err != nil {
+			return nil, err
+		}
+		return newBufferedWriterCloser(f), nil
 	}
 	return &lumberjack.Logger{
 		Filename:   cfg.Path,

--- a/exporter/fileexporter/factory_test.go
+++ b/exporter/fileexporter/factory_test.go
@@ -17,7 +17,6 @@ package fileexporter
 import (
 	"context"
 	"io"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -123,7 +122,7 @@ func TestBuildFileWriter(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, closer io.WriteCloser) {
-				_, ok := closer.(*os.File)
+				_, ok := closer.(*bufferedWriteCloser)
 				assert.Equal(t, true, ok)
 			},
 		},

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -35,7 +35,6 @@ require (
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.11.2 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.69.2-0.20230112233839-f2a0133bf677
 	go.opentelemetry.io/collector/consumer v0.69.2-0.20230112233839-f2a0133bf677
 	go.opentelemetry.io/collector/pdata v1.0.0-rc3.0.20230112233839-f2a0133bf677
+	go.uber.org/multierr v1.9.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 


### PR DESCRIPTION
**Description:** 
Using the library `bufio` to help improve overall performance with the exporter

**Link to tracking Issue:**
N/A

**Testing:** 

I'ver included benchmarks to help verify improvements, on my local these are the expected changes:

```
BenchmarkWriter/buffered-discard-10         	67764800	        17.55 ns/op	      24 B/op	       1 allocs/op
BenchmarkWriter/raw-file-10                 	25841067	        46.40 ns/op	      72 B/op	       2 allocs/op
BenchmarkWriter/buffered-file-10            	74804418	        16.13 ns/op	      24 B/op	       1 allocs/op
BenchmarkWriter/discard-10                  	75218797	        15.92 ns/op	      24 B/op	       1 allocs/op
```

**Documentation:**

N/A, completely transparent to the user.