### PR TITLE
[exporter/signalfx] Metadata updater lifecycle

### DIFF
--- a/.chloggen/fix-signalfxmetadataupdater-dependency-to-exporter.yaml
+++ b/.chloggen/fix-signalfxmetadataupdater-dependency-to-exporter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make sure the metadata updater is tied to the exporter itself, so it can tack on the exporter lifecycle.
+
+# One or more tracking issues related to the change
+issues: [17976]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -54,11 +54,11 @@ type baseLogsExporter struct {
 
 type signalfMetadataExporter struct {
 	exporter.Metrics
-	pushMetadata func(metadata []*metadata.MetadataUpdate) error
+	exporter *signalfxExporter
 }
 
 func (sme *signalfMetadataExporter) ConsumeMetadata(metadata []*metadata.MetadataUpdate) error {
-	return sme.pushMetadata(metadata)
+	return sme.exporter.pushMetadata(metadata)
 }
 
 type signalfxExporter struct {

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -987,11 +987,11 @@ func TestConsumeMetadata(t *testing.T) {
 				})
 			dimClient.Start()
 
-			se := signalfxExporter{
+			se := &signalfxExporter{
 				pushMetadata: dimClient.PushMetadata,
 			}
 			sme := signalfMetadataExporter{
-				pushMetadata: se.pushMetadata,
+				exporter: se,
 			}
 
 			err = sme.ConsumeMetadata(tt.args.metadata)
@@ -1294,11 +1294,11 @@ func TestTLSAPIConnection(t *testing.T) {
 				})
 			dimClient.Start()
 
-			se := signalfxExporter{
+			se := &signalfxExporter{
 				pushMetadata: dimClient.PushMetadata,
 			}
 			sme := signalfMetadataExporter{
-				pushMetadata: se.pushMetadata,
+				exporter: se,
 			}
 
 			err = sme.ConsumeMetadata(metadata)

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -149,8 +149,8 @@ func createMetricsExporter(
 	}
 
 	return &signalfMetadataExporter{
-		Metrics:      me,
-		pushMetadata: exp.pushMetadata,
+		Metrics:  me,
+		exporter: exp,
 	}, nil
 }
 


### PR DESCRIPTION

**Description:**
Make sure the metadata updater is tied to the exporter itself, so it can tack on the exporter lifecycle.


**Link to tracking Issue:**
#17976

**Testing:**
Unit tests pass