### PR TITLE
[receiver/windowseventlog] Fixed unsafe pointer required event buffer to resize to 0

### DIFF
--- a/.chloggen/windowseventlog-zero-buffer-fix.yaml
+++ b/.chloggen/windowseventlog-zero-buffer-fix.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: windowseventlogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed a panic that could create an empty buffer due to incorrect use of unsafe pointers in syscall.
+
+# One or more tracking issues related to the change
+issues: [17878]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Fixed a potential panic due to a syscall indicating a that the event buffer should resize to 0. The next used of that resized buffer would result in an index out of bounds panic.
+
+  Also, added a safety check for buffer resize cases that if the syscall indicates it needs the buffer size to be 0, an error will be returned.

--- a/pkg/stanza/operator/input/windows/api.go
+++ b/pkg/stanza/operator/input/windows/api.go
@@ -149,11 +149,12 @@ func evtOpenPublisherMetadata(session uintptr, publisherIdentity *uint16, logFil
 }
 
 // evtFormatMessage is the direct syscall implementation of EvtFormatMessage (https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage)
-func evtFormatMessage(publisherMetadata uintptr, event uintptr, messageID uint32, valueCount uint32, values uintptr, flags uint32, bufferSize uint32, buffer *byte, bufferUsed *uint32) error {
+func evtFormatMessage(publisherMetadata uintptr, event uintptr, messageID uint32, valueCount uint32, values uintptr, flags uint32, bufferSize uint32, buffer *byte) (*uint32, error) {
+	bufferUsed := new(uint32)
 	_, _, err := formatMessageProc.Call(publisherMetadata, event, uintptr(messageID), uintptr(valueCount), values, uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)))
 	if err != ErrorSuccess {
-		return err
+		return bufferUsed, err
 	}
 
-	return nil
+	return bufferUsed, nil
 }

--- a/pkg/stanza/operator/input/windows/event.go
+++ b/pkg/stanza/operator/input/windows/event.go
@@ -18,8 +18,12 @@
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 
 import (
+	"errors"
 	"fmt"
 )
+
+// errUnknownNextFrame is an error returned when a systemcall indicates the next frame is 0 bytes.
+var errUnknownNextFrame = errors.New("the buffer size needed by the next frame of a render syscall was 0, unable to determine size of next frame")
 
 // Event is an event stored in windows event log.
 type Event struct {
@@ -56,10 +60,14 @@ func (e *Event) RenderFormatted(buffer Buffer, publisher Publisher) (EventXML, e
 		return EventXML{}, fmt.Errorf("event handle does not exist")
 	}
 
-	var bufferUsed uint32
-	err := evtFormatMessage(publisher.handle, e.handle, 0, 0, 0, EvtFormatMessageXML, buffer.SizeWide(), buffer.FirstByte(), &bufferUsed)
+	bufferUsed, err := evtFormatMessage(publisher.handle, e.handle, 0, 0, 0, EvtFormatMessageXML, buffer.SizeWide(), buffer.FirstByte())
 	if err == ErrorInsufficientBuffer {
-		buffer.UpdateSizeWide(bufferUsed)
+		// If the bufferUsed is 0 return an error as we don't want to make a recursive call with no buffer
+		if *bufferUsed == 0 {
+			return EventXML{}, errUnknownNextFrame
+		}
+
+		buffer.UpdateSizeWide(*bufferUsed)
 		return e.RenderFormatted(buffer, publisher)
 	}
 
@@ -67,7 +75,7 @@ func (e *Event) RenderFormatted(buffer Buffer, publisher Publisher) (EventXML, e
 		return EventXML{}, fmt.Errorf("syscall to 'EvtFormatMessage' failed: %w", err)
 	}
 
-	bytes, err := buffer.ReadWideChars(bufferUsed)
+	bytes, err := buffer.ReadWideChars(*bufferUsed)
 	if err != nil {
 		return EventXML{}, fmt.Errorf("failed to read bytes from buffer: %w", err)
 	}
@@ -96,6 +104,11 @@ func (e *Event) RenderRaw(buffer Buffer) (EventRaw, error) {
 
 	bufferUsed, _, err := evtRender(0, e.handle, EvtRenderEventXML, buffer.SizeBytes(), buffer.FirstByte())
 	if err == ErrorInsufficientBuffer {
+		// If the bufferUsed is 0 return an error as we don't want to make a recursive call with no buffer
+		if *bufferUsed == 0 {
+			return EventRaw{}, errUnknownNextFrame
+		}
+
 		buffer.UpdateSizeBytes(*bufferUsed)
 		return e.RenderRaw(buffer)
 	}


### PR DESCRIPTION
**Description:** 
Fixes #17878

Used the same unsafe pointer pattern from `evtRender` in `evtFormatMessage` to prevent `bufferUsed` from getting set to 0 and causing the event buffer to resize to 0.

Added a safety check in the event of a buffer resize to return an error if the new buffer size is indicated to be 0.

**Link to tracking Issue:** 17878

**Testing:** Applied this fix to a live system that was showing a panic before and let it run for two weeks straight. No panic was witnessed.