### PR TITLE
[processor/spanmetricsprocessor] Allow set metrics namespace

### DIFF
--- a/.chloggen/spanmetricsprocessor_support_set_namespace.yaml
+++ b/.chloggen/spanmetricsprocessor_support_set_namespace.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support set metrics namespace
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+

--- a/.chloggen/spanmetricsprocessor_support_set_namespace.yaml
+++ b/.chloggen/spanmetricsprocessor_support_set_namespace.yaml
@@ -8,7 +8,7 @@ component: spanmetricsprocessor
 note: Support set metrics namespace
 
 # One or more tracking issues related to the change
-issues: []
+issues: [18199]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/processor/spanmetricsprocessor/config.go
+++ b/processor/spanmetricsprocessor/config.go
@@ -73,7 +73,7 @@ type Config struct {
 	// MetricsEmitInterval is the time period between when metrics are flushed or emitted to the configured MetricsExporter.
 	MetricsFlushInterval time.Duration `mapstructure:"metrics_flush_interval"`
 
-	// Namespace
+	// Namespace defines the namespace for the metrics exported by the spanmetricsprocessor.
 	Namespace string
 }
 

--- a/processor/spanmetricsprocessor/config.go
+++ b/processor/spanmetricsprocessor/config.go
@@ -72,6 +72,9 @@ type Config struct {
 
 	// MetricsEmitInterval is the time period between when metrics are flushed or emitted to the configured MetricsExporter.
 	MetricsFlushInterval time.Duration `mapstructure:"metrics_flush_interval"`
+
+	// Namespace
+	Namespace string
 }
 
 // GetAggregationTemporality converts the string value given in the config into a AggregationTemporality.

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -47,8 +47,8 @@ const (
 
 	defaultDimensionsCacheSize = 1000
 
-	metricLatency = "latency"
-	metricCalls   = "calls"
+	metricLatency    = "latency"
+	metricCallsTotal = "calls_total"
 )
 
 var defaultLatencyHistogramBucketsMs = []float64{
@@ -362,7 +362,7 @@ func (p *processorImp) collectLatencyMetrics(ilm pmetric.ScopeMetrics) {
 // into the given instrumentation library metrics.
 func (p *processorImp) collectCallMetrics(ilm pmetric.ScopeMetrics) {
 	mCalls := ilm.Metrics().AppendEmpty()
-	mCalls.SetName(buildMetricName(p.config.Namespace, metricCalls))
+	mCalls.SetName(buildMetricName(p.config.Namespace, metricLatency))
 	mCalls.SetEmptySum().SetIsMonotonic(true)
 	mCalls.Sum().SetAggregationTemporality(p.config.GetAggregationTemporality())
 	dps := mCalls.Sum().DataPoints()

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -47,8 +47,8 @@ const (
 
 	defaultDimensionsCacheSize = 1000
 
-	metricLatency    = "latency"
-	metricCallsTotal = "calls_total"
+	metricLatency = "latency"
+	metricCalls   = "calls"
 )
 
 var defaultLatencyHistogramBucketsMs = []float64{
@@ -325,7 +325,7 @@ func (p *processorImp) buildMetrics() pmetric.Metrics {
 // Otherwise, only the metric name will be returned.
 func buildMetricName(namespace, metricName string) string {
 	if namespace != "" {
-		return namespace + "_" + metricName
+		return namespace + "." + metricName
 	}
 	return metricName
 }
@@ -362,7 +362,7 @@ func (p *processorImp) collectLatencyMetrics(ilm pmetric.ScopeMetrics) {
 // into the given instrumentation library metrics.
 func (p *processorImp) collectCallMetrics(ilm pmetric.ScopeMetrics) {
 	mCalls := ilm.Metrics().AppendEmpty()
-	mCalls.SetName(buildMetricName(p.config.Namespace, metricCallsTotal))
+	mCalls.SetName(buildMetricName(p.config.Namespace, metricCalls))
 	mCalls.SetEmptySum().SetIsMonotonic(true)
 	mCalls.Sum().SetAggregationTemporality(p.config.GetAggregationTemporality())
 	dps := mCalls.Sum().DataPoints()

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -1101,3 +1101,22 @@ func TestConsumeTracesEvictedCacheKey(t *testing.T) {
 	wg.Wait()
 	assert.Empty(t, wantDataPointCounts)
 }
+
+func TestBuildMetricName(t *testing.T) {
+	tests := []struct {
+		namespace  string
+		metricName string
+		expected   string
+	}{
+		{"", "metric", "metric"},
+		{"ns", "metric", "ns_metric"},
+		{"longer_namespace", "metric", "longer_namespace_metric"},
+	}
+
+	for _, test := range tests {
+		actual := buildMetricName(test.namespace, test.metricName)
+		if actual != test.expected {
+			t.Errorf("buildMetricName(%q, %q) = %q, expected %q", test.namespace, test.metricName, actual, test.expected)
+		}
+	}
+}

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -1115,8 +1115,6 @@ func TestBuildMetricName(t *testing.T) {
 
 	for _, test := range tests {
 		actual := buildMetricName(test.namespace, test.metricName)
-		if actual != test.expected {
-			t.Errorf("buildMetricName(%q, %q) = %q, expected %q", test.namespace, test.metricName, actual, test.expected)
-		}
+		assert.Equal(t, test.expected, actual)
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The currently generated metric name differs from the description in the Tempo APM table document, such as `calls_total `vs `traces_spanmetrics_calls_total`. Why don't we simply open up the setting of the namespace on the processor side, so that I can easily integrate with the Tempo APM table?
so we can just do this:
```yaml
processors:
  batch:
  spanmetrics:
    metrics_exporter: otlp/spanmetrics
    namespace: traces_spanmetrics
    latency_histogram_buckets: [100us, 1ms, 2ms, 6ms, 10ms, 100ms, 250ms]
    dimensions:
      - name: http.method
        default: GET
      - name: http.status_code
    dimensions_cache_size: 1000
    aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"  
```
**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>