### PR TITLE
[internal/comparetest] Do not sort resources by default, use an option

### DIFF
--- a/.chloggen/do-not-sort-resources-comparetest.yaml
+++ b/.chloggen/do-not-sort-resources-comparetest.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: internal/comparetest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not ignore order of Resource[Metrics|Traces|Logs] by default, use an option for that.
+
+# One or more tracking issues related to the change
+issues: [17551]

--- a/internal/comparetest/logs_test.go
+++ b/internal/comparetest/logs_test.go
@@ -53,6 +53,20 @@ func TestCompareLogs(t *testing.T) {
 			},
 		},
 		{
+			name: "ignore-resource-order",
+			compareOptions: []LogsCompareOption{
+				IgnoreResourceOrder(),
+			},
+			withoutOptions: expectation{
+				err:    errors.New("ResourceLogs with attributes map[testKey1:one] expected at index 0, found a at index 1"),
+				reason: "Resource order mismatch will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err:    nil,
+				reason: "Ignored resource order mismatch should not cause a failure.",
+			},
+		},
+		{
 			name: "resource-instrumentation-library-extra",
 			withoutOptions: expectation{
 				err:    errors.New("number of instrumentation libraries does not match expected: 1, actual: 2"),

--- a/internal/comparetest/metrics_test.go
+++ b/internal/comparetest/metrics_test.go
@@ -538,18 +538,32 @@ func TestCompareMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "ignore-resource-order",
+			compareOptions: []MetricsCompareOption{
+				IgnoreResourceOrder(),
+			},
+			withoutOptions: expectation{
+				err:    errors.New("ResourceMetrics with attributes map[node_id:BB903] expected at index 1, found a at index 2"),
+				reason: "Resource order mismatch will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err:    nil,
+				reason: "Ignored resource order mismatch should not cause a failure.",
+			},
+		},
+		{
 			name: "ignore-one-resource-attribute-multiple-resources",
 			compareOptions: []MetricsCompareOption{
 				IgnoreResourceAttributeValue("node_id"),
 			},
 			withoutOptions: expectation{
 				err: multierr.Combine(
-					errors.New("missing expected resource with attributes: map[namespace:BB904-test node_id:BB904-expected]"),
 					errors.New("missing expected resource with attributes: map[namespace:BB902-test node_id:BB902-expected]"),
+					errors.New("missing expected resource with attributes: map[namespace:BB904-test node_id:BB904-expected]"),
 					errors.New("missing expected resource with attributes: map[namespace:BB903-test node_id:BB903-expected]"),
+					errors.New("extra resource with attributes: map[namespace:BB902-test node_id:BB902-actual]"),
 					errors.New("extra resource with attributes: map[namespace:BB904-test node_id:BB904-actual]"),
 					errors.New("extra resource with attributes: map[namespace:BB903-test node_id:BB903-actual]"),
-					errors.New("extra resource with attributes: map[namespace:BB902-test node_id:BB902-actual]"),
 				),
 				reason: "An unpredictable resource attribute will cause failures if not ignored.",
 			},

--- a/internal/comparetest/options.go
+++ b/internal/comparetest/options.go
@@ -288,3 +288,25 @@ func maskObservedTimestamp(logs plog.Logs, ts pcommon.Timestamp) {
 		}
 	}
 }
+
+// IgnoreResourceOrder is a CompareOption that ignores the order of resource traces/metrics/logs.
+func IgnoreResourceOrder() CompareOption {
+	return ignoreResourceOrder{}
+}
+
+type ignoreResourceOrder struct{}
+
+func (opt ignoreResourceOrder) applyOnTraces(expected, actual ptrace.Traces) {
+	expected.ResourceSpans().Sort(sortResourceSpans)
+	actual.ResourceSpans().Sort(sortResourceSpans)
+}
+
+func (opt ignoreResourceOrder) applyOnMetrics(expected, actual pmetric.Metrics) {
+	expected.ResourceMetrics().Sort(sortResourceMetrics)
+	actual.ResourceMetrics().Sort(sortResourceMetrics)
+}
+
+func (opt ignoreResourceOrder) applyOnLogs(expected, actual plog.Logs) {
+	expected.ResourceLogs().Sort(sortResourceLogs)
+	actual.ResourceLogs().Sort(sortResourceLogs)
+}

