### PR TITLE
[chore] use opentelemetrybot

### DIFF
--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
-git config user.name $GITHUB_ACTOR
-git config user.email $GITHUB_ACTOR@users.noreply.github.com
+git config user.name opentelemetrybot
+git config user.email 107717825+opentelemetrybot@users.noreply.github.com
 
 PR_NAME=dependabot-prs/`date +'%Y-%m-%dT%H%M%S'`
 git checkout -b $PR_NAME


### PR DESCRIPTION
This works around the limitation that a PR created by an action doesn't trigger workflows automatically by using the opentelemetrybot's token. See https://github.com/open-telemetry/community/blob/main/assets.md#opentelemetry-bot

Signed-off-by: Alex Boten <aboten@lightstep.com>
