### PR TITLE
[chore] Simplify tool management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ local/
 *.dylib
 bin/
 dist/
+.tools/
 
 # Emacs
 *~

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ golint:
 	$(MAKE) $(FOR_GROUP_TARGET) TARGET="lint"
 
 .PHONY: goimpi
-goimpi: $(TOOLS_BIN_DIR)/impi
+goimpi: $(IMPI)
 	@$(MAKE) $(FOR_GROUP_TARGET) TARGET="impi"
 
 .PHONY: goporto

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,8 @@ goimpi: $(TOOLS_BIN_DIR)/impi
 	@$(MAKE) $(FOR_GROUP_TARGET) TARGET="impi"
 
 .PHONY: goporto
-goporto: $(TOOLS_BIN_DIR)/porto
-	$(TOOLS_BIN_DIR)/porto -w --include-internal --skip-dirs "^cmd$$" ./
+goporto: $(PORTO)
+	$(PORTO) -w --include-internal --skip-dirs "^cmd$$" ./
 
 .PHONY: for-all
 for-all:
@@ -126,9 +126,9 @@ COMMIT?=HEAD
 MODSET?=contrib-core
 REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-contrib.git
 .PHONY: push-tags
-push-tags:
-	$(TOOLS_BIN_DIR)/multimod verify
-	set -e; for tag in `$(TOOLS_BIN_DIR)/multimod tag -m ${MODSET} -c ${COMMIT} --print-tags | grep -v "Using" `; do \
+push-tags: $(MULITMOD) 
+	$(MULITMOD) verify
+	set -e; for tag in `$(MULITMOD) tag -m ${MODSET} -c ${COMMIT} --print-tags | grep -v "Using" `; do \
 		echo "pushing tag $${tag}"; \
 		git push ${REMOTE} $${tag}; \
 	done;
@@ -236,20 +236,20 @@ mdatagen-test:
 
 FILENAME?=$(shell git branch --show-current)
 .PHONY: chlog-new
-chlog-new: $(TOOLS_BIN_DIR)/chloggen
-	$(TOOLS_BIN_DIR)/chloggen new --filename $(FILENAME)
+chlog-new: $(CHLOGGEN)
+	$(CHLOGGEN) new --filename $(FILENAME)
 
 .PHONY: chlog-validate
-chlog-validate: $(TOOLS_BIN_DIR)/chloggen
-	$(TOOLS_BIN_DIR)/chloggen validate
+chlog-validate: $(CHLOGGEN)
+	$(CHLOGGEN) validate
 
 .PHONY: chlog-preview
-chlog-preview: $(TOOLS_BIN_DIR)/chloggen
-	$(TOOLS_BIN_DIR)/chloggen update --dry
+chlog-preview: $(CHLOGGEN)
+	$(CHLOGGEN) update --dry
 
 .PHONY: chlog-update
-chlog-update: $(TOOLS_BIN_DIR)/chloggen
-	$(TOOLS_BIN_DIR)/chloggen update --version $(VERSION)
+chlog-update: $(CHLOGGEN)
+	$(CHLOGGEN) update --version $(VERSION)
 
 # Build the Collector executable.
 .PHONY: otelcontribcol
@@ -303,8 +303,8 @@ build-examples:
 
 # Verify existence of READMEs for components specified as default components in the collector.
 .PHONY: checkdoc
-checkdoc: $(TOOLS_BIN_DIR)/checkdoc
-	$(TOOLS_BIN_DIR)/checkdoc --project-path $(CURDIR) --component-rel-path $(COMP_REL_PATH) --module-name $(MOD_NAME)
+checkdoc: $(CHECKDOC)
+	$(CHECKDOC) --project-path $(CURDIR) --component-rel-path $(COMP_REL_PATH) --module-name $(MOD_NAME)
 
 .PHONY: all-checklinks
 all-checklinks:
@@ -331,24 +331,24 @@ certs:
 	$(foreach dir, $(CERT_DIRS), $(call exec-command, @internal/buildscripts/gen-certs.sh -o $(dir)))
 
 .PHONY: multimod-verify
-multimod-verify: $(TOOLS_BIN_DIR)/multimod
+multimod-verify: $(MULITMOD)
 	@echo "Validating versions.yaml"
