### PR TITLE
[pkg/pdatatest] Bring reported errors to a consistent state

### DIFF
--- a/.chloggen/improve-pdatetest-errors.yaml
+++ b/.chloggen/improve-pdatetest-errors.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bring reported errors to a consistent state.
+
+# One or more tracking issues related to the change
+issues: [18041]

--- a/pkg/pdatatest/internal/util.go
+++ b/pkg/pdatatest/internal/util.go
@@ -15,11 +15,23 @@
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/internal"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/multierr"
 )
 
 func MaskResourceAttributeValue(res pcommon.Resource, attr string) {
 	if _, ok := res.Attributes().Get(attr); ok {
 		res.Attributes().Remove(attr)
 	}
+}
+
+// AddErrPrefix adds a prefix to every multierr error.
+func AddErrPrefix(prefix string, in error) error {
+	var out error
+	for _, err := range multierr.Errors(in) {
+		out = multierr.Append(out, fmt.Errorf("%s: %w", prefix, err))
+	}
+	return out
 }

--- a/pkg/pdatatest/plogtest/logs_test.go
+++ b/pkg/pdatatest/plogtest/logs_test.go
@@ -40,13 +40,13 @@ func TestCompareLogs(t *testing.T) {
 		},
 		{
 			name:           "missing",
-			withoutOptions: errors.New("amount of ResourceLogs between Logs are not equal expected: 2, actual: 1"),
+			withoutOptions: errors.New("number of resources doesn't match expected: 2, actual: 1"),
 		},
 		{
 			name: "resource-attributes-mismatch",
 			withoutOptions: multierr.Combine(
-				errors.New("missing expected resource with attributes: map[testKey2:two]"),
-				errors.New("extra resource with attributes: map[testKey2:one]"),
+				errors.New("missing expected resource: map[testKey2:two]"),
+				errors.New("unexpected resource: map[testKey2:one]"),
 			),
 		},
 		{
@@ -55,138 +55,76 @@ func TestCompareLogs(t *testing.T) {
 				IgnoreResourceLogsOrder(),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[testKey1:one] expected at index 0, found at index 1"),
-				errors.New("ResourceLogs with attributes map[testKey2:one] expected at index 1, found at index 0"),
+				errors.New(`resources are out of order: resource "map[testKey1:one]" expected at index 0, found at index 1`),
+				errors.New(`resources are out of order: resource "map[testKey2:one]" expected at index 1, found at index 0`),
 			),
 			withOptions: nil,
 		},
 		{
-			name: "resource-instrumentation-library-extra",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[] does not match expected"),
-				errors.New("number of scope logs does not match expected: 1, actual: 2"),
-			),
+			name:           "resource-instrumentation-library-extra",
+			withoutOptions: errors.New(`resource "map[]": number of scopes doesn't match expected: 1, actual: 2`),
 		},
 		{
-			name: "resource-instrumentation-library-missing",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[] does not match expected"),
-				errors.New("number of scope logs does not match expected: 2, actual: 1"),
-			),
+			name:           "resource-instrumentation-library-missing",
+			withoutOptions: errors.New(`resource "map[]": number of scopes doesn't match expected: 2, actual: 1`),
 		},
 		{
 			name: "resource-instrumentation-library-name-mismatch",
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[] does not match expected"),
-				errors.New("missing ScopeLogs with scope name: one"),
-				errors.New("unexpected ScopeLogs with scope name: two"),
+				errors.New(`resource "map[]": missing expected scope: one`),
+				errors.New(`resource "map[]": unexpected scope: two`),
 			),
 		},
 		{
-			name: "resource-instrumentation-library-version-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[] does not match expected"),
-				errors.New(`ScopeLogs with scope name "one" do not match expected`),
-				errors.New("scope version does not match expected: 1.0, actual: 2.0"),
-			),
+			name:           "resource-instrumentation-library-version-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "one": version doesn't match expected: 1.0, actual: 2.0`),
 		},
 		{
-			name: "logrecords-missing",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("number of log records does not match expected: 1, actual: 0"),
-			),
+			name:           "logrecords-missing",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": number of log records doesn't match expected: 1, actual: 0`),
 		},
 		{
 			name: "logrecords-attributes-mismatch",
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log missing expected resource with attributes: map[testKey2:teststringvalue2 testKey3:teststringvalue3]"),
-				errors.New("log has extra record with attributes: map[testKey1:teststringvalue1 testKey2:teststringvalue2]"),
+				errors.New(`resource "map[type:one]": scope "": missing expected log record: map[testKey2:teststringvalue2 testKey3:teststringvalue3]`),
+				errors.New(`resource "map[type:one]": scope "": unexpected log record: map[testKey1:teststringvalue1 testKey2:teststringvalue2]`),
 			),
 		},
 		{
-			name: "logrecords-flag-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log record with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New("log record Flags doesn't match expected: 1, actual: 2"),
-			),
+			name:           "logrecords-flag-mismatch",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": flags doesn't match expected: 1, actual: 2`),
 		},
 		{
-			name: "logrecords-droppedattributescount-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log record with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New("log record DroppedAttributesCount doesn't match expected: 0, actual: 10"),
-			),
+			name:           "logrecords-droppedattributescount-mismatch",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": dropped attributes count doesn't match expected: 0, actual: 10`),
 		},
 		{
-			name: "logrecords-timestamp-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log record with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New("log record Timestamp doesn't match expected: 11651379494838206464, actual: 11651379494838200000"),
-			),
+			name:           "logrecords-timestamp-mismatch",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": timestamp doesn't match expected: 11651379494838206464, actual: 11651379494838200000`),
 		},
 		{
-			name: "logrecords-observedtimestamp-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log record with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New("log record ObservedTimestamp doesn't match expected: 11651379494838206464, actual: 11651379494838200000"),
-			),
+			name:           "logrecords-observedtimestamp-mismatch",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": observed timestamp doesn't match expected: 11651379494838206464, actual: 11651379494838200000`),
 		},
 		{
-			name: "logrecords-severitynumber-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log record with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New("log record SeverityNumber doesn't match expected: Info, actual: Trace"),
-			),
+			name:           "logrecords-severitynumber-mismatch",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": severity number doesn't match expected: Info, actual: Trace`),
 		},
 		{
-			name: "logrecords-severitytext-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log record with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New("log record SeverityText doesn't match expected: TEST, actual: OPEN"),
-			),
+			name:           "logrecords-severitytext-mismatch",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": severity text doesn't match expected: TEST, actual: OPEN`),
 		},
 		{
-			name: "logrecords-traceid-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log record with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New("log record TraceID doesn't match expected: [139 32 209 52 158 249 182 214 249 212 209 212 163 172 46 130], actual: [123 32 209 52 158 249 182 214 249 212 209 212 163 172 46 130]"),
-			),
+			name:           "logrecords-traceid-mismatch",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": trace ID doesn't match expected: [139 32 209 52 158 249 182 214 249 212 209 212 163 172 46 130], actual: [123 32 209 52 158 249 182 214 249 212 209 212 163 172 46 130]`),
 		},
 		{
-			name: "logrecords-spanid-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log record with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New("log record SpanID doesn't match expected: [12 42 217 36 225 119 22 64], actual: [12 42 217 36 225 119 22 48]"),
-			),
+			name:           "logrecords-spanid-mismatch",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": span ID doesn't match expected: [12 42 217 36 225 119 22 64], actual: [12 42 217 36 225 119 22 48]`),
 		},
 		{
-			name: "logrecords-body-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[type:one] does not match expected"),
-				errors.New(`ScopeLogs with scope name "" do not match expected`),
-				errors.New("log record with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New("log record Body doesn't match expected: testscopevalue1, actual: testscopevalue2"),
-			),
+			name:           "logrecords-body-mismatch",
+			withoutOptions: errors.New(`resource "map[type:one]": scope "": log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": body doesn't match expected: testscopevalue1, actual: testscopevalue2`),
 		},
 		{
 			name: "sort-unordered-log-slice",
@@ -194,11 +132,8 @@ func TestCompareLogs(t *testing.T) {
 				IgnoreLogRecordsOrder(),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2] does not match expected"),
-				errors.New(`ScopeLogs with scope name "collector" do not match expected`),
-				errors.New("LogRecord with attributes map[testKey3:teststringvalue4] expected at index 0, found at index 1"),
-				errors.New("LogRecord with attributes map[testKey1:teststringvalue1 testKey2:teststringvalue2"+
-					"] expected at index 1, found at index 0"),
+				errors.New(`resource "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": scope "collector": log records are out of order: log record "map[testKey3:teststringvalue4]" expected at index 0, found at index 1`),
+				errors.New(`resource "map[testKey1:teststringvalue1 testKey2:teststringvalue2]": scope "collector": log records are out of order: log record "map[testKey1:teststringvalue1 testKey2:teststringvalue2]" expected at index 1, found at index 0`),
 			),
 			withOptions: nil,
 		},
