### PR TITLE
Update gcp readme with product links

### DIFF
--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -6,7 +6,9 @@
 | Supported pipeline types | traces, metrics, logs |
 | Distributions            | [contrib]             |
 
-This exporter can be used to send metrics and traces to Google Cloud Monitoring and Trace (formerly known as Stackdriver) respectively.
+This exporter can be used to send traces to [Google Cloud Monitoring](https://cloud.google.com/monitoring)
+(formerly Stackdriver), traces to [Google Cloud Trace](https://cloud.google.com/trace),
+and logs to [Google Cloud Logging](https://cloud.google.com/logging).
 
 ## Getting started
 


### PR DESCRIPTION
**Description:**
Addresses confusion over which GCP product signals are sent to.  See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17900#issuecomment-1401991742

**Link to tracking Issue:**

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17900
