### PR TITLE
[pkg/pdatatest] Do not ignore timestamps in CompareMetrics, use options

### DIFF
--- a/.chloggen/pmetrictest-dont-ignore-timestamps.yaml
+++ b/.chloggen/pmetrictest-dont-ignore-timestamps.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not ignore timestamps implicitly, provide explicit options for that.
+
+# One or more tracking issues related to the change
+issues: [17865]

--- a/pkg/pdatatest/README.md
+++ b/pkg/pdatatest/README.md
@@ -23,7 +23,8 @@ func TestMetricsScraper(t *testing.T) {
 	expectedFile, err := readMetrics(filepath.Join("testdata", "expected.json"))
 	require.NoError(err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreStartTimestamp(), 
+		pmetrictest.IgnoreTimestamp()))))
 }
 ```
 

--- a/pkg/pdatatest/pmetrictest/metrics.go
+++ b/pkg/pdatatest/pmetrictest/metrics.go
@@ -355,6 +355,12 @@ func compareNumberDataPointSlices(expected, actual pmetric.NumberDataPointSlice)
 // CompareNumberDataPoint compares each part of two given NumberDataPoints and returns
 // an error if they don't match. The error describes what didn't match.
 func CompareNumberDataPoint(expected, actual pmetric.NumberDataPoint) error {
+	if expected.StartTimestamp() != actual.StartTimestamp() {
+		return fmt.Errorf("metric datapoint StartTimestamp doesn't match expected: %d, actual: %d", expected.StartTimestamp(), actual.StartTimestamp())
+	}
+	if expected.Timestamp() != actual.Timestamp() {
+		return fmt.Errorf("metric datapoint Timestamp doesn't match expected: %d, actual: %d", expected.Timestamp(), actual.Timestamp())
+	}
 	if expected.ValueType() != actual.ValueType() {
 		return fmt.Errorf("metric datapoint types don't match: expected type: %s, actual type: %s", expected.ValueType(), actual.ValueType())
 	}

--- a/pkg/pdatatest/pmetrictest/metrics_test.go
+++ b/pkg/pdatatest/pmetrictest/metrics_test.go
@@ -511,9 +511,34 @@ func TestCompareMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "ignore-timestamp",
+			name: "ignore-start-timestamp",
+			compareOptions: []CompareMetricsOption{
+				IgnoreStartTimestamp(),
+			},
 			withoutOptions: internal.Expectation{
-				Err:    nil,
+				Err: multierr.Combine(
+					errors.New("ResourceMetrics with attributes map[] does not match expected"),
+					errors.New(`ScopeMetrics with scope name "" does not match expected`),
+					errors.New("metric gauge.one does not match expected"),
+					errors.New("datapoint with attributes: map[], does not match expected"),
+					errors.New("metric datapoint StartTimestamp doesn't match expected: 0, actual: 11651379494838206464"),
+				),
+				Reason: "Timestamps are always ignored, so no error is expected.",
+			},
+		},
+		{
+			name: "ignore-timestamp",
+			compareOptions: []CompareMetricsOption{
+				IgnoreTimestamp(),
+			},
+			withoutOptions: internal.Expectation{
+				Err: multierr.Combine(
+					errors.New("ResourceMetrics with attributes map[] does not match expected"),
+					errors.New(`ScopeMetrics with scope name "" does not match expected`),
+					errors.New("metric gauge.one does not match expected"),
+					errors.New("datapoint with attributes: map[], does not match expected"),
+					errors.New("metric datapoint Timestamp doesn't match expected: 0, actual: 11651379494838206464"),
+				),
 				Reason: "Timestamps are always ignored, so no error is expected.",
 			},
 		},

--- a/pkg/pdatatest/pmetrictest/options.go
+++ b/pkg/pdatatest/pmetrictest/options.go
@@ -17,6 +17,7 @@ package pmetrictest // import "github.com/open-telemetry/opentelemetry-collector
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -86,6 +87,90 @@ func maskDataPointSliceValues(dataPoints pmetric.NumberDataPointSlice) {
 		dataPoint := dataPoints.At(i)
 		dataPoint.SetIntValue(0)
 		dataPoint.SetDoubleValue(0)
+	}
+}
+
+// IgnoreTimestamp is a CompareMetricsOption that clears Timestamp fields on all the data points.
+func IgnoreTimestamp() CompareMetricsOption {
+	return compareMetricsOptionFunc(func(expected, actual pmetric.Metrics) {
+		now := pcommon.NewTimestampFromTime(time.Now())
+		maskTimestamp(expected, now)
+		maskTimestamp(actual, now)
+	})
+}
+
+func maskTimestamp(metrics pmetric.Metrics, ts pcommon.Timestamp) {
+	rms := metrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		for j := 0; j < rms.At(i).ScopeMetrics().Len(); j++ {
+			for k := 0; k < rms.At(i).ScopeMetrics().At(j).Metrics().Len(); k++ {
+				m := rms.At(i).ScopeMetrics().At(j).Metrics().At(k)
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					for l := 0; l < m.Gauge().DataPoints().Len(); l++ {
+						m.Gauge().DataPoints().At(l).SetTimestamp(ts)
+					}
+				case pmetric.MetricTypeSum:
+					for l := 0; l < m.Sum().DataPoints().Len(); l++ {
+						m.Sum().DataPoints().At(l).SetTimestamp(ts)
+					}
+				case pmetric.MetricTypeHistogram:
+					for l := 0; l < m.Histogram().DataPoints().Len(); l++ {
+						m.Histogram().DataPoints().At(l).SetTimestamp(ts)
+					}
+				case pmetric.MetricTypeExponentialHistogram:
+					for l := 0; l < m.ExponentialHistogram().DataPoints().Len(); l++ {
+						m.ExponentialHistogram().DataPoints().At(l).SetTimestamp(ts)
+					}
+				case pmetric.MetricTypeSummary:
+					for l := 0; l < m.Summary().DataPoints().Len(); l++ {
+						m.Summary().DataPoints().At(l).SetTimestamp(ts)
+					}
+				}
+			}
+		}
+	}
+}
+
+// IgnoreStartTimestamp is a CompareMetricsOption that clears StartTimestamp fields on all the data points.
+func IgnoreStartTimestamp() CompareMetricsOption {
+	return compareMetricsOptionFunc(func(expected, actual pmetric.Metrics) {
+		now := pcommon.NewTimestampFromTime(time.Now())
+		maskStartTimestamp(expected, now)
+		maskStartTimestamp(actual, now)
+	})
+}
+
+func maskStartTimestamp(metrics pmetric.Metrics, ts pcommon.Timestamp) {
+	rms := metrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		for j := 0; j < rms.At(i).ScopeMetrics().Len(); j++ {
+			for k := 0; k < rms.At(i).ScopeMetrics().At(j).Metrics().Len(); k++ {
+				m := rms.At(i).ScopeMetrics().At(j).Metrics().At(k)
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					for l := 0; l < m.Gauge().DataPoints().Len(); l++ {
+						m.Gauge().DataPoints().At(l).SetStartTimestamp(ts)
+					}
+				case pmetric.MetricTypeSum:
+					for l := 0; l < m.Sum().DataPoints().Len(); l++ {
+						m.Sum().DataPoints().At(l).SetStartTimestamp(ts)
+					}
+				case pmetric.MetricTypeHistogram:
+					for l := 0; l < m.Histogram().DataPoints().Len(); l++ {
+						m.Histogram().DataPoints().At(l).SetStartTimestamp(ts)
+					}
+				case pmetric.MetricTypeExponentialHistogram:
+					for l := 0; l < m.ExponentialHistogram().DataPoints().Len(); l++ {
+						m.ExponentialHistogram().DataPoints().At(l).SetStartTimestamp(ts)
+					}
+				case pmetric.MetricTypeSummary:
+					for l := 0; l < m.Summary().DataPoints().Len(); l++ {
+						m.Summary().DataPoints().At(l).SetStartTimestamp(ts)
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/pkg/pdatatest/pmetrictest/testdata/ignore-start-timestamp/actual.json
+++ b/pkg/pdatatest/pmetrictest/testdata/ignore-start-timestamp/actual.json
@@ -1,0 +1,34 @@
+{
+   "resourceMetrics": [
+      {
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "name": "gauge.one",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 123.456,
+                              "startTimeUnixNano": "11651379494838206464"
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "name": "sum.one",
+                     "sum": {
+                        "dataPoints": [
+                           {
+                              "asInt": 123,
+                              "startTimeUnixNano": "11651379494838206464"
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}

--- a/pkg/pdatatest/pmetrictest/testdata/ignore-start-timestamp/expected.json
+++ b/pkg/pdatatest/pmetrictest/testdata/ignore-start-timestamp/expected.json
@@ -1,0 +1,34 @@
+{
+   "resourceMetrics": [
+      {
+         "scopeMetrics": [
+            {
+               "metrics": [
+                  {
+                     "name": "gauge.one",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 123.456,
+                              "startTimeUnixNano": "0"
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "name": "sum.one",
+                     "sum": {
+                        "dataPoints": [
+                           {
+                              "asInt": 123,
+                              "startTimeUnixNano": "0"
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}

--- a/receiver/aerospikereceiver/integration_test.go
+++ b/receiver/aerospikereceiver/integration_test.go
@@ -324,7 +324,7 @@ func TestAerospikeIntegration(t *testing.T) {
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricValues(),
 		pmetrictest.IgnoreResourceAttributeValue("aerospike.node.name"),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 
 	// now do a run in cluster mode
 	cfg.CollectClusterMetrics = true
@@ -348,6 +348,6 @@ func TestAerospikeIntegration(t *testing.T) {
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricValues(),
 		pmetrictest.IgnoreResourceAttributeValue("aerospike.node.name"),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 
 }

--- a/receiver/aerospikereceiver/scraper_test.go
+++ b/receiver/aerospikereceiver/scraper_test.go
@@ -154,7 +154,7 @@ func TestScrape_CollectClusterMetrics(t *testing.T) {
 
 	expectedMetrics := expectedMB.Emit()
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 
 	require.NoError(t, receiver.shutdown(context.Background()))
 

--- a/receiver/apachereceiver/integration_test.go
+++ b/receiver/apachereceiver/integration_test.go
@@ -78,7 +78,7 @@ func TestApacheIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricValues(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func getContainer(t *testing.T, req testcontainers.ContainerRequest) testcontainers.Container {

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -62,7 +62,7 @@ func TestScraper(t *testing.T) {
 
 	// The port is random, so we shouldn't check if this value matches.
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestScraperFailedStart(t *testing.T) {

--- a/receiver/bigipreceiver/integration_test.go
+++ b/receiver/bigipreceiver/integration_test.go
@@ -64,7 +64,9 @@ func TestBigIpIntegration(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreMetricValues()))
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+		pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreMetricValues(),
+		pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 const (

--- a/receiver/bigipreceiver/scraper_test.go
+++ b/receiver/bigipreceiver/scraper_test.go
@@ -272,7 +272,9 @@ func TestScaperScrape(t *testing.T) {
 
 			expectedMetrics := tc.expectedMetricGen(t)
 
-			err = pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder())
+			err = pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+				pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreStartTimestamp(),
+				pmetrictest.IgnoreTimestamp())
 			require.NoError(t, err)
 		})
 	}

--- a/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_golden.json
+++ b/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_golden.json
@@ -40,7 +40,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -53,7 +53,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -66,7 +66,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -82,7 +82,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -105,7 +105,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -118,7 +118,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -140,7 +140,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -153,7 +153,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -177,7 +177,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -190,7 +190,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -206,7 +206,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -262,7 +262,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -275,7 +275,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -288,7 +288,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -304,7 +304,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -327,7 +327,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -340,7 +340,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -362,7 +362,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -375,7 +375,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -399,7 +399,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -412,7 +412,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -428,7 +428,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -484,7 +484,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -497,7 +497,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -510,7 +510,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -526,7 +526,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -549,7 +549,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -562,7 +562,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -584,7 +584,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -597,7 +597,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -621,7 +621,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -634,7 +634,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -650,7 +650,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -706,7 +706,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -719,7 +719,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -732,7 +732,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -748,7 +748,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -771,7 +771,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -784,7 +784,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -806,7 +806,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -819,7 +819,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -843,7 +843,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -856,7 +856,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -872,7 +872,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],

--- a/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_with_members_golden.json
+++ b/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_with_members_golden.json
@@ -40,7 +40,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -53,7 +53,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -66,7 +66,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -82,7 +82,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -105,7 +105,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -118,7 +118,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -140,7 +140,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -153,7 +153,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -177,7 +177,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -190,7 +190,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -206,7 +206,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -262,7 +262,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -275,7 +275,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -288,7 +288,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -304,7 +304,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -327,7 +327,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -340,7 +340,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -362,7 +362,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -375,7 +375,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -399,7 +399,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -412,7 +412,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -428,7 +428,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -484,7 +484,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -497,7 +497,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -510,7 +510,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -526,7 +526,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -549,7 +549,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -562,7 +562,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -584,7 +584,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -597,7 +597,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -621,7 +621,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -634,7 +634,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -650,7 +650,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -706,7 +706,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -719,7 +719,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -732,7 +732,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -748,7 +748,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -771,7 +771,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -784,7 +784,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -806,7 +806,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -819,7 +819,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ]
@@ -843,7 +843,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            },
                            {
@@ -856,7 +856,7 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],
@@ -872,7 +872,7 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1651783494930451000",
+                              "startTimeUnixNano": "0",
                               "timeUnixNano": "1651783494931319000"
                            }
                         ],

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -60,7 +60,8 @@ func TestScrape(t *testing.T) {
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
-		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder()))
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 	})
 
 	t.Run("scrape from couchdb 3.12", func(t *testing.T) {
@@ -76,7 +77,8 @@ func TestScrape(t *testing.T) {
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
-		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder()))
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 	})
 
 	t.Run("scrape returns nothing", func(t *testing.T) {
@@ -177,7 +179,8 @@ func TestMetricSettings(t *testing.T) {
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", "scraper", "only_db_ops.json"))
 	require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expected, metrics, pmetrictest.IgnoreMetricDataPointsOrder()))
+	require.NoError(t, pmetrictest.CompareMetrics(expected, metrics, pmetrictest.IgnoreMetricDataPointsOrder(),
+		pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 	require.Equal(t, metrics.MetricCount(), 1)
 }
 

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -205,7 +205,8 @@ func TestScrapeV2(t *testing.T) {
 			expectedMetrics, err := golden.ReadMetrics(tc.expectedMetricsFile)
 
 			assert.NoError(t, err)
-			assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder()))
+			assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+				pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 		})
 	}
 }

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -103,7 +103,7 @@ func TestScraper(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestScraperSkipClusterMetrics(t *testing.T) {
@@ -134,7 +134,7 @@ func TestScraperSkipClusterMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestScraperNoNodesMetrics(t *testing.T) {
@@ -165,7 +165,7 @@ func TestScraperNoNodesMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestScraperFailedStart(t *testing.T) {

--- a/receiver/expvarreceiver/scraper_test.go
+++ b/receiver/expvarreceiver/scraper_test.go
@@ -124,7 +124,8 @@ func TestAllMetrics(t *testing.T) {
 	expectedFile := filepath.Join("testdata", "metrics", "expected_all_metrics.json")
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+		pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestNoMetrics(t *testing.T) {

--- a/receiver/flinkmetricsreceiver/integration_test.go
+++ b/receiver/flinkmetricsreceiver/integration_test.go
@@ -138,7 +138,8 @@ func TestFlinkIntegration(t *testing.T) {
 	expectedFile := filepath.Join("testdata", "integration", "expected.json")
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricValues()))
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricValues(),
+		pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func getContainer(t *testing.T, req testcontainers.ContainerRequest) testcontainers.Container {

--- a/receiver/flinkmetricsreceiver/scraper_test.go
+++ b/receiver/flinkmetricsreceiver/scraper_test.go
@@ -269,7 +269,8 @@ func TestScraperScrape(t *testing.T) {
 			expectedMetrics, err := golden.ReadMetrics(tc.expectedMetricFile)
 			require.NoError(t, err)
 
-			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
+			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+				pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 		})
 	}
 }

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -115,6 +115,8 @@ func TestScaperScrape(t *testing.T) {
 				pmetrictest.IgnoreMetricAttributeValue("http.url"),
 				pmetrictest.IgnoreMetricValues("httpcheck.duration"),
 				pmetrictest.IgnoreMetricDataPointsOrder(),
+				pmetrictest.IgnoreStartTimestamp(),
+				pmetrictest.IgnoreTimestamp(),
 			},
 		},
 		{
@@ -131,6 +133,8 @@ func TestScaperScrape(t *testing.T) {
 				pmetrictest.IgnoreMetricAttributeValue("http.url"),
 				pmetrictest.IgnoreMetricValues("httpcheck.duration"),
 				pmetrictest.IgnoreMetricDataPointsOrder(),
+				pmetrictest.IgnoreStartTimestamp(),
+				pmetrictest.IgnoreTimestamp(),
 			},
 		},
 		{
@@ -147,6 +151,8 @@ func TestScaperScrape(t *testing.T) {
 				pmetrictest.IgnoreMetricValues("httpcheck.duration"),
 				pmetrictest.IgnoreMetricAttributeValue("error.message"),
 				pmetrictest.IgnoreMetricDataPointsOrder(),
+				pmetrictest.IgnoreStartTimestamp(),
+				pmetrictest.IgnoreTimestamp(),
 			},
 		},
 	}

--- a/receiver/memcachedreceiver/integration_test.go
+++ b/receiver/memcachedreceiver/integration_test.go
@@ -78,5 +78,5 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricValues(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }

--- a/receiver/memcachedreceiver/scraper_test.go
+++ b/receiver/memcachedreceiver/scraper_test.go
@@ -43,5 +43,5 @@ func TestScraper(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }

--- a/receiver/mongodbreceiver/integration_test.go
+++ b/receiver/mongodbreceiver/integration_test.go
@@ -168,7 +168,7 @@ func TestMongodbIntegration(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricValues(),
-				pmetrictest.IgnoreMetricDataPointsOrder()))
+				pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 		})
 	}
 }

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -326,7 +326,7 @@ func TestScraperScrape(t *testing.T) {
 			expectedMetrics := tc.expectedMetricGen(t)
 
 			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
-				pmetrictest.IgnoreMetricDataPointsOrder()))
+				pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 		})
 	}
 }

--- a/receiver/mysqlreceiver/integration_test.go
+++ b/receiver/mysqlreceiver/integration_test.go
@@ -68,7 +68,8 @@ func TestMySqlIntegration(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
-			pmetrictest.IgnoreMetricValues(), pmetrictest.IgnoreMetricDataPointsOrder()))
+			pmetrictest.IgnoreMetricValues(), pmetrictest.IgnoreMetricDataPointsOrder(),
+			pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 	})
 }
 

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -85,7 +85,7 @@ func TestScrape(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, pmetrictest.CompareMetrics(actualMetrics, expectedMetrics,
-			pmetrictest.IgnoreMetricDataPointsOrder()))
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 	})
 
 	t.Run("scrape has partial failure", func(t *testing.T) {
@@ -119,7 +119,8 @@ func TestScrape(t *testing.T) {
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 		assert.NoError(t, pmetrictest.CompareMetrics(actualMetrics, expectedMetrics,
-			pmetrictest.IgnoreMetricDataPointsOrder()))
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(),
+			pmetrictest.IgnoreTimestamp()))
 
 		var partialError scrapererror.PartialScrapeError
 		require.True(t, errors.As(scrapeErr, &partialError), "returned error was not PartialScrapeError")

--- a/receiver/nginxreceiver/scraper_test.go
+++ b/receiver/nginxreceiver/scraper_test.go
@@ -51,7 +51,8 @@ func TestScraper(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreStartTimestamp(),
+		pmetrictest.IgnoreTimestamp()))
 }
 
 func TestScraperError(t *testing.T) {

--- a/receiver/nsxtreceiver/scraper_test.go
+++ b/receiver/nsxtreceiver/scraper_test.go
@@ -71,7 +71,7 @@ func TestScrape(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(filepath.Join("testdata", "metrics", "expected_metrics.json"))
 	require.NoError(t, err)
 
-	err = pmetrictest.CompareMetrics(metrics, expectedMetrics)
+	err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp())
 	require.NoError(t, err)
 }
 

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -160,6 +160,8 @@ func TestPostgreSQLIntegration(t *testing.T) {
 				pmetrictest.IgnoreMetricValues(),
 				pmetrictest.IgnoreSubsequentDataPoints("postgresql.backends"),
 				pmetrictest.IgnoreMetricDataPointsOrder(),
+				pmetrictest.IgnoreStartTimestamp(),
+				pmetrictest.IgnoreTimestamp(),
 			))
 		})
 	}

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -62,7 +62,7 @@ func TestScraper(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestScraperNoDatabaseSingle(t *testing.T) {
@@ -82,7 +82,7 @@ func TestScraperNoDatabaseSingle(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestScraperNoDatabaseMultiple(t *testing.T) {
@@ -102,7 +102,7 @@ func TestScraperNoDatabaseMultiple(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestScraperWithResourceAttributeFeatureGate(t *testing.T) {
@@ -120,7 +120,7 @@ func TestScraperWithResourceAttributeFeatureGate(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestScraperWithResourceAttributeFeatureGateSingle(t *testing.T) {
@@ -138,7 +138,7 @@ func TestScraperWithResourceAttributeFeatureGateSingle(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder()))
+		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 type mockClientFactory struct{ mock.Mock }

--- a/receiver/rabbitmqreceiver/scraper_test.go
+++ b/receiver/rabbitmqreceiver/scraper_test.go
@@ -153,7 +153,8 @@ func TestScaperScrape(t *testing.T) {
 
 			expectedMetrics := tc.expectedMetricGen(t)
 
-			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
+			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+				pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 		})
 	}
 }

--- a/receiver/riakreceiver/scraper_test.go
+++ b/receiver/riakreceiver/scraper_test.go
@@ -208,7 +208,8 @@ func TestScaperScrape(t *testing.T) {
 
 			expectedMetrics := tc.expectedMetricGen(t)
 
-			err = pmetrictest.CompareMetrics(expectedMetrics, actualMetrics)
+			err = pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreStartTimestamp(),
+				pmetrictest.IgnoreTimestamp())
 			require.NoError(t, err)
 		})
 	}

--- a/receiver/saphanareceiver/scraper_test.go
+++ b/receiver/saphanareceiver/scraper_test.go
@@ -47,7 +47,8 @@ func TestScraper(t *testing.T) {
 	actualMetrics, err := sc.Scrape(context.Background())
 	require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder()))
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+		pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 func TestDisabledMetrics(t *testing.T) {
@@ -112,7 +113,8 @@ func TestDisabledMetrics(t *testing.T) {
 	actualMetrics, err := sc.Scrape(context.Background())
 	require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder()))
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+		pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
 type queryJSON struct {

--- a/receiver/snmpreceiver/integration_test.go
+++ b/receiver/snmpreceiver/integration_test.go
@@ -85,7 +85,8 @@ func TestSnmpReceiverIntegration(t *testing.T) {
 			expectedFile := filepath.Join("testdata", "integration", testCase.expectedResultsFilename)
 			expectedMetrics, err := golden.ReadMetrics(expectedFile)
 			require.NoError(t, err)
-			err = pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricsOrder())
+			err = pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricsOrder(),
+				pmetrictest.IgnoreTimestamp())
 			require.NoError(t, err)
 		})
 	}

--- a/receiver/snmpreceiver/scraper_test.go
+++ b/receiver/snmpreceiver/scraper_test.go
@@ -265,7 +265,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -312,7 +312,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -361,7 +361,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -410,7 +410,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -474,7 +474,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -540,7 +540,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -612,7 +612,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -758,7 +758,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -822,7 +822,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -888,7 +888,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -954,7 +954,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -1036,7 +1036,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -1129,7 +1129,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -1220,7 +1220,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -1452,7 +1452,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -1529,7 +1529,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -1606,7 +1606,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -1683,7 +1683,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -1768,7 +1768,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -2013,7 +2013,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -2111,7 +2111,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},
@@ -2187,7 +2187,7 @@ func TestScrape(t *testing.T) {
 				expectedMetrics := expectedMetricGen(t)
 				metrics, err := scraper.scrape(context.Background())
 				require.NoError(t, err)
-				err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+				err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreTimestamp())
 				require.NoError(t, err)
 			},
 		},

--- a/receiver/snmpreceiver/testdata/expected_metrics/10_indexed_scalar_metrics_same_resource_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/10_indexed_scalar_metrics_same_resource_golden.json
@@ -13,7 +13,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "0",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }
@@ -28,7 +28,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -41,7 +41,7 @@
                                     },
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/11_indexed_multiple_metrics_same_resource_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/11_indexed_multiple_metrics_same_resource_golden.json
@@ -13,7 +13,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "0",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -26,7 +26,7 @@
                                     },
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -48,7 +48,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -61,7 +61,7 @@
                                     },
                                     {
                                         "asInt": "3",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/12_indexed_metrics_w_all_attrs_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/12_indexed_metrics_w_all_attrs_golden.json
@@ -13,7 +13,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -38,7 +38,7 @@
                                     },
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/13_indexed_metrics_w_column_oid_attr_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/13_indexed_metrics_w_column_oid_attr_golden.json
@@ -13,7 +13,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -26,7 +26,7 @@
                                     },
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/14_indexed_column_oid_float_attr_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/14_indexed_column_oid_float_attr_golden.json
@@ -13,7 +13,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -26,7 +26,7 @@
                                     },
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/15_indexed_column_oid_int_attr_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/15_indexed_column_oid_int_attr_golden.json
@@ -13,7 +13,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -26,7 +26,7 @@
                                     },
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/16_indexed_prefix_res_attr_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/16_indexed_prefix_res_attr_golden.json
@@ -20,7 +20,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }
@@ -35,7 +35,7 @@
                                 "dataPoints": [
                                     {
                                         "asDouble": "1.0",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }
@@ -72,7 +72,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }
@@ -87,7 +87,7 @@
                                 "dataPoints": [
                                     {
                                         "asDouble": "2.0",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }

--- a/receiver/snmpreceiver/testdata/expected_metrics/17_indexed_oid_res_attr_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/17_indexed_oid_res_attr_golden.json
@@ -20,7 +20,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }
@@ -35,7 +35,7 @@
                                 "dataPoints": [
                                     {
                                         "asDouble": "1.0",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }
@@ -72,7 +72,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }
@@ -87,7 +87,7 @@
                                 "dataPoints": [
                                     {
                                         "asDouble": "2.0",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }

--- a/receiver/snmpreceiver/testdata/expected_metrics/18_indexed_oid_and_prefix_res_attr_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/18_indexed_oid_and_prefix_res_attr_golden.json
@@ -26,7 +26,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }
@@ -69,7 +69,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": []
                                     }

--- a/receiver/snmpreceiver/testdata/expected_metrics/1_scalar_metrics_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/1_scalar_metrics_golden.json
@@ -14,7 +14,7 @@
                                     {
                                         "asInt": "1",
                                         "attributes": [],
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000"
                                     }
                                 ]

--- a/receiver/snmpreceiver/testdata/expected_metrics/2_scalar_metrics_sum_cumulative_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/2_scalar_metrics_sum_cumulative_golden.json
@@ -16,7 +16,7 @@
                                     {
                                         "asDouble": "1.0",
                                         "attributes": [],
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000"
                                     }
                                 ]

--- a/receiver/snmpreceiver/testdata/expected_metrics/3_scalar_metrics_sum_delta_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/3_scalar_metrics_sum_delta_golden.json
@@ -16,7 +16,7 @@
                                     {
                                         "asInt": "1",
                                         "attributes": [],
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000"
                                     }
                                 ]

--- a/receiver/snmpreceiver/testdata/expected_metrics/4_scalar_multiple_metrics_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/4_scalar_multiple_metrics_golden.json
@@ -14,7 +14,7 @@
                                     {
                                         "asInt": "1",
                                         "attributes": [],
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000"
                                     }
                                 ]
@@ -29,7 +29,7 @@
                                     {
                                         "asInt": "2",
                                         "attributes": [],
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000"
                                     }
                                 ]

--- a/receiver/snmpreceiver/testdata/expected_metrics/5_scalar_metric_w_attr_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/5_scalar_metric_w_attr_golden.json
@@ -13,7 +13,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/6_scalar_metric_w_multi_datapoint_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/6_scalar_metric_w_multi_datapoint_golden.json
@@ -13,7 +13,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -26,7 +26,7 @@
                                     },
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/7_indexed_metrics_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/7_indexed_metrics_golden.json
@@ -13,7 +13,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -26,7 +26,7 @@
                                     },
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/8_indexed_metrics_sum_cumulative_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/8_indexed_metrics_sum_cumulative_golden.json
@@ -15,7 +15,7 @@
                                 "dataPoints": [
                                     {
                                         "asDouble": "1.0",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -28,7 +28,7 @@
                                     },
                                     {
                                         "asDouble": "2.0",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snmpreceiver/testdata/expected_metrics/9_indexed_metrics_sum_delta_golden.json
+++ b/receiver/snmpreceiver/testdata/expected_metrics/9_indexed_metrics_sum_delta_golden.json
@@ -15,7 +15,7 @@
                                 "dataPoints": [
                                     {
                                         "asInt": "1",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {
@@ -28,7 +28,7 @@
                                     },
                                     {
                                         "asInt": "2",
-                                        "startTimeUnixNano": "1651783494930451000",
+                                        "startTimeUnixNano": "0",
                                         "timeUnixNano": "1651783494931319000",
                                         "attributes": [
                                             {

--- a/receiver/snowflakereceiver/scraper_test.go
+++ b/receiver/snowflakereceiver/scraper_test.go
@@ -68,7 +68,8 @@ func TestScraper(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err, "error reading expected metrics")
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreStartTimestamp(),
+		pmetrictest.IgnoreTimestamp()))
 }
 
 func TestStart(t *testing.T) {

--- a/receiver/vcenterreceiver/scraper_test.go
+++ b/receiver/vcenterreceiver/scraper_test.go
@@ -71,7 +71,7 @@ func testScrape(ctx context.Context, t *testing.T, cfg *Config) {
 	expectedMetrics, err := golden.ReadMetrics(goldenPath)
 	require.NoError(t, err)
 
-	err = pmetrictest.CompareMetrics(expectedMetrics, metrics)
+	err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp())
 	require.NoError(t, err)
 	require.NoError(t, scraper.Shutdown(ctx))
 }

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -270,7 +270,8 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			expectedMetrics, err := golden.ReadMetrics(expectedFile)
 			require.NoError(t, err)
 
-			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
+			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+				pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 		})
 	}
 }


### PR DESCRIPTION
It's pretty common to ignore timestamps when using CompareMetrics in tests for scrapers, but it's not apparent behavior for other use cases. We should provide options to ignore timestamps explicitly. That will make the `Compare...` functions provide a clean comparison with no implicit behavior.

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17865