### PR TITLE
[receiver/jmxreceiver] add temp_folder to jmx receiver config

### DIFF
--- a/.chloggen/configure-temp-dir-jmx.yaml
+++ b/.chloggen/configure-temp-dir-jmx.yaml
@@ -13,4 +13,4 @@ issues: [14757]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Adds a configuration property allowing the user to decide where to place the temporary properties file used by the JMX receiver Java process.
+subtext: Adds an optional configuration property allowing the user to decide where to place the temporary properties file used by the JMX receiver Java process.

--- a/.chloggen/configure-temp-dir-jmx.yaml
+++ b/.chloggen/configure-temp-dir-jmx.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: jmxreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `temp_folder` configuration key to JMX receiver
+note: Add `temp_dir` configuration key to JMX receiver
 
 # One or more tracking issues related to the change
 issues: [14757]

--- a/.chloggen/configure-temp-dir-jmx.yaml
+++ b/.chloggen/configure-temp-dir-jmx.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: jmxreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `temp_folder` configuration key to JMX receiver
+
+# One or more tracking issues related to the change
+issues: [14757]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Adds a configuration property allowing the user to decide where to place the temporary properties file used by the JMX receiver Java process.

--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -186,7 +186,7 @@ Corresponds to the `org.slf4j.simpleLogger.defaultLogLevel` property.
 
 ### temp_dir (default: operating system temporary directory)
 
-The location of the directory where the receiver will store configuration used by the Java process. The configuration is typically stored as a properties file, as a temporary file that is deleted on exit of the collector.
+The location of the directory where the receiver will store configuration used by the Java process. The configuration is typically stored as a properties file, which is deleted on exit of the collector.
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -42,6 +42,8 @@ receivers:
     log_level: info
     additional_jars:
       - /path/to/other.jar
