### PR TITLE
[chore] [pkg/pdatatest] Make exported API consistent

### DIFF
--- a/pkg/pdatatest/plogtest/logs.go
+++ b/pkg/pdatatest/plogtest/logs.go
@@ -96,6 +96,11 @@ func CompareLogs(expected, actual plog.Logs, options ...CompareLogsOption) error
 // CompareResourceLogs compares each part of two given ResourceLogs and returns
 // an error if they don't match. The error describes what didn't match.
 func CompareResourceLogs(expected, actual plog.ResourceLogs) error {
+	if !reflect.DeepEqual(expected.Resource().Attributes().AsRaw(), actual.Resource().Attributes().AsRaw()) {
+		return fmt.Errorf("resource attributes do not match expected: %v, actual: %v",
+			expected.Resource().Attributes().AsRaw(), actual.Resource().Attributes().AsRaw())
+	}
+
 	eilms := expected.ScopeLogs()
 	ailms := actual.ScopeLogs()
 
@@ -105,30 +110,31 @@ func CompareResourceLogs(expected, actual plog.ResourceLogs) error {
 	}
 
 	for i := 0; i < eilms.Len(); i++ {
-		eilm, ailm := eilms.At(i), ailms.At(i)
-		eil, ail := eilm.Scope(), ailm.Scope()
-
-		if eil.Name() != ail.Name() {
-			return fmt.Errorf("instrumentation library Name does not match expected: %s, actual: %s", eil.Name(), ail.Name())
-		}
-		if eil.Version() != ail.Version() {
-			return fmt.Errorf("instrumentation library Version does not match expected: %s, actual: %s", eil.Version(), ail.Version())
-		}
-		if err := CompareLogRecordSlices(eilm.LogRecords(), ailm.LogRecords()); err != nil {
+		if err := CompareScopeLogs(eilms.At(i), ailms.At(i)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// CompareLogRecordSlices compares each part of two given LogRecordSlices and returns
+// CompareScopeLogs compares each part of two given LogRecordSlices and returns
 // an error if they don't match. The error describes what didn't match.
-func CompareLogRecordSlices(expected, actual plog.LogRecordSlice) error {
-	if expected.Len() != actual.Len() {
-		return fmt.Errorf("number of log records does not match expected: %d, actual: %d", expected.Len(), actual.Len())
+func CompareScopeLogs(expected, actual plog.ScopeLogs) error {
+	if expected.Scope().Name() != actual.Scope().Name() {
+		return fmt.Errorf("scope name does not match expected: %s, actual: %s",
+			expected.Scope().Name(), actual.Scope().Name())
+	}
+	if expected.Scope().Version() != actual.Scope().Version() {
+		return fmt.Errorf("scope version does not match expected: %s, actual: %s",
+			expected.Scope().Version(), actual.Scope().Version())
 	}
 
-	numLogRecords := expected.Len()
+	if expected.LogRecords().Len() != actual.LogRecords().Len() {
+		return fmt.Errorf("number of log records does not match expected: %d, actual: %d",
+			expected.LogRecords().Len(), actual.LogRecords().Len())
+	}
+
+	numLogRecords := expected.LogRecords().Len()
 
 	// Keep track of matching records so that each record can only be matched once
 	matchingLogRecords := make(map[plog.LogRecord]plog.LogRecord, numLogRecords)
@@ -136,10 +142,10 @@ func CompareLogRecordSlices(expected, actual plog.LogRecordSlice) error {
 	var errs error
 	var outOfOrderErrs error
 	for e := 0; e < numLogRecords; e++ {
-		elr := expected.At(e)
+		elr := expected.LogRecords().At(e)
 		var foundMatch bool
 		for a := 0; a < numLogRecords; a++ {
-			alr := actual.At(a)
+			alr := actual.LogRecords().At(a)
 			if _, ok := matchingLogRecords[alr]; ok {
 				continue
 			}
@@ -160,9 +166,9 @@ func CompareLogRecordSlices(expected, actual plog.LogRecordSlice) error {
 	}
 
 	for i := 0; i < numLogRecords; i++ {
-		if _, ok := matchingLogRecords[actual.At(i)]; !ok {
+		if _, ok := matchingLogRecords[actual.LogRecords().At(i)]; !ok {
 			errs = multierr.Append(errs, fmt.Errorf("log has extra record with attributes: %v",
-				actual.At(i).Attributes().AsRaw()))
+				actual.LogRecords().At(i).Attributes().AsRaw()))
 		}
 	}
 
@@ -174,16 +180,21 @@ func CompareLogRecordSlices(expected, actual plog.LogRecordSlice) error {
 	}
 
 	for alr, elr := range matchingLogRecords {
-		if err := CompareLogRecords(alr, elr); err != nil {
+		if err := CompareLogRecord(alr, elr); err != nil {
 			return multierr.Combine(fmt.Errorf("log record with attributes: %v, does not match expected", alr.Attributes().AsRaw()), err)
 		}
 	}
 	return nil
 }
 
-// CompareLogRecords compares each part of two given LogRecord and returns
+// CompareLogRecord compares each part of two given LogRecord and returns
 // an error if they don't match. The error describes what didn't match.
-func CompareLogRecords(expected, actual plog.LogRecord) error {
+func CompareLogRecord(expected, actual plog.LogRecord) error {
+	if !reflect.DeepEqual(expected.Attributes().AsRaw(), actual.Attributes().AsRaw()) {
+		return fmt.Errorf("log record attributes do not match expected: %v, actual: %v",
+			expected.Attributes().AsRaw(), actual.Attributes().AsRaw())
+	}
+
 	if expected.Flags() != actual.Flags() {
 		return fmt.Errorf("log record Flags doesn't match expected: %d, actual: %d",
 			expected.Flags(),

--- a/pkg/pdatatest/pmetrictest/metrics_test.go
+++ b/pkg/pdatatest/pmetrictest/metrics_test.go
@@ -77,14 +77,14 @@ func TestCompareMetrics(t *testing.T) {
 		{
 			name: "resource-instrumentation-library-name-mismatch",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("instrumentation library Name does not match expected: one, actual: two"),
+				Err:    errors.New("scope Name does not match expected: one, actual: two"),
 				Reason: "An instrumentation library with a different name is a different library.",
 			},
 		},
 		{
 			name: "resource-instrumentation-library-version-mismatch",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("instrumentation library Version does not match expected: 1.0, actual: 2.0"),
+				Err:    errors.New("scope Version does not match expected: 1.0, actual: 2.0"),
 				Reason: "An instrumentation library with a different version is a different library.",
 			},
 		},
@@ -105,14 +105,20 @@ func TestCompareMetrics(t *testing.T) {
 		{
 			name: "metric-type-expect-gauge",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("metric DataType does not match expected: Gauge, actual: Sum"),
+				Err: multierr.Combine(
+					errors.New("metric should.be.gauge does not match"),
+					errors.New("metric DataType does not match expected: Gauge, actual: Sum"),
+				),
 				Reason: "A metric with the wrong instrument type should cause a failure.",
 			},
 		},
 		{
 			name: "metric-type-expect-sum",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("metric DataType does not match expected: Sum, actual: Gauge"),
+				Err: multierr.Combine(
+					errors.New("metric should.be.sum does not match"),
+					errors.New("metric DataType does not match expected: Sum, actual: Gauge"),
+				),
 				Reason: "A metric with the wrong instrument type should cause a failure.",
 			},
 		},
@@ -129,14 +135,20 @@ func TestCompareMetrics(t *testing.T) {
 		{
 			name: "metric-description-mismatch",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("metric Description does not match expected: Gauge One, actual: Gauge Two"),
+				Err: multierr.Combine(
+					errors.New("metric gauge.one does not match"),
+					errors.New("metric Description does not match expected: Gauge One, actual: Gauge Two"),
+				),
 				Reason: "A metric with the wrong description should cause a failure.",
 			},
 		},
 		{
 			name: "metric-unit-mismatch",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("metric Unit does not match expected: By, actual: 1"),
+				Err: multierr.Combine(
+					errors.New("metric gauge.one does not match"),
+					errors.New("metric Unit does not match expected: By, actual: 1"),
+				),
 				Reason: "A metric with the wrong unit should cause a failure.",
 			},
 		},
@@ -144,7 +156,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-slice-extra",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("number of datapoints does not match expected: 1, actual: 2"),
 				),
 				Reason: "A data point slice with an extra data point should cause a failure.",
@@ -154,7 +166,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-slice-missing",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric sum.one does not match"),
 					errors.New("number of datapoints does not match expected: 2, actual: 1"),
 				),
 				Reason: "A data point slice with a missing data point should cause a failure.",
@@ -164,7 +176,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-slice-dedup",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric sum.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:two]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.one:one]"),
 				),
@@ -175,7 +187,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-attribute-extra",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:one]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.one:one attribute.two:two]"),
 				),
@@ -186,7 +198,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-attribute-missing",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric sum.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:one attribute.two:two]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.two:two]"),
 				),
@@ -197,7 +209,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-attribute-key",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric sum.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:one]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.two:one]"),
 				),
