### PR TITLE
http_forwarder: specify beta stability and add codeowner

### DIFF
--- a/.chloggen/httpforwarderowners.yaml
+++ b/.chloggen/httpforwarderowners.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: http_forwarder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set factory stability level to beta.
+
+# One or more tracking issues related to the change
+issues: [18100]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,7 +81,7 @@ extension/basicauthextension/                            @open-telemetry/collect
 extension/bearertokenauthextension/                      @open-telemetry/collector-contrib-approvers @jpkrohling @pavankrish123
 extension/headerssetterextension/                        @open-telemetry/collector-contrib-approvers @jpkrohling @kovrus
 extension/healthcheckextension/                          @open-telemetry/collector-contrib-approvers @jpkrohling
-extension/httpforwarder                                  @open-telemetry/collector-contrib-approvers @atoulme
+extension/httpforwarder                                  @open-telemetry/collector-contrib-approvers @atoulme @rmfitzpatrick
 extension/jaegerremotesampling/                          @open-telemetry/collector-contrib-approvers @jpkrohling @frzifus
 extension/oauth2clientauthextension/                     @open-telemetry/collector-contrib-approvers @pavankrish123 @jpkrohling
 extension/observer/                                      @open-telemetry/collector-contrib-approvers @dmitryax @rmfitzpatrick

--- a/extension/httpforwarder/factory.go
+++ b/extension/httpforwarder/factory.go
@@ -37,7 +37,7 @@ func NewFactory() extension.Factory {
 		typeStr,
 		createDefaultConfig,
 		createExtension,
-		component.StabilityLevelUnmaintained)
+		component.StabilityLevelBeta)
 }
 
 func createDefaultConfig() component.Config {


### PR DESCRIPTION
**Description:**
These changes update the advertised status to beta and add myself as a codeowner.

**Documentation:**
Readme was already updated in https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/d485b8f68dd800c9f52163de7852fc4be6a79ee1.