### PR TITLE
[chore] add prepare-release action/script

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,38 @@
+name: Automation - Prepare Release
+
+on:
+  workflow_dispatch:
+    # Determine the version number that will be assigned to the release. During the beta phase, we increment
+    # the minor version number and set the patch number to 0.
+    inputs:
+      candidate-beta:
+        required: true
+        description: Release candidate version (beta, like 0.70.0)
+
+      current-beta:
+        required: true
+        description: Current version (beta, like 0.69.1)
+jobs:
+  # Releasing opentelemetry-collector-contrib
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'open-telemetry/opentelemetry-collector'
+          path: opentelemetry-collector
+      - uses: actions/checkout@v3
+        with:
+          path: opentelemetry-collector-contrib
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Prepare release for contrib
+        working-directory: opentelemetry-collector-contrib
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector-contrib
+          CANDIDATE_BETA: ${{ inputs.candidate-beta }}
+          CURRENT_BETA: ${{ inputs.current-beta }}
+        run: ./.github/workflows/scripts/release-prepare-release.sh

--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -ex
+
+make chlog-update VERSION="${CANDIDATE_BETA}"
+git config user.name opentelemetrybot
+git config user.email 107717825+opentelemetrybot@users.noreply.github.com
+
+BRANCH="prepare-release-prs/${CANDIDATE_BETA}"
+git checkout -b "${BRANCH}"
+git add --all
+git commit -m "changelog update ${CANDIDATE_BETA}"
+
+sed -i.bak "s/${CURRENT_BETA}/${CANDIDATE_BETA}/g" versions.yaml
+find . -name "*.bak" -type f -delete
+git add versions.yaml
+git commit -m "update version.yaml ${CANDIDATE_BETA}"
+
+make multimod-prerelease
+git add .
+git commit -m "make multimod-prerelease changes ${CANDIDATE_BETA}" || (echo "no multimod changes to commit")
+
+make multimod-sync
+git add .
+git commit -m "make multimod-sync changes ${CANDIDATE_BETA}" || (echo "no multimod changes to commit")
+
+make otelcontribcol
+
+git push origin "${BRANCH}"
+
+gh pr create --title "[chore] Prepare release ${CANDIDATE_BETA}" --body "
+The following commands were run to prepare this release:
+- make chlog-update VERSION=${CANDIDATE_BETA}
+- sed -i.bak s/${CURRENT_BETA}/${CANDIDATE_BETA}/g versions.yaml
+- make multimod-prerelease
+- make multimod-sync
+"


### PR DESCRIPTION
This will reduce the amount of time spent releasing for maintainers.

See example PR created here: https://github.com/codeboten/opentelemetry-collector-contrib/pull/6167

Signed-off-by: Alex Boten <aboten@lightstep.com>