@@ -208,7 +220,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-attribute-value",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:one]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.one:two]"),
 				),
@@ -218,28 +230,40 @@ func TestCompareMetrics(t *testing.T) {
 		{
 			name: "data-point-aggregation-expect-delta",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("metric AggregationTemporality does not match expected: Delta, actual: Cumulative"),
+				Err: multierr.Combine(
+					errors.New("metric delta.one does not match"),
+					errors.New("metric AggregationTemporality does not match expected: Delta, actual: Cumulative"),
+				),
 				Reason: "A data point with the wrong aggregation temporality should cause a failure.",
 			},
 		},
 		{
 			name: "data-point-aggregation-expect-cumulative",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("metric AggregationTemporality does not match expected: Cumulative, actual: Delta"),
+				Err: multierr.Combine(
+					errors.New("metric delta.one does not match"),
+					errors.New("metric AggregationTemporality does not match expected: Cumulative, actual: Delta"),
+				),
 				Reason: "A data point with the wrong aggregation temporality should cause a failure.",
 			},
 		},
 		{
 			name: "data-point-monotonic-expect-true",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("metric IsMonotonic does not match expected: true, actual: false"),
+				Err: multierr.Combine(
+					errors.New("metric monotonic does not match"),
+					errors.New("metric IsMonotonic does not match expected: true, actual: false"),
+				),
 				Reason: "A data point with the wrong monoticity should cause a failure.",
 			},
 		},
 		{
 			name: "data-point-monotonic-expect-false",
 			withoutOptions: internal.Expectation{
-				Err:    errors.New("metric IsMonotonic does not match expected: false, actual: true"),
+				Err: multierr.Combine(
+					errors.New("metric nonmonotonic does not match"),
+					errors.New("metric IsMonotonic does not match expected: false, actual: true"),
+				),
 				Reason: "A data point with the wrong monoticity should cause a failure.",
 			},
 		},
