### PR TITLE
[exporter/azuremonitor] map enduser.id to UserID tag

### DIFF
--- a/.chloggen/userid.yaml
+++ b/.chloggen/userid.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Map enduser.id to Azure UserID tag
+
+# One or more tracking issues related to the change
+issues: [18103]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -85,6 +85,10 @@ func spanToEnvelopes(
 
 	data := contracts.NewData()
 
+	if userID, exists := attributeMap.Get(conventions.AttributeEnduserID); exists {
+		envelope.Tags[contracts.UserId] = userID.Str()
+	}
+
 	if spanKind == ptrace.SpanKindServer || spanKind == ptrace.SpanKindConsumer {
 		requestData := spanToRequestData(span, incomingSpanType)
 		dataProperties = requestData.Properties

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -308,7 +308,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet3(t *testing.T) {
 }
 
 // Tests proper assignment for a HTTP client span
-// http.scheme, net.peer.ip, net.peer.port, http.target
+// http.scheme, net.peer.ip, net.peer.port, http.target, enduser.id
 func TestHTTPClientSpanToRemoteDependencyAttributeSet4(t *testing.T) {
 	span := getDefaultHTTPClientSpan()
 	spanAttributes := span.Attributes()
@@ -318,6 +318,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet4(t *testing.T) {
 	spanAttributes.PutStr(conventions.AttributeNetPeerIP, "127.0.0.1")
 	spanAttributes.PutInt(conventions.AttributeNetPeerPort, 81)
 	spanAttributes.PutStr(conventions.AttributeHTTPTarget, "/bar?biz=baz")
+	spanAttributes.PutStr(conventions.AttributeEnduserID, "12345")
 
 	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
 	envelope := envelopes[0]
@@ -325,6 +326,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet4(t *testing.T) {
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultHTTPRemoteDependencyDataValidations(t, span, data)
 	assert.Equal(t, "https://127.0.0.1:81/bar?biz=baz", data.Data)
+	assert.Equal(t, "12345", envelope.Tags[contracts.UserId])
 }
 
 // Tests proper assignment for an RPC server span
@@ -472,18 +474,20 @@ func TestMessagingProducerSpanToRequestData(t *testing.T) {
 	assert.Equal(t, "foo:81", data.Target)
 }
 
-// Tests proper assignment for an internal span
+// Tests proper assignment for an internal span and enduser.id
 func TestUnknownInternalSpanToRemoteDependencyData(t *testing.T) {
 	span := getDefaultInternalSpan()
 	spanAttributes := span.Attributes()
 
 	spanAttributes.PutStr("foo", "bar")
+	spanAttributes.PutStr(conventions.AttributeEnduserID, "4567")
 
 	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultInternalRemoteDependencyDataValidations(t, span, data)
+	assert.Equal(t, "4567", envelope.Tags[contracts.UserId])
 }
 
 // Tests that spans with unspecified kind are treated similar to internal spans


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The official exporters made by Microsoft map enduser.id to azure's anonymous user id tag. The collector exporter should do the same thing.

[Java exporter](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/SpanDataMapper.java#L800-L805)
[Python exporter](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py#L127-L128)

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
I have added the optional attribute to some tests to make sure everything works.

**Documentation:** <Describe the documentation added.>
