### PR TITLE
docs(receiver/hostmetrics/process): update descriptions of OS-specific metrics

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
@@ -70,6 +70,8 @@ metrics:
 
 Number of times the process has been context switched.
 
+This metric is only available on Linux.
+
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | {count} | Sum | Int | Cumulative | true |
@@ -136,13 +138,17 @@ Percentage of total physical memory that is used by the process.
 
 Number of file descriptors in use by the process.
 
+This metric is only available on Linux.
+
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | {count} | Sum | Int | Cumulative | false |
 
 ### process.paging.faults
 
-Number of page faults the process has made. This metric is only available on Linux.
+Number of page faults the process has made.
+
+This metric is only available on Linux.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -156,7 +162,9 @@ Number of page faults the process has made. This metric is only available on Lin
 
 ### process.signals_pending
 
-Number of pending signals for the process. This metric is only available on Linux.
+Number of pending signals for the process.
+
+This metric is only available on Linux.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -837,7 +837,7 @@ type metricProcessPagingFaults struct {
 // init fills process.paging.faults metric with initial data.
 func (m *metricProcessPagingFaults) init() {
 	m.data.SetName("process.paging.faults")
-	m.data.SetDescription("Number of page faults the process has made. This metric is only available on Linux.")
+	m.data.SetDescription("Number of page faults the process has made.")
 	m.data.SetUnit("{faults}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
@@ -890,7 +890,7 @@ type metricProcessSignalsPending struct {
 // init fills process.signals_pending metric with initial data.
 func (m *metricProcessSignalsPending) init() {
 	m.data.SetName("process.signals_pending")
-	m.data.SetDescription("Number of pending signals for the process. This metric is only available on Linux.")
+	m.data.SetDescription("Number of pending signals for the process.")
 	m.data.SetUnit("{signals}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
@@ -356,7 +356,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["process.paging.faults"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Number of page faults the process has made. This metric is only available on Linux.", ms.At(i).Description())
+					assert.Equal(t, "Number of page faults the process has made.", ms.At(i).Description())
 					assert.Equal(t, "{faults}", ms.At(i).Unit())
 					assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
@@ -373,7 +373,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["process.signals_pending"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Number of pending signals for the process. This metric is only available on Linux.", ms.At(i).Description())
+					assert.Equal(t, "Number of pending signals for the process.", ms.At(i).Description())
 					assert.Equal(t, "{signals}", ms.At(i).Unit())
 					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -155,7 +155,8 @@ metrics:
 
   process.paging.faults:
     enabled: false
-    description: Number of page faults the process has made. This metric is only available on Linux.
+    description: Number of page faults the process has made.
+    extended_documentation: This metric is only available on Linux.
     unit: "{faults}"
     sum:
       value_type: int
@@ -165,7 +166,8 @@ metrics:
 
   process.signals_pending:
     enabled: false
-    description: Number of pending signals for the process. This metric is only available on Linux.
+    description: Number of pending signals for the process.
+    extended_documentation: This metric is only available on Linux.
     unit: "{signals}"
     sum:
       value_type: int
@@ -184,6 +186,7 @@ metrics:
   process.open_file_descriptors:
     enabled: false
     description: Number of file descriptors in use by the process.
+    extended_documentation: This metric is only available on Linux.
     unit: '{count}'
     sum:
       value_type: int
@@ -193,6 +196,7 @@ metrics:
   process.context_switches:
     enabled: false
     description: Number of times the process has been context switched.
+    extended_documentation: This metric is only available on Linux.
     unit: '{count}'
     sum:
       value_type: int


### PR DESCRIPTION
**Description:**

The two metrics are Linux-only (not supported on Windows) but there was no mention of this in the documentation:

- process.open_file_descriptors
- process.context_switches

I have added "This metric is only available on Linux" similar to what other Linux-only metrics have.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17555

**Testing:** N/A

**Documentation:** Yes :slightly_smiling_face: 