### PR TITLE
[pkg/ottl] Handle nil val in IsMatch

### DIFF
--- a/.chloggen/ottl-fix-ismatch.yaml
+++ b/.chloggen/ottl-fix-ismatch.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where IsMatch returned an error if the target val was nil
+
+# One or more tracking issues related to the change
+issues: [17572]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Affected components
+    - `filterprocessor`
+    - `routingprocessor`
+    - `transformprocessor`

--- a/pkg/ottl/ottlfuncs/func_is_match.go
+++ b/pkg/ottl/ottlfuncs/func_is_match.go
@@ -38,6 +38,9 @@ func IsMatch[K any](target ottl.Getter[K], pattern string) (ottl.ExprFunc[K], er
 		if err != nil {
 			return nil, err
 		}
+		if val == nil {
+			return false, nil
+		}
 
 		switch v := val.(type) {
 		case string:

--- a/pkg/ottl/ottlfuncs/func_is_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_match_test.go
@@ -104,6 +104,16 @@ func Test_isMatch(t *testing.T) {
 			pattern:  `test`,
 			expected: true,
 		},
+		{
+			name: "nil target",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			pattern:  "impossible to match",
+			expected: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:**
Fixes a bug where IsMatch would return an error if the target returned a nil val.  This broke conditions that used IsMatch as it is reasonable to check an attribute in a where clause that might not exist.

**Link to tracking Issue:**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17563

**Testing:**
Added new unit test