@@ -247,7 +271,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-value-double-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint DoubleVal doesn't match expected: 123.456000, actual: 654.321000"),
 				),
@@ -258,7 +282,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-value-int-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric sum.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint IntVal doesn't match expected: 123, actual: 654"),
 				),
@@ -269,7 +293,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-value-expect-int",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint types don't match: expected type: Int, actual type: Double"),
 				),
@@ -280,7 +304,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "data-point-value-expect-double",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint types don't match: expected type: Double, actual type: Int"),
 				),
@@ -291,7 +315,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "histogram-data-point-count-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `histogram.one`, do not match expected"),
+					errors.New("metric histogram.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint Count doesn't match expected: 123, actual: 654"),
 				),
@@ -302,7 +326,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "histogram-data-point-sum-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `histogram.one`, do not match expected"),
+					errors.New("metric histogram.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint Sum doesn't match expected: 123.456000, actual: 654.321000"),
 				),
@@ -312,7 +336,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "histogram-data-point-buckets-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `histogram.one`, do not match expected"),
+					errors.New("metric histogram.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint BucketCounts doesn't match expected: [1 2 3], actual: [3 2 1]"),
 				),
@@ -322,7 +346,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "exp-histogram-data-point-count-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `exponential_histogram.one`, do not match expected"),
+					errors.New("metric exponential_histogram.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint Count doesn't match expected: 123, actual: 654"),
 				),