@@ -207,13 +142,8 @@ func TestCompareLogs(t *testing.T) {
 			compareOptions: []CompareLogsOption{
 				IgnoreObservedTimestamp(),
 			},
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceLogs with attributes map[] does not match expected"),
-				errors.New(`ScopeLogs with scope name "collector" do not match expected`),
-				errors.New("log record with attributes map[] does not match expected"),
-				errors.New("log record ObservedTimestamp doesn't match expected: 11651379494838206465, actual: 11651379494838206464"),
-			),
-			withOptions: nil,
+			withoutOptions: errors.New(`resource "map[]": scope "collector": log record "map[]": observed timestamp doesn't match expected: 11651379494838206465, actual: 11651379494838206464`),
+			withOptions:    nil,
 		},
 	}
 
@@ -227,13 +157,23 @@ func TestCompareLogs(t *testing.T) {
 			actual, err := golden.ReadLogs(filepath.Join(dir, "actual.json"))
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.withoutOptions, CompareLogs(expected, actual))
+			err = CompareLogs(expected, actual)
+			if tc.withoutOptions == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, tc.withoutOptions, err.Error())
+			}
 
 			if tc.compareOptions == nil {
 				return
 			}
 
-			assert.Equal(t, tc.withOptions, CompareLogs(expected, actual, tc.compareOptions...))
+			err = CompareLogs(expected, actual, tc.compareOptions...)
+			if tc.withOptions == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, tc.withOptions, err.Error())
+			}
 		})
 	}
 }