--- a/internal/comparetest/testdata/logs/ignore-resource-order/actual.json
+++ b/internal/comparetest/testdata/logs/ignore-resource-order/actual.json
@@ -1,0 +1,28 @@
+{
+    "resourceLogs": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "testKey2",
+                        "value": {
+                            "stringValue": "one"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "testKey1",
+                        "value": {
+                            "stringValue": "one"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/internal/comparetest/testdata/logs/ignore-resource-order/expected.json
+++ b/internal/comparetest/testdata/logs/ignore-resource-order/expected.json
@@ -1,0 +1,28 @@
+{
+    "resourceLogs": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "testKey1",
+                        "value": {
+                            "stringValue": "one"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "testKey2",
+                        "value": {
+                            "stringValue": "one"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/internal/comparetest/testdata/metrics/ignore-resource-order/actual.json
+++ b/internal/comparetest/testdata/metrics/ignore-resource-order/actual.json
@@ -1,0 +1,1054 @@
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB902"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8513765"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41913920"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2,
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB904"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8522202"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41955456"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2,
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB903"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8343140"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41073920"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2,
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/comparetest/testdata/metrics/ignore-resource-order/expected.json
+++ b/internal/comparetest/testdata/metrics/ignore-resource-order/expected.json
@@ -1,0 +1,1054 @@
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB902"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8513765"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41913920"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2,
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB903"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8343140"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41073920"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2,
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB904"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8522202"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41955456"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": 2,
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/comparetest/testdata/traces/ignore-one-resource-attribute/actual.json
+++ b/internal/comparetest/testdata/traces/ignore-one-resource-attribute/actual.json
@@ -89,15 +89,9 @@
             "resource": {
                 "attributes": [
                     {
-                        "key": "testKey3",
+                        "key": "host.name",
                         "value": {
-                            "stringValue": "teststringvalue3"
-                        }
-                    },
-                    {
-                        "key": "testKey4",
-                        "value": {
-                            "stringValue": "teststringvalue4"
+                            "stringValue": "host2"
                         }
                     }
                 ]

--- a/internal/comparetest/testdata/traces/ignore-resource-order/actual.json
+++ b/internal/comparetest/testdata/traces/ignore-resource-order/actual.json
@@ -6,11 +6,62 @@
                     {
                         "key": "host.name",
                         "value": {
-                            "stringValue": "different-node1"
+                            "stringValue": "host2"
                         }
                     }
-                ],
-                "droppedAttributesCount": 0
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "spans": [
+                        {
+                            "attributes": [
+                                {
+                                    "key": "testKey3",
+                                    "value": {
+                                        "stringValue": "teststringvalue3"
+                                    }
+                                },
+                                {
+                                    "key": "testKey4",
+                                    "value": {
+                                        "stringValue": "teststringvalue4"
+                                    }
+                                }
+                            ],
+                            "droppedAttributesCount": 0,
+                            "endTimeUnixNano": "11651379494838206464",
+                            "startTimeUnixNano": "11651379494838206464",
+                            "status": {},
+                            "events": [],
+                            "droppedEventsCount": 0,
+                            "links": [],
+                            "droppedLinksCount": 0,
+                            "name": "",
+                            "kind": 2,
+                            "parentSpanId": "",
+                            "traceState": "",
+                            "spanId": "",
+                            "traceId": ""
+                        }
+                    ],
+                    "scope": {
+                        "name": "collector",
+                        "version": "v0.1.0"
+                    }
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "host1"
+                        }
+                    }
+                ]
             },
             "scopeSpans": [
                 {
@@ -81,59 +132,6 @@
                         "version": "v0.1.0"
                     },
                     "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
-                }
-            ],
-            "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
-        },
-        {
-            "resource": {
-                "attributes": [
-                    {
-                        "key": "host.name",
-                        "value": {
-                            "stringValue": "host2"
-                        }
-                    }
-                ]
-            },
-            "scopeSpans": [
-                {
-                    "spans": [
-                        {
-                            "attributes": [
-                                {
-                                    "key": "testKey3",
-                                    "value": {
-                                        "stringValue": "teststringvalue3"
-                                    }
-                                },
-                                {
-                                    "key": "testKey4",
-                                    "value": {
-                                        "stringValue": "teststringvalue4"
-                                    }
-                                }
-                            ],
-                            "droppedAttributesCount": 0,
-                            "endTimeUnixNano": "11651379494838206464",
-                            "startTimeUnixNano": "11651379494838206464",
-                            "status": {},
-                            "events": [],
-                            "droppedEventsCount": 0,
-                            "links": [],
-                            "droppedLinksCount": 0,
-                            "name": "",
-                            "kind": 2,
-                            "parentSpanId": "",
-                            "traceState": "",
-                            "spanId": "",
-                            "traceId": ""
-                        }
-                    ],
-                    "scope": {
-                        "name": "collector",
-                        "version": "v0.1.0"
-                    }
                 }
             ]
         }

