### PR TITLE
[chore] fix verify-dist script

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -563,6 +563,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: collector-binaries
+          path: ./bin/
       - name: Download Packages
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/scripts/verify-dist-files-exist.sh
+++ b/.github/workflows/scripts/verify-dist-files-exist.sh
@@ -9,9 +9,10 @@ files=(
     dist/otel-contrib-collector_*_amd64.deb
     dist/otel-contrib-collector-*.x86_64.rpm
     dist/otel-contrib-collector_*_arm64.deb
+    dist/otel-contrib-collector-*.ppc64le.rpm
     dist/otel-contrib-collector_*_ppc64le.deb
-    dist/otel-contrib-collector_*_ppc64le.rpm
-    dist/otel-contrib-collector-*amd64.msi
+    # skip. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10113
+    # dist/otel-contrib-collector-*amd64.msi
 
 );
 for f in "${files[@]}"
@@ -20,7 +21,7 @@ do
     then
         echo "$f does not exist."
         echo "passed=false" >> $GITHUB_OUTPUT
-        exit 0
+        exit 1
     fi
 done
 echo "passed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The filename for ppc64le was incorrect, and the check for the msi should have been disabled at the same time as the msi job was disabled. I've also updated the script to return an error, to prevent it from failing silently for months.

Signed-off-by: Alex Boten <aboten@lightstep.com>