@@ -277,7 +217,7 @@ func TestCompareResourceLogs(t *testing.T) {
 				rl.Resource().Attributes().PutStr("key1", "value1")
 				return rl
 			}(),
-			err: errors.New("resource attributes do not match expected: map[key1:value1 key2:value2], actual: map[key1:value1]"),
+			err: errors.New("attributes don't match expected: map[key1:value1 key2:value2], actual: map[key1:value1]"),
 		},
 		{
 			name: "scope-logs-number-mismatch",
@@ -292,7 +232,7 @@ func TestCompareResourceLogs(t *testing.T) {
 				rl.ScopeLogs().AppendEmpty()
 				return rl
 			}(),
-			err: errors.New("number of scope logs does not match expected: 2, actual: 1"),
+			err: errors.New("number of scopes doesn't match expected: 2, actual: 1"),
 		},
 	}
 	for _, test := range tests {
@@ -340,7 +280,7 @@ func TestCompareScopeLogs(t *testing.T) {
 				sl.Scope().SetName("scope-name-2")
 				return sl
 			}(),
-			err: errors.New("scope name does not match expected: scope-name, actual: scope-name-2"),
+			err: errors.New("name doesn't match expected: scope-name, actual: scope-name-2"),
 		},
 		{
 			name: "scope-version-mismatch",
@@ -354,7 +294,7 @@ func TestCompareScopeLogs(t *testing.T) {
 				sl.Scope().SetVersion("scope-version-2")
 				return sl
 			}(),
-			err: errors.New("scope version does not match expected: scope-version, actual: scope-version-2"),
+			err: errors.New("version doesn't match expected: scope-version, actual: scope-version-2"),
 		},
 		{
 			name: "log-records-number-mismatch",
@@ -369,7 +309,7 @@ func TestCompareScopeLogs(t *testing.T) {
 				sl.LogRecords().AppendEmpty()
 				return sl
 			}(),
-			err: errors.New("number of log records does not match expected: 2, actual: 1"),
+			err: errors.New("number of log records doesn't match expected: 2, actual: 1"),
 		},
 		{
 			name: "log-records-order-mismatch",
@@ -394,8 +334,8 @@ func TestCompareScopeLogs(t *testing.T) {
 				return sl
 			}(),
 			err: multierr.Combine(
-				errors.New("LogRecord with attributes map[log-attr1:value1] expected at index 0, found at index 1"),
-				errors.New("LogRecord with attributes map[log-attr2:value2] expected at index 1, found at index 0"),
+				errors.New(`log records are out of order: log record "map[log-attr1:value1]" expected at index 0, found at index 1`),
+				errors.New(`log records are out of order: log record "map[log-attr2:value2]" expected at index 1, found at index 0`),
 			),
 		},
 	}
@@ -450,8 +390,7 @@ func TestCompareLogRecord(t *testing.T) {
 				lr.Attributes().PutStr("key2", "value2")
 				return lr
 			}(),
