### PR TITLE
[receiver/kubeletstats] Add support for kubeConfig auth_type (#17561)

### DIFF
--- a/.chloggen/kubeletstatsreceiver-kubeconfig.yaml
+++ b/.chloggen/kubeletstatsreceiver-kubeconfig.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kubeletstatsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for `kubeConfig` auth_type in kubeletstatsreceiver
+
+# One or more tracking issues related to the change
+issues: [17562]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/k8sconfig/config.go
+++ b/internal/k8sconfig/config.go
@@ -76,8 +76,8 @@ func (c APIConfig) Validate() error {
 	return nil
 }
 
-// createRestConfig creates an Kubernetes API config from user configuration.
-func createRestConfig(apiConf APIConfig) (*rest.Config, error) {
+// CreateRestConfig creates an Kubernetes API config from user configuration.
+func CreateRestConfig(apiConf APIConfig) (*rest.Config, error) {
 	var authConf *rest.Config
 	var err error
 
@@ -133,7 +133,7 @@ func MakeClient(apiConf APIConfig) (k8s.Interface, error) {
 		return nil, err
 	}
 
-	authConf, err := createRestConfig(apiConf)
+	authConf, err := CreateRestConfig(apiConf)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func MakeDynamicClient(apiConf APIConfig) (dynamic.Interface, error) {
 		return nil, err
 	}
 
-	authConf, err := createRestConfig(apiConf)
+	authConf, err := CreateRestConfig(apiConf)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func MakeOpenShiftQuotaClient(apiConf APIConfig) (quotaclientset.Interface, erro
 		return nil, err
 	}
 
-	authConf, err := createRestConfig(apiConf)
+	authConf, err := CreateRestConfig(apiConf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+	"k8s.io/client-go/rest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/sanitize"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
@@ -61,6 +62,12 @@ func NewClientProvider(endpoint string, cfg *ClientConfig, logger *zap.Logger) (
 			endpoint: endpoint,
 			logger:   logger,
 		}, nil
+	case k8sconfig.AuthTypeKubeConfig:
+		return &kubeConfigClientProvider{
+			endpoint: endpoint,
+			cfg:      cfg,
+			logger:   logger,
+		}, nil
 	default:
 		return nil, fmt.Errorf("AuthType [%s] not supported", cfg.APIConfig.AuthType)
 	}
@@ -68,6 +75,42 @@ func NewClientProvider(endpoint string, cfg *ClientConfig, logger *zap.Logger) (
 
 type ClientProvider interface {
 	BuildClient() (Client, error)
+}
+
+type kubeConfigClientProvider struct {
+	endpoint string
+	cfg      *ClientConfig
+	logger   *zap.Logger
+}
+
+func (p *kubeConfigClientProvider) BuildClient() (Client, error) {
+	authConf, err := k8sconfig.CreateRestConfig(p.cfg.APIConfig)
+	if err != nil {
+		return nil, err
+	}
+	if p.cfg.InsecureSkipVerify {
+		// Override InsecureSkipVerify from kubeconfig
+		authConf.TLSClientConfig.CAFile = ""
+		authConf.TLSClientConfig.CAData = nil
+		authConf.TLSClientConfig.Insecure = true
+	}
+
+	client, err := rest.HTTPClientFor(authConf)
+	if err != nil {
+		return nil, err
+	}
+
+	joinPath, err := url.JoinPath(authConf.Host, "/api/v1/nodes/", p.endpoint, "/proxy/")
+	if err != nil {
+		return nil, err
+	}
+	return &clientImpl{
+		baseURL:    joinPath,
+		httpClient: *client,
+		tok:        nil,
+		logger:     p.logger,
+	}, nil
+
 }
 
 type readOnlyClientProvider struct {

--- a/internal/kubelet/client_test.go
+++ b/internal/kubelet/client_test.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -32,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 )
@@ -89,6 +92,18 @@ func TestNewSAClientProvider(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestNewKubeConfigClientProvider(t *testing.T) {
+	p, err := NewClientProvider("localhost:9876", &ClientConfig{
+		APIConfig: k8sconfig.APIConfig{
+			AuthType: k8sconfig.AuthTypeKubeConfig,
+		},
+	}, zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	_, ok := p.(*kubeConfigClientProvider)
+	require.True(t, ok)
+}
+
 func TestDefaultTLSClient(t *testing.T) {
 	endpoint := "localhost:9876"
 	client, err := defaultTLSClient(endpoint, true, &x509.CertPool{}, nil, nil, zap.NewNop())
@@ -107,6 +122,40 @@ func TestSvcAcctClient(t *testing.T) {
 	cl, err := p.BuildClient()
 	require.NoError(t, err)
 	require.Equal(t, "s3cr3t", string(cl.(*clientImpl).tok))
+}
+
+func TestNewKubeConfigClient(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Check if call is authenticated using provided kubeconfig
+		require.Equal(t, req.Header.Get("Authorization"), "Bearer my-token")
+		require.Equal(t, "/api/v1/nodes/nodename/proxy/", req.URL.EscapedPath())
+		// Send response to be tested
+		_, err := rw.Write([]byte(`OK`))
+		require.NoError(t, err)
+	}))
+	server.StartTLS()
+	defer server.Close()
+
+	kubeConfig, err := clientcmd.LoadFromFile("testdata/kubeconfig")
+	require.NoError(t, err)
+	kubeConfig.Clusters["my-cluster"].Server = "https://" + server.Listener.Addr().String()
+	tempKubeConfig := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, clientcmd.WriteToFile(*kubeConfig, tempKubeConfig))
+	t.Setenv("KUBECONFIG", tempKubeConfig)
+
+	p, err := NewClientProvider("nodename", &ClientConfig{
+		APIConfig: k8sconfig.APIConfig{
+			AuthType: k8sconfig.AuthTypeKubeConfig,
+		},
+		InsecureSkipVerify: true,
+	}, zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	client, err := p.BuildClient()
+	require.NoError(t, err)
+	resp, err := client.Get("/")
+	require.NoError(t, err)
+	require.Equal(t, []byte(`OK`), resp)
 }
 
 func TestBuildEndpoint(t *testing.T) {

--- a/internal/kubelet/go.mod
+++ b/internal/kubelet/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/collector v0.73.0
 	go.uber.org/zap v1.24.0
+	k8s.io/client-go v0.26.2
 )
 
 require (
@@ -49,7 +50,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.26.2 // indirect
 	k8s.io/apimachinery v0.26.2 // indirect
-	k8s.io/client-go v0.26.2 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d // indirect

--- a/internal/kubelet/testdata/kubeconfig
+++ b/internal/kubelet/testdata/kubeconfig
@@ -1,0 +1,19 @@
+kind: Config
+preferences: {}
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Y2VydA==
+    server: https://my-cluster.address
+  name: my-cluster
+contexts:
+- context:
+    cluster: my-cluster
+    namespace: my-namespace
+    user: my-user
+  name: my-context
+current-context: my-context
+users:
+- name: my-user
+  user:
+    token: my-token

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -24,6 +24,8 @@ endpoint will be used if `auth_type` set to any of the following values:
 `ca_file`, `key_file`, and `cert_file` also be set.
 - `serviceAccount` tells this receiver to use the default service account token
 to authenticate to the kubelet API.
+- `kubeConfig` tells this receiver to use the kubeconfig file (KUBECONFIG env variable or ~/.kube/config)
+to authenticate and use API server proxy to access the kubelet API.
 
 ### TLS Example
 
@@ -105,6 +107,29 @@ service:
       receivers: [kubeletstats]
       exporters: [file]
 ```
+
+### Kubeconfig example
+
+The following config can be used to collect Kubelet metrics from read-only endpoint, proxied by the API server:
+
+```yaml
+receivers:
+  kubeletstats:
+    collection_interval: 20s
+    auth_type: "kubeConfig"
+    insecure_skip_verify: true
+    endpoint: "${K8S_NODE_NAME}"
+exporters:
+  file:
+    path: "fileexporter.txt"
+service:
+  pipelines:
+    metrics:
+      receivers: [kubeletstats]
+      exporters: [file]
+```
+Note that using `auth_type` `kubeConfig`, the endpoint should only be the node name as the communication to the kubelet is proxied by the API server configured in the `kubeConfig`.
+`insecure_skip_verify` still applies by overriding the `kubeConfig` settings.
 
 ### Extra metadata labels
 


### PR DESCRIPTION
make sure to handle InsecureSkipVerify and override any root certificate declared in the kubeconfig

Signed-off-by: JACQUES Francois <hypnoce@donarproject.org>

**Description:** <Describe what has changed.>
Add support for auth_type kubeConfig in kubelet stats receiver.

**Link to tracking Issue:** 17561

**Testing:** add bearer auth test using kubeconfig.

**Documentation:** added documentation in kubeletstats receiver README for new auth_type