### PR TITLE
[exporter/awsxray] Add support for AWS X-Ray annotations attribute in exporter.

### DIFF
--- a/.chloggen/forward-xray-annotations.yaml
+++ b/.chloggen/forward-xray-annotations.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/awsxray
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds `aws.xray.annotations` attribute to forward annotation keys from the AWS X-Ray receiver to the AWS X-Ray exporter.
+
+# One or more tracking issues related to the change
+issues: [17550]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsxrayexporter/README.md
+++ b/exporter/awsxrayexporter/README.md
@@ -47,7 +47,7 @@ by the Span Resource object. X-Ray uses this data to generate inferred segments 
 
 ## Exporter Configuration
 
-The following exporter configuration parameters are supported. They mirror and have the same affect as the
+The following exporter configuration parameters are supported. They mirror and have the same effect as the
 comparable AWS X-Ray Daemon configuration values.
 
 | Name                   | Description                                                                        | Default |

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -346,6 +346,20 @@ func makeXRayAttributes(attributes map[string]pcommon.Value, resource pcommon.Re
 		}
 	}
 
+	annotationKeys, ok := attributes[awsxray.AWSXraySegmentAnnotationsAttribute]
+	if ok && annotationKeys.Type() == pcommon.ValueTypeSlice {
+		slice := annotationKeys.Slice()
+		for i := 0; i < slice.Len(); i++ {
+			value := slice.At(i)
+			if value.Type() != pcommon.ValueTypeStr {
+				continue
+			}
+			key := value.AsString()
+			indexedKeys[key] = true
+		}
+		delete(attributes, awsxray.AWSXraySegmentAnnotationsAttribute)
+	}
+
 	if storeResource {
 		resource.Attributes().Range(func(key string, value pcommon.Value) bool {
 			key = "otel.resource." + key

--- a/internal/aws/xray/awsxray.go
+++ b/internal/aws/xray/awsxray.go
@@ -41,6 +41,10 @@ const (
 	// AWSXRayTracedAttribute is the `traced` field in an X-Ray subsegment
 	AWSXRayTracedAttribute = "aws.xray.traced"
 
+	// AWSXraySegmentAnnotationsAttribute is the attribute that
+	// will be treated by the X-Ray exporter as the annotation keys.
+	AWSXraySegmentAnnotationsAttribute = "aws.xray.annotations"
+
 	// AWSXraySegmentMetadataAttributePrefix is the prefix of the attribute that
 	// will be treated by the X-Ray exporter as metadata. The key of a metadata
 	// will be AWSXraySegmentMetadataAttributePrefix + <metadata_key>.

--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.186
+	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy v0.70.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray v0.70.0

--- a/receiver/awsxrayreceiver/go.sum
+++ b/receiver/awsxrayreceiver/go.sum
@@ -165,6 +165,7 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/receiver/awsxrayreceiver/internal/translator/annotations.go
+++ b/receiver/awsxrayreceiver/internal/translator/annotations.go
@@ -14,26 +14,35 @@
 
 package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver/internal/translator"
 
-import "go.opentelemetry.io/collector/pdata/pcommon"
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
+)
 
 func addAnnotations(annos map[string]interface{}, attrs pcommon.Map) {
-	for k, v := range annos {
-		switch t := v.(type) {
-		case int:
-			attrs.PutInt(k, int64(t))
-		case int32:
-			attrs.PutInt(k, int64(t))
-		case int64:
-			attrs.PutInt(k, t)
-		case string:
-			attrs.PutStr(k, t)
-		case bool:
-			attrs.PutBool(k, t)
-		case float32:
-			attrs.PutDouble(k, float64(t))
-		case float64:
-			attrs.PutDouble(k, t)
-		default:
+	if len(annos) > 0 {
+		keys := attrs.PutEmptySlice(awsxray.AWSXraySegmentAnnotationsAttribute)
+		keys.EnsureCapacity(len(annos))
+		for k, v := range annos {
+			keys.AppendEmpty().SetStr(k)
+			switch t := v.(type) {
+			case int:
+				attrs.PutInt(k, int64(t))
+			case int32:
+				attrs.PutInt(k, int64(t))
+			case int64:
+				attrs.PutInt(k, t)
+			case string:
+				attrs.PutStr(k, t)
+			case bool:
+				attrs.PutBool(k, t)
+			case float32:
+				attrs.PutDouble(k, float64(t))
+			case float64:
+				attrs.PutDouble(k, t)
+			default:
+			}
 		}
 	}
 }

--- a/receiver/awsxrayreceiver/internal/translator/annotations_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/annotations_test.go
@@ -17,8 +17,12 @@ package translator
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
 
 func TestAddAnnotations(t *testing.T) {
@@ -41,6 +45,15 @@ func TestAddAnnotations(t *testing.T) {
 	expectedAttrMap.PutInt("int", 0)
 	expectedAttrMap.PutInt("int32", 1)
 	expectedAttrMap.PutInt("int64", 2)
+	expectedKeys := expectedAttrMap.PutEmptySlice(awsxray.AWSXraySegmentAnnotationsAttribute)
+	expectedKeys.AppendEmpty().SetStr("int")
+	expectedKeys.AppendEmpty().SetStr("int32")
+	expectedKeys.AppendEmpty().SetStr("int64")
+	expectedKeys.AppendEmpty().SetStr("bool")
+	expectedKeys.AppendEmpty().SetStr("float32")
+	expectedKeys.AppendEmpty().SetStr("float64")
 
-	assert.Equal(t, expectedAttrMap.AsRaw(), attrMap.AsRaw(), "attribute maps differ")
+	assert.True(t, cmp.Equal(expectedAttrMap.AsRaw(), attrMap.AsRaw(), cmpopts.SortSlices(func(x, y interface{}) bool {
+		return x.(string) < y.(string)
+	})), "attribute maps differ")
 }

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -154,15 +154,17 @@ func TestTranslation(t *testing.T) {
 				// this is the subsegment with ID that starts with 7df6
 				subseg7df6 := seg.Subsegments[0]
 				childSpan7df6Attrs := pcommon.NewMap()
+				childKeys := childSpan7df6Attrs.PutEmptySlice(awsxray.AWSXraySegmentAnnotationsAttribute)
 				for k, v := range subseg7df6.Annotations {
 					childSpan7df6Attrs.PutStr(k, v.(string))
+					childKeys.AppendEmpty().SetStr(k)
 				}
 				for k, v := range subseg7df6.Metadata {
 					m, err := json.Marshal(v)
 					assert.NoError(t, err, "metadata marshaling failed")
 					childSpan7df6Attrs.PutStr(awsxray.AWSXraySegmentMetadataAttributePrefix+k, string(m))
 				}
-				assert.Equal(t, 2, childSpan7df6Attrs.Len(), testCase+": childSpan7df6Attrs has incorrect size")
+				assert.Equal(t, 3, childSpan7df6Attrs.Len(), testCase+": childSpan7df6Attrs has incorrect size")
 				childSpan7df6Evts := initExceptionEvents(&subseg7df6)
 				assert.Len(t, childSpan7df6Evts, 1, testCase+": childSpan7df6Evts has incorrect size")
 				childSpan7df6 := perSpanProperties{


### PR DESCRIPTION
**Description:** If the original segment received by the `awsxrayreceiver` had annotations, adds an `aws.xray.annotations` attribute to the translated spans. The attribute is a slice attribute that contains each of the string keys. If found on the span, the `awsxrayexporter` will use them in addition to the `indexed_attributes` configuration field when categorizing the attributes.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17550

**Testing:** Updated and added unit tests.

**Documentation:** None