+    # temporary folder for Java configuration file, defaults to OS temporary directory
+    temp_dir: "/var/run/"
 ```
 
 ### jar_path (default: `/opt/opentelemetry-java-contrib-jmx-metrics.jar`)
@@ -181,6 +183,10 @@ Corresponds to the `otel.resource.attributes` property.
 SLF4J log level for the JMX metrics gatherer. Must be one of: `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`, `"off"`. If not provided, will attempt to match to the current log level of the collector.
 
 Corresponds to the `org.slf4j.simpleLogger.defaultLogLevel` property.
+
+### temp_dir (default: operating system temporary directory)
+
+The location of the directory where the receiver will store configuration used by the Java process. The configuration is typically stored as a properties file, as a temporary file that is deleted on exit of the collector.
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -72,7 +72,7 @@ type Config struct {
 	// `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`, `"off"`
 	LogLevel string `mapstructure:"log_level"`
 	// The temporary folder used to store configuration for the JVM (uses the OS temporary folder by default).
-	TempFolder string `mapstructure:"temp_folder"`
+	TempDir string `mapstructure:"temp_dir"`
 }
 
 // We don't embed the existing OTLP Exporter config as most fields are unsupported

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -71,6 +71,8 @@ type Config struct {
 	// Log level used by the JMX metric gatherer. Should be one of:
 	// `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`, `"off"`
 	LogLevel string `mapstructure:"log_level"`
+	// The temporary folder used to store configuration for the JVM (uses the OS temporary folder by default).
+	TempFolder string `mapstructure:"temp_folder"`
 }
 
 // We don't embed the existing OTLP Exporter config as most fields are unsupported

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -71,7 +71,7 @@ type Config struct {
 	// Log level used by the JMX metric gatherer. Should be one of:
 	// `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`, `"off"`
 	LogLevel string `mapstructure:"log_level"`
-	// The temporary folder used to store configuration for the JVM (uses the OS temporary folder by default).
+	// The temporary directory used to store configuration for the JVM (uses the OS temporary folder by default).
 	TempDir string `mapstructure:"temp_dir"`
 }
 

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -15,6 +15,7 @@
 package jmxreceiver
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -75,6 +76,7 @@ func TestLoadConfig(t *testing.T) {
 				ResourceAttributes: map[string]string{
 					"one": "two",
 				},
+				TempFolder: os.TempDir(),
 			},
 		},
 		{
@@ -90,6 +92,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
+				TempFolder: os.TempDir(),
 			},
 		},
 		{
@@ -105,6 +108,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
+				TempFolder: os.TempDir(),
 			},
 		},
 		{
@@ -121,6 +125,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
+				TempFolder: os.TempDir(),
 			},
 		},
 		{
@@ -137,6 +142,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: -100 * time.Millisecond,
 					},
 				},
+				TempFolder: os.TempDir(),
 			},
 		},
 
@@ -155,6 +161,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
+				TempFolder: os.TempDir(),
 			},
 		},
 		{
@@ -171,6 +178,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
+				TempFolder: os.TempDir(),
 			},
 		},
 		{
@@ -188,6 +196,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
+				TempFolder: os.TempDir(),
 			},
 		},
 		{
@@ -204,6 +213,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
+				TempFolder: os.TempDir(),
 			},
 		},
 	}

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -76,7 +76,7 @@ func TestLoadConfig(t *testing.T) {
 				ResourceAttributes: map[string]string{
 					"one": "two",
 				},
-				TempFolder: os.TempDir(),
+				TempDir: os.TempDir(),
 			},
 		},
 		{
@@ -92,7 +92,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
-				TempFolder: os.TempDir(),
+				TempDir: os.TempDir(),
 			},
 		},
 		{
@@ -108,7 +108,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
-				TempFolder: os.TempDir(),
+				TempDir: os.TempDir(),
 			},
 		},
 		{
@@ -125,7 +125,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
-				TempFolder: os.TempDir(),
+				TempDir: os.TempDir(),
 			},
 		},
 		{
@@ -142,7 +142,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: -100 * time.Millisecond,
 					},
 				},
-				TempFolder: os.TempDir(),
+				TempDir: os.TempDir(),
 			},
 		},
 
@@ -161,7 +161,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
-				TempFolder: os.TempDir(),
+				TempDir: os.TempDir(),
 			},
 		},
 		{
@@ -178,7 +178,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
-				TempFolder: os.TempDir(),
+				TempDir: os.TempDir(),
 			},
 		},
 		{
@@ -196,7 +196,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
-				TempFolder: os.TempDir(),
+				TempDir: os.TempDir(),
 			},
 		},
 		{
@@ -213,7 +213,7 @@ func TestLoadConfig(t *testing.T) {
 						Timeout: 5 * time.Second,
 					},
 				},
-				TempFolder: os.TempDir(),
+				TempDir: os.TempDir(),
 			},
 		},
 	}

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -76,7 +76,7 @@ func TestLoadConfig(t *testing.T) {
 				ResourceAttributes: map[string]string{
 					"one": "two",
 				},
-				TempDir: os.TempDir(),
+				TempDir: "/opt/otel/run",
 			},
 		},
 		{

--- a/receiver/jmxreceiver/factory.go
+++ b/receiver/jmxreceiver/factory.go
@@ -16,6 +16,7 @@ package jmxreceiver // import "github.com/open-telemetry/opentelemetry-collector
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -47,6 +48,7 @@ func createDefaultConfig() component.Config {
 				Timeout: 5 * time.Second,
 			},
 		},
+		TempFolder: os.TempDir(),
 	}
 }
 

--- a/receiver/jmxreceiver/factory.go
+++ b/receiver/jmxreceiver/factory.go
@@ -48,7 +48,7 @@ func createDefaultConfig() component.Config {
 				Timeout: 5 * time.Second,
 			},
 		},
-		TempFolder: os.TempDir(),
+		TempDir: os.TempDir(),
 	}
 }
 

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -76,7 +76,7 @@ func (jmx *jmxMetricReceiver) Start(ctx context.Context, host component.Host) er
 		return err
 	}
 
-	tmpFile, err := os.CreateTemp(jmx.config.TempFolder, "jmx-config-*.properties")
+	tmpFile, err := os.CreateTemp(jmx.config.TempDir, "jmx-config-*.properties")
 	if err != nil {
 		return fmt.Errorf("failed to get tmp file for jmxreceiver config: %w", err)
 	}

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -76,7 +76,7 @@ func (jmx *jmxMetricReceiver) Start(ctx context.Context, host component.Host) er
 		return err
 	}
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "jmx-config-*.properties")
+	tmpFile, err := os.CreateTemp(jmx.config.TempFolder, "jmx-config-*.properties")
 	if err != nil {
 		return fmt.Errorf("failed to get tmp file for jmxreceiver config: %w", err)
 	}

--- a/receiver/jmxreceiver/receiver_test.go
+++ b/receiver/jmxreceiver/receiver_test.go
@@ -40,7 +40,7 @@ func TestReceiver(t *testing.T) {
 		OTLPExporterConfig: otlpExporterConfig{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
-		TempFolder: tempDir,
+		TempDir: tempDir,
 	}
 
 	receiver := newJMXMetricReceiver(params, config, consumertest.NewNop())

--- a/receiver/jmxreceiver/testdata/config.yaml
+++ b/receiver/jmxreceiver/testdata/config.yaml
@@ -24,6 +24,7 @@ jmx/all:
     one: two
   additional_jars:
     - testdata/fake_additional.jar
+  temp_dir: /opt/otel/run
 jmx/missingendpoint:
   jar_path: testdata/fake_jmx.jar
   target_system: jvm


### PR DESCRIPTION
**Description:**
Adds a configuration property allowing the user to decide where to place the temporary properties file used by the JMX receiver Java process.

**Link to tracking Issue:** 
Fixes #14757

**Testing:**
Unit tests

**Documentation:**
Added to README