### PR TITLE
[chore] [receiver/mysql] Enable integration test

### DIFF
--- a/receiver/mysqlreceiver/integration_test.go
+++ b/receiver/mysqlreceiver/integration_test.go
@@ -67,7 +67,8 @@ func TestMySqlIntegration(t *testing.T) {
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
-		pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricValues())
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+			pmetrictest.IgnoreMetricValues(), pmetrictest.IgnoreMetricDataPointsOrder()))
 	})
 }
 

--- a/receiver/mysqlreceiver/testdata/integration/expected.8_0.json
+++ b/receiver/mysqlreceiver/testdata/integration/expected.8_0.json
@@ -1,12 +1,18 @@
 {
    "resourceMetrics": [
       {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "mysql.instance.endpoint",
+                  "value": {
+                     "stringValue": "localhost:3306"
+                  }
+               }
+            ]
+         },
          "scopeMetrics": [
             {
-               "scope": {
-                  "name": "otelcol/mysqlreceiver",
-                  "version": "latest"
-               },
                "metrics": [
                   {
                      "description": "The number of data pages in the InnoDB buffer pool.",
@@ -15,7 +21,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "228",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "status",
@@ -24,11 +30,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "2",
+                              "asInt": "1148",
                               "attributes": [
                                  {
                                     "key": "status",
@@ -37,8 +43,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ]
                      },
@@ -52,8 +58,8 @@
                         "dataPoints": [
                            {
                               "asInt": "134217728",
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ]
                      },
@@ -66,20 +72,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "240",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "reads"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "241",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -88,11 +81,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "238",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -101,11 +94,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "239",
+                              "asInt": "15767",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -114,24 +107,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "242",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "write_requests"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "237",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -140,11 +120,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "236",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -153,8 +133,34 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "993",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "reads"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "2233",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "write_requests"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -169,8 +175,8 @@
                         "dataPoints": [
                            {
                               "asInt": "232",
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -184,7 +190,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "234",
+                              "asInt": "4",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -193,24 +199,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "230",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "data"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "233",
+                              "asInt": "7040",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -219,8 +212,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "1148",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "data"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ]
                      },
@@ -233,7 +239,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "229",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "status",
@@ -242,11 +248,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "2",
+                              "asInt": "18808832",
                               "attributes": [
                                  {
                                     "key": "status",
@@ -255,101 +261,12 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ]
                      },
                      "unit": "By"
-                  },
-                  {
-                     "description": "The number of times each type of command has been executed.",
-                     "name": "mysql.commands",
-                     "sum": {
-                        "aggregationTemporality": 2,
-                        "dataPoints": [
-                           {
-                              "asInt": "165",
-                              "attributes": [
-                                 {
-                                    "key": "command",
-                                    "value": {
-                                       "stringValue": "prepare"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "163",
-                              "attributes": [
-                                 {
-                                    "key": "command",
-                                    "value": {
-                                       "stringValue": "close"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "167",
-                              "attributes": [
-                                 {
-                                    "key": "command",
-                                    "value": {
-                                       "stringValue": "send_long_data"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "166",
-                              "attributes": [
-                                 {
-                                    "key": "command",
-                                    "value": {
-                                       "stringValue": "reset"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "162",
-                              "attributes": [
-                                 {
-                                    "key": "command",
-                                    "value": {
-                                       "stringValue": "execute"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "164",
-                              "attributes": [
-                                 {
-                                    "key": "command",
-                                    "value": {
-                                       "stringValue": "fetch"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "1"
                   },
                   {
                      "description": "The number of writes to the InnoDB doublewrite buffer.",
@@ -358,7 +275,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "251",
+                              "asInt": "91",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -367,11 +284,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "252",
+                              "asInt": "25",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -380,8 +297,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -395,202 +312,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "211",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "213",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "external_lock"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "225",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "savepoint_rollback"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "200",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "commit"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "223",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "rollback"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "212",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "discover"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "214",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "mrr_init"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "217",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "read_key"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "222",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "read_rnd_next"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "219",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "read_next"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "226",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "update"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "216",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "read_first"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "224",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "savepoint"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "215",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "prepare"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "220",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "read_prev"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "227",
+                              "asInt": "345",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -599,24 +321,50 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "218",
+                              "asInt": "1759",
                               "attributes": [
                                  {
                                     "key": "kind",
                                     "value": {
-                                       "stringValue": "read_last"
+                                       "stringValue": "read_key"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "221",
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_prev"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "16",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "prepare"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -625,8 +373,193 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "discover"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "4010",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_next"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "608",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "savepoint_rollback"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "583",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_rnd_next"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "savepoint"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_last"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "6459",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "external_lock"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "330",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "12",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "mrr_init"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "50",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_first"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "rollback"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of attempts to connect to locked user accounts.",
+                     "name": "mysql.locked_connects",
+                     "sum": {
+                        "aggregationTemporality": 2,
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -640,7 +573,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "441",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -649,11 +582,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "440",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -662,8 +595,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -677,20 +610,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "255",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "writes"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "254",
+                              "asInt": "1085",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -699,11 +619,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "253",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -712,8 +632,121 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "77",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "writes"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of mysqlx connections.",
+                     "name": "mysql.mysqlx_connections",
+                     "sum": {
+                        "aggregationTemporality": 2,
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "rejected"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "closed"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "status",
+                                    "value": {
+                                       "stringValue": "accepted"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of opened resources.",
+                     "name": "mysql.opened_resources",
+                     "sum": {
+                        "aggregationTemporality": 2,
+                        "dataPoints": [
+                           {
+                              "asInt": "193",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "table"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "77",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "table_definition"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "file"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -727,20 +760,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "248",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "reads"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "243",
+                              "asInt": "132",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -749,11 +769,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "249",
+                              "asInt": "363",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -762,8 +782,21 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "1014",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "reads"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -777,7 +810,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "263",
+                              "asInt": "232",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -786,24 +819,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "261",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "created"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "262",
+                              "asInt": "992",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -812,8 +832,110 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "156",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "created"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of times each type of prepared statement command has been issued.",
+                     "name": "mysql.prepared_statements",
+                     "sum": {
+                        "aggregationTemporality": 2,
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "reset"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "close"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "fetch"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "send_long_data"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "execute"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "prepare"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -827,7 +949,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "266",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -836,11 +958,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "269",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -849,8 +971,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -864,7 +986,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "270",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -873,11 +995,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "273",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -886,11 +1008,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "272",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -899,11 +1021,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "271",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "operation",
@@ -912,8 +1034,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -927,20 +1049,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "416",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "merge_passes"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "417",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -949,11 +1058,24 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "418",
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "merge_passes"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -962,11 +1084,11 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "419",
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -975,8 +1097,8 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ],
                         "isMonotonic": true
@@ -990,33 +1112,7 @@
                         "aggregationTemporality": 2,
                         "dataPoints": [
                            {
-                              "asInt": "450",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "created"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "451",
-                              "attributes": [
-                                 {
-                                    "key": "kind",
-                                    "value": {
-                                       "stringValue": "running"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "449",
+                              "asInt": "1",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -1025,11 +1121,24 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "448",
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "created"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
+                           {
+                              "asInt": "0",
                               "attributes": [
                                  {
                                     "key": "kind",
@@ -1038,509 +1147,83 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           }
-                        ]
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "The total count of I/O wait events for a table.",
-                     "name": "mysql.table.io.waits.count",
-                     "sum": {
-                        "aggregationTemporality": 2,
-                        "isMonotonic": true,
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
                               "asInt": "2",
                               "attributes": [
                                  {
-                                    "key": "operation",
+                                    "key": "kind",
                                     "value": {
-                                       "stringValue": "fetch"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
+                                       "stringValue": "running"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "3",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "4",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "update"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
                         ]
                      },
                      "unit": "1"
                   },
                   {
-                     "description": "The total time of I/O wait events for a table.",
-                     "name": "mysql.table.io.waits.time",
+                     "description": "The number of created temporary resources.",
+                     "name": "mysql.tmp_resources",
                      "sum": {
                         "aggregationTemporality": 2,
-                        "isMonotonic": true,
                         "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "resource",
+                                    "value": {
+                                       "stringValue": "disk_tables"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
+                           },
                            {
                               "asInt": "5",
                               "attributes": [
                                  {
-                                    "key": "operation",
+                                    "key": "resource",
                                     "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
+                                       "stringValue": "files"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            },
                            {
-                              "asInt": "6",
+                              "asInt": "2",
                               "attributes": [
                                  {
-                                    "key": "operation",
+                                    "key": "resource",
                                     "value": {
-                                       "stringValue": "fetch"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
+                                       "stringValue": "tables"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "7",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "8",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "update"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
+                              "startTimeUnixNano": "1674545255370693000",
+                              "timeUnixNano": "1674545265375344000"
                            }
-                        ]
-                     },
-                     "unit": "ns"
-                  },
-                  {
-                     "description": "The total count of I/O wait events for an index.",
-                     "name": "mysql.index.io.waits.count",
-                     "sum": {
-                        "aggregationTemporality": 2,
-                        "isMonotonic": true,
-                        "dataPoints": [
-                           {
-                              "asInt": "9",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 },
-                                 {
-                                    "key": "index",
-                                    "value": {
-                                       "stringValue": "an_index"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "10",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "fetch"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 },
-                                 {
-                                    "key": "index",
-                                    "value": {
-                                       "stringValue": "an_index"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "11",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 },
-                                 {
-                                    "key": "index",
-                                    "value": {
-                                       "stringValue": "an_index"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "12",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "update"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 },
-                                 {
-                                    "key": "index",
-                                    "value": {
-                                       "stringValue": "an_index"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           }
-                        ]
+                        ],
+                        "isMonotonic": true
                      },
                      "unit": "1"
-                  },
-                  {
-                     "description": "The total time of I/O wait events for an index.",
-                     "name": "mysql.index.io.waits.time",
-                     "sum": {
-                        "aggregationTemporality": 2,
-                        "isMonotonic": true,
-                        "dataPoints": [
-                           {
-                              "asInt": "13",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "delete"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 },
-                                 {
-                                    "key": "index",
-                                    "value": {
-                                       "stringValue": "an_index"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "14",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "fetch"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 },
-                                 {
-                                    "key": "index",
-                                    "value": {
-                                       "stringValue": "an_index"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "15",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "insert"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 },
-                                 {
-                                    "key": "index",
-                                    "value": {
-                                       "stringValue": "an_index"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           },
-                           {
-                              "asInt": "16",
-                              "attributes": [
-                                 {
-                                    "key": "operation",
-                                    "value": {
-                                       "stringValue": "update"
-                                    }
-                                 },
-                                 {
-                                    "key": "table",
-                                    "value": {
-                                       "stringValue": "a_table"
-                                    }
-                                 },
-                                 {
-                                    "key": "schema",
-                                    "value": {
-                                       "stringValue": "a_schema"
-                                    }
-                                 },
-                                 {
-                                    "key": "index",
-                                    "value": {
-                                       "stringValue": "an_index"
-                                    }
-                                 }
-                              ],
-                              "startTimeUnixNano": "1644862687825728000",
-                              "timeUnixNano": "1644862687825772000"
-                           }
-                        ]
-                     },
-                     "unit": "ns"
                   }
-               ]
+               ],
+               "scope": {
+                  "name": "otelcol/mysqlreceiver",
+                  "version": "latest"
+               }
             }
-         ],
-         "resource": {}
+         ]
       }
    ]
 }


### PR DESCRIPTION
The metrics comparison was never applied. This change enables the test and updates the expected payload by applying `golden.WriteMetrics`.