-	$(TOOLS_BIN_DIR)/multimod verify
+	$(MULITMOD) verify
 
 .PHONY: multimod-prerelease
-multimod-prerelease: $(TOOLS_BIN_DIR)/multimod
-	$(TOOLS_BIN_DIR)/multimod prerelease -s=true -b=false -v ./versions.yaml -m contrib-base
+multimod-prerelease: $(MULITMOD)
+	$(MULITMOD) prerelease -s=true -b=false -v ./versions.yaml -m contrib-base
 	$(MAKE) gotidy
 
 .PHONY: multimod-sync
-multimod-sync: $(TOOLS_BIN_DIR)/multimod
-	$(TOOLS_BIN_DIR)/multimod sync -a=true -s=true -o ../opentelemetry-collector
+multimod-sync: $(MULITMOD)
+	$(MULITMOD) sync -a=true -s=true -o ../opentelemetry-collector
 	$(MAKE) gotidy
 
 .PHONY: crosslink
-crosslink: $(TOOLS_BIN_DIR)/crosslink
+crosslink: $(CROSSLINK)
 	@echo "Executing crosslink"
-	$(TOOLS_BIN_DIR)/crosslink --root=$(shell pwd)
+	$(CROSSLINK) --root=$(shell pwd)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -203,22 +203,6 @@ for-other-target: $(OTHER_MODS)
 all-pwd:
 	$(MAKE) $(FOR_GROUP_TARGET) TARGET="pwd"
 
-TOOLS_MOD_DIR := ./internal/tools
-.PHONY: install-tools
-install-tools:
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install github.com/client9/misspell/cmd/misspell
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install github.com/google/addlicense
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install github.com/jstemmer/go-junit-report
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install github.com/pavius/impi/cmd/impi
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install github.com/tcnksm/ghr
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install go.opentelemetry.io/build-tools/checkdoc
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install go.opentelemetry.io/build-tools/issuegenerator
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install golang.org/x/tools/cmd/goimports
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install go.opentelemetry.io/build-tools/multimod
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install github.com/jcchavezs/porto/cmd/porto
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install go.opentelemetry.io/build-tools/crosslink
-
 .PHONY: run
 run:
 	cd ./cmd/otelcontribcol && GO111MODULE=on $(GOCMD) run --race . --config ../../${RUN_CONFIG} ${RUN_ARGS}

--- a/Makefile
+++ b/Makefile
@@ -105,12 +105,12 @@ golint:
 	$(MAKE) $(FOR_GROUP_TARGET) TARGET="lint"
 
 .PHONY: goimpi
-goimpi: install-tools
+goimpi: $(TOOLS_BIN_DIR)/impi
 	@$(MAKE) $(FOR_GROUP_TARGET) TARGET="impi"
 
 .PHONY: goporto
-goporto: install-tools
-	porto -w --include-internal --skip-dirs "^cmd$$" ./
+goporto: $(TOOLS_BIN_DIR)/porto
+	$(TOOLS_BIN_DIR)/porto -w --include-internal --skip-dirs "^cmd$$" ./
 
 .PHONY: for-all
 for-all:
@@ -127,8 +127,8 @@ MODSET?=contrib-core
 REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-contrib.git
 .PHONY: push-tags
 push-tags:
-	multimod verify
-	set -e; for tag in `multimod tag -m ${MODSET} -c ${COMMIT} --print-tags | grep -v "Using" `; do \
+	$(TOOLS_BIN_DIR)/multimod verify
+	set -e; for tag in `$(TOOLS_BIN_DIR)/multimod tag -m ${MODSET} -c ${COMMIT} --print-tags | grep -v "Using" `; do \
 		echo "pushing tag $${tag}"; \
 		git push ${REMOTE} $${tag}; \
 	done;
@@ -234,26 +234,22 @@ mdatagen-test:
 	cd cmd/mdatagen && $(GOCMD) install .
 	cd cmd/mdatagen && $(GOCMD) generate ./...
 
-.PHONY: chlog-install
-chlog-install:
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) install go.opentelemetry.io/build-tools/chloggen
-
 FILENAME?=$(shell git branch --show-current)
 .PHONY: chlog-new
