### PR TITLE
[chore] Add @kovrus as codeownder for pkg/translator/prw.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,7 +117,7 @@ pkg/translator/jaeger/                                   @open-telemetry/collect
 pkg/translator/loki/                                     @open-telemetry/collector-contrib-approvers @gouthamve @jpkrohling @kovrus @mar4uk
 pkg/translator/opencensus/                               @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 pkg/translator/prometheus/                               @open-telemetry/collector-contrib-approvers @dashpole @bertysentry
-pkg/translator/prometheusremotewrite/                    @open-telemetry/collector-contrib-approvers @Aneurysm9
+pkg/translator/prometheusremotewrite/                    @open-telemetry/collector-contrib-approvers @Aneurysm9 @kovrus
 pkg/translator/signalfx/                                 @open-telemetry/collector-contrib-approvers @pmcollins @pjanotti @dmitryax
 pkg/translator/zipkin/                                   @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 pkg/winperfcounters/                                     @open-telemetry/collector-contrib-approvers @dashpole @mrod1598 @binaryfissiongames


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
I would like to become a codeowner for the `pkg/translator/prometheusremotewrite` package. @Aneurysm9 is fine with that.  I’ve checked [becoming-a-code-owner](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner) and seems that I satisfy the requirements.

I’ve already contributed to this package :
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17370
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17417
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17498
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17411
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17372

and plan to keep on contributing to this package.