### PR TITLE
[receiver/kafka] Allow Azure Resource Logs format to be used by Kafka Receiver

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -1,0 +1,15 @@
+dist:
+  name: otelcol-dev
+  description: Basic OTel Collector distribution for Developers
+  output_path: ./otelcol-dev
+  otelcol_version: 0.70.0
+
+exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.70.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter main
+
+processors:
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.70.0
+
+receivers:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver main

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter v0.70.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.70.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter v0.70.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.70.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/skywalkingexporter v0.70.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.70.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter v0.70.0
@@ -939,7 +938,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluen
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver => ./receiver/kafkametricsreceiver
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver => ./receiver/kafkareceiver
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver => github.com/cparkins/opentelemetry-collector-contrib/receiver/kafkareceiver 3d4d204224
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver => ./receiver/kubeletstatsreceiver
 

--- a/receiver/kafkareceiver/azureresourcelogs_unmarshaler.go
+++ b/receiver/kafkareceiver/azureresourcelogs_unmarshaler.go
@@ -1,0 +1,200 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
+
+import (
+	"bytes"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/relvacode/iso8601"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	conventions "go.opentelemetry.io/collector/semconv/v1.13.0"
+)
+
+// Constants for OpenTelemetry Specs
+const receiverScopeName = "otelcol/" + typeStr
+
+// Constants for Azure Log Records
+const azureCategory = "azure.category"
+const azureCorrelationID = "azure.correlation.id"
+const azureDuration = "azure.duration"
+const azureIdentity = "azure.identity"
+const azureOperationName = "azure.operation.name"
+const azureOperationVersion = "azure.operation.version"
+const azureProperties = "azure.properties"
+const azureResourceID = "azure.resource.id"
+const azureResultType = "azure.result.type"
+const azureResultSignature = "azure.result.signature"
+const azureResultDescription = "azure.result.description"
+const azureTenantID = "azure.tenant.id"
+
+type azureResourceLogsUnmarshaler struct{}
+
+// azureRecords represents an array of Azure log records
+// as exported via an Azure Event Hub
+type azureRecords struct {
+	Records []azureLogRecord `json:"records"`
+}
+
+// azureLogRecord represents a single Azure log following
+// the common schema:
+// https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/resource-logs-schema
+type azureLogRecord struct {
+	Time              string       `json:"time"`
+	ResourceID        string       `json:"resourceId"`
+	TenantID          *string      `json:"tenantId"`
+	OperationName     string       `json:"operationName"`
+	OperationVersion  *string      `json:"operationVersion"`
+	Category          string       `json:"category"`
+	ResultType        *string      `json:"resultType"`
+	ResultSignature   *string      `json:"resultSignature"`
+	ResultDescription *string      `json:"resultDescription"`
+	DurationMs        *string      `json:"durationMs"`
+	CallerIPAddress   *string      `json:"callerIpAddress"`
+	CorrelationID     *string      `json:"correlationId"`
+	Identity          *interface{} `json:"identity"`
+	Level             *string      `json:"Level"`
+	Location          *string      `json:"location"`
+	Properties        *interface{} `json:"properties"`
+}
+
+func newRawLogsUnmarshaler() LogsUnmarshaler {
+	return rawLogsUnmarshaler{}
+}
+
+func newAzureResourceLogsUnmarshaler() LogsUnmarshaler {
+	return azureResourceLogsUnmarshaler{}
+}
+
+func (r azureResourceLogsUnmarshaler) Unmarshal(buf []byte) (plog.Logs, error) {
+	l := plog.NewLogs()
+
+	var azureLogs azureRecords
+	decoder := jsoniter.NewDecoder(bytes.NewReader(buf))
+	if err := decoder.Decode(&azureLogs); err != nil {
+		return l, err
+	}
+
+	resourceLogs := l.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.Scope().SetName(receiverScopeName)
+	scopeLogs.Scope().SetVersion("0.70.0")
+	logRecords := scopeLogs.LogRecords()
+
+	resourceID := ""
+	for _, azureLog := range azureLogs.Records {
+		resourceID = azureLog.ResourceID
+		nanos, err := asTimestamp(azureLog.Time)
+		if err != nil {
+			continue
+		}
+
+		lr := logRecords.AppendEmpty()
+
+		lr.SetTimestamp(nanos)
+
+		if azureLog.Level != nil {
+			severity := asSeverity(*azureLog.Level)
+			lr.SetSeverityNumber(severity)
+			lr.SetSeverityText(*azureLog.Level)
+		}
+
+		if err := lr.Attributes().FromRaw(extractRawAttributes(azureLog)); err != nil {
+			return l, err
+		}
+
+		// The Azure resource ID will be pulled into a common resource attribute.
+		// This implementation assumes that a single log message from Azure will
+		// contain ONLY logs from a single resource.
+		if resourceID != "" {
+			resourceLogs.Resource().Attributes().PutStr(azureResourceID, resourceID)
+		}
+	}
+
+	return l, nil
+}
+
+func (r azureResourceLogsUnmarshaler) Encoding() string {
+	return "azureresourcelogs"
+}
+
+// asTimestamp will parse an ISO8601 string into an OpenTelemetry
+// nanosecond timestamp. If the string cannot be parsed, it will
+// return zero and the error.
+func asTimestamp(s string) (pcommon.Timestamp, error) {
+	t, err := iso8601.ParseString(s)
+	if err != nil {
+		return 0, err
+	}
+	return pcommon.Timestamp(t.UnixNano()), nil
+}
+
+// asSeverity converts the Azure log level to equivalent
+// OpenTelemetry severity numbers. If the log level is not
+// valid, then the 'Unspecified' value is returned.
+func asSeverity(s string) plog.SeverityNumber {
+	switch s {
+	case "Informational":
+		return plog.SeverityNumberInfo
+	case "Warning":
+		return plog.SeverityNumberWarn
+	case "Error":
+		return plog.SeverityNumberError
+	case "Critical":
+		return plog.SeverityNumberFatal
+	default:
+		return plog.SeverityNumberUnspecified
+	}
+}
+
+func extractRawAttributes(log azureLogRecord) map[string]interface{} {
+	var attrs = map[string]interface{}{}
+
+	attrs[azureCategory] = log.Category
+	setIf(attrs, azureCorrelationID, log.CorrelationID)
+	if log.DurationMs != nil {
+		duration, err := strconv.ParseInt(*log.DurationMs, 10, 64)
+		if err == nil {
+			attrs[azureDuration] = duration
+		}
+	}
+	if log.Identity != nil {
+		attrs[azureIdentity] = *log.Identity
+	}
+	attrs[azureOperationName] = log.OperationName
+	setIf(attrs, azureOperationVersion, log.OperationVersion)
+	if log.Properties != nil {
+		attrs[azureProperties] = *log.Properties
+	}
+	setIf(attrs, azureResultDescription, log.ResultDescription)
+	setIf(attrs, azureResultSignature, log.ResultSignature)
+	setIf(attrs, azureResultType, log.ResultType)
+	setIf(attrs, azureTenantID, log.TenantID)
+
+	setIf(attrs, conventions.AttributeCloudRegion, log.Location)
+	attrs[conventions.AttributeCloudProvider] = conventions.AttributeCloudProviderAzure
+
+	setIf(attrs, conventions.AttributeNetSockPeerAddr, log.CallerIPAddress)
+	return attrs
+}
+
+func setIf(attrs map[string]interface{}, key string, value *string) {
+	if value != nil && *value != "" {
+		attrs[key] = *value
+	}
+}

