### PR TITLE
[chore] Fix "add codeowners to PR" workflow

### DIFF
--- a/.github/workflows/scripts/add-codeowners-to-pr.sh
+++ b/.github/workflows/scripts/add-codeowners-to-pr.sh
@@ -50,7 +50,11 @@ main () {
     declare -A REVIEWED
 
     for REVIEWER in ${REVIEW_LOGINS}; do
-        REVIEWED["@${REVIEWER}"]=true
+        # GitHub adds "app/" in front of user logins. The API docs don't make
+        # it clear what this means or whether it will always be present. The
+        # '/' character isn't a valid character for usernames, so this won't
+        # replace characters within a username.
+        REVIEWED["@${REVIEWER//app\//}"]=true
     done
 
     for COMPONENT in ${COMPONENTS}; do


### PR DESCRIPTION
**Description:**

GitHub has started to prepend usernames with "app/", causing the workflow to re-request reviews from users. Removing the "app/" prefix fixes the issue.

**Testing:**

Tested locally to confirm that the check works again after removing the "app/" prefix.