### PR TITLE
[chore] skip all jobs on PRs created by dependabot

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Lint
         run: make -j2 golint GROUP=${{ matrix.group }}
   lint:
-    if: ${{ always() }}
+    if: ${{ github.actor != 'dependabot[bot]' && always() }}
     runs-on: ubuntu-latest
     needs: [setup-environment, lint-matrix]
     steps:
@@ -241,7 +241,7 @@ jobs:
           test_path: |
             ./**/foresight-test*.txt
   unittest:
-    if: ${{ always() }}
+    if: ${{ github.actor != 'dependabot[bot]' && always() }}
     strategy:
       matrix:
         go-version: [1.19, 1.18]

--- a/.github/workflows/ping-codeowners-prs.yml
+++ b/.github/workflows/ping-codeowners-prs.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   ping-owners:
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'open-telemetry' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v3
     


### PR DESCRIPTION
There are still a few CI actions triggered by PRs created by dependabot. Since those PRs will never be merged, there's no point in running any actions for them.

Signed-off-by: Alex Boten <aboten@lightstep.com>
