### PR TITLE
[pkg/pdatatest] add fatsheep9146 as owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -110,7 +110,7 @@ internal/sharedcomponent/                                @open-telemetry/collect
 
 pkg/batchpersignal/                                      @open-telemetry/collector-contrib-approvers @jpkrohling
 pkg/ottl/                                                @open-telemetry/collector-contrib-approvers @TylerHelmuth @kentquirk @bogdandrutu @evan-bradley
-pkg/pdatatest/                                           @open-telemetry/collector-contrib-approvers @djaglowski
+pkg/pdatatest/                                           @open-telemetry/collector-contrib-approvers @djaglowski @fatsheep9146
 pkg/pdatautil/                                           @open-telemetry/collector-contrib-approvers @dmitryax
 pkg/resourcetotelemetry/                                 @open-telemetry/collector-contrib-approvers @mx-psi
 pkg/stanza/                                              @open-telemetry/collector-contrib-approvers @djaglowski


### PR DESCRIPTION
Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>

I volunteer myself as code owners for pkg/pdatatest, since I've already made some contributions to this package, and willing to contribute more.

related contributions
#17544