### PR TITLE
processor/datadogprocessor: move to beta

### DIFF
--- a/.chloggen/gbbr_processor-beta.yaml
+++ b/.chloggen/gbbr_processor-beta.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Now that the Datadog processor is part of the official contrib distribution, it has been moved to the beta stability level.
+
+# One or more tracking issues related to the change
+issues: [17862]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/datadogprocessor/README.md
+++ b/processor/datadogprocessor/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |               |
 |--------------------------|---------------|
-| Stability                | [development] |
+| Stability                | [beta]        |
 | Supported pipeline types | traces        |
 | Distributions            | [contrib]     |
 
@@ -96,5 +96,5 @@ When using in conjunction with the Datadog Agent's OTLP Ingest, the minimum requ
 
 If not using the Datadog backend, the processor will still create valid RED metrics, but in that situation you may prefer to use the [spanmetricsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanmetricsprocessor) instead.
 
-[development]: https://github.com/open-telemetry/opentelemetry-collector#development
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
The processor is safe to be marked as beta. It is using already existing Datadog Exporter / Agent code and it's not really under development as per the stability level [descriptions](https://github.com/open-telemetry/opentelemetry-collector#development). 

Closes #17862