### PR TITLE
[exporter/loki] Do not retry on 4xx status code (excluding 429)

### DIFF
--- a/.chloggen/loki-do-not-retry-on-permanent-error.yaml
+++ b/.chloggen/loki-do-not-retry-on-permanent-error.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/loki
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Do not retry on 4xx status code (excluding 429), as these are permanent errors"
+
+# One or more tracking issues related to the change
+issues: [18059]

--- a/exporter/lokiexporter/next_exporter.go
+++ b/exporter/lokiexporter/next_exporter.go
@@ -109,6 +109,14 @@ func (l *nextLokiExporter) sendPushRequest(ctx context.Context, tenant string, r
 			line = scanner.Text()
 		}
 		err = fmt.Errorf("HTTP %d %q: %s", resp.StatusCode, http.StatusText(resp.StatusCode), line)
+
+		// Errors with 4xx status code (excluding 429) should not be retried
+		if resp.StatusCode >= http.StatusBadRequest &&
+			resp.StatusCode < http.StatusInternalServerError &&
+			resp.StatusCode != http.StatusTooManyRequests {
+			return consumererror.NewPermanent(err)
+		}
+
 		return consumererror.NewLogs(err, ld)
 	}
 


### PR DESCRIPTION
**Description:**
Do not retry on 4xx status code (excluding 429), as these are permanent errors (i.e. retrying will _never_ change the state). Therefore causing an unnecessary increase in retries (and its queue).  

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18059

**Testing:** 
Tested locally with a full setup:

- Logs that do not receive a 4xx status code (excluding 429) continue to get pushed into Loki
- Logs that do get a 4xx status code (excluding 429) get dropped:
```
2023-01-28T14:20:18.105+0100	error	exporterhelper/queued_retry.go:394	Exporting failed. The error is not retryable. Dropping data.	{"kind": "exporter", "data_type": "logs", "name": "loki", "error": "Permanent error: HTTP 400 \"Bad Request\": entry for stream '{exporter=\"OTLP\"}' has timestamp too old: 2023-01-01T16:06:26Z, oldest acceptable timestamp is: 2023-01-21T13:20:18Z", "dropped_items": 19}
```

I was considering making tests for it, but actually seems somewhat challenging to do properly. Might require a new issue to improve test coverage in general.

**Documentation:** 
Change-log added