### PR TITLE
feat(pdatautil): add pdatautil.MapKeysHash()

### DIFF
--- a/.chloggen/jgm-pdatautil-mapkeyshash.yaml
+++ b/.chloggen/jgm-pdatautil-mapkeyshash.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/pdatautil
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add function MapKeysHash(), similar to MapHash(), but hashes only a pcommon.Map keys.
+
+# One or more tracking issues related to the change
+issues: [17985]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/jgm-pdatautil-mapkeyshash.yaml
+++ b/.chloggen/jgm-pdatautil-mapkeyshash.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: pkg/pdatautil

--- a/pkg/pdatautil/hash_test.go
+++ b/pkg/pdatautil/hash_test.go
@@ -211,6 +211,21 @@ func TestMapKeysHash(t *testing.T) {
 			}(),
 			equal: true,
 		},
+		{
+			name: "different_maps",
+			maps: func() []pcommon.Map {
+				m := []pcommon.Map{pcommon.NewMap(), pcommon.NewMap()}
+				m[0].PutStr("k1", "v1")
+				m[0].PutInt("k2", 1)
+				m[0].PutDouble("k3", 1)
+
+				m[1].PutStr("k1", "v1")
+				m[1].PutDouble("k3", 1)
+
+				return m
+			}(),
+			equal: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Add function `MapKeysHash()`, similar to `MapHash()`, but hashes only a `pcommon.Map` keys, not values. This helper/util function fills a need after `pcommon.Map.Sort()` has been deprecated in v0.70.0.

**Link to tracking Issue:** <Issue number if applicable>
n/a

**Testing:** <Describe what testing was performed and which tests were added.>
Added relevant unit test `TestMapKeysHash()`, similar to `TestMapHash()`.

**Documentation:** <Describe the documentation added.>
n/a