### PR TITLE
[receiver/prometheus] Replace usage of Map.Sort with pdatautil.MapHash

### DIFF
--- a/receiver/prometheusexecreceiver/go.mod
+++ b/receiver/prometheusexecreceiver/go.mod
@@ -104,6 +104,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.69.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.69.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect

--- a/receiver/prometheusreceiver/go.mod
+++ b/receiver/prometheusreceiver/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.69.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.69.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.69.0
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/prometheus v0.41.0

--- a/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	semconv "go.opentelemetry.io/collector/semconv/v1.8.0"
 	"go.uber.org/zap"
@@ -668,5 +669,24 @@ func runScript(t *testing.T, ma MetricsAdjuster, job, instance string, tests []*
 			test.adjusted.ResourceMetrics().At(0).Resource().Attributes().PutStr(semconv.AttributeServiceName, job)
 			assert.EqualValues(t, test.adjusted, adjusted)
 		})
+	}
+}
+
+func BenchmarkGetAttributesSignature(b *testing.B) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("key1", "some-random-test-value-1")
+	attrs.PutStr("key2", "some-random-test-value-2")
+	attrs.PutStr("key6", "some-random-test-value-6")
+	attrs.PutStr("key3", "some-random-test-value-3")
+	attrs.PutStr("key4", "some-random-test-value-4")
+	attrs.PutStr("key5", "some-random-test-value-5")
+	attrs.PutStr("key7", "some-random-test-value-7")
+	attrs.PutStr("key8", "some-random-test-value-8")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		getAttributesSignature(attrs)
 	}
 }

--- a/receiver/purefareceiver/go.mod
+++ b/receiver/purefareceiver/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.69.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.69.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect

--- a/receiver/simpleprometheusreceiver/go.mod
+++ b/receiver/simpleprometheusreceiver/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.69.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.69.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect


### PR DESCRIPTION
The method will be removed soon

This is an approach alternative to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17868 which is less performant.

Before
```
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal
BenchmarkGetAttributesSignature
BenchmarkGetAttributesSignature-10    	 4262202	       281.0 ns/op	     440 B/op	       5 allocs/op
PASS
```

After:
```
BenchmarkGetAttributesSignature
BenchmarkGetAttributesSignature-10    	 1273216	      1061 ns/op	     632 B/op	      13 allocs/op
PASS
```

If we don't make a map copy, it's still less performant but uses less memory:
```
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal
BenchmarkGetAttributesSignature
BenchmarkGetAttributesSignature-10    	 2674786	       447.3 ns/op	      24 B/op	       1 allocs/op
PASS

```