### PR TITLE
[exporter/datadog] Fix a nil dereferencing in http response

### DIFF
--- a/.chloggen/datadogexporter-fix-nil-dereference.yaml
+++ b/.chloggen/datadogexporter-fix-nil-dereference.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a nil dereferencing bug on http response
+
+# One or more tracking issues related to the change
+issues: [18099]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/internal/clientutil/error_converter.go
+++ b/exporter/datadogexporter/internal/clientutil/error_converter.go
@@ -22,7 +22,7 @@ import (
 
 // WrapError wraps an error to a permanent consumer error that won't be retried if the http response code is non-retriable.
 func WrapError(err error, resp *http.Response) error {
-	if err == nil || !isNonRetriable(resp) {
+	if err == nil || resp == nil || !isNonRetriable(resp) {
 		return err
 	}
 	return consumererror.NewPermanent(err)

--- a/exporter/datadogexporter/internal/clientutil/error_converter_test.go
+++ b/exporter/datadogexporter/internal/clientutil/error_converter_test.go
@@ -32,4 +32,5 @@ func TestWrapError(t *testing.T) {
 	assert.False(t, consumererror.IsPermanent(WrapError(err, &respRetriable)))
 	assert.True(t, consumererror.IsPermanent(WrapError(err, &respNonRetriable)))
 	assert.False(t, consumererror.IsPermanent(WrapError(nil, &respNonRetriable)))
+	assert.False(t, consumererror.IsPermanent(WrapError(err, nil)))
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fix a nil dereferencing on `*http.Response`

**Link to tracking Issue:** <Issue number if applicable>
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18099