### PR TITLE
[receiver/windowseventlogreceiver] Support sending the raw XML of the event

### DIFF
--- a/.chloggen/windowseventlog-raw.yaml
+++ b/.chloggen/windowseventlog-raw.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: windowseventlogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support sending the raw XML of the event
+
+# One or more tracking issues related to the change
+issues: [17858]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/operator/input/windows/raw.go
+++ b/pkg/stanza/operator/input/windows/raw.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
+
+import (
+	"encoding/xml"
+	"fmt"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+)
+
+// EventRaw is the rendered xml of an event, however, its message is the original XML of the entire event.
+type EventRaw struct {
+	TimeCreated   TimeCreated `xml:"System>TimeCreated"`
+	RenderedLevel string      `xml:"RenderingInfo>Level"`
+	Level         string      `xml:"System>Level"`
+	bytes         []byte
+}
+
+// parseTimestamp will parse the timestamp of the event.
+func (e *EventRaw) parseTimestamp() time.Time {
+	if timestamp, err := time.Parse(time.RFC3339Nano, e.TimeCreated.SystemTime); err == nil {
+		return timestamp
+	}
+	return time.Now()
+}
+
+// parseRenderedSeverity will parse the severity of the event.
+func (e *EventRaw) parseRenderedSeverity() entry.Severity {
+	switch e.RenderedLevel {
+	case "":
+		return e.parseSeverity()
+	case "Critical":
+		return entry.Fatal
+	case "Error":
+		return entry.Error
+	case "Warning":
+		return entry.Warn
+	case "Information":
+		return entry.Info
+	default:
+		return entry.Default
+	}
+}
+
+// parseSeverity will parse the severity of the event when RenderingInfo is not populated
+func (e *EventRaw) parseSeverity() entry.Severity {
+	switch e.Level {
+	case "1":
+		return entry.Fatal
+	case "2":
+		return entry.Error
+	case "3":
+		return entry.Warn
+	case "4":
+		return entry.Info
+	default:
+		return entry.Default
+	}
+}
+
+// parseBody will parse a body from the event.
+func (e *EventRaw) parseBody() []byte {
+	return e.bytes
+}
+
+// unmarshalEventRaw will unmarshal EventRaw from xml bytes.
+func unmarshalEventRaw(bytes []byte) (EventRaw, error) {
+	var eventRaw EventRaw
+	if err := xml.Unmarshal(bytes, &eventRaw); err != nil {
+		return EventRaw{}, fmt.Errorf("failed to unmarshal xml bytes into event: %w (%s)", err, string(bytes))
+	}
+	eventRaw.bytes = bytes
+	return eventRaw, nil
+}

--- a/pkg/stanza/operator/input/windows/raw_test.go
+++ b/pkg/stanza/operator/input/windows/raw_test.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package windows
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+)
+
+func TestParseValidTimestampRaw(t *testing.T) {
+	raw := EventRaw{
+		TimeCreated: TimeCreated{
+			SystemTime: "2020-07-30T01:01:01.123456789Z",
+		},
+	}
+	timestamp := raw.parseTimestamp()
+	expected, _ := time.Parse(time.RFC3339Nano, "2020-07-30T01:01:01.123456789Z")
+	require.Equal(t, expected, timestamp)
+}
+
+func TestParseInvalidTimestampRaw(t *testing.T) {
+	raw := EventRaw{
+		TimeCreated: TimeCreated{
+			SystemTime: "invalid",
+		},
+	}
+	timestamp := raw.parseTimestamp()
+	require.Equal(t, time.Now().Year(), timestamp.Year())
+	require.Equal(t, time.Now().Month(), timestamp.Month())
+	require.Equal(t, time.Now().Day(), timestamp.Day())
+}
+
+func TestParseSeverityRaw(t *testing.T) {
+	rawRenderedCritical := EventRaw{RenderedLevel: "Critical"}
+	rawRenderedError := EventRaw{RenderedLevel: "Error"}
+	rawRenderedWarning := EventRaw{RenderedLevel: "Warning"}
+	rawRenderedInformation := EventRaw{RenderedLevel: "Information"}
+	rawRenderedUnknown := EventRaw{RenderedLevel: "Unknown"}
+	rawCritical := EventRaw{Level: "1"}
+	rawError := EventRaw{Level: "2"}
+	rawWarning := EventRaw{Level: "3"}
+	rawInformation := EventRaw{Level: "4"}
+	rawUnknown := EventRaw{Level: "0"}
+	require.Equal(t, entry.Fatal, rawRenderedCritical.parseRenderedSeverity())
+	require.Equal(t, entry.Error, rawRenderedError.parseRenderedSeverity())
+	require.Equal(t, entry.Warn, rawRenderedWarning.parseRenderedSeverity())
+	require.Equal(t, entry.Info, rawRenderedInformation.parseRenderedSeverity())
+	require.Equal(t, entry.Default, rawRenderedUnknown.parseRenderedSeverity())
+	require.Equal(t, entry.Fatal, rawCritical.parseRenderedSeverity())
+	require.Equal(t, entry.Error, rawError.parseRenderedSeverity())
+	require.Equal(t, entry.Warn, rawWarning.parseRenderedSeverity())
+	require.Equal(t, entry.Info, rawInformation.parseRenderedSeverity())
+	require.Equal(t, entry.Default, rawUnknown.parseRenderedSeverity())
+}
+
+func TestParseBodyRaw(t *testing.T) {
+	raw := EventRaw{
+		bytes: []byte("foo"),
+	}
+
+	require.Equal(t, []byte("foo"), raw.parseBody())
+}
+
+func TestInvalidUnmarshalRaw(t *testing.T) {
+	_, err := unmarshalEventRaw([]byte("Test \n Invalid \t Unmarshal"))
+	require.Error(t, err)
+
+}
+func TestUnmarshalRaw(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "rawSample.raw"))
+	require.NoError(t, err)
+
+	event, err := unmarshalEventRaw(data)
+	require.NoError(t, err)
+
+	raw := EventRaw{
+		TimeCreated: TimeCreated{
+			SystemTime: "2022-04-22T10:20:52.3778625Z",
+		},
+		Level: "4",
+		bytes: data,
+	}
+
+	require.Equal(t, raw, event)
+}

