### PR TITLE
[chore] rename dependabot PR action

### DIFF
--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -1,4 +1,4 @@
-name: dependabot-pr
+name: Automation - Dependabot PR
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This makes finding it in the menu a bit easier. Otherwise we always have to expand the list of action to select the action.

Signed-off-by: Alex Boten <aboten@lightstep.com>
