### PR TITLE
address issues with "flaky sftp test"

### DIFF
--- a/receiver/sshcheckreceiver/internal/configssh/configssh.go
+++ b/receiver/sshcheckreceiver/internal/configssh/configssh.go
@@ -65,7 +65,7 @@ func (c *Client) Dial(endpoint string) (err error) {
 }
 
 func (c *Client) SFTPClient() (*SFTPClient, error) {
-	if c.Client.Conn == nil {
+	if c.Client == nil || c.Client.Conn == nil {
 		return nil, fmt.Errorf("SSH client not initialized")
 	}
 	client, err := sftp.NewClient(c.Client)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
(1) Remove calls to `t.Parallel()` from the module with the container tests. 
(2) Check for an uninitialized memory access that was reported on test failure and return an error instead of panic.

A container based test was failing intermittently in CI. The stack trace led to a line calling a method on a nil. I added a check for this case to return an error instead of panic in this instance. But handling failure differently doesn't change the situation, which was failures occurring in unexpected places.

I could still see intermittent failures in tests until I removed calls to `t.Parallel()`. While the project recommends using `t.Parallel()` for new development, I believe this is the better approach in this limited case. First of all, there's some subtlety to the behavior of the test runner when `t.Parallel()` is called within a `t.Run` call. I previously hadn't handled it properly in tests for this receiver. Secondarily, I wasn't able to resolve the intermittent failure with changes to the approach using `t.Parallel`. I believe the use of `testcontainers` here complicates the testing situation and I'll need to explore this systematically.

**Link to tracking Issue:** <Issue number if applicable>

Resolves #18193 

**Testing:** <Describe what testing was performed and which tests were added.>

The scraper now includes a test to confirm we return an error and don't panic.

**Documentation:** <Describe the documentation added.>

Did not make documentation changes as the changes in behavior are test specific and align more closely with what would be expected than the previous state did.