### PR TITLE
[chore] [processor/cumulativetodelta] Fix test failing on Windows

### DIFF
--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
@@ -238,8 +238,8 @@ func Test_metricTracker_sweeper(t *testing.T) {
 		staleBefore := <-sweepEvent
 		tickTime := time.Since(start) + tr.maxStaleness*time.Duration(i)
 		require.False(t, closed.Load())
-		assert.Less(t, tr.maxStaleness, tickTime)
-		assert.Less(t, tr.maxStaleness, time.Since(staleBefore.AsTime()))
+		assert.LessOrEqual(t, tr.maxStaleness, tickTime)
+		assert.LessOrEqual(t, tr.maxStaleness, time.Since(staleBefore.AsTime()))
 	}
 	cancel()
 	for range sweepEvent {


### PR DESCRIPTION
Fix test failing on Windows:

```
=== RUN   Test_metricTracker_sweeper
    tracker_test.go:242: 
        	Error Trace:	D:\a\opentelemetry-collector-contrib\opentelemetry-collector-contrib\processor\cumulativetodeltaprocessor\internal\tracking\tracker_test.go:242
        	Error:      	"1ms" is not less than "1ms"
        	Test:       	Test_metricTracker_sweeper
    tracker_test.go:242: 
        	Error Trace:	D:\a\opentelemetry-collector-contrib\opentelemetry-collector-contrib\processor\cumulativetodeltaprocessor\internal\tracking\tracker_test.go:242
        	Error:      	"1ms" is not less than "1ms"
        	Test:       	Test_metricTracker_sweeper
--- FAIL: Test_metricTracker_sweeper (0.03s)
```

https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/3998807556/jobs/6862454387

It brings back the assert condition that was changed in https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/6970681a72ed6adcbcc8505eacba96af64ebd2bc#diff-c682b4c7e2267244801e3de5f58cc71717a480600e8ecf400436eed65d49bc39 