-chlog-new: chlog-install
-	chloggen new --filename $(FILENAME)
+chlog-new: $(TOOLS_BIN_DIR)/chloggen
+	$(TOOLS_BIN_DIR)/chloggen new --filename $(FILENAME)
 
 .PHONY: chlog-validate
-chlog-validate: chlog-install
-	chloggen validate
+chlog-validate: $(TOOLS_BIN_DIR)/chloggen
+	$(TOOLS_BIN_DIR)/chloggen validate
 
 .PHONY: chlog-preview
-chlog-preview: chlog-install
-	chloggen update --dry
+chlog-preview: $(TOOLS_BIN_DIR)/chloggen
+	$(TOOLS_BIN_DIR)/chloggen update --dry
 
 .PHONY: chlog-update
-chlog-update: chlog-install
-	chloggen update --version $(VERSION)
+chlog-update: $(TOOLS_BIN_DIR)/chloggen
+	$(TOOLS_BIN_DIR)/chloggen update --version $(VERSION)
 
 # Build the Collector executable.
 .PHONY: otelcontribcol
@@ -307,8 +303,8 @@ build-examples:
 
 # Verify existence of READMEs for components specified as default components in the collector.
 .PHONY: checkdoc
-checkdoc:
-	checkdoc --project-path $(CURDIR) --component-rel-path $(COMP_REL_PATH) --module-name $(MOD_NAME)
+checkdoc: $(TOOLS_BIN_DIR)/checkdoc
+	$(TOOLS_BIN_DIR)/checkdoc --project-path $(CURDIR) --component-rel-path $(COMP_REL_PATH) --module-name $(MOD_NAME)
 
 .PHONY: all-checklinks
 all-checklinks:
@@ -335,24 +331,24 @@ certs:
 	$(foreach dir, $(CERT_DIRS), $(call exec-command, @internal/buildscripts/gen-certs.sh -o $(dir)))
 
 .PHONY: multimod-verify
-multimod-verify: install-tools
+multimod-verify: $(TOOLS_BIN_DIR)/multimod
 	@echo "Validating versions.yaml"
-	multimod verify
+	$(TOOLS_BIN_DIR)/multimod verify
 
 .PHONY: multimod-prerelease
-multimod-prerelease: install-tools
-	multimod prerelease -s=true -b=false -v ./versions.yaml -m contrib-base
+multimod-prerelease: $(TOOLS_BIN_DIR)/multimod
+	$(TOOLS_BIN_DIR)/multimod prerelease -s=true -b=false -v ./versions.yaml -m contrib-base
 	$(MAKE) gotidy
 
 .PHONY: multimod-sync
-multimod-sync: install-tools
-	multimod sync -a=true -s=true -o ../opentelemetry-collector
+multimod-sync: $(TOOLS_BIN_DIR)/multimod
+	$(TOOLS_BIN_DIR)/multimod sync -a=true -s=true -o ../opentelemetry-collector
 	$(MAKE) gotidy
 
 .PHONY: crosslink
-crosslink: install-tools
+crosslink: $(TOOLS_BIN_DIR)/crosslink
 	@echo "Executing crosslink"
-	crosslink --root=$(shell pwd)
+	$(TOOLS_BIN_DIR)/crosslink --root=$(shell pwd)
 
 .PHONY: clean
 clean:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -10,7 +10,7 @@ else
 endif
 
 # SRC_ROOT is the top of the source tree.
-SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+SRC_ROOT := $(PWD)
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
@@ -22,12 +22,34 @@ GOCMD?= go
 GOTEST=$(GOCMD) test
 GOOS=$(shell $(GOCMD) env GOOS)
 GOARCH=$(shell $(GOCMD) env GOARCH)
