### PR TITLE
[chore] remove comment

### DIFF
--- a/receiver/oracledbreceiver/db_client.go
+++ b/receiver/oracledbreceiver/db_client.go
@@ -26,7 +26,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// This will be removed and imported from pkg/sqlquery once https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14321 is merged.
 type dbClient interface {
 	metricRows(ctx context.Context) ([]metricRow, error)
 }


### PR DESCRIPTION
Remove comment that points to a TODO that is no longer applicable or in scope of effort.
As it stands, there is no immediate need to refactor and move this logic to a shared package in my opinion.