### PR TITLE
[pkg/stanza/operator/transformer/recombine] Add the max_log_size config to recombine operator (#17387)

### DIFF
--- a/.chloggen/feature_addBytesLimit.yaml
+++ b/.chloggen/feature_addBytesLimit.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza/operator/transformer/recombine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add a new "max_log_size" config parameter to limit the max bytes size of the combined field 
+
+# One or more tracking issues related to the change
+issues: [17387]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/docs/operators/recombine.md
+++ b/pkg/stanza/docs/operators/recombine.md
@@ -18,6 +18,7 @@ The `recombine` operator combines consecutive logs into single logs based on sim
 | `force_flush_period` | `5s`             | Flush timeout after which entries will be flushed aborting the wait for their sub parts to be merged with. |
 | `source_identifier`  | `$attributes["file.path"]` | The [field](../types/field.md) to separate one source of logs from others when combining them. |
 | `max_sources`        | 1000             | The maximum number of unique sources allowed concurrently to be tracked for combining separately. |
+| `max_log_size`       | 0                | The maximum bytes size of the combined field. Once the size exceeds the limit, all received entries of the source will be combined and flushed. "0" of max_log_size means no limit. |
 
 Exactly one of `is_first_entry` and `is_last_entry` must be specified.
 

--- a/pkg/stanza/operator/transformer/recombine/config_test.go
+++ b/pkg/stanza/operator/transformer/recombine/config_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
 )
 
@@ -82,6 +83,15 @@ func TestUnmarshal(t *testing.T) {
 				Expect: func() *Config {
 					cfg := NewConfig()
 					cfg.CombineWith = "line1\nLINE2"
+					return cfg
+				}(),
+			},
+			{
+				Name:      "custom_max_log_size",
+				ExpectErr: false,
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.MaxLogSize = helper.ByteSize(256000)
 					return cfg
 				}(),
 			},

--- a/pkg/stanza/operator/transformer/recombine/testdata/config.yaml
+++ b/pkg/stanza/operator/transformer/recombine/testdata/config.yaml
@@ -16,5 +16,8 @@ combine_with_tab:
 custom_id:
   type: recombine
   id: merge-split-lines
+custom_max_log_size:
+  type: recombine
+  max_log_size: 256kb
 default:
   type: recombine


### PR DESCRIPTION
"max_log_size" is added to the config of recombine operator. Once the total bytes size of the combined field exceeds the limit, all received entries of the source will be combined and flushed.

We've had discussion around this feature (see #17387). Here I choose the "soft limit" rather than truncating the log to get the fixed bytes size when total size exceeds the limit because I think soft limitation is enough for users on this occasion.