--- a/internal/comparetest/testdata/traces/ignore-resource-order/expected.json
+++ b/internal/comparetest/testdata/traces/ignore-resource-order/expected.json
@@ -6,11 +6,10 @@
                     {
                         "key": "host.name",
                         "value": {
-                            "stringValue": "different-node1"
+                            "stringValue": "host1"
                         }
                     }
-                ],
-                "droppedAttributesCount": 0
+                ]
             },
             "scopeSpans": [
                 {
@@ -82,8 +81,7 @@
                     },
                     "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
                 }
-            ],
-            "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
+            ]
         },
         {
             "resource": {

--- a/internal/comparetest/traces_test.go
+++ b/internal/comparetest/traces_test.go
@@ -52,6 +52,21 @@ func TestCompareTraces(t *testing.T) {
 				reason: "The unpredictable resource attribute was ignored on each resource that carried it.",
 			},
 		},
+		{
+			name: "ignore-resource-order",
+			compareOptions: []TracesCompareOption{
+				IgnoreResourceOrder(),
+			},
+			withoutOptions: expectation{
+				err: errors.New("ResourceTraces with attributes map[host.name:host1] expected at index 0, " +
+					"found a at index 1"),
+				reason: "Resource order mismatch will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err:    nil,
+				reason: "Ignored resource order mismatch should not cause a failure.",
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/receiver/aerospikereceiver/scraper_test.go
+++ b/receiver/aerospikereceiver/scraper_test.go
@@ -153,7 +153,7 @@ func TestScrape_CollectClusterMetrics(t *testing.T) {
 	require.EqualError(t, err, "failed to parse int64 for AerospikeNamespaceMemoryUsage, value was badval: strconv.ParseInt: parsing \"badval\": invalid syntax")
 
 	expectedMetrics := expectedMB.Emit()
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 
 	require.NoError(t, receiver.shutdown(context.Background()))
 

--- a/receiver/bigipreceiver/integration_test.go
+++ b/receiver/bigipreceiver/integration_test.go
@@ -64,7 +64,7 @@ func TestBigIpIntegration(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreMetricValues()))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder(), comparetest.IgnoreMetricValues()))
 }
 
 const (

--- a/receiver/bigipreceiver/scraper_test.go
+++ b/receiver/bigipreceiver/scraper_test.go
@@ -272,7 +272,7 @@ func TestScaperScrape(t *testing.T) {
 
 			expectedMetrics := tc.expectedMetricGen(t)
 
-			err = comparetest.CompareMetrics(expectedMetrics, actualMetrics)
+			err = comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder())
 			require.NoError(t, err)
 		})
 	}

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -205,7 +205,7 @@ func TestScrapeV2(t *testing.T) {
 			expectedMetrics, err := golden.ReadMetrics(tc.expectedMetricsFile)
 
 			assert.NoError(t, err)
-			assert.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+			assert.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 		})
 	}
 }

