### PR TITLE
[pkg/batchperresourceattr] Don't reset the original resource instance, use copy instead

### DIFF
--- a/.chloggen/pkg-batchperresourceattr.yaml
+++ b/.chloggen/pkg-batchperresourceattr.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: batchperresourceattr
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Optimize batch processor attribute and don't reset the caller's instance, instead make a copy of the original resource attributes
+
+# One or more tracking issues related to the change
+issues: [17835]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/batchperresourceattr/batchperresourceattr.go
+++ b/pkg/batchperresourceattr/batchperresourceattr.go
@@ -49,27 +49,29 @@ func (bt *batchTraces) ConsumeTraces(ctx context.Context, td ptrace.Traces) erro
 		return bt.next.ConsumeTraces(ctx, td)
 	}
 
-	tracesByAttr := make(map[string]ptrace.Traces)
+	indicesByAttr := make(map[string][]int)
 	for i := 0; i < lenRss; i++ {
 		rs := rss.At(i)
 		var attrVal string
 		if attributeValue, ok := rs.Resource().Attributes().Get(bt.attrKey); ok {
 			attrVal = attributeValue.Str()
 		}
-
-		tracesForAttr, ok := tracesByAttr[attrVal]
-		if !ok {
-			tracesForAttr = ptrace.NewTraces()
-			tracesByAttr[attrVal] = tracesForAttr
-		}
-
-		// Append ResourceSpan to ptrace.Traces for this attribute value.
-		rs.MoveTo(tracesForAttr.ResourceSpans().AppendEmpty())
+		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
+	}
+	// If there is a single attribute value, then call next.
+	if len(indicesByAttr) <= 1 {
+		return bt.next.ConsumeTraces(ctx, td)
 	}
 
+	// Build the resource spans for each attribute value using CopyTo and call next for each one.
 	var errs error
-	for _, td := range tracesByAttr {
-		errs = multierr.Append(errs, bt.next.ConsumeTraces(ctx, td))
+	for _, indices := range indicesByAttr {
+		tracesForAttr := ptrace.NewTraces()
+		for _, i := range indices {
+			rs := rss.At(i)
+			rs.CopyTo(tracesForAttr.ResourceSpans().AppendEmpty())
+		}
+		errs = multierr.Append(errs, bt.next.ConsumeTraces(ctx, tracesForAttr))
 	}
 	return errs
 }