-ADDLICENCESE= addlicense
-MDLINKCHECK=markdown-link-check
-MISSPELL=misspell -error
-MISSPELL_CORRECTION=misspell -w
-LINT=golangci-lint
-IMPI=impi
+
+# In order to help reduce toil related to managing tooling for the open telemetry collector
+# this section of the makefile looks at only requiring command definitions to be defined 
+# as part of $(TOOLS_MOD_DIR)/tools.go, following the existing practice.
+# Modifying the tools' `go.mod` file will trigger a rebuild of the tools to help 
+# ensure that all contributors are using the most recent version to make builds repeatable everywhere.
+TOOLS_MOD_DIR    := $(PWD)/internal/tools
+TOOLS_MOD_REGEX  := "\s+_\s+\".*\""
+TOOLS_PKG_NAMES  := $(shell grep -E $(TOOLS_MOD_REGEX) < $(TOOLS_MOD_DIR)/tools.go | tr -d " _\"")
+TOOLS_BIN_DIR    := $(PWD)/bin
+TOOLS_BIN_NAMES  := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(TOOLS_PKG_NAMES)))
+
+.PHONY: install-tools
+install-tools: $(TOOLS_BIN_NAMES)
+
+$(TOOLS_BIN_DIR):
+	mkdir $(PWD)/bin
+
+$(TOOLS_BIN_NAMES): $(TOOLS_BIN_DIR) $(TOOLS_MOD_DIR)/go.mod
+	cd $(TOOLS_MOD_DIR) && $(GOCMD) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))
+
+ADDLICENCESE        := $(TOOLS_BIN_DIR)/addlicense
+MDLINKCHECK         := $(TOOLS_BIN_DIR)/markdown-link-check
+MISSPELL            := $(TOOLS_BIN_DIR)/misspell -error
+MISSPELL_CORRECTION := $(TOOLS_BIN_DIR)/misspell -w
+LINT                := $(TOOLS_BIN_DIR)/golangci-lint
+IMPI                := $(TOOLS_BIN_DIR)/impi
+
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
 RUNNING_ON_GITHUB_ACTION=$(GITHUB_ACTIONS)

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -10,7 +10,7 @@ else
 endif
 
 # SRC_ROOT is the top of the source tree.
-SRC_ROOT := $(PWD)
+SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
@@ -24,9 +24,9 @@ GOOS=$(shell $(GOCMD) env GOOS)
 GOARCH=$(shell $(GOCMD) env GOARCH)
 
 # In order to help reduce toil related to managing tooling for the open telemetry collector
-# this section of the makefile looks at only requiring command definitions to be defined 
+# this section of the makefile looks at only requiring command definitions to be defined
 # as part of $(TOOLS_MOD_DIR)/tools.go, following the existing practice.
-# Modifying the tools' `go.mod` file will trigger a rebuild of the tools to help 
+# Modifying the tools' `go.mod` file will trigger a rebuild of the tools to help
 # ensure that all contributors are using the most recent version to make builds repeatable everywhere.
 TOOLS_MOD_DIR    := $(PWD)/internal/tools
 TOOLS_MOD_REGEX  := "\s+_\s+\".*\""
@@ -121,7 +121,7 @@ benchmark:
 	$(GOTEST) -bench=. -run=notests --tags=$(GO_BUILD_TAGS) $(ALL_PKGS)
 
 .PHONY: addlicense
-addlicense:
+addlicense: $(ADDLICENCESE)
 	@ADDLICENCESEOUT=`$(ADDLICENCESE) -y "" -c 'The OpenTelemetry Authors' $(ALL_SRC) 2>&1`; \
 		if [ "$$ADDLICENCESEOUT" ]; then \
 			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
@@ -132,7 +132,7 @@ addlicense:
 		fi
 
 .PHONY: checklicense
-checklicense:
+checklicense: $(ADDLICENCESE)
 	@ADDLICENCESEOUT=`$(ADDLICENCESE) -check $(ALL_SRC) 2>&1`; \
 		if [ "$$ADDLICENCESEOUT" ]; then \
 			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
@@ -150,12 +150,12 @@ checklinks:
 		$(MDLINKCHECK) -q -c $(SRC_ROOT)/.github/workflows/check_links_config.json || true
 
 .PHONY: fmt
-fmt:
+fmt: $(TOOLS_BIN_DIR)/goimports
 	gofmt  -w -s ./
-	goimports -w  -local github.com/open-telemetry/opentelemetry-collector-contrib ./
+	$(TOOLS_BIN_DIR)/goimports -w  -local github.com/open-telemetry/opentelemetry-collector-contrib ./
 
 .PHONY: lint