-			err: errors.New("log record attributes do not match expected: map[key1:value1 key2:value1], " +
-				"actual: map[key1:value1 key2:value2]"),
+			err: errors.New("attributes don't match expected: map[key1:value1 key2:value1], actual: map[key1:value1 key2:value2]"),
 		},
 		{
 			name: "body-mismatch",
@@ -465,7 +404,7 @@ func TestCompareLogRecord(t *testing.T) {
 				lr.Body().SetStr("log-body-2")
 				return lr
 			}(),
-			err: errors.New("log record Body doesn't match expected: log-body, actual: log-body-2"),
+			err: errors.New("body doesn't match expected: log-body, actual: log-body-2"),
 		},
 		{
 			name: "timestamp-mismatch",
@@ -479,7 +418,7 @@ func TestCompareLogRecord(t *testing.T) {
 				lr.SetTimestamp(pcommon.Timestamp(987654321))
 				return lr
 			}(),
-			err: errors.New("log record Timestamp doesn't match expected: 123456789, actual: 987654321"),
+			err: errors.New("timestamp doesn't match expected: 123456789, actual: 987654321"),
 		},
 		{
 			name: "severity-number-mismatch",
@@ -493,7 +432,7 @@ func TestCompareLogRecord(t *testing.T) {
 				lr.SetSeverityNumber(plog.SeverityNumberWarn)
 				return lr
 			}(),
-			err: errors.New("log record SeverityNumber doesn't match expected: Info, actual: Warn"),
+			err: errors.New("severity number doesn't match expected: Info, actual: Warn"),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/pdatatest/pmetrictest/metrics_test.go
+++ b/pkg/pdatatest/pmetrictest/metrics_test.go
@@ -38,365 +38,187 @@ func TestCompareMetrics(t *testing.T) {
 		},
 		{
 			name:           "resource-extra",
-			withoutOptions: errors.New("number of resources does not match expected: 1, actual: 2"),
+			withoutOptions: errors.New("number of resources doesn't match expected: 1, actual: 2"),
 		},
 		{
 			name:           "resource-missing",
-			withoutOptions: errors.New("number of resources does not match expected: 2, actual: 1"),
+			withoutOptions: errors.New("number of resources doesn't match expected: 2, actual: 1"),
 		},
 		{
 			name: "resource-attributes-mismatch",
 			withoutOptions: multierr.Combine(
-				errors.New("missing expected resource with attributes: map[type:two]"),
-				errors.New("extra resource with attributes: map[type:three]"),
+				errors.New("missing expected resource: map[type:two]"),
+				errors.New("unexpected resource: map[type:three]"),
 			),
 		},
 		{
-			name: "resource-instrumentation-library-extra",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New("number of ScopeMetrics does not match expected: 1, actual: 2"),
-			),
+			name:           "resource-instrumentation-library-extra",
+			withoutOptions: errors.New(`resource "map[]": number of scopes doesn't match expected: 1, actual: 2`),
 		},
 		{
-			name: "resource-instrumentation-library-missing",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New("number of ScopeMetrics does not match expected: 2, actual: 1"),
-			),
+			name:           "resource-instrumentation-library-missing",
+			withoutOptions: errors.New(`resource "map[]": number of scopes doesn't match expected: 2, actual: 1`),
 		},
 		{
 			name: "resource-instrumentation-library-name-mismatch",
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New("missing expected ScopeMetrics with scope name: one"),
-				errors.New("extra ScopeMetrics with scope name: two"),
+				errors.New(`resource "map[]": missing expected scope: one`),
+				errors.New(`resource "map[]": unexpected scope: two`),
 			),
 		},
 		{
-			name: "resource-instrumentation-library-version-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "one" does not match expected`),
-				errors.New("scope Version does not match expected: 1.0, actual: 2.0"),
-			),
+			name:           "resource-instrumentation-library-version-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "one": version doesn't match expected: 1.0, actual: 2.0`),
 		},
 		{
-			name: "metric-slice-extra",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New("number of metrics does not match expected: 1, actual: 2"),
-			),
+			name:           "metric-slice-extra",
+			withoutOptions: errors.New(`resource "map[]": scope "": number of metrics doesn't match expected: 1, actual: 2`),
 		},
 		{
-			name: "metric-slice-missing",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New("number of metrics does not match expected: 1, actual: 0"),
-			),
+			name:           "metric-slice-missing",
+			withoutOptions: errors.New(`resource "map[]": scope "": number of metrics doesn't match expected: 1, actual: 0`),
 		},
 		{
-			name: "metric-type-expect-gauge",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric should.be.gauge does not match expected`),
-				errors.New("metric DataType does not match expected: Gauge, actual: Sum"),
-			),
+			name:           "metric-type-expect-gauge",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "should.be.gauge": type doesn't match expected: Gauge, actual: Sum`),
 		},
 		{
-			name: "metric-type-expect-sum",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric should.be.sum does not match expected`),
-				errors.New("metric DataType does not match expected: Sum, actual: Gauge"),
-			),
+			name:           "metric-type-expect-sum",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "should.be.sum": type doesn't match expected: Sum, actual: Gauge`),
 		},
 		{
 			name: "metric-name-mismatch",
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New("missing expected metric: expected.name"),
-				errors.New("unexpected metric: wrong.name"),
+				errors.New(`resource "map[]": scope "": missing expected metric: expected.name`),
+				errors.New(`resource "map[]": scope "": unexpected metric: wrong.name`),
 			),
 		},
 		{
-			name: "metric-description-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("metric Description does not match expected: Gauge One, actual: Gauge Two"),
-			),
+			name:           "metric-description-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "gauge.one": description doesn't match expected: Gauge One, actual: Gauge Two`),
 		},
 		{
-			name: "metric-unit-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("metric Unit does not match expected: By, actual: 1"),
-			),
+			name:           "metric-unit-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "gauge.one": unit doesn't match expected: By, actual: 1`),
 		},
 		{
-			name: "data-point-slice-extra",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("number of datapoints does not match expected: 1, actual: 2"),
-			),
+			name:           "data-point-slice-extra",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "gauge.one": number of datapoints doesn't match expected: 1, actual: 2`),
 		},
 		{
-			name: "data-point-slice-missing",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.one does not match expected`),
-				errors.New("number of datapoints does not match expected: 2, actual: 1"),
-			),
+			name:           "data-point-slice-missing",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "sum.one": number of datapoints doesn't match expected: 2, actual: 1`),
 		},
 		{
 			name: "data-point-slice-dedup",
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.one:two]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.one:one]"),
+				errors.New(`resource "map[]": scope "": metric "sum.one": missing expected datapoint: map[attribute.one:two]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": unexpected datapoint: map[attribute.one:one]`),
 			),
 		},
 		{
 			name: "data-point-attribute-extra",
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.one:one]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.one:one attribute.two:two]"),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.one:one]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.one:one attribute.two:two]`),
 			),
 		},
 		{
 			name: "data-point-attribute-missing",
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.one:one attribute.two:two]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.two:two]"),
+				errors.New(`resource "map[]": scope "": metric "sum.one": missing expected datapoint: map[attribute.one:one attribute.two:two]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": unexpected datapoint: map[attribute.two:two]`),
 			),
 		},
 		{
 			name: "data-point-attribute-key",
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.one:one]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.two:one]"),
+				errors.New(`resource "map[]": scope "": metric "sum.one": missing expected datapoint: map[attribute.one:one]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": unexpected datapoint: map[attribute.two:one]`),
 			),
 		},
 		{
 			name: "data-point-attribute-value",
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.one:one]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.one:two]"),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.one:one]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.one:two]`),
 			),
 		},
 		{
-			name: "data-point-aggregation-expect-delta",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric delta.one does not match expected`),
-				errors.New("metric AggregationTemporality does not match expected: Delta, actual: Cumulative"),
-			),
+			name:           "data-point-aggregation-expect-delta",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "delta.one": aggregation temporality doesn't match expected: Delta, actual: Cumulative`),
 		},
 		{
-			name: "data-point-aggregation-expect-cumulative",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric delta.one does not match expected`),
-				errors.New("metric AggregationTemporality does not match expected: Cumulative, actual: Delta"),
-			),
+			name:           "data-point-aggregation-expect-cumulative",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "delta.one": aggregation temporality doesn't match expected: Cumulative, actual: Delta`),
 		},
 		{
-			name: "data-point-monotonic-expect-true",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric monotonic does not match expected`),
-				errors.New("metric IsMonotonic does not match expected: true, actual: false"),
-			),
+			name:           "data-point-monotonic-expect-true",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "monotonic": is monotonic doesn't match expected: true, actual: false`),
 		},
 		{
-			name: "data-point-monotonic-expect-false",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric nonmonotonic does not match expected`),
-				errors.New("metric IsMonotonic does not match expected: false, actual: true"),
-			),
+			name:           "data-point-monotonic-expect-false",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "nonmonotonic": is monotonic doesn't match expected: false, actual: true`),
 		},
 		{
-			name: "data-point-value-double-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint DoubleVal doesn't match expected: 123.456000, actual: 654.321000"),
-			),
+			name:           "data-point-value-double-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "gauge.one": datapoint "map[]": double value doesn't match expected: 123.456000, actual: 654.321000`),
 		},
 		{
-			name: "data-point-value-int-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint IntVal doesn't match expected: 123, actual: 654"),
-			),
+			name:           "data-point-value-int-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "sum.one": datapoint "map[]": int value doesn't match expected: 123, actual: 654`),
 		},
 		{
-			name: "data-point-value-expect-int",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint types don't match: expected type: Int, actual type: Double"),
-			),
+			name:           "data-point-value-expect-int",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "gauge.one": datapoint "map[]": value type doesn't match expected: Int, actual: Double`),
 		},
 		{
-			name: "data-point-value-expect-double",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint types don't match: expected type: Double, actual type: Int"),
-			),
+			name:           "data-point-value-expect-double",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "gauge.one": datapoint "map[]": value type doesn't match expected: Double, actual: Int`),
 		},
 		{
-			name: "histogram-data-point-count-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric histogram.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint Count doesn't match expected: 123, actual: 654"),
-			),
+			name:           "histogram-data-point-count-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "histogram.one": datapoint "map[]": count doesn't match expected: 123, actual: 654`),
 		},
 		{
-			name: "histogram-data-point-sum-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric histogram.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint Sum doesn't match expected: 123.456000, actual: 654.321000"),
-			),
+			name:           "histogram-data-point-sum-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "histogram.one": datapoint "map[]": sum doesn't match expected: 123.456000, actual: 654.321000`),
 		},
 		{
-			name: "histogram-data-point-buckets-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric histogram.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint BucketCounts doesn't match expected: [1 2 3], actual: [3 2 1]"),
-			),
+			name:           "histogram-data-point-buckets-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "histogram.one": datapoint "map[]": bucket counts don't match expected: [1 2 3], actual: [3 2 1]`),
 		},
 		{
-			name: "exp-histogram-data-point-count-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric exponential_histogram.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint Count doesn't match expected: 123, actual: 654"),
-			),
+			name:           "exp-histogram-data-point-count-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "exponential_histogram.one": datapoint "map[]": count doesn't match expected: 123, actual: 654`),
 		},
 		{
-			name: "exp-histogram-data-point-sum-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric exponential_histogram.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint Sum doesn't match expected: 123.456000, actual: 654.321000"),
-			),
+			name:           "exp-histogram-data-point-sum-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "exponential_histogram.one": datapoint "map[]": sum doesn't match expected: 123.456000, actual: 654.321000`),
 		},
 		{
-			name: "exp-histogram-data-point-positive-buckets-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric exponential_histogram.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint Positive BucketCounts doesn't match expected: [1 2 3], "+
-					"actual: [3 2 1]"),
-			),
+			name:           "exp-histogram-data-point-positive-buckets-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "exponential_histogram.one": datapoint "map[]": positive bucket counts don't match expected: [1 2 3], actual: [3 2 1]`),
 		},
 		{
-			name: "exp-histogram-data-point-negative-offset-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric exponential_histogram.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint Negative Offset doesn't match expected: 10, actual: 1"),
-			),
+			name:           "exp-histogram-data-point-negative-offset-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "exponential_histogram.one": datapoint "map[]": negative offset doesn't match expected: 10, actual: 1`),
 		},
 		{
-			name: "summary-data-point-count-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric summary.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint Count doesn't match expected: 123, actual: 654"),
-			),
+			name:           "summary-data-point-count-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "summary.one": datapoint "map[]": count doesn't match expected: 123, actual: 654`),
 		},
 		{
-			name: "summary-data-point-sum-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric summary.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint Sum doesn't match expected: 123.456000, actual: 654.321000"),
-			),
+			name:           "summary-data-point-sum-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "summary.one": datapoint "map[]": sum doesn't match expected: 123.456000, actual: 654.321000`),
 		},
 		{
-			name: "summary-data-point-quantile-values-length-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric summary.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint QuantileValues length doesn't match expected: 3, actual: 2"),
-			),
+			name:           "summary-data-point-quantile-values-length-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "summary.one": datapoint "map[]": quantile values length doesn't match expected: 3, actual: 2`),
 		},
 		{
-			name: "summary-data-point-quantile-values-mismatch",
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric summary.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint value at quantile 0.990000 doesn't match expected: 99.000000, "+
-					"actual: 110.000000"),
-			),
+			name:           "summary-data-point-quantile-values-mismatch",
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "summary.one": datapoint "map[]": value at quantile 0.990000 doesn't match expected: 99.000000, actual: 110.000000`),
 		},
 		{
 			name: "ignore-start-timestamp",
@@ -404,11 +226,8 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreStartTimestamp(),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New("metric gauge.one does not match expected"),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint StartTimestamp doesn't match expected: 0, actual: 11651379494838206464"),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": datapoint "map[]": start timestamp doesn't match expected: 0, actual: 11651379494838206464`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": datapoint "map[]": start timestamp doesn't match expected: 0, actual: 11651379494838206464`),
 			),
 		},
 		{
@@ -417,11 +236,8 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreTimestamp(),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New("metric gauge.one does not match expected"),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint Timestamp doesn't match expected: 0, actual: 11651379494838206464"),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": datapoint "map[]": timestamp doesn't match expected: 0, actual: 11651379494838206464`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": datapoint "map[]": timestamp doesn't match expected: 0, actual: 11651379494838206464`),
 			),
 		},
 		{
@@ -429,26 +245,14 @@ func TestCompareMetrics(t *testing.T) {
 			compareOptions: []CompareMetricsOption{
 				IgnoreMetricValues(),
 			},
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint DoubleVal doesn't match expected: 123.456000, actual: 654.321000"),
-			),
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "gauge.one": datapoint "map[]": double value doesn't match expected: 123.456000, actual: 654.321000`),
 		},
 		{
 			name: "ignore-data-point-value-int-mismatch",
 			compareOptions: []CompareMetricsOption{
 				IgnoreMetricValues(),
 			},
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.one does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint IntVal doesn't match expected: 123, actual: 654"),
-			),
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "sum.one": datapoint "map[]": int value doesn't match expected: 123, actual: 654`),
 		},
 		{
 			name: "ignore-subsequent-data-points-all",
@@ -456,10 +260,8 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreSubsequentDataPoints(),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.one does not match expected`),
-				errors.New("number of datapoints does not match expected: 1, actual: 2"),
+				errors.New(`resource "map[]": scope "": metric "sum.one": number of datapoints doesn't match expected: 1, actual: 2`),
+				errors.New(`resource "map[]": scope "": metric "sum.two": number of datapoints doesn't match expected: 1, actual: 2`),
 			),
 		},
 		{
@@ -467,25 +269,14 @@ func TestCompareMetrics(t *testing.T) {
 			compareOptions: []CompareMetricsOption{
 				IgnoreSubsequentDataPoints("sum.one"),
 			},
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.one does not match expected`),
-				errors.New("number of datapoints does not match expected: 1, actual: 2"),
-			),
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "sum.one": number of datapoints doesn't match expected: 1, actual: 2`),
 		},
 		{
 			name: "ignore-single-metric",
 			compareOptions: []CompareMetricsOption{
 				IgnoreMetricValues("sum.two"),
 			},
-			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.two does not match expected`),
-				errors.New("datapoint with attributes: map[], does not match expected"),
-				errors.New("metric datapoint IntVal doesn't match expected: 123, actual: 654"),
-			),
+			withoutOptions: errors.New(`resource "map[]": scope "": metric "sum.two": datapoint "map[]": int value doesn't match expected: 123, actual: 654`),
 		},
 		{
 			name: "ignore-global-attribute-value",
@@ -493,13 +284,12 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreMetricAttributeValue("hostname"),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.two:value B hostname:random]"),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value A hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value B hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value A hostname:random]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value B hostname:random]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": missing expected datapoint: map[hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": unexpected datapoint: map[hostname:randomvalue]`),
 			),
 			withOptions: nil,
 		},