@@ -94,32 +96,34 @@ func (bt *batchMetrics) Capabilities() consumer.Capabilities {
 func (bt *batchMetrics) ConsumeMetrics(ctx context.Context, td pmetric.Metrics) error {
 	rms := td.ResourceMetrics()
 	lenRms := rms.Len()
-	// If zero or one resource spans just call next.
+	// If zero or one resource metrics just call next.
 	if lenRms <= 1 {
 		return bt.next.ConsumeMetrics(ctx, td)
 	}
 
-	metricsByAttr := make(map[string]pmetric.Metrics)
+	indicesByAttr := make(map[string][]int)
 	for i := 0; i < lenRms; i++ {
 		rm := rms.At(i)
 		var attrVal string
 		if attributeValue, ok := rm.Resource().Attributes().Get(bt.attrKey); ok {
 			attrVal = attributeValue.Str()
 		}
-
-		metricsForAttr, ok := metricsByAttr[attrVal]
-		if !ok {
-			metricsForAttr = pmetric.NewMetrics()
-			metricsByAttr[attrVal] = metricsForAttr
-		}
-
-		// Append ResourceSpan to pmetric.Metrics for this attribute value.
-		rm.MoveTo(metricsForAttr.ResourceMetrics().AppendEmpty())
+		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
+	}
+	// If there is a single attribute value, then call next.
+	if len(indicesByAttr) <= 1 {
+		return bt.next.ConsumeMetrics(ctx, td)
 	}
 
+	// Build the resource metrics for each attribute value using CopyTo and call next for each one.
 	var errs error
-	for _, td := range metricsByAttr {
-		errs = multierr.Append(errs, bt.next.ConsumeMetrics(ctx, td))
+	for _, indices := range indicesByAttr {
+		metricsForAttr := pmetric.NewMetrics()
+		for _, i := range indices {
+			rm := rms.At(i)
+			rm.CopyTo(metricsForAttr.ResourceMetrics().AppendEmpty())
+		}
+		errs = multierr.Append(errs, bt.next.ConsumeMetrics(ctx, metricsForAttr))
 	}
 	return errs
 }
@@ -144,32 +148,34 @@ func (bt *batchLogs) Capabilities() consumer.Capabilities {
 func (bt *batchLogs) ConsumeLogs(ctx context.Context, td plog.Logs) error {
 	rls := td.ResourceLogs()
 	lenRls := rls.Len()
-	// If zero or one resource spans just call next.
+	// If zero or one resource logs just call next.
 	if lenRls <= 1 {
 		return bt.next.ConsumeLogs(ctx, td)
 	}
 
-	logsByAttr := make(map[string]plog.Logs)
+	indicesByAttr := make(map[string][]int)
 	for i := 0; i < lenRls; i++ {
 		rl := rls.At(i)
 		var attrVal string
 		if attributeValue, ok := rl.Resource().Attributes().Get(bt.attrKey); ok {
 			attrVal = attributeValue.Str()
 		}
-
-		logsForAttr, ok := logsByAttr[attrVal]
-		if !ok {
-			logsForAttr = plog.NewLogs()
-			logsByAttr[attrVal] = logsForAttr
-		}
-
-		// Append ResourceSpan to plog.Logs for this attribute value.
-		rl.MoveTo(logsForAttr.ResourceLogs().AppendEmpty())
+		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
+	}
+	// If there is a single attribute value, then call next.
+	if len(indicesByAttr) <= 1 {
+		return bt.next.ConsumeLogs(ctx, td)
 	}
 
+	// Build the resource logs for each attribute value using CopyTo and call next for each one.
 	var errs error
-	for _, td := range logsByAttr {
-		errs = multierr.Append(errs, bt.next.ConsumeLogs(ctx, td))
+	for _, indices := range indicesByAttr {
+		logsForAttr := plog.NewLogs()
+		for _, i := range indices {
+			rl := rls.At(i)
+			rl.CopyTo(logsForAttr.ResourceLogs().AppendEmpty())
+		}
+		errs = multierr.Append(errs, bt.next.ConsumeLogs(ctx, logsForAttr))
 	}
 	return errs
 }

--- a/pkg/batchperresourceattr/batchperresourceattr_test.go
+++ b/pkg/batchperresourceattr/batchperresourceattr_test.go
@@ -43,6 +43,19 @@ func TestSplitTracesOneResourceSpans(t *testing.T) {
 	assert.Equal(t, inBatch, outBatches[0])
 }
 
+func TestOriginalResourceSpansUnchanged(t *testing.T) {
+	inBatch := ptrace.NewTraces()
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+
+	sink := new(consumertest.TracesSink)
+	bpr := NewBatchPerResourceTraces("attr_key", sink)
+	assert.NoError(t, bpr.ConsumeTraces(context.Background(), inBatch))
+	outBatches := sink.AllTraces()
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, inBatch, outBatches[0])
+}
+
 func TestSplitTracesReturnError(t *testing.T) {
 	inBatch := ptrace.NewTraces()
 	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
@@ -111,6 +124,19 @@ func TestSplitMetricsOneResourceMetrics(t *testing.T) {
 	assert.Equal(t, expected, outBatches[0])
 }
 
+func TestOriginalResourceMetricsUnchanged(t *testing.T) {
+	inBatch := pmetric.NewMetrics()
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
+
+	sink := new(consumertest.MetricsSink)
+	bpr := NewBatchPerResourceMetrics("attr_key", sink)
+	assert.NoError(t, bpr.ConsumeMetrics(context.Background(), inBatch))
+	outBatches := sink.AllMetrics()
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, inBatch, outBatches[0])
+}
+
 func TestSplitMetricsReturnError(t *testing.T) {
 	inBatch := pmetric.NewMetrics()
 	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
@@ -177,6 +203,19 @@ func TestSplitLogsOneResourceLogs(t *testing.T) {
 	outBatches := sink.AllLogs()
 	require.Len(t, outBatches, 1)
 	assert.Equal(t, expected, outBatches[0])
+}
+
+func TestOriginalResourceLogsUnchanged(t *testing.T) {
+	inBatch := plog.NewLogs()
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
+
+	sink := new(consumertest.LogsSink)
+	bpr := NewBatchPerResourceLogs("attr_key", sink)
+	assert.NoError(t, bpr.ConsumeLogs(context.Background(), inBatch))
+	outBatches := sink.AllLogs()
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, inBatch, outBatches[0])
 }
 
 func TestSplitLogsReturnError(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

The `batchperresourceattr` , which is currently used by `sapm`, `signalfx` and `splunkhec` exporters, resets the original object passed down by the caller (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/batchperresourceattr/batchperresourceattr.go#L117)  . 
This causes an issue when the caller reuse the resource instance and in my particular case it was in the [routing processor,](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/routingprocessor/metrics.go#L126) which made debugging the issue a tricky job

Note:
I was debating whether to fix the routing processor to pass a copy of the instance, but then I settled to this fix.


**Testing:** <Describe what testing was performed and which tests were added.>
Repro steps can be found [here](https://github.com/dloucasfx/SWAT-5350) , same steps used for validating the fix.
I also added a new test.
Note: I only did end to end test for metrics and just tested logs and spans as unit test

**Documentation:** <Describe the documentation added.>
N/A