### PR TITLE
Partially revert usage of ${env:ENV} style syntax in examples

### DIFF
--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -95,7 +95,7 @@ exporters:
     ## @param endpoint - string - required
     ## Endpoint where to send telemetry. On gateway mode, we set it to the gateway host IP.
     #
-    # endpoint: ${env:GATEWAY_HOST_IP}:4317
+    # endpoint: ${GATEWAY_HOST_IP}:4317
 
   # The Datadog exporter is necessary for exporting telemetry signals to Datadog.
   datadog:

--- a/exporter/sapmexporter/examples/signalfx-collector.yaml
+++ b/exporter/sapmexporter/examples/signalfx-collector.yaml
@@ -2,7 +2,7 @@ extensions:
   health_check:
   http_forwarder:
     egress:
-      endpoint: "https://api.${env:SFX_REALM}.signalfx.com"
+      endpoint: "https://api.${SFX_REALM}.signalfx.com"
   zpages:
 receivers:
   sapm:
@@ -62,7 +62,7 @@ exporters:
     access_token: "${env:SFX_TOKEN}"
     # This expects SFX_REALM environment variable to contain the realm (e.g. us0).
     # Alternatively, specify the relm directly in the endpoint url here.
-    endpoint: "https://ingest.${env:SFX_REALM}.signalfx.com/v2/trace"
+    endpoint: "https://ingest.${SFX_REALM}.signalfx.com/v2/trace"
   # Metrics + Events
   signalfx:
     # See above for SFX_TOKEN and SFX_REALM.

--- a/exporter/sapmexporter/examples/signalfx-k8s.yaml
+++ b/exporter/sapmexporter/examples/signalfx-k8s.yaml
@@ -12,7 +12,7 @@ data:
       health_check:
       http_forwarder:
         egress:
-          endpoint: "https://api.${env:SFX_REALM}.signalfx.com"
+          endpoint: "https://api.${SFX_REALM}.signalfx.com"
       zpages:
     receivers:
       sapm:
@@ -68,7 +68,7 @@ data:
       # Traces
       sapm:
         access_token: "${env:SFX_TOKEN}"
-        endpoint: "https://ingest.${env:SFX_REALM}.signalfx.com/v2/trace"
+        endpoint: "https://ingest.${SFX_REALM}.signalfx.com/v2/trace"
       # Metrics
       signalfx:
         access_token: "${env:SFX_TOKEN}"

--- a/extension/basicauthextension/README.md
+++ b/extension/basicauthextension/README.md
@@ -35,7 +35,7 @@ extensions:
     htpasswd: 
       file: .htpasswd
       inline: |
-        ${env:BASIC_AUTH_USERNAME}:${env:BASIC_AUTH_PASSWORD}
+        ${BASIC_AUTH_USERNAME}:${BASIC_AUTH_PASSWORD}
   
   basicauth/client:
     client_auth: 

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -69,7 +69,7 @@ receivers:
   kubeletstats:
     collection_interval: 20s
     auth_type: "serviceAccount"
-    endpoint: "https://${env:K8S_NODE_NAME}:10250"
+    endpoint: "https://${K8S_NODE_NAME}:10250"
     insecure_skip_verify: true
 exporters:
   file:
@@ -95,7 +95,7 @@ receivers:
   kubeletstats:
     collection_interval: 20s
     auth_type: "none"
-    endpoint: "http://${env:K8S_NODE_NAME}:10255"
+    endpoint: "http://${K8S_NODE_NAME}:10255"
 exporters:
   file:
     path: "fileexporter.txt"
@@ -127,7 +127,7 @@ receivers:
   kubeletstats:
     collection_interval: 10s
     auth_type: "serviceAccount"
-    endpoint: "${env:K8S_NODE_NAME}:10250"
+    endpoint: "${K8S_NODE_NAME}:10250"
     insecure_skip_verify: true
     extra_metadata_labels:
       - container.id
@@ -146,7 +146,7 @@ receivers:
   kubeletstats:
     collection_interval: 10s
     auth_type: "serviceAccount"
-    endpoint: "${env:K8S_NODE_NAME}:10250"
+    endpoint: "${K8S_NODE_NAME}:10250"
     insecure_skip_verify: true
     extra_metadata_labels:
       - k8s.volume.type
@@ -170,7 +170,7 @@ receivers:
   kubeletstats:
     collection_interval: 10s
     auth_type: "serviceAccount"
-    endpoint: "${env:K8S_NODE_NAME}:10250"
+    endpoint: "${K8S_NODE_NAME}:10250"
     insecure_skip_verify: true
     metric_groups:
       - node

--- a/receiver/prometheusreceiver/testdata/config_k8s.yaml
+++ b/receiver/prometheusreceiver/testdata/config_k8s.yaml
@@ -7,7 +7,7 @@ prometheus:
         selectors:
         - role: pod
           # only scrape data from pods running on the same node as collector
-          field: "spec.nodeName=${env:NODE_NAME}"
+          field: "spec.nodeName=${NODE_NAME}"
       relabel_configs:
       # scrape pods annotated with "prometheus.io/scrape: true"
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]


### PR DESCRIPTION
**Description:** 

Partial revert of #17300 because of open-telemetry/opentelemetry-collector/issues/6932

**Link to tracking Issue:** Relates to open-telemetry/opentelemetry-collector/issues/6932 and #17299