--- a/receiver/kafkareceiver/azureresourcelogs_unmarshaler.go
+++ b/receiver/kafkareceiver/azureresourcelogs_unmarshaler.go
@@ -73,10 +73,6 @@ type azureLogRecord struct {
 	Properties        *interface{} `json:"properties"`
 }
 
-func newRawLogsUnmarshaler() LogsUnmarshaler {
-	return rawLogsUnmarshaler{}
-}
-
 func newAzureResourceLogsUnmarshaler() LogsUnmarshaler {
 	return azureResourceLogsUnmarshaler{}
 }

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
-
+	
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 )
 

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
+module github.com/cparkins/opentelemetry-collector-contrib/receiver/kafkareceiver
 
 go 1.18
 
@@ -7,11 +7,13 @@ require (
 	github.com/apache/thrift v0.17.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/jaegertracing/jaeger v1.41.0
+	github.com/json-iterator/go v1.1.12
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.70.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.70.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.70.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.70.0
 	github.com/openzipkin/zipkin-go v0.4.1
+	github.com/relvacode/iso8601 v1.3.0
 	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector v0.70.0
@@ -41,7 +43,6 @@ require (
 	github.com/jcmturner/gokrb5/v8 v8.4.3 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
@@ -73,6 +74,8 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver => ../../receiver/kafkareceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter => ../../exporter/kafkaexporter
 

--- a/receiver/kafkareceiver/go.sum
+++ b/receiver/kafkareceiver/go.sum
@@ -292,6 +292,8 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/statsd_exporter v0.22.7 h1:7Pji/i2GuhK6Lu7DHrtTkFmNBCudCPT1pX2CziuyQR0=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/relvacode/iso8601 v1.3.0 h1:HguUjsGpIMh/zsTczGN3DVJFxTU/GX+MMmzcKoMO7ko=
+github.com/relvacode/iso8601 v1.3.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=

--- a/receiver/kafkareceiver/unmarshaler.go
+++ b/receiver/kafkareceiver/unmarshaler.go
@@ -78,8 +78,10 @@ func defaultMetricsUnmarshalers() map[string]MetricsUnmarshaler {
 func defaultLogsUnmarshalers() map[string]LogsUnmarshaler {
 	otlpPb := newPdataLogsUnmarshaler(&plog.ProtoUnmarshaler{}, defaultEncoding)
 	raw := newRawLogsUnmarshaler()
+	azureresourcelogs := newAzureResourceLogsUnmarshaler()
 	return map[string]LogsUnmarshaler{
 		otlpPb.Encoding(): otlpPb,
 		raw.Encoding():    raw,
+		azureresourcelogs.Encoding(): azureresourcelogs,
 	}
 }

--- a/receiver/oracledbreceiver/config_test.go
+++ b/receiver/oracledbreceiver/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package oracledbreceiver // import "github.com/open-telemetry/open-telemetry-collector-contrib/receiver/oracledbreceiver"
+package oracledbreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver"
 
 import (
 	"path/filepath"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Allow the Kafka Receiver to accept data from Azure in Azure Resource Log format similar to the Event Hub Receiver.

**Link to tracking Issue:** <Issue number if applicable>
#18210

**Testing:** <Describe what testing was performed and which tests were added.>
Need to add tests.

**Documentation:** <Describe the documentation added.>
Need to add Documentation for Kafka Receiver.