-lint: checklicense misspell
+lint: $(LINT) checklicense misspell
 	$(LINT) run --allow-parallel-runners
 
 .PHONY: tidy
@@ -164,16 +164,16 @@ tidy:
 	$(GOCMD) mod tidy -compat=1.18
 
 .PHONY: misspell
-misspell:
+misspell: $(TOOLS_BIN_DIR)/misspell
 	@echo "running $(MISSPELL)"
 	@$(MISSPELL) $(ALL_SRC_AND_DOC)
 
 .PHONY: misspell-correction
-misspell-correction:
+misspell-correction: $(TOOLS_BIN_DIR)/misspell
 	$(MISSPELL_CORRECTION) $(ALL_SRC_AND_DOC)
 
 .PHONY: impi
-impi:
+impi: $(IMPI)
 	@$(IMPI) --local github.com/open-telemetry/opentelemetry-collector-contrib --scheme stdThirdPartyLocal ./...
 
 .PHONY: moddownload

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -31,7 +31,7 @@ GOARCH=$(shell $(GOCMD) env GOARCH)
 TOOLS_MOD_DIR    := $(PWD)/internal/tools
 TOOLS_MOD_REGEX  := "\s+_\s+\".*\""
 TOOLS_PKG_NAMES  := $(shell grep -E $(TOOLS_MOD_REGEX) < $(TOOLS_MOD_DIR)/tools.go | tr -d " _\"")
-TOOLS_BIN_DIR    := $(PWD)/bin
+TOOLS_BIN_DIR    := $(PWD)/.tools
 TOOLS_BIN_NAMES  := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(TOOLS_PKG_NAMES)))
 
 .PHONY: install-tools
@@ -49,6 +49,12 @@ MISSPELL            := $(TOOLS_BIN_DIR)/misspell -error
 MISSPELL_CORRECTION := $(TOOLS_BIN_DIR)/misspell -w
 LINT                := $(TOOLS_BIN_DIR)/golangci-lint
 IMPI                := $(TOOLS_BIN_DIR)/impi
+MULITMOD            := $(TOOLS_BIN_DIR)/multimod
+CHLOGGEN            := $(TOOLS_BIN_DIR)/chloggen
+GOIMPORTS           := $(TOOLS_BIN_DIR)/goimports
+PORTO               := $(TOOLS_BIN_DIR)/porto
+CHECKDOC            := $(TOOLS_BIN_DIR)/checkdoc
+CROSSLINK           := $(TOOLS_BIN_DIR)/crosslink
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
@@ -150,9 +156,9 @@ checklinks:
 		$(MDLINKCHECK) -q -c $(SRC_ROOT)/.github/workflows/check_links_config.json || true
 
 .PHONY: fmt
-fmt: $(TOOLS_BIN_DIR)/goimports
+fmt: $(GOIMPORTS)
 	gofmt  -w -s ./
-	$(TOOLS_BIN_DIR)/goimports -w  -local github.com/open-telemetry/opentelemetry-collector-contrib ./
+	$(GOIMPORTS) -w  -local github.com/open-telemetry/opentelemetry-collector-contrib ./
 
 .PHONY: lint
 lint: $(LINT) checklicense misspell

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -38,7 +38,7 @@ TOOLS_BIN_NAMES  := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(TOOLS_PKG_NAMES)))
 install-tools: $(TOOLS_BIN_NAMES)
 
 $(TOOLS_BIN_DIR):
-	mkdir $(PWD)/bin
+	mkdir -p $(PWD)/bin
 
 $(TOOLS_BIN_NAMES): $(TOOLS_BIN_DIR) $(TOOLS_MOD_DIR)/go.mod
 	cd $(TOOLS_MOD_DIR) && $(GOCMD) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))


### PR DESCRIPTION
**Description:**
I wanted to explore the idea of making it easier to manage tools and ensure that those who are contributing to the project, are using the same command's as they are built each time in the CI platform

**Link to tracking Issue:** 
N/A

**Testing:** 
I've ensured that the binaries are created and that they are part of the git ignore.
I will run this in CI to make sure it works there.

**Documentation:** 

I think this can result in reduced documentation since it no longer requires `install-tools` to be run but i've kept it there for convenience. 