### PR TITLE
clickhouse / string type cast fix

### DIFF
--- a/.chloggen/string-type-cast-fix.yaml
+++ b/.chloggen/string-type-cast-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: clickhousexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Clickhouse string type cast function of insert flow changed because of missing span values
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/string-type-cast-fix.yaml
+++ b/.chloggen/string-type-cast-fix.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: clickhousexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Clickhouse string type cast function of insert flow changed because of missing span values
+note: Clickhouse string type cast function of insert flow changed because of missing span values.
 
 # One or more tracking issues related to the change
 issues: []

--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -121,7 +121,7 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 func attributesToMap(attributes pcommon.Map) map[string]string {
 	m := make(map[string]string, attributes.Len())
 	attributes.Range(func(k string, v pcommon.Value) bool {
-		m[k] = v.Str()
+		m[k] = v.AsString()
 		return true
 	})
 	return m


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Change Clickhouse string type cast function of insert flow.

Before this fix (check http.status_code):
`{'http.method': 'GET', 'http.scheme': 'http', 'http.target': '/hc', 'http.url': 'url', 'http.flavor': '1.1', 'http.user_agent': 'Envoy/HC', 'http.status_code': '', 'net.host.name': 'url'}`

After this fix (check http.status_code)::
`{'http.method': 'GET', 'http.scheme': 'http', 'http.target': '/hc', 'http.url': 'url', 'http.flavor': '1.1', 'http.user_agent': 'Envoy/HC', 'http.status_code': '200', 'net.host.name': 'url'}`