### PR TITLE
[chore][internal/comparetest]Make all exported Compare functions not mutated

### DIFF
--- a/internal/comparetest/logs.go
+++ b/internal/comparetest/logs.go
@@ -184,62 +184,58 @@ func CompareLogRecordSlices(expected, actual plog.LogRecordSlice) error {
 // CompareLogRecords compares each part of two given LogRecord and returns
 // an error if they don't match. The error describes what didn't match.
 func CompareLogRecords(expected, actual plog.LogRecord) error {
-	exp, act := plog.NewLogRecord(), plog.NewLogRecord()
-	expected.CopyTo(exp)
-	actual.CopyTo(act)
-
-	if exp.Flags() != act.Flags() {
+	if expected.Flags() != actual.Flags() {
 		return fmt.Errorf("log record Flags doesn't match expected: %d, actual: %d",
-			exp.Flags(),
-			act.Flags())
+			expected.Flags(),
+			actual.Flags())
 	}
 
-	if exp.DroppedAttributesCount() != act.DroppedAttributesCount() {
+	if expected.DroppedAttributesCount() != actual.DroppedAttributesCount() {
 		return fmt.Errorf("log record DroppedAttributesCount doesn't match expected: %d, actual: %d",
 			expected.DroppedAttributesCount(),
-			act.DroppedAttributesCount())
+			actual.DroppedAttributesCount())
 	}
 
-	if exp.Timestamp() != act.Timestamp() {
+	if expected.Timestamp() != actual.Timestamp() {
 		return fmt.Errorf("log record Timestamp doesn't match expected: %d, actual: %d",
 			expected.Timestamp(),
-			act.Timestamp())
+			actual.Timestamp())
 	}
 
-	if exp.ObservedTimestamp() != act.ObservedTimestamp() {
+	if expected.ObservedTimestamp() != actual.ObservedTimestamp() {
 		return fmt.Errorf("log record ObservedTimestamp doesn't match expected: %d, actual: %d",
-			exp.ObservedTimestamp(),
-			act.ObservedTimestamp())
+			expected.ObservedTimestamp(),
+			actual.ObservedTimestamp())
 	}
 
-	if exp.SeverityNumber() != act.SeverityNumber() {
+	if expected.SeverityNumber() != actual.SeverityNumber() {
 		return fmt.Errorf("log record SeverityNumber doesn't match expected: %d, actual: %d",
-			exp.SeverityNumber(),
-			act.SeverityNumber())
+			expected.SeverityNumber(),
+			actual.SeverityNumber())
 	}
 
-	if exp.SeverityText() != act.SeverityText() {
+	if expected.SeverityText() != actual.SeverityText() {
 		return fmt.Errorf("log record SeverityText doesn't match expected: %s, actual: %s",
-			exp.SeverityText(),
-			act.SeverityText())
+			expected.SeverityText(),
+			actual.SeverityText())
 	}
 
-	if exp.TraceID() != act.TraceID() {
+	if expected.TraceID() != actual.TraceID() {
 		return fmt.Errorf("log record TraceID doesn't match expected: %d, actual: %d",
-			exp.TraceID(),
-			act.TraceID())
+			expected.TraceID(),
+			actual.TraceID())
 	}
 
-	if exp.SpanID() != act.SpanID() {
+	if expected.SpanID() != actual.SpanID() {
 		return fmt.Errorf("log record SpanID doesn't match expected: %d, actual: %d",
-			exp.SpanID(),
-			act.SpanID())
+			expected.SpanID(),
+			actual.SpanID())
 	}
 
-	if !reflect.DeepEqual(exp.Body().AsRaw(), act.Body().AsRaw()) {
+	if !reflect.DeepEqual(expected.Body().AsRaw(), actual.Body().AsRaw()) {
 		return fmt.Errorf("log record Body doesn't match expected: %s, actual: %s",
-			exp.Body().AsString(),
-			act.Body().AsString())
+			expected.Body().AsString(),
+			actual.Body().AsString())
 	}
 
 	return nil

--- a/internal/comparetest/metrics.go
+++ b/internal/comparetest/metrics.go
@@ -196,25 +196,21 @@ func CompareMetricSlices(expected, actual pmetric.MetricSlice) error {
 // CompareNumberDataPointSlices compares each part of two given NumberDataPointSlices and returns
 // an error if they don't match. The error describes what didn't match.
 func CompareNumberDataPointSlices(expected, actual pmetric.NumberDataPointSlice) error {
-	exp, act := pmetric.NewNumberDataPointSlice(), pmetric.NewNumberDataPointSlice()
-	expected.CopyTo(exp)
-	actual.CopyTo(act)
-
-	if exp.Len() != act.Len() {
-		return fmt.Errorf("number of datapoints does not match expected: %d, actual: %d", exp.Len(), act.Len())
+	if expected.Len() != actual.Len() {
+		return fmt.Errorf("number of datapoints does not match expected: %d, actual: %d", expected.Len(), actual.Len())
 	}
 
-	numPoints := exp.Len()
+	numPoints := expected.Len()
 
 	// Keep track of matching data points so that each point can only be matched once
 	matchingDPS := make(map[pmetric.NumberDataPoint]pmetric.NumberDataPoint, numPoints)
 
 	var errs error
 	for e := 0; e < numPoints; e++ {
-		edp := exp.At(e)
+		edp := expected.At(e)
 		var foundMatch bool
 		for a := 0; a < numPoints; a++ {
-			adp := act.At(a)
+			adp := actual.At(a)
 			if _, ok := matchingDPS[adp]; ok {
 				continue
 			}
@@ -231,8 +227,8 @@ func CompareNumberDataPointSlices(expected, actual pmetric.NumberDataPointSlice)
 	}
 
 	for i := 0; i < numPoints; i++ {
-		if _, ok := matchingDPS[act.At(i)]; !ok {
-			errs = multierr.Append(errs, fmt.Errorf("metric has extra datapoint with attributes: %v", act.At(i).Attributes().AsRaw()))
+		if _, ok := matchingDPS[actual.At(i)]; !ok {
+			errs = multierr.Append(errs, fmt.Errorf("metric has extra datapoint with attributes: %v", actual.At(i).Attributes().AsRaw()))
 		}
 	}
 

--- a/internal/comparetest/metrics.go
+++ b/internal/comparetest/metrics.go
@@ -251,18 +251,14 @@ func CompareNumberDataPointSlices(expected, actual pmetric.NumberDataPointSlice)
 // CompareNumberDataPoints compares each part of two given NumberDataPoints and returns
 // an error if they don't match. The error describes what didn't match.
 func CompareNumberDataPoints(expected, actual pmetric.NumberDataPoint) error {
-	exp, act := pmetric.NewNumberDataPoint(), pmetric.NewNumberDataPoint()
-	expected.CopyTo(exp)
-	actual.CopyTo(act)
-
-	if exp.ValueType() != act.ValueType() {
-		return fmt.Errorf("metric datapoint types don't match: expected type: %s, actual type: %s", numberTypeToString(exp.ValueType()), numberTypeToString(act.ValueType()))
+	if expected.ValueType() != actual.ValueType() {
+		return fmt.Errorf("metric datapoint types don't match: expected type: %s, actual type: %s", numberTypeToString(expected.ValueType()), numberTypeToString(actual.ValueType()))
 	}
-	if exp.IntValue() != act.IntValue() {
-		return fmt.Errorf("metric datapoint IntVal doesn't match expected: %d, actual: %d", exp.IntValue(), act.IntValue())
+	if expected.IntValue() != actual.IntValue() {
+		return fmt.Errorf("metric datapoint IntVal doesn't match expected: %d, actual: %d", expected.IntValue(), actual.IntValue())
 	}
-	if exp.DoubleValue() != act.DoubleValue() {
-		return fmt.Errorf("metric datapoint DoubleVal doesn't match expected: %f, actual: %f", exp.DoubleValue(), act.DoubleValue())
+	if expected.DoubleValue() != actual.DoubleValue() {
+		return fmt.Errorf("metric datapoint DoubleVal doesn't match expected: %f, actual: %f", expected.DoubleValue(), actual.DoubleValue())
 	}
 	return nil
 }

--- a/internal/comparetest/traces.go
+++ b/internal/comparetest/traces.go
@@ -184,98 +184,94 @@ func CompareSpanSlices(expected, actual ptrace.SpanSlice) error {
 // CompareSpans compares each part of two given Span and returns
 // an error if they don't match. The error describes what didn't match.
 func CompareSpans(expected, actual ptrace.Span) error {
-	exp, act := ptrace.NewSpan(), ptrace.NewSpan()
-	expected.CopyTo(exp)
-	actual.CopyTo(act)
-
-	if exp.TraceID() != act.TraceID() {
+	if expected.TraceID() != actual.TraceID() {
 		return fmt.Errorf("span TraceID doesn't match expected: %d, actual: %d",
-			exp.TraceID(),
-			act.TraceID())
+			expected.TraceID(),
+			actual.TraceID())
 	}
 
-	if exp.SpanID() != act.SpanID() {
+	if expected.SpanID() != actual.SpanID() {
 		return fmt.Errorf("span SpanID doesn't match expected: %d, actual: %d",
-			exp.SpanID(),
-			act.SpanID())
+			expected.SpanID(),
+			actual.SpanID())
 	}
 
-	if exp.TraceState().AsRaw() != act.TraceState().AsRaw() {
+	if expected.TraceState().AsRaw() != actual.TraceState().AsRaw() {
 		return fmt.Errorf("span TraceState doesn't match expected: %s, actual: %s",
-			exp.TraceState().AsRaw(),
-			act.TraceState().AsRaw())
+			expected.TraceState().AsRaw(),
+			actual.TraceState().AsRaw())
 	}
 
-	if exp.ParentSpanID() != act.ParentSpanID() {
+	if expected.ParentSpanID() != actual.ParentSpanID() {
 		return fmt.Errorf("span ParentSpanID doesn't match expected: %d, actual: %d",
-			exp.ParentSpanID(),
-			act.ParentSpanID())
+			expected.ParentSpanID(),
+			actual.ParentSpanID())
 	}
 
-	if exp.Name() != act.Name() {
+	if expected.Name() != actual.Name() {
 		return fmt.Errorf("span Name doesn't match expected: %s, actual: %s",
-			exp.Name(),
-			act.Name())
+			expected.Name(),
+			actual.Name())
 	}
 
-	if exp.Kind() != act.Kind() {
+	if expected.Kind() != actual.Kind() {
 		return fmt.Errorf("span Kind doesn't match expected: %d, actual: %d",
-			exp.Kind(),
-			act.Kind())
+			expected.Kind(),
+			actual.Kind())
 	}
 
-	if exp.StartTimestamp() != act.StartTimestamp() {
+	if expected.StartTimestamp() != actual.StartTimestamp() {
 		return fmt.Errorf("span StartTimestamp doesn't match expected: %d, actual: %d",
-			exp.StartTimestamp(),
-			act.StartTimestamp())
+			expected.StartTimestamp(),
+			actual.StartTimestamp())
 	}
 
-	if exp.EndTimestamp() != act.EndTimestamp() {
+	if expected.EndTimestamp() != actual.EndTimestamp() {
 		return fmt.Errorf("span EndTimestamp doesn't match expected: %d, actual: %d",
-			exp.EndTimestamp(),
-			act.EndTimestamp())
+			expected.EndTimestamp(),
+			actual.EndTimestamp())
 	}
 
-	if !reflect.DeepEqual(exp.Attributes().AsRaw(), act.Attributes().AsRaw()) {
+	if !reflect.DeepEqual(expected.Attributes().AsRaw(), actual.Attributes().AsRaw()) {
 		return fmt.Errorf("span Attributes doesn't match expected: %s, actual: %s",
-			exp.Attributes().AsRaw(),
-			act.Attributes().AsRaw())
+			expected.Attributes().AsRaw(),
+			actual.Attributes().AsRaw())
 	}
 
-	if exp.DroppedAttributesCount() != act.DroppedAttributesCount() {
+	if expected.DroppedAttributesCount() != actual.DroppedAttributesCount() {
 		return fmt.Errorf("span DroppedAttributesCount doesn't match expected: %d, actual: %d",
-			exp.DroppedAttributesCount(),
-			act.DroppedAttributesCount())
+			expected.DroppedAttributesCount(),
+			actual.DroppedAttributesCount())
 	}
 
-	if !reflect.DeepEqual(exp.Events(), act.Events()) {
+	if !reflect.DeepEqual(expected.Events(), actual.Events()) {
 		return fmt.Errorf("span Events doesn't match expected: %v, actual: %v",
-			exp.Events(),
-			act.Events())
+			expected.Events(),
+			actual.Events())
 	}
 
-	if exp.DroppedEventsCount() != act.DroppedEventsCount() {
+	if expected.DroppedEventsCount() != actual.DroppedEventsCount() {
 		return fmt.Errorf("span DroppedEventsCount doesn't match expected: %d, actual: %d",
-			exp.DroppedEventsCount(),
-			act.DroppedEventsCount())
+			expected.DroppedEventsCount(),
+			actual.DroppedEventsCount())
 	}
 
-	if !reflect.DeepEqual(exp.Links(), act.Links()) {
+	if !reflect.DeepEqual(expected.Links(), actual.Links()) {
 		return fmt.Errorf("span Links doesn't match expected: %v, actual: %v",
-			exp.Links(),
-			act.Links())
+			expected.Links(),
+			actual.Links())
 	}
 
-	if exp.DroppedLinksCount() != act.DroppedLinksCount() {
+	if expected.DroppedLinksCount() != actual.DroppedLinksCount() {
 		return fmt.Errorf("span DroppedLinksCount doesn't match expected: %d, actual: %d",
-			exp.DroppedLinksCount(),
+			expected.DroppedLinksCount(),
 			actual.DroppedLinksCount())
 	}
 
-	if !reflect.DeepEqual(exp.Status(), act.Status()) {
+	if !reflect.DeepEqual(expected.Status(), actual.Status()) {
 		return fmt.Errorf("span Status doesn't match expected: %v, actual: %v",
-			exp.Status(),
-			act.Status())
+			expected.Status(),
+			actual.Status())
 	}
 
 	return nil


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Make all exported Compare functions not mutated for Logs, Metrics, and Traces.
All the data from the source are copied before any mutation is done on the copied data.

**Link to tracking Issue:** <Issue number if applicable>
#17549

**Testing:** <Describe what testing was performed and which tests were added.>
N/A

**Documentation:** <Describe the documentation added.>
N/A