@@ -509,20 +299,16 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreMetricAttributeValue("hostname", "gauge.one"),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.two:value B hostname:random]"),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value A hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value B hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value A hostname:random]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value B hostname:random]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": missing expected datapoint: map[hostname:also unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": unexpected datapoint: map[hostname:also random]`),
 			),
 			withOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric sum.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[hostname:also unpredictable]"),
-				errors.New("metric has extra datapoint with attributes: map[hostname:also random]"),
+				errors.New(`resource "map[]": scope "": metric "sum.one": missing expected datapoint: map[hostname:also unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": unexpected datapoint: map[hostname:also random]`),
 			),
 		},
 		{
@@ -531,8 +317,8 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreResourceAttributeValue("node_id"),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("missing expected resource with attributes: map[node_id:a-different-random-id]"),
-				errors.New("extra resource with attributes: map[node_id:a-random-id]"),
+				errors.New("missing expected resource: map[node_id:a-different-random-id]"),
+				errors.New("unexpected resource: map[node_id:a-random-id]"),
 			),
 			withOptions: nil,
 		},
@@ -542,8 +328,8 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreResourceMetricsOrder(),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[node_id:BB903] expected at index 1, found at index 2"),
-				errors.New("ResourceMetrics with attributes map[node_id:BB904] expected at index 2, found at index 1"),
+				errors.New(`resources are out of order: resource "map[node_id:BB903]" expected at index 1, found at index 2`),
+				errors.New(`resources are out of order: resource "map[node_id:BB904]" expected at index 2, found at index 1`),
 			),
 			withOptions: nil,
 		},
