### PR TITLE
exporter/datadogexporter: rename exportTraceMetrics to exportHostMetrics

### DIFF
--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -115,11 +115,11 @@ func (exp *traceExporter) consumeTraces(
 		}
 	}
 
-	exp.exportTraceMetrics(ctx, hosts, tags)
+	exp.exportHostMetrics(ctx, hosts, tags)
 	return nil
 }
 
-func (exp *traceExporter) exportTraceMetrics(ctx context.Context, hosts map[string]struct{}, tags map[string]struct{}) {
+func (exp *traceExporter) exportHostMetrics(ctx context.Context, hosts map[string]struct{}, tags map[string]struct{}) {
 	now := pcommon.NewTimestampFromTime(time.Now())
 	var err error
 	if isMetricExportV2Enabled() {


### PR DESCRIPTION
We don't want for it to be confused with APM Stats. This method is unrelated to APM Stats, which are on occasion referred to as "trace metrics".