--- a/receiver/elasticsearchreceiver/integration_test.go
+++ b/receiver/elasticsearchreceiver/integration_test.go
@@ -93,7 +93,10 @@ func TestElasticsearchIntegration(t *testing.T) {
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
-		comparetest.CompareMetrics(expectedMetrics, actualMtrics, comparetest.IgnoreMetricValues(), comparetest.IgnoreResourceAttributeValue("elasticsearch.node.name"))
+		comparetest.CompareMetrics(expectedMetrics, actualMtrics,
+			comparetest.IgnoreResourceOrder(),
+			comparetest.IgnoreMetricValues(),
+			comparetest.IgnoreResourceAttributeValue("elasticsearch.node.name"))
 	})
 	t.Run("Running elasticsearch 7.16.3", func(t *testing.T) {
 		t.Parallel()
@@ -125,7 +128,10 @@ func TestElasticsearchIntegration(t *testing.T) {
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
-		comparetest.CompareMetrics(expectedMetrics, actualMtrics, comparetest.IgnoreMetricValues(), comparetest.IgnoreResourceAttributeValue("elasticsearch.node.name"))
+		comparetest.CompareMetrics(expectedMetrics, actualMtrics,
+			comparetest.IgnoreResourceOrder(),
+			comparetest.IgnoreMetricValues(),
+			comparetest.IgnoreResourceAttributeValue("elasticsearch.node.name"))
 	})
 }
 

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -102,7 +102,7 @@ func TestScraper(t *testing.T) {
 	actualMetrics, err := sc.scrape(context.Background())
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 func TestScraperSkipClusterMetrics(t *testing.T) {
@@ -132,7 +132,7 @@ func TestScraperSkipClusterMetrics(t *testing.T) {
 	actualMetrics, err := sc.scrape(context.Background())
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 func TestScraperNoNodesMetrics(t *testing.T) {
@@ -162,7 +162,7 @@ func TestScraperNoNodesMetrics(t *testing.T) {
 	actualMetrics, err := sc.scrape(context.Background())
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 func TestScraperFailedStart(t *testing.T) {

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -156,6 +156,7 @@ func TestPostgreSQLIntegration(t *testing.T) {
 
 			require.NoError(t, comparetest.CompareMetrics(
 				expectedMetrics, actualMetrics,
+				comparetest.IgnoreResourceOrder(),
 				comparetest.IgnoreMetricValues(),
 				comparetest.IgnoreSubsequentDataPoints("postgresql.backends"),
 			))

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -61,7 +61,7 @@ func TestScraper(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 func TestScraperNoDatabaseSingle(t *testing.T) {
@@ -80,7 +80,7 @@ func TestScraperNoDatabaseSingle(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 func TestScraperNoDatabaseMultiple(t *testing.T) {
@@ -99,7 +99,7 @@ func TestScraperNoDatabaseMultiple(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 func TestScraperWithResourceAttributeFeatureGate(t *testing.T) {
@@ -116,7 +116,7 @@ func TestScraperWithResourceAttributeFeatureGate(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 func TestScraperWithResourceAttributeFeatureGateSingle(t *testing.T) {
@@ -133,7 +133,7 @@ func TestScraperWithResourceAttributeFeatureGateSingle(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 type mockClientFactory struct{ mock.Mock }

--- a/receiver/saphanareceiver/scraper_test.go
+++ b/receiver/saphanareceiver/scraper_test.go
@@ -47,7 +47,7 @@ func TestScraper(t *testing.T) {
 	actualMetrics, err := sc.Scrape(context.Background())
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 func TestDisabledMetrics(t *testing.T) {
@@ -112,7 +112,7 @@ func TestDisabledMetrics(t *testing.T) {
 	actualMetrics, err := sc.Scrape(context.Background())
 	require.NoError(t, err)
 
-	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, comparetest.CompareMetrics(expectedMetrics, actualMetrics, comparetest.IgnoreResourceOrder()))
 }
 
 type queryJSON struct {


### PR DESCRIPTION
As a result of the discussion in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17286, it was decided not to sort all the slices by default but do it only if users ask for that explicitly. This change removes default sorting for resource metrics/traces/logs and introduces a new option `IgnoreResourceOrder` that can be used if the sorting is needed.

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17551