### PR TITLE
[receiver/purefa] Add the mandatory scraper on config file

### DIFF
--- a/.chloggen/add_missing_config_patter_purefa.yaml
+++ b/.chloggen/add_missing_config_patter_purefa.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/purefareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add missing scrapers to the config file
+
+# One or more tracking issues related to the change
+issues: [14886]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 

--- a/.chloggen/add_missing_config_patter_purefa.yaml
+++ b/.chloggen/add_missing_config_patter_purefa.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: receiver/purefareceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add missing scrapers to the config file
+note: Updating documentation to include required configuration fields.
 
 # One or more tracking issues related to the change
 issues: [14886]

--- a/receiver/purefareceiver/README.md
+++ b/receiver/purefareceiver/README.md
@@ -26,9 +26,25 @@ receivers:
   purefa:
     endpoint: http://172.0.0.1:9490/metrics
     arrays:
-    - address: gse-array01
-      auth:
-        authenticator: bearertokenauth/array01
+      - address: gse-array01
+        auth:
+          authenticator: bearertokenauth/array01
+    host:
+      - address: gse-array01
+        auth:
+          authenticator: bearertokenauth/array01
+    directories:
+      - address: gse-array01
+        auth:
+          authenticator: bearertokenauth/array01
+    pods:
+      - address: gse-array01
+        auth:
+          authenticator: bearertokenauth/array01
+    volumes:
+      - address: gse-array01
+        auth:
+          authenticator: bearertokenauth/array01
     env: dev
     settings:
       reload_intervals:

--- a/receiver/purefareceiver/testdata/config.yaml
+++ b/receiver/purefareceiver/testdata/config.yaml
@@ -8,9 +8,22 @@ receivers:
       - address: gse-array01
         auth:
           authenticator: bearertokenauth/array01
-      - address: gse-array02
+    host:
+      - address: gse-array01
         auth:
-          authenticator: bearertokenauth/array02
+          authenticator: bearertokenauth/array01
+    directories:
+      - address: gse-array01
+        auth:
+          authenticator: bearertokenauth/array01
+    pods:
+      - address: gse-array01
+        auth:
+          authenticator: bearertokenauth/array01
+    volumes:
+      - address: gse-array01
+        auth:
+          authenticator: bearertokenauth/array01
     env: dev
     settings:
       reload_intervals:


### PR DESCRIPTION
**Description:**
There are a mandatory config that need to be inside de config.yaml works properly

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14886

**Testing:**
Same present on **README.md** section

**Documentation:**
Still in progress