@@ -553,12 +339,12 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreResourceAttributeValue("node_id"),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("missing expected resource with attributes: map[namespace:BB902-test node_id:BB902-expected]"),
-				errors.New("missing expected resource with attributes: map[namespace:BB904-test node_id:BB904-expected]"),
-				errors.New("missing expected resource with attributes: map[namespace:BB903-test node_id:BB903-expected]"),
-				errors.New("extra resource with attributes: map[namespace:BB902-test node_id:BB902-actual]"),
-				errors.New("extra resource with attributes: map[namespace:BB904-test node_id:BB904-actual]"),
-				errors.New("extra resource with attributes: map[namespace:BB903-test node_id:BB903-actual]"),
+				errors.New("missing expected resource: map[namespace:BB902-test node_id:BB902-expected]"),
+				errors.New("missing expected resource: map[namespace:BB904-test node_id:BB904-expected]"),
+				errors.New("missing expected resource: map[namespace:BB903-test node_id:BB903-expected]"),
+				errors.New("unexpected resource: map[namespace:BB902-test node_id:BB902-actual]"),
+				errors.New("unexpected resource: map[namespace:BB904-test node_id:BB904-actual]"),
+				errors.New("unexpected resource: map[namespace:BB903-test node_id:BB903-actual]"),
 			),
 			withOptions: nil,
 		},
