### PR TITLE
[exporter/loki] Fix README config examples

### DIFF
--- a/exporter/lokiexporter/README.md
+++ b/exporter/lokiexporter/README.md
@@ -34,17 +34,23 @@ processors:
   attributes:
     actions:
     - action: insert
+      key: event_domain
+      from_attribute: event.domain
+    - action: insert
       key: loki.attribute.labels
-      value: http.status_code
+      value: event_domain
 
   resource:
     attributes:
     - action: insert
-      key: loki.attribute.labels
-      value: http.status
+      key: service_name
+      from_attribute: service.name
+    - action: insert
+      key: service_namespace
+      from_attribute: service.namespace
     - action: insert
       key: loki.resource.labels
-      value: host.name, pod.name
+      value: service_name, service_namespace
 
 extensions:
 
@@ -60,28 +66,38 @@ service:
 The full list of settings exposed for this exporter are documented [here](./config.go) with detailed sample
 configurations [here](./testdata/config.yaml).
 
+More information on how to send logs to Grafana Loki using the OpenTelemetry Collector could be found [here](https://grafana.com/docs/opentelemetry/collector/send-logs-to-loki/)
 ## Labels
 
 The Loki exporter can convert OTLP resource and log attributes into Loki labels, which are indexed. For that, you need to configure
 hints, specifying which attributes should be placed as labels. The hints are themselves attributes and will be ignored when
-exporting to Loki. The following example uses the `attributes` processor to hint the Loki exporter to set the `http.status_code` 
-attribute as label and the `resource` processor to give a hint to the Loki exporter to set the `pod.name` as label.
+exporting to Loki. The following example uses the `attributes` processor to hint the Loki exporter to set the `event.domain` 
+attribute as label and the `resource` processor to give a hint to the Loki exporter to set the `service.name` as label.
 
 ```yaml
 processors:
   attributes:
     actions:
-    - action: insert
-      key: loki.attribute.labels
-      value: http.status_code
+      - action: insert
+        key: event_domain
+        from_attribute: event.domain
+      - action: insert
+        key: loki.attribute.labels
+        value: event_domain
 
   resource:
     attributes:
-    - action: insert
-      key: loki.resource.labels
-      value: pod.name
+      - action: insert
+        key: service_name
+        from_attribute: service.name
+      - action: insert
+        key: loki.resource.labels
+        value: service_name
 ```
 
+Currently, Loki does not support labels with dots. 
+That’s why to add Loki label based on `event.domain` OTLP attribute we need to specify two actions. The first one inserts a new attribute `event_domain` from the OTLP attribute `event.domain`. The second one is a hint for Loki, specifying that the `event_domain` attribute should be placed as a Loki label.
+The same approach is applicable to placing Loki labels from resource attribute `service.name`.
 ## Tenant information
 
 It is recommended to use the [`header_setter`](../../extension/headerssetterextension/README.md) extension to configure the tenant information to send to Loki. In case a static tenant
@@ -104,7 +120,10 @@ processors:
     attributes:
     - action: insert
       key: loki.tenant
-      value: host.name
+      value: host_name
+    - action: insert
+      key: host_name
+      from_attribute: host.name
 ```
 
 In this case the value of the `host.name` resource attribute is used to group logs


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fixing loki exporter README config examples.
Currently, Loki doesn't support labels with dots, that's why the workaround is needed to promote OTLP attributes and resource attributes with dots to Loki labels

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17445