@@ -333,7 +357,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "exp-histogram-data-point-sum-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `exponential_histogram.one`, do not match expected"),
+					errors.New("metric exponential_histogram.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint Sum doesn't match expected: 123.456000, actual: 654.321000"),
 				),
@@ -343,7 +367,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "exp-histogram-data-point-positive-buckets-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `exponential_histogram.one`, do not match expected"),
+					errors.New("metric exponential_histogram.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint Positive BucketCounts doesn't match expected: [1 2 3], "+
 						"actual: [3 2 1]"),
@@ -354,7 +378,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "exp-histogram-data-point-negative-offset-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `exponential_histogram.one`, do not match expected"),
+					errors.New("metric exponential_histogram.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint Negative Offset doesn't match expected: 10, actual: 1"),
 				),
@@ -364,7 +388,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "summary-data-point-count-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `summary.one`, do not match expected"),
+					errors.New("metric summary.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint Count doesn't match expected: 123, actual: 654"),
 				),
@@ -375,7 +399,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "summary-data-point-sum-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `summary.one`, do not match expected"),
+					errors.New("metric summary.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint Sum doesn't match expected: 123.456000, actual: 654.321000"),
 				),
@@ -385,7 +409,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "summary-data-point-quantile-values-length-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `summary.one`, do not match expected"),
+					errors.New("metric summary.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint QuantileValues length doesn't match expected: 3, actual: 2"),
 				),
@@ -395,7 +419,7 @@ func TestCompareMetrics(t *testing.T) {
 			name: "summary-data-point-quantile-values-mismatch",
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `summary.one`, do not match expected"),
+					errors.New("metric summary.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint value at quantile 0.990000 doesn't match expected: 99.000000, "+
 						"actual: 110.000000"),
@@ -416,7 +440,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint DoubleVal doesn't match expected: 123.456000, actual: 654.321000"),
 				),
@@ -430,7 +454,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric sum.one does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint IntVal doesn't match expected: 123, actual: 654"),
 				),
@@ -444,7 +468,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric sum.one does not match"),
 					errors.New("number of datapoints does not match expected: 1, actual: 2"),
 				),
 				Reason: "An unpredictable data point value will cause failures if not ignored.",
@@ -457,7 +481,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric sum.one does not match"),
 					errors.New("number of datapoints does not match expected: 1, actual: 2"),
 				),
 				Reason: "An unpredictable data point value will cause failures if not ignored.",
