### PR TITLE
[chore] [CI] Fix automation making a release

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -686,8 +686,7 @@ jobs:
         run: ./.github/workflows/scripts/set_release_tag.sh
       - name: Create Github Release
         run: |
-          mkdir -p dist/
-          ghr -t $GITHUB_TOKEN -u open-telemetry -r opentelemetry-collector-contrib --replace $RELEASE_TAG dist/
+          ./.tools/ghr -t $GITHUB_TOKEN -u open-telemetry -r opentelemetry-collector-contrib --replace $RELEASE_TAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.github_tag.outputs.tag }}


### PR DESCRIPTION
Last time release automation failed on the last step trying to create a Github release with the following error:

```
/home/runner/work/_temp/d189ca92-b6ea-46f8-ab7b-1afdb560e1cd.sh: line 2: ghr: command not found
Error: Process completed with exit code [12](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/3992250363/jobs/6848426043#step:10:13)7.
```

See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/3992250363/jobs/6848426043

This change should fix it