--- a/receiver/windowseventlogreceiver/README.md
+++ b/receiver/windowseventlogreceiver/README.md
@@ -10,16 +10,17 @@ Tails and parses logs from windows event log API using the [opentelemetry-log-co
 
 ### Configuration Fields
 
-| Field           | Default                  | Description                                                                                                                    |
-| ---             | ---                      | ---                                                                                                                            |
-| `channel`       | required                 | The windows event log channel to monitor                                                                                       |
-| `max_reads`     | 100                      | The maximum number of records read into memory, before beginning a new batch                                                   |
-| `start_at`      | `end`                    | On first startup, where to start reading logs from the API. Options are `beginning` or `end`                                   |
-| `poll_interval` | 1s                       | The interval at which the channel is checked for new log entries. This check begins again after all new bodies have been read. |
-| `attributes`    | {}                       | A map of `key: value` pairs to add to the entry's attributes. |
-| `resource`      | {}                       | A map of `key: value` pairs to add to the entry's resource. |
-| `operators`            | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
-| `storage`       | none             | The ID of a storage extension to be used to store bookmarks. Bookmarks allow the receiver to pick up where it left off in the case of a collector restart. If no storage extension is used, the receiver will manage bookmarks in memory only. |
+| Field           | Default  | Description                                                                                                                                                                                                                                    |
+|-----------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `channel`       | required | The windows event log channel to monitor                                                                                                                                                                                                       |
+| `max_reads`     | 100      | The maximum number of records read into memory, before beginning a new batch                                                                                                                                                                   |
+| `start_at`      | `end`    | On first startup, where to start reading logs from the API. Options are `beginning` or `end`                                                                                                                                                   |
+| `poll_interval` | 1s       | The interval at which the channel is checked for new log entries. This check begins again after all new bodies have been read.                                                                                                                 |
+| `attributes`    | {}       | A map of `key: value` pairs to add to the entry's attributes.                                                                                                                                                                                  |
+| `resource`      | {}       | A map of `key: value` pairs to add to the entry's resource.                                                                                                                                                                                    |
+| `operators`     | []       | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details                                                            |
+| `raw`           | false    | If true, the windows events are not processed and sent as XML.                                                                                                                                                                                 |
+| `storage`       | none     | The ID of a storage extension to be used to store bookmarks. Bookmarks allow the receiver to pick up where it left off in the case of a collector restart. If no storage extension is used, the receiver will manage bookmarks in memory only. |
 
 ### Operators
 


### PR DESCRIPTION
**Description:** 
Support sending the raw XML of the event

**Link to tracking Issue:**
Fixes #17858

**Testing:**
Unit tests.

**Documentation:**
`raw` config parameter added to README.