@@ -470,7 +494,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.two`, do not match expected"),
+					errors.New("metric sum.two does not match"),
 					errors.New("datapoint with attributes: map[], does not match expected"),
 					errors.New("metric datapoint IntVal doesn't match expected: 123, actual: 654"),
 				),
@@ -484,7 +508,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
@@ -504,7 +528,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
@@ -514,7 +538,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric sum.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[hostname:also unpredictable]"),
 					errors.New("metric has extra datapoint with attributes: map[hostname:also random]"),
 				),
@@ -598,7 +622,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `aerospike.namespace.scan.count`, do not match expected"),
+					errors.New("metric aerospike.namespace.scan.count does not match"),
 					errors.New("datapoints are out of order, datapoint with attributes map[result:complete type:aggr] expected at index 1, found a at index 2"),
 					errors.New("datapoints are out of order, datapoint with attributes map[result:error type:aggr] expected at index 2, found a at index 3"),
 					errors.New("datapoints are out of order, datapoint with attributes map[result:abort type:basic] expected at index 3, found a at index 1"),
@@ -617,7 +641,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
@@ -637,7 +661,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:one attribute.two:same]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:two attribute.two:same]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.one attribute.two:same]"),
@@ -657,7 +681,7 @@ func TestCompareMetrics(t *testing.T) {
 			},
 			withoutOptions: internal.Expectation{
 				Err: multierr.Combine(
-					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric gauge.one does not match"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:unpredictable.one attribute.two:same]"),
 					errors.New("metric missing expected datapoint with attributes: map[attribute.one:unpredictable.two attribute.two:same]"),
 					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.two attribute.two:same]"),

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -46,7 +46,7 @@ func TestMessageEventConversion(t *testing.T) {
 			},
 		},
 	).ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
-	require.NoError(t, plogtest.CompareLogRecords(expectedLog, event.LogRecords().At(0)))
+	require.NoError(t, plogtest.CompareLogRecord(expectedLog, event.LogRecords().At(0)))
 }
 
 func TestAttributeTypeConversion(t *testing.T) {
@@ -101,7 +101,7 @@ func TestAttributeTypeConversion(t *testing.T) {
 
 	le := event.LogRecords().At(0)
 
-	require.NoError(t, plogtest.CompareLogRecords(Logs(
+	require.NoError(t, plogtest.CompareLogRecord(Logs(
 		Log{
 			Timestamp: 5000000000000,
 			Body:      pcommon.NewValueEmpty(),
@@ -247,7 +247,7 @@ func TestBodyConversion(t *testing.T) {
 	cv := body.Map().PutEmptyMap("c")
 	cv.PutInt("d", 24)
 
-	require.NoError(t, plogtest.CompareLogRecords(Logs(
+	require.NoError(t, plogtest.CompareLogRecord(Logs(
 		Log{
 			Timestamp: 5000000000000,
 			Body:      body,

--- a/receiver/signalfxreceiver/signalfxv2_event_to_logdata_test.go
+++ b/receiver/signalfxreceiver/signalfxv2_event_to_logdata_test.go
@@ -51,9 +51,9 @@ func TestSignalFxV2EventsToLogData(t *testing.T) {
 		}
 	}
 
-	buildDefaultLogs := func() plog.LogRecordSlice {
-		logSlice := plog.NewLogRecordSlice()
-		l := logSlice.AppendEmpty()
+	buildDefaultLogs := func() plog.ScopeLogs {
+		sl := plog.NewScopeLogs()
+		l := sl.LogRecords().AppendEmpty()
 		l.SetTimestamp(pcommon.NewTimestampFromTime(now.Truncate(time.Millisecond)))
 		attrs := l.Attributes()
 		attrs.PutStr("com.splunk.signalfx.event_type", "shutdown")
@@ -69,13 +69,13 @@ func TestSignalFxV2EventsToLogData(t *testing.T) {
 		propMap.PutDouble("temp", 40.5)
 		propMap.PutEmpty("nullProp")
 
-		return logSlice
+		return sl
 	}
 
 	tests := []struct {
 		name      string
 		sfxEvents []*sfxpb.Event
-		expected  plog.LogRecordSlice
+		expected  plog.ScopeLogs
 	}{
 		{
 			name:      "default",
@@ -89,9 +89,9 @@ func TestSignalFxV2EventsToLogData(t *testing.T) {
 				e.Category = nil
 				return []*sfxpb.Event{e}
 			}(),
-			expected: func() plog.LogRecordSlice {
+			expected: func() plog.ScopeLogs {
 				lrs := buildDefaultLogs()
-				lrs.At(0).Attributes().PutEmpty("com.splunk.signalfx.event_category")
+				lrs.LogRecords().At(0).Attributes().PutEmpty("com.splunk.signalfx.event_category")
 				return lrs
 			}(),
 		},
@@ -99,9 +99,9 @@ func TestSignalFxV2EventsToLogData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lrs := plog.NewLogRecordSlice()
-			signalFxV2EventsToLogRecords(tt.sfxEvents, lrs)
-			assert.NoError(t, plogtest.CompareLogRecordSlices(tt.expected, lrs))
+			sl := plog.NewScopeLogs()
+			signalFxV2EventsToLogRecords(tt.sfxEvents, sl.LogRecords())
+			assert.NoError(t, plogtest.CompareScopeLogs(tt.expected, sl))
 		})
 	}
 }


### PR DESCRIPTION
This change updates the exported functions to be consistently applied on pdata non-slice objects and called `Compare<pdata_type>`. If we want to export Compare functions for slices, we can do it later for all the slice types.

The name `Compare<pdata_type>` with `<pdata_type>` in singular form is needed to avoid `CompareMetrics` conflict
