### PR TITLE
[receiver/windowseventlog] Fixed panic that can occur in windows event channel during buffer resize

### DIFF
--- a/.chloggen/windowseventlog-resize-panic-fix.yaml
+++ b/.chloggen/windowseventlog-resize-panic-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: windowseventlogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix panic that can occur when event is larger than current buffer size.
+
+# One or more tracking issues related to the change
+issues: [17879]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/operator/input/windows/api.go
+++ b/pkg/stanza/operator/input/windows/api.go
@@ -102,7 +102,7 @@ func evtRender(context uintptr, fragment uintptr, flags uint32, bufferSize uint3
 	propertyCount := new(uint32)
 	_, _, err := renderProc.Call(context, fragment, uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)), uintptr(unsafe.Pointer(propertyCount)))
 	if err != ErrorSuccess {
-		return nil, nil, err
+		return bufferUsed, propertyCount, err
 	}
 
 	return bufferUsed, propertyCount, nil


### PR DESCRIPTION
**Description:** 
Fixes #17879

In any error case of `evtRender` system call return the pointers for `bufferUsed` and `propertyCount`. This is safe because the pointers are initialized with `new` so they'll never be nil.

**Link to tracking Issue:** 17879

**Testing:** Manually reduced the hardcoded default buffer sized to 1 then tested on a live system with the fix. Saw resize work correctly where it had before caused a panic.