### PR TITLE
[chore] update dependabot pr script

### DIFF
--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -40,4 +40,4 @@ git commit -m "dependabot updates `date`
 $message"
 git push origin $PR_NAME
 
-gh pr create --title "[chore] dependabot updates `date`" --body "$message" -l "Skip Changelog"
+gh pr create --title "[chore] dependabot updates `date`" --body "$message"


### PR DESCRIPTION
This removes the need for the "Skip changelog" label as the title already contains "[chore]".

Signed-off-by: Alex Boten <aboten@lightstep.com>