@@ -568,12 +354,10 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreMetricsOrder(),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[namespace:test] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "otelcol/aerospikereceiver" does not match expected`),
-				errors.New("metric aerospike.namespace.memory.free expected at index 0, found at index 2"),
-				errors.New("metric aerospike.namespace.memory.usage expected at index 1, found at index 3"),
-				errors.New("metric aerospike.namespace.disk.available expected at index 2, found at index 1"),
-				errors.New("metric aerospike.namespace.scan.count expected at index 3, found at index 0"),
+				errors.New(`resource "map[namespace:test]": scope "otelcol/aerospikereceiver": metrics are out of order: metric "aerospike.namespace.memory.free" expected at index 0, found at index 2`),
+				errors.New(`resource "map[namespace:test]": scope "otelcol/aerospikereceiver": metrics are out of order: metric "aerospike.namespace.memory.usage" expected at index 1, found at index 3`),
+				errors.New(`resource "map[namespace:test]": scope "otelcol/aerospikereceiver": metrics are out of order: metric "aerospike.namespace.disk.available" expected at index 2, found at index 1`),
+				errors.New(`resource "map[namespace:test]": scope "otelcol/aerospikereceiver": metrics are out of order: metric "aerospike.namespace.scan.count" expected at index 3, found at index 0`),
 			),
 			withOptions: nil,
 		},
@@ -583,12 +367,9 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreMetricDataPointsOrder(),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[namespace:test] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "otelcol/aerospikereceiver" does not match expected`),
-				errors.New(`metric aerospike.namespace.scan.count does not match expected`),
-				errors.New("datapoints are out of order, datapoint with attributes map[result:complete type:aggr] expected at index 1, found at index 2"),
-				errors.New("datapoints are out of order, datapoint with attributes map[result:error type:aggr] expected at index 2, found at index 3"),
-				errors.New("datapoints are out of order, datapoint with attributes map[result:abort type:basic] expected at index 3, found at index 1"),
+				errors.New(`resource "map[namespace:test]": scope "otelcol/aerospikereceiver": metric "aerospike.namespace.scan.count": datapoints are out of order: datapoint "map[result:complete type:aggr]" expected at index 1, found at index 2`),
+				errors.New(`resource "map[namespace:test]": scope "otelcol/aerospikereceiver": metric "aerospike.namespace.scan.count": datapoints are out of order: datapoint "map[result:error type:aggr]" expected at index 2, found at index 3`),
+				errors.New(`resource "map[namespace:test]": scope "otelcol/aerospikereceiver": metric "aerospike.namespace.scan.count": datapoints are out of order: datapoint "map[result:abort type:basic]" expected at index 3, found at index 1`),
 			),
 			withOptions: nil,
 		},
