### PR TITLE
[chore] Fixing up references

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -28,10 +28,10 @@ GOARCH=$(shell $(GOCMD) env GOARCH)
 # as part of $(TOOLS_MOD_DIR)/tools.go, following the existing practice.
 # Modifying the tools' `go.mod` file will trigger a rebuild of the tools to help
 # ensure that all contributors are using the most recent version to make builds repeatable everywhere.
-TOOLS_MOD_DIR    := $(PWD)/internal/tools
+TOOLS_MOD_DIR    := $(SRC_ROOT)/internal/tools
 TOOLS_MOD_REGEX  := "\s+_\s+\".*\""
 TOOLS_PKG_NAMES  := $(shell grep -E $(TOOLS_MOD_REGEX) < $(TOOLS_MOD_DIR)/tools.go | tr -d " _\"")
-TOOLS_BIN_DIR    := $(PWD)/.tools
+TOOLS_BIN_DIR    := $(SRC_ROOT)/.tools
 TOOLS_BIN_NAMES  := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(TOOLS_PKG_NAMES)))
 
 .PHONY: install-tools


### PR DESCRIPTION
The directories being used are relative from where the `make` command being invoked, this resolves this to use the absolute path on the system to the root directory of the project.

Resolves #18009 