### PR TITLE
[receiver/oracledb] Fix the oracledb.instance.name resource attribute so it contains the database name

### DIFF
--- a/.chloggen/fix-oracledb-instance-name.yaml
+++ b/.chloggen/fix-oracledb-instance-name.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: oracledbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: the resource attribute oracledb.instance.name now captures the database name.
+
+# One or more tracking issues related to the change
+issues: [17850]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/fix-oracledb-instance-name.yaml
+++ b/.chloggen/fix-oracledb-instance-name.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: oracledbreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: the resource attribute oracledb.instance.name now captures the database name.
+note: "the resource attribute `oracledb.instance.name` now captures the database name."
 
 # One or more tracking issues related to the change
 issues: [17850]

--- a/receiver/oracledbreceiver/factory.go
+++ b/receiver/oracledbreceiver/factory.go
@@ -63,12 +63,10 @@ func createReceiverFunc(sqlOpenerFunc sqlOpenerFunc, clientProviderFunc clientPr
 	) (receiver.Metrics, error) {
 		sqlCfg := cfg.(*Config)
 		metricsBuilder := metadata.NewMetricsBuilder(sqlCfg.MetricsSettings, settings)
-		datasourceURL, _ := url.Parse(sqlCfg.DataSource)
-		instanceName := datasourceURL.Host
 
 		mp, err := newScraper(settings.ID, metricsBuilder, sqlCfg.MetricsSettings, sqlCfg.ScraperControllerSettings, settings.TelemetrySettings.Logger, func() (*sql.DB, error) {
 			return sqlOpenerFunc(sqlCfg.DataSource)
-		}, clientProviderFunc, instanceName)
+		}, clientProviderFunc, getInstanceName(sqlCfg.DataSource))
 		if err != nil {
 			return nil, err
 		}
@@ -81,4 +79,10 @@ func createReceiverFunc(sqlOpenerFunc sqlOpenerFunc, clientProviderFunc clientPr
 			opt,
 		)
 	}
+}
+
+func getInstanceName(datasource string) string {
+	datasourceURL, _ := url.Parse(datasource)
+	instanceName := datasourceURL.Host + datasourceURL.Path
+	return instanceName
 }

--- a/receiver/oracledbreceiver/factory_test.go
+++ b/receiver/oracledbreceiver/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -40,4 +41,8 @@ func TestNewFactory(t *testing.T) {
 		consumertest.NewNop(),
 	)
 	require.NoError(t, err)
+}
+func TestGetInstanceName(t *testing.T) {
+	instanceName := getInstanceName("oracle://example.com:1521/mydb")
+	assert.Equal(t, "example.com:1521/mydb", instanceName)
 }

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -77,6 +77,9 @@ func TestScraper_Scrape(t *testing.T) {
 	m, err := scrpr.scrape(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 16, m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	name, ok := m.ResourceMetrics().At(0).Resource().Attributes().Get("oracledb.instance.name")
+	assert.True(t, ok)
+	assert.Equal(t, "", name.Str())
 }
 
 func TestPartial_InvalidScrape(t *testing.T) {


### PR DESCRIPTION
**Description:** 
the resource attribute oracledb.instance.name now captures the database name.

**Link to tracking Issue:**
#17850

**Testing:**
Unit tests.