### PR TITLE
[exporter/mezmoexporter] Remove specific path requirement

### DIFF
--- a/.chloggen/remove-path-requirement.yaml
+++ b/.chloggen/remove-path-requirement.yaml
@@ -1,0 +1,8 @@
+change_type: bug_fix
+
+component: mezmoexporter
+
+note: "No longer require a specific path.  This will allow for compatibility with both log analysis and pipeline."
+
+issues: [18011]
+

--- a/exporter/mezmoexporter/config.go
+++ b/exporter/mezmoexporter/config.go
@@ -17,7 +17,6 @@ package mezmoexporter // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -69,10 +68,6 @@ func (c *Config) Validate() error {
 	parsed, err = url.Parse(c.IngestURL)
 	if c.IngestURL == "" || err != nil {
 		return fmt.Errorf(`"ingest_url" must be a valid URL`)
-	}
-
-	if !strings.HasSuffix(c.IngestURL, "/otel/ingest/rest") {
-		return fmt.Errorf(`"ingest_url" must end with "/otel/ingest/rest"`)
 	}
 
 	if parsed.Host == "" {

--- a/exporter/mezmoexporter/config_test.go
+++ b/exporter/mezmoexporter/config_test.go
@@ -93,12 +93,16 @@ func TestConfig_Validate_Path(t *testing.T) {
 	factory := NewFactory()
 
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.IngestURL = "https://example.com:8088/otel/ingest/rest"
+	cfg.IngestURL = "https://example.com:8088/ingest/rest"
+	cfg.IngestKey = "1234-1234"
+	assert.NoError(t, cfg.Validate())
+
+	cfg.IngestURL = "https://example.com:8088/v1/ABC123"
 	cfg.IngestKey = "1234-1234"
 	assert.NoError(t, cfg.Validate())
 
 	// Set values that don't have a valid default.
-	cfg.IngestURL = "https://example.com"
+	cfg.IngestURL = "/nohost/path"
 	cfg.IngestKey = "testToken"
 	assert.Error(t, cfg.Validate())
 }

--- a/exporter/mezmoexporter/factory_test.go
+++ b/exporter/mezmoexporter/factory_test.go
@@ -52,10 +52,10 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 func TestIngestUrlMustConform(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.IngestURL = "https://example.com:8088/services/collector"
+	cfg.IngestURL = "/collector"
 	cfg.IngestKey = "1234-1234"
 
-	assert.Error(t, cfg.Validate(), `"ingest_url" must end with "/otel/ingest/rest"`)
+	assert.Error(t, cfg.Validate(), `"ingest_url" must contain a valid host`)
 }
 
 func TestCreateLogsExporter(t *testing.T) {


### PR DESCRIPTION
**Description:** No longer require a specific url when setting ingest_url

**Link to tracking Issue:** #18011

**Testing:** unit tests