### PR TITLE
Move jpkrohling to the bottom of rotating sponsor list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,11 +132,11 @@ The following GitHub users are the currently available sponsors, either by being
 * [@codeboten](https://github.com/codeboten)
 * [@Aneurysm9](https://github.com/Aneurysm9)
 * [@mx-psi](https://github.com/mx-psi)
-* [@jpkrohling](https://github.com/jpkrohling)
 * [@dmitryax](https://github.com/dmitryax)
 * [@evan-bradley](https://github.com/evan-bradley)
 * [@MovieStoreGuy](https://github.com/MovieStoreGuy)
 * [@bogdandrutu](https://github.com/bogdandrutu)
+* [@jpkrohling](https://github.com/jpkrohling)
 
 Whenever a sponsor is picked from the top of this list, please move them to the bottom.
 


### PR DESCRIPTION
I volunteered for sponsoring the vendor component `purefbreceiver`.

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17528

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