@@ -598,13 +379,12 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreMetricAttributeValue("hostname", "gauge.one", "sum.one"),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.two:value B hostname:random]"),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value A hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value B hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value A hostname:random]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value B hostname:random]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": missing expected datapoint: map[hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": unexpected datapoint: map[hostname:randomvalue]`),
 			),
 			withOptions: nil,
 		},
@@ -614,13 +394,10 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreMetricAttributeValue("attribute.one"),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.one:one attribute.two:same]"),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.one:two attribute.two:same]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.one:random.one attribute.two:same]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.one:random.two attribute.two:same]"),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.one:one attribute.two:same]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.one:two attribute.two:same]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.one:random.one attribute.two:same]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.one:random.two attribute.two:same]`),
 			),
 			withOptions: nil,
 		},
@@ -630,13 +407,10 @@ func TestCompareMetrics(t *testing.T) {
 				IgnoreMetricAttributeValue("attribute.one"),
 			},
 			withoutOptions: multierr.Combine(
-				errors.New("ResourceMetrics with attributes map[] does not match expected"),
-				errors.New(`ScopeMetrics with scope name "" does not match expected`),
-				errors.New(`metric gauge.one does not match expected`),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.one:unpredictable.one attribute.two:same]"),
-				errors.New("metric missing expected datapoint with attributes: map[attribute.one:unpredictable.two attribute.two:same]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.one:random.two attribute.two:same]"),
-				errors.New("metric has extra datapoint with attributes: map[attribute.one:random.one attribute.two:same]"),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.one:unpredictable.one attribute.two:same]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.one:unpredictable.two attribute.two:same]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.one:random.two attribute.two:same]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.one:random.one attribute.two:same]`),
 			),
 			withOptions: nil,
 		},
@@ -655,13 +429,23 @@ func TestCompareMetrics(t *testing.T) {
 			actual, err := golden.ReadMetrics(filepath.Join(dir, "actual.json"))
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.withoutOptions, CompareMetrics(expected, actual))
+			err = CompareMetrics(expected, actual)
+			if tc.withoutOptions == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, tc.withoutOptions, err.Error())
+			}
 
 			if tc.compareOptions == nil {
 				return
 			}
 
-			assert.Equal(t, tc.withOptions, CompareMetrics(expected, actual, tc.compareOptions...))
+			err = CompareMetrics(expected, actual, tc.compareOptions...)
+			if tc.withOptions == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, tc.withOptions, err.Error())
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR applies several changes to the reported errors:
- Instead of mixing different level errors (resource/scope/etc) and the same level errors with multierr, use prefixes to represent levels.
- Return as many errors as possible
- Bring error messaging to a consistent concise view 
- Use lowercase to avoid linter complains
