### PR TITLE
[extension/jaegerremotesampling] remove misleading agent endpoint

### DIFF
--- a/.chloggen/remove_misleading_jaegerremotesampling_endpoint.yaml
+++ b/.chloggen/remove_misleading_jaegerremotesampling_endpoint.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/jaegerremotesampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove misleading http endpoint from jaegerremotesampling extension.
+
+# One or more tracking issues related to the change
+issues: [18058]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/remove_misleading_jaegerremotesampling_endpoint.yaml
+++ b/.chloggen/remove_misleading_jaegerremotesampling_endpoint.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: extension/jaegerremotesampling

--- a/extension/jaegerremotesampling/internal/http.go
+++ b/extension/jaegerremotesampling/internal/http.go
@@ -58,9 +58,6 @@ func NewHTTP(telemetry component.TelemetrySettings, settings confighttp.HTTPServ
 	}
 
 	srv.mux = http.NewServeMux()
-	// the legacy endpoint
-	srv.mux.Handle("/", http.HandlerFunc(srv.samplingStrategyHandler))
-
 	// the new endpoint -- not strictly necessary, as the previous one would match it
 	// already, but good to have it explicit here
 	srv.mux.Handle("/sampling", http.HandlerFunc(srv.samplingStrategyHandler))

--- a/extension/jaegerremotesampling/internal/http_test.go
+++ b/extension/jaegerremotesampling/internal/http_test.go
@@ -57,10 +57,6 @@ func TestEndpointsAreWired(t *testing.T) {
 		endpoint string
 	}{
 		{
-			desc:     "legacy",
-			endpoint: "/",
-		},
-		{
 			desc:     "new",
 			endpoint: "/sampling",
 		},


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Removed `/` http endpoint from remotesampling extension.

**Link to tracking Issue:** 
- Closes #18058
