### PR TITLE
[receiver/prometheus] Replace usage of Map.Sort with sorting raw slices

### DIFF
--- a/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	semconv "go.opentelemetry.io/collector/semconv/v1.8.0"
 	"go.uber.org/zap"
@@ -668,5 +669,34 @@ func runScript(t *testing.T, ma MetricsAdjuster, job, instance string, tests []*
 			test.adjusted.ResourceMetrics().At(0).Resource().Attributes().PutStr(semconv.AttributeServiceName, job)
 			assert.EqualValues(t, test.adjusted, adjusted)
 		})
+	}
+}
+
+func TestGetAttributesSignature(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("key1", "3value-1")
+	attrs.PutStr("key3", "1value-6")
+	attrs.PutStr("key4", "")
+	attrs.PutStr("key2", "2value-2")
+
+	assert.Equal(t, "3value-1,2value-2,1value-6", getAttributesSignature(attrs))
+}
+
+func BenchmarkGetAttributesSignature(b *testing.B) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("key1", "some-random-test-value-1")
+	attrs.PutStr("key2", "some-random-test-value-2")
+	attrs.PutStr("key6", "some-random-test-value-6")
+	attrs.PutStr("key3", "some-random-test-value-3")
+	attrs.PutStr("key4", "some-random-test-value-4")
+	attrs.PutStr("key5", "some-random-test-value-5")
+	attrs.PutStr("key7", "some-random-test-value-7")
+	attrs.PutStr("key8", "some-random-test-value-8")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		getAttributesSignature(attrs)
 	}
 }


### PR DESCRIPTION
The method will be removed soon.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/6688

Before:

```
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal
BenchmarkGetAttributesSignature
BenchmarkGetAttributesSignature-10    	 4262202	       281.0 ns/op	     440 B/op	       5 allocs/op
PASS
```

After:

```
BenchmarkGetAttributesSignature
BenchmarkGetAttributesSignature-10    	 3466792	       345.2 ns/op	     512 B/op	       4 allocs/op
PASS
```