### PR TITLE
[k8sclusterreceiver] Change internal metric store to use pdata

### DIFF
--- a/.chloggen/k8sclusterreceiverpdatastore.yaml
+++ b/.chloggen/k8sclusterreceiverpdatastore.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sclusterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change internal metric store to use pdata
+
+# One or more tracking issues related to the change
+issues: [18214]

--- a/receiver/k8sclusterreceiver/go.mod
+++ b/receiver/k8sclusterreceiver/go.mod
@@ -20,7 +20,6 @@ require (
 	go.opentelemetry.io/collector/semconv v0.70.0
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.24.0
-	google.golang.org/protobuf v1.28.1
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
@@ -87,6 +86,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 // indirect
 	google.golang.org/grpc v1.52.3 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/receiver/k8sclusterreceiver/internal/collection/clusteresourcequotas.go
+++ b/receiver/k8sclusterreceiver/internal/collection/clusteresourcequotas.go
@@ -17,6 +17,7 @@ package collection // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"strings"
 
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -72,7 +73,7 @@ var appliedClusterResourceQuotaUsedMetric = &metricspb.MetricDescriptor{
 	},
 }
 
-func getMetricsForClusterResourceQuota(rq *quotav1.ClusterResourceQuota) []*resourceMetrics {
+func getMetricsForClusterResourceQuota(rq *quotav1.ClusterResourceQuota) []*agentmetricspb.ExportMetricsServiceRequest {
 	var metrics []*metricspb.Metric
 
 	metrics = appendClusterQuotaMetrics(metrics, clusterResourceQuotaLimitMetric, rq.Status.Total.Hard, "")
@@ -81,10 +82,10 @@ func getMetricsForClusterResourceQuota(rq *quotav1.ClusterResourceQuota) []*reso
 		metrics = appendClusterQuotaMetrics(metrics, appliedClusterResourceQuotaLimitMetric, ns.Status.Hard, ns.Namespace)
 		metrics = appendClusterQuotaMetrics(metrics, appliedClusterResourceQuotaUsedMetric, ns.Status.Used, ns.Namespace)
 	}
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForClusterResourceQuota(rq),
-			metrics:  metrics,
+			Resource: getResourceForClusterResourceQuota(rq),
+			Metrics:  metrics,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/collection/clusterresourcequotas_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/clusterresourcequotas_test.go
@@ -35,9 +35,9 @@ func TestClusterRequestQuotaMetrics(t *testing.T) {
 
 	require.Equal(t, 1, len(actualResourceMetrics))
 
-	metrics := actualResourceMetrics[0].metrics
+	metrics := actualResourceMetrics[0].Metrics
 	require.Equal(t, 6, len(metrics))
-	testutils.AssertResource(t, actualResourceMetrics[0].resource, k8sType,
+	testutils.AssertResource(t, actualResourceMetrics[0].Resource, k8sType,
 		map[string]string{
 			"openshift.clusterquota.uid":  "test-clusterquota-1-uid",
 			"openshift.clusterquota.name": "test-clusterquota-1",

--- a/receiver/k8sclusterreceiver/internal/collection/cronjobs.go
+++ b/receiver/k8sclusterreceiver/internal/collection/cronjobs.go
@@ -15,6 +15,7 @@
 package collection // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection"
 
 import (
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -40,7 +41,7 @@ var activeJobs = &metricspb.MetricDescriptor{
 
 // TODO: All the CronJob related functions below can be de-duplicated using generics from go 1.18
 
-func getMetricsForCronJob(cj *batchv1.CronJob) []*resourceMetrics {
+func getMetricsForCronJob(cj *batchv1.CronJob) []*agentmetricspb.ExportMetricsServiceRequest {
 	metrics := []*metricspb.Metric{
 		{
 			MetricDescriptor: activeJobs,
@@ -50,15 +51,15 @@ func getMetricsForCronJob(cj *batchv1.CronJob) []*resourceMetrics {
 		},
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForCronJob(cj),
-			metrics:  metrics,
+			Resource: getResourceForCronJob(cj),
+			Metrics:  metrics,
 		},
 	}
 }
 
-func getMetricsForCronJobBeta(cj *batchv1beta1.CronJob) []*resourceMetrics {
+func getMetricsForCronJobBeta(cj *batchv1beta1.CronJob) []*agentmetricspb.ExportMetricsServiceRequest {
 	metrics := []*metricspb.Metric{
 		{
 			MetricDescriptor: activeJobs,
@@ -68,10 +69,10 @@ func getMetricsForCronJobBeta(cj *batchv1beta1.CronJob) []*resourceMetrics {
 		},
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForCronJobBeta(cj),
-			metrics:  metrics,
+			Resource: getResourceForCronJobBeta(cj),
+			Metrics:  metrics,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/collection/cronjobs_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/cronjobs_test.go
@@ -34,8 +34,8 @@ func TestCronJobMetrics(t *testing.T) {
 
 	require.Equal(t, 1, len(actualResourceMetrics))
 
-	require.Equal(t, 1, len(actualResourceMetrics[0].metrics))
-	testutils.AssertResource(t, actualResourceMetrics[0].resource, k8sType,
+	require.Equal(t, 1, len(actualResourceMetrics[0].Metrics))
+	testutils.AssertResource(t, actualResourceMetrics[0].Resource, k8sType,
 		map[string]string{
 			"k8s.cronjob.uid":    "test-cronjob-1-uid",
 			"k8s.cronjob.name":   "test-cronjob-1",
@@ -43,7 +43,7 @@ func TestCronJobMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[0], "k8s.cronjob.active_jobs",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[0], "k8s.cronjob.active_jobs",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 }
 

--- a/receiver/k8sclusterreceiver/internal/collection/daemonsets.go
+++ b/receiver/k8sclusterreceiver/internal/collection/daemonsets.go
@@ -15,6 +15,7 @@
 package collection // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection"
 
 import (
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -52,7 +53,7 @@ var daemonSetReadyMetric = &metricspb.MetricDescriptor{
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
-func getMetricsForDaemonSet(ds *appsv1.DaemonSet) []*resourceMetrics {
+func getMetricsForDaemonSet(ds *appsv1.DaemonSet) []*agentmetricspb.ExportMetricsServiceRequest {
 	metrics := []*metricspb.Metric{
 		{
 			MetricDescriptor: daemonSetCurrentScheduledMetric,
@@ -80,10 +81,10 @@ func getMetricsForDaemonSet(ds *appsv1.DaemonSet) []*resourceMetrics {
 		},
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForDaemonSet(ds),
-			metrics:  metrics,
+			Resource: getResourceForDaemonSet(ds),
+			Metrics:  metrics,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/collection/daemonsets_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/daemonsets_test.go
@@ -32,10 +32,10 @@ func TestDaemonsetMetrics(t *testing.T) {
 	actualResourceMetrics := getMetricsForDaemonSet(ds)
 
 	require.Equal(t, 1, len(actualResourceMetrics))
-	require.Equal(t, 4, len(actualResourceMetrics[0].metrics))
+	require.Equal(t, 4, len(actualResourceMetrics[0].Metrics))
 
 	rm := actualResourceMetrics[0]
-	testutils.AssertResource(t, rm.resource, k8sType,
+	testutils.AssertResource(t, rm.Resource, k8sType,
 		map[string]string{
 			"k8s.daemonset.uid":  "test-daemonset-1-uid",
 			"k8s.daemonset.name": "test-daemonset-1",
@@ -43,16 +43,16 @@ func TestDaemonsetMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsInt(t, rm.metrics[0], "k8s.daemonset.current_scheduled_nodes",
+	testutils.AssertMetricsInt(t, rm.Metrics[0], "k8s.daemonset.current_scheduled_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 
-	testutils.AssertMetricsInt(t, rm.metrics[1], "k8s.daemonset.desired_scheduled_nodes",
+	testutils.AssertMetricsInt(t, rm.Metrics[1], "k8s.daemonset.desired_scheduled_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 5)
 
-	testutils.AssertMetricsInt(t, rm.metrics[2], "k8s.daemonset.misscheduled_nodes",
+	testutils.AssertMetricsInt(t, rm.Metrics[2], "k8s.daemonset.misscheduled_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1)
 
-	testutils.AssertMetricsInt(t, rm.metrics[3], "k8s.daemonset.ready_nodes",
+	testutils.AssertMetricsInt(t, rm.Metrics[3], "k8s.daemonset.ready_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 }
 

--- a/receiver/k8sclusterreceiver/internal/collection/deployments.go
+++ b/receiver/k8sclusterreceiver/internal/collection/deployments.go
@@ -15,6 +15,7 @@
 package collection // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection"
 
 import (
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,15 +23,15 @@ import (
 	metadata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata"
 )
 
-func getMetricsForDeployment(dep *appsv1.Deployment) []*resourceMetrics {
+func getMetricsForDeployment(dep *appsv1.Deployment) []*agentmetricspb.ExportMetricsServiceRequest {
 	if dep.Spec.Replicas == nil {
 		return nil
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForDeployment(dep),
-			metrics: getReplicaMetrics(
+			Resource: getResourceForDeployment(dep),
+			Metrics: getReplicaMetrics(
 				"deployment",
 				*dep.Spec.Replicas,
 				dep.Status.AvailableReplicas,

--- a/receiver/k8sclusterreceiver/internal/collection/deployments_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/deployments_test.go
@@ -32,10 +32,10 @@ func TestDeploymentMetrics(t *testing.T) {
 	actualResourceMetrics := getMetricsForDeployment(dep)
 
 	require.Equal(t, 1, len(actualResourceMetrics))
-	require.Equal(t, 2, len(actualResourceMetrics[0].metrics))
+	require.Equal(t, 2, len(actualResourceMetrics[0].Metrics))
 
 	rm := actualResourceMetrics[0]
-	testutils.AssertResource(t, rm.resource, k8sType,
+	testutils.AssertResource(t, rm.Resource, k8sType,
 		map[string]string{
 			"k8s.deployment.uid":  "test-deployment-1-uid",
 			"k8s.deployment.name": "test-deployment-1",
@@ -43,10 +43,10 @@ func TestDeploymentMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsInt(t, rm.metrics[0], "k8s.deployment.desired",
+	testutils.AssertMetricsInt(t, rm.Metrics[0], "k8s.deployment.desired",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetricsInt(t, rm.metrics[1], "k8s.deployment.available",
+	testutils.AssertMetricsInt(t, rm.Metrics[1], "k8s.deployment.available",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 }
 

--- a/receiver/k8sclusterreceiver/internal/collection/hpa.go
+++ b/receiver/k8sclusterreceiver/internal/collection/hpa.go
@@ -15,6 +15,7 @@
 package collection // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection"
 
 import (
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -52,7 +53,7 @@ var hpaDesiredReplicasMetric = &metricspb.MetricDescriptor{
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
-func getMetricsForHPA(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) []*resourceMetrics {
+func getMetricsForHPA(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) []*agentmetricspb.ExportMetricsServiceRequest {
 	metrics := []*metricspb.Metric{
 		{
 			MetricDescriptor: hpaMaxReplicasMetric,
@@ -80,10 +81,10 @@ func getMetricsForHPA(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) []*resour
 		},
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForHPA(hpa),
-			metrics:  metrics,
+			Resource: getResourceForHPA(hpa),
+			Metrics:  metrics,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/collection/hpa_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/hpa_test.go
@@ -32,10 +32,10 @@ func TestHPAMetrics(t *testing.T) {
 	actualResourceMetrics := getMetricsForHPA(hpa)
 
 	require.Equal(t, 1, len(actualResourceMetrics))
-	require.Equal(t, 4, len(actualResourceMetrics[0].metrics))
+	require.Equal(t, 4, len(actualResourceMetrics[0].Metrics))
 
 	rm := actualResourceMetrics[0]
-	testutils.AssertResource(t, rm.resource, k8sType,
+	testutils.AssertResource(t, rm.Resource, k8sType,
 		map[string]string{
 			"k8s.hpa.uid":        "test-hpa-1-uid",
 			"k8s.hpa.name":       "test-hpa-1",
@@ -43,16 +43,16 @@ func TestHPAMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsInt(t, rm.metrics[0], "k8s.hpa.max_replicas",
+	testutils.AssertMetricsInt(t, rm.Metrics[0], "k8s.hpa.max_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetricsInt(t, rm.metrics[1], "k8s.hpa.min_replicas",
+	testutils.AssertMetricsInt(t, rm.Metrics[1], "k8s.hpa.min_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
-	testutils.AssertMetricsInt(t, rm.metrics[2], "k8s.hpa.current_replicas",
+	testutils.AssertMetricsInt(t, rm.Metrics[2], "k8s.hpa.current_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 5)
 
-	testutils.AssertMetricsInt(t, rm.metrics[3], "k8s.hpa.desired_replicas",
+	testutils.AssertMetricsInt(t, rm.Metrics[3], "k8s.hpa.desired_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 7)
 }
 

--- a/receiver/k8sclusterreceiver/internal/collection/jobs.go
+++ b/receiver/k8sclusterreceiver/internal/collection/jobs.go
@@ -15,6 +15,7 @@
 package collection // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection"
 
 import (
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -59,7 +60,7 @@ var podsSuccessfulMetric = &metricspb.MetricDescriptor{
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
-func getMetricsForJob(j *batchv1.Job) []*resourceMetrics {
+func getMetricsForJob(j *batchv1.Job) []*agentmetricspb.ExportMetricsServiceRequest {
 	metrics := make([]*metricspb.Metric, 0, 5)
 	metrics = append(metrics, []*metricspb.Metric{
 		{
@@ -98,10 +99,10 @@ func getMetricsForJob(j *batchv1.Job) []*resourceMetrics {
 			}})
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForJob(j),
-			metrics:  metrics,
+			Resource: getResourceForJob(j),
+			Metrics:  metrics,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/collection/jobs_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/jobs_test.go
@@ -33,8 +33,8 @@ func TestJobMetrics(t *testing.T) {
 
 	require.Equal(t, 1, len(actualResourceMetrics))
 
-	require.Equal(t, 5, len(actualResourceMetrics[0].metrics))
-	testutils.AssertResource(t, actualResourceMetrics[0].resource, k8sType,
+	require.Equal(t, 5, len(actualResourceMetrics[0].Metrics))
+	testutils.AssertResource(t, actualResourceMetrics[0].Resource, k8sType,
 		map[string]string{
 			"k8s.job.uid":        "test-job-1-uid",
 			"k8s.job.name":       "test-job-1",
@@ -42,19 +42,19 @@ func TestJobMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[0], "k8s.job.active_pods",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[0], "k8s.job.active_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[1], "k8s.job.failed_pods",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[1], "k8s.job.failed_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[2], "k8s.job.successful_pods",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[2], "k8s.job.successful_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[3], "k8s.job.desired_successful_pods",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[3], "k8s.job.desired_successful_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[4], "k8s.job.max_parallel_pods",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[4], "k8s.job.max_parallel_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
 	// Test with nil values.
@@ -62,15 +62,15 @@ func TestJobMetrics(t *testing.T) {
 	j.Spec.Parallelism = nil
 	actualResourceMetrics = getMetricsForJob(j)
 	require.Equal(t, 1, len(actualResourceMetrics))
-	require.Equal(t, 3, len(actualResourceMetrics[0].metrics))
+	require.Equal(t, 3, len(actualResourceMetrics[0].Metrics))
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[0], "k8s.job.active_pods",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[0], "k8s.job.active_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[1], "k8s.job.failed_pods",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[1], "k8s.job.failed_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[2], "k8s.job.successful_pods",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[2], "k8s.job.successful_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 }
 

--- a/receiver/k8sclusterreceiver/internal/collection/namespaces.go
+++ b/receiver/k8sclusterreceiver/internal/collection/namespaces.go
@@ -15,6 +15,7 @@
 package collection // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection"
 
 import (
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -23,7 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/utils"
 )
 
-func getMetricsForNamespace(ns *corev1.Namespace) []*resourceMetrics {
+func getMetricsForNamespace(ns *corev1.Namespace) []*agentmetricspb.ExportMetricsServiceRequest {
 	metrics := []*metricspb.Metric{
 		{
 			MetricDescriptor: &metricspb.MetricDescriptor{
@@ -37,10 +38,10 @@ func getMetricsForNamespace(ns *corev1.Namespace) []*resourceMetrics {
 		},
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForNamespace(ns),
-			metrics:  metrics,
+			Resource: getResourceForNamespace(ns),
+			Metrics:  metrics,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/collection/namespaces_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/namespaces_test.go
@@ -33,15 +33,15 @@ func TestNamespaceMetrics(t *testing.T) {
 
 	require.Equal(t, 1, len(actualResourceMetrics))
 
-	require.Equal(t, 1, len(actualResourceMetrics[0].metrics))
-	testutils.AssertResource(t, actualResourceMetrics[0].resource, k8sType,
+	require.Equal(t, 1, len(actualResourceMetrics[0].Metrics))
+	testutils.AssertResource(t, actualResourceMetrics[0].Resource, k8sType,
 		map[string]string{
 			"k8s.namespace.uid":  "test-namespace-1-uid",
 			"k8s.namespace.name": "test-namespace",
 		},
 	)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[0], "k8s.namespace.phase",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[0], "k8s.namespace.phase",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 }
 

--- a/receiver/k8sclusterreceiver/internal/collection/nodes.go
+++ b/receiver/k8sclusterreceiver/internal/collection/nodes.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/iancoleman/strcase"
@@ -42,7 +43,7 @@ var allocatableDesciption = map[string]string{
 	"storage":           "How many bytes of storage remaining that the node can allocate to pods",
 }
 
-func getMetricsForNode(node *corev1.Node, nodeConditionTypesToReport, allocatableTypesToReport []string, logger *zap.Logger) []*resourceMetrics {
+func getMetricsForNode(node *corev1.Node, nodeConditionTypesToReport, allocatableTypesToReport []string, logger *zap.Logger) []*agentmetricspb.ExportMetricsServiceRequest {
 	metrics := make([]*metricspb.Metric, 0, len(nodeConditionTypesToReport)+len(allocatableTypesToReport))
 	// Adding 'node condition type' metrics
 	for _, nodeConditionTypeValue := range nodeConditionTypesToReport {
@@ -91,10 +92,10 @@ func getMetricsForNode(node *corev1.Node, nodeConditionTypesToReport, allocatabl
 		})
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForNode(node),
-			metrics:  metrics,
+			Resource: getResourceForNode(node),
+			Metrics:  metrics,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/collection/nodes_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/nodes_test.go
@@ -35,27 +35,27 @@ func TestNodeMetricsReportCPUMetrics(t *testing.T) {
 
 	require.Equal(t, 1, len(actualResourceMetrics))
 
-	require.Equal(t, 5, len(actualResourceMetrics[0].metrics))
-	testutils.AssertResource(t, actualResourceMetrics[0].resource, k8sType,
+	require.Equal(t, 5, len(actualResourceMetrics[0].Metrics))
+	testutils.AssertResource(t, actualResourceMetrics[0].Resource, k8sType,
 		map[string]string{
 			"k8s.node.uid":  "test-node-1-uid",
 			"k8s.node.name": "test-node-1",
 		},
 	)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[0], "k8s.node.condition_ready",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[0], "k8s.node.condition_ready",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[1], "k8s.node.condition_memory_pressure",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[1], "k8s.node.condition_memory_pressure",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 
-	testutils.AssertMetricsDouble(t, actualResourceMetrics[0].metrics[2], "k8s.node.allocatable_cpu",
+	testutils.AssertMetricsDouble(t, actualResourceMetrics[0].Metrics[2], "k8s.node.allocatable_cpu",
 		metricspb.MetricDescriptor_GAUGE_DOUBLE, 0.123)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[3], "k8s.node.allocatable_memory",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[3], "k8s.node.allocatable_memory",
 		metricspb.MetricDescriptor_GAUGE_INT64, 456)
 
-	testutils.AssertMetricsInt(t, actualResourceMetrics[0].metrics[4], "k8s.node.allocatable_ephemeral_storage",
+	testutils.AssertMetricsInt(t, actualResourceMetrics[0].Metrics[4], "k8s.node.allocatable_ephemeral_storage",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1234)
 }
 

--- a/receiver/k8sclusterreceiver/internal/collection/replicasets.go
+++ b/receiver/k8sclusterreceiver/internal/collection/replicasets.go
@@ -15,6 +15,7 @@
 package collection // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection"
 
 import (
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,15 +23,15 @@ import (
 	metadata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata"
 )
 
-func getMetricsForReplicaSet(rs *appsv1.ReplicaSet) []*resourceMetrics {
+func getMetricsForReplicaSet(rs *appsv1.ReplicaSet) []*agentmetricspb.ExportMetricsServiceRequest {
 	if rs.Spec.Replicas == nil {
 		return nil
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForReplicaSet(rs),
-			metrics: getReplicaMetrics(
+			Resource: getResourceForReplicaSet(rs),
+			Metrics: getReplicaMetrics(
 				"replicaset",
 				*rs.Spec.Replicas,
 				rs.Status.AvailableReplicas,

--- a/receiver/k8sclusterreceiver/internal/collection/replicasets_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/replicasets_test.go
@@ -32,10 +32,10 @@ func TestReplicasetMetrics(t *testing.T) {
 	actualResourceMetrics := getMetricsForReplicaSet(rs)
 
 	require.Equal(t, 1, len(actualResourceMetrics))
-	require.Equal(t, 2, len(actualResourceMetrics[0].metrics))
+	require.Equal(t, 2, len(actualResourceMetrics[0].Metrics))
 
 	rm := actualResourceMetrics[0]
-	testutils.AssertResource(t, rm.resource, k8sType,
+	testutils.AssertResource(t, rm.Resource, k8sType,
 		map[string]string{
 			"k8s.replicaset.uid":  "test-replicaset-1-uid",
 			"k8s.replicaset.name": "test-replicaset-1",
@@ -43,10 +43,10 @@ func TestReplicasetMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsInt(t, rm.metrics[0], "k8s.replicaset.desired",
+	testutils.AssertMetricsInt(t, rm.Metrics[0], "k8s.replicaset.desired",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 
-	testutils.AssertMetricsInt(t, rm.metrics[1], "k8s.replicaset.available",
+	testutils.AssertMetricsInt(t, rm.Metrics[1], "k8s.replicaset.available",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 }
 

--- a/receiver/k8sclusterreceiver/internal/collection/replicationcontrollers.go
+++ b/receiver/k8sclusterreceiver/internal/collection/replicationcontrollers.go
@@ -15,6 +15,7 @@
 package collection // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection"
 
 import (
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	corev1 "k8s.io/api/core/v1"
@@ -22,15 +23,15 @@ import (
 	metadata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata"
 )
 
-func getMetricsForReplicationController(rc *corev1.ReplicationController) []*resourceMetrics {
+func getMetricsForReplicationController(rc *corev1.ReplicationController) []*agentmetricspb.ExportMetricsServiceRequest {
 	if rc.Spec.Replicas == nil {
 		return nil
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForReplicationController(rc),
-			metrics: getReplicaMetrics(
+			Resource: getResourceForReplicationController(rc),
+			Metrics: getReplicaMetrics(
 				"replication_controller",
 				*rc.Spec.Replicas,
 				rc.Status.AvailableReplicas,

--- a/receiver/k8sclusterreceiver/internal/collection/resourcequotas.go
+++ b/receiver/k8sclusterreceiver/internal/collection/resourcequotas.go
@@ -17,6 +17,7 @@ package collection // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"strings"
 
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -45,7 +46,7 @@ var resourceQuotaUsedMetric = &metricspb.MetricDescriptor{
 	}},
 }
 
-func getMetricsForResourceQuota(rq *corev1.ResourceQuota) []*resourceMetrics {
+func getMetricsForResourceQuota(rq *corev1.ResourceQuota) []*agentmetricspb.ExportMetricsServiceRequest {
 	var metrics []*metricspb.Metric
 
 	for _, t := range []struct {
@@ -79,10 +80,10 @@ func getMetricsForResourceQuota(rq *corev1.ResourceQuota) []*resourceMetrics {
 		}
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForResourceQuota(rq),
-			metrics:  metrics,
+			Resource: getResourceForResourceQuota(rq),
+			Metrics:  metrics,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/collection/resourcequotas_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/resourcequotas_test.go
@@ -34,8 +34,8 @@ func TestRequestQuotaMetrics(t *testing.T) {
 
 	require.Equal(t, 1, len(actualResourceMetrics))
 
-	require.Equal(t, 2, len(actualResourceMetrics[0].metrics))
-	testutils.AssertResource(t, actualResourceMetrics[0].resource, k8sType,
+	require.Equal(t, 2, len(actualResourceMetrics[0].Metrics))
+	testutils.AssertResource(t, actualResourceMetrics[0].Resource, k8sType,
 		map[string]string{
 			"k8s.resourcequota.uid":  "test-resourcequota-1-uid",
 			"k8s.resourcequota.name": "test-resourcequota-1",
@@ -43,10 +43,10 @@ func TestRequestQuotaMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].metrics[0], "k8s.resource_quota.hard_limit",
+	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].Metrics[0], "k8s.resource_quota.hard_limit",
 		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "requests.cpu"}, 2000)
 
-	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].metrics[1], "k8s.resource_quota.used",
+	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].Metrics[1], "k8s.resource_quota.used",
 		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "requests.cpu"}, 1000)
 }
 

--- a/receiver/k8sclusterreceiver/internal/collection/statefulsets.go
+++ b/receiver/k8sclusterreceiver/internal/collection/statefulsets.go
@@ -15,6 +15,7 @@
 package collection // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection"
 
 import (
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -58,9 +59,9 @@ var statefulSetReplicasUpdatedMetric = &metricspb.MetricDescriptor{
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
-func getMetricsForStatefulSet(ss *appsv1.StatefulSet) []*resourceMetrics {
+func getMetricsForStatefulSet(ss *appsv1.StatefulSet) []*agentmetricspb.ExportMetricsServiceRequest {
 	if ss.Spec.Replicas == nil {
-		return []*resourceMetrics{}
+		return []*agentmetricspb.ExportMetricsServiceRequest{}
 	}
 
 	metrics := []*metricspb.Metric{
@@ -90,10 +91,10 @@ func getMetricsForStatefulSet(ss *appsv1.StatefulSet) []*resourceMetrics {
 		},
 	}
 
-	return []*resourceMetrics{
+	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			resource: getResourceForStatefulSet(ss),
-			metrics:  metrics,
+			Resource: getResourceForStatefulSet(ss),
+			Metrics:  metrics,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/collection/statefulsets_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/statefulsets_test.go
@@ -32,10 +32,10 @@ func TestStatefulsettMetrics(t *testing.T) {
 	actualResourceMetrics := getMetricsForStatefulSet(ss)
 
 	require.Equal(t, 1, len(actualResourceMetrics))
-	require.Equal(t, 4, len(actualResourceMetrics[0].metrics))
+	require.Equal(t, 4, len(actualResourceMetrics[0].Metrics))
 
 	rm := actualResourceMetrics[0]
-	testutils.AssertResource(t, rm.resource, k8sType,
+	testutils.AssertResource(t, rm.Resource, k8sType,
 		map[string]string{
 			"k8s.statefulset.uid":  "test-statefulset-1-uid",
 			"k8s.statefulset.name": "test-statefulset-1",
@@ -43,16 +43,16 @@ func TestStatefulsettMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsInt(t, rm.metrics[0], "k8s.statefulset.desired_pods",
+	testutils.AssertMetricsInt(t, rm.Metrics[0], "k8s.statefulset.desired_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetricsInt(t, rm.metrics[1], "k8s.statefulset.ready_pods",
+	testutils.AssertMetricsInt(t, rm.Metrics[1], "k8s.statefulset.ready_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 7)
 
-	testutils.AssertMetricsInt(t, rm.metrics[2], "k8s.statefulset.current_pods",
+	testutils.AssertMetricsInt(t, rm.Metrics[2], "k8s.statefulset.current_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 5)
 
-	testutils.AssertMetricsInt(t, rm.metrics[3], "k8s.statefulset.updated_pods",
+	testutils.AssertMetricsInt(t, rm.Metrics[3], "k8s.statefulset.updated_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 }
 


### PR DESCRIPTION
This PR allows to change independently each metrics getter to pdata.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
