### PR TITLE
[processor/cumulativetodelta]: always drop first metric point

### DIFF
--- a/.chloggen/cumulativetodelta-first-point.yaml
+++ b/.chloggen/cumulativetodelta-first-point.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cumulativetodeltaprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: exclude the first point even in monotonic metrics
+
+# One or more tracking issues related to the change
+issues: [17190, 18053]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -81,24 +81,10 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool) {
 	hashableID := b.String()
 	identityBufferPool.Put(b)
 
-	var s interface{}
-	var ok bool
-	if s, ok = t.states.Load(hashableID); !ok {
-		s, ok = t.states.LoadOrStore(hashableID, &State{
-			PrevPoint: metricPoint,
-		})
-	}
-
+	s, ok := t.states.LoadOrStore(hashableID, &State{
+		PrevPoint: metricPoint,
+	})
 	if !ok {
-		if metricID.MetricIsMonotonic {
-			out = DeltaValue{
-				StartTimestamp: metricPoint.ObservedTimestamp,
-				FloatValue:     metricPoint.FloatValue,
-				IntValue:       metricPoint.IntValue,
-				HistogramValue: metricPoint.HistogramValue,
-			}
-			valid = true
-		}
 		return
 	}
 	valid = true

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
@@ -47,19 +47,16 @@ func TestMetricTracker_Convert(t *testing.T) {
 		name    string
 		value   ValuePoint
 		wantOut DeltaValue
+		noOut   bool
 	}{
 		{
-			name: "Initial Value recorded",
+			name: "Initial Value not recorded",
 			value: ValuePoint{
 				ObservedTimestamp: 10,
 				FloatValue:        100.0,
 				IntValue:          100,
 			},
-			wantOut: DeltaValue{
-				StartTimestamp: 10,
-				FloatValue:     100.0,
-				IntValue:       100,
-			},
+			noOut: true,
 		},
 		{
 			name: "Higher Value Recorded",
@@ -126,14 +123,18 @@ func TestMetricTracker_Convert(t *testing.T) {
 			}
 
 			gotOut, valid := m.Convert(floatPoint)
-			require.True(t, valid)
-			assert.Equal(t, tt.wantOut.StartTimestamp, gotOut.StartTimestamp)
-			assert.Equal(t, tt.wantOut.FloatValue, gotOut.FloatValue)
+			if !tt.noOut {
+				require.True(t, valid)
+				assert.Equal(t, tt.wantOut.StartTimestamp, gotOut.StartTimestamp)
+				assert.Equal(t, tt.wantOut.FloatValue, gotOut.FloatValue)
+			}
 
 			gotOut, valid = m.Convert(intPoint)
-			require.True(t, valid)
-			assert.Equal(t, tt.wantOut.StartTimestamp, gotOut.StartTimestamp)
-			assert.Equal(t, tt.wantOut.IntValue, gotOut.IntValue)
+			if !tt.noOut {
+				require.True(t, valid)
+				assert.Equal(t, tt.wantOut.StartTimestamp, gotOut.StartTimestamp)
+				assert.Equal(t, tt.wantOut.IntValue, gotOut.IntValue)
+			}
 		})
 	}
 

--- a/processor/cumulativetodeltaprocessor/processor_test.go
+++ b/processor/cumulativetodeltaprocessor/processor_test.go
@@ -90,7 +90,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			},
 			inMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100, 200, 500}, {4}},
+				metricValues: [][]float64{{0, 100, 200, 500}, {4}},
 				isCumulative: []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{
@@ -110,7 +110,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			},
 			inMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100, 200, math.NaN()}, {4}},
+				metricValues: [][]float64{{0, 100, 200, math.NaN()}, {4}},
 				isCumulative: []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{
@@ -157,18 +157,18 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			},
 			inMetrics: generateTestHistogramMetrics(testHistogramMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
-				metricCounts: [][]uint64{{100, 200, 500}, {4}},
-				metricSums:   [][]float64{{100, 200, 500}, {4}},
+				metricCounts: [][]uint64{{0, 100, 200, 500}, {4}},
+				metricSums:   [][]float64{{0, 100, 200, 500}, {4}},
 				metricBuckets: [][][]uint64{
-					{{50, 25, 25}, {100, 50, 50}, {250, 125, 125}},
+					{{0, 0, 0}, {50, 25, 25}, {100, 50, 50}, {250, 125, 125}},
 					{{4, 4, 4}},
 				},
 				metricMins: [][]float64{
-					{5.0, 2.0, 3.0},
+					{0, 5.0, 2.0, 3.0},
 					{2.0, 2.0, 2.0},
 				},
 				metricMaxes: [][]float64{
-					{800.0, 825.0, 800.0},
+					{0, 800.0, 825.0, 800.0},
 					{3.0, 3.0, 3.0},
 				},
 				isCumulative: []bool{true, true},
@@ -203,10 +203,10 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			},
 			inMetrics: generateTestHistogramMetrics(testHistogramMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
-				metricCounts: [][]uint64{{100, 200, 500}, {4}},
-				metricSums:   [][]float64{{100, 200, 500}, {4}},
+				metricCounts: [][]uint64{{0, 100, 200, 500}, {4}},
+				metricSums:   [][]float64{{0, 100, 200, 500}, {4}},
 				metricBuckets: [][][]uint64{
-					{{50, 25, 25}, {100, 50, 50}, {250, 125, 125}},
+					{{0, 0, 0}, {50, 25, 25}, {100, 50, 50}, {250, 125, 125}},
 					{{4, 4, 4}},
 				},
 				isCumulative: []bool{true, true},
@@ -233,10 +233,10 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			},
 			inMetrics: generateTestHistogramMetrics(testHistogramMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
-				metricCounts: [][]uint64{{100, 200, 500}, {4}},
-				metricSums:   [][]float64{{100, math.NaN(), 500}, {4}},
+				metricCounts: [][]uint64{{0, 100, 200, 500}, {4}},
+				metricSums:   [][]float64{{0, 100, math.NaN(), 500}, {4}},
 				metricBuckets: [][][]uint64{
-					{{50, 25, 25}, {100, 50, 50}, {250, 125, 125}},
+					{{0, 0, 0}, {50, 25, 25}, {100, 50, 50}, {250, 125, 125}},
 					{{4, 4, 4}},
 				},
 				isCumulative: []bool{true, true},
@@ -263,10 +263,10 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			},
 			inMetrics: generateTestHistogramMetrics(testHistogramMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
-				metricCounts: [][]uint64{{100, 200, 500}, {4}},
+				metricCounts: [][]uint64{{0, 100, 200, 500}, {4}},
 				metricSums:   [][]float64{{}, {4}},
 				metricBuckets: [][][]uint64{
-					{{50, 25, 25}, {100, 50, 50}, {250, 125, 125}},
+					{{0, 0, 0}, {50, 25, 25}, {100, 50, 50}, {250, 125, 125}},
 					{{4, 4, 4}},
 				},
 				isCumulative: []bool{true, true},
@@ -293,7 +293,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			},
 			inMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100, 200, 500}, {4, 5}},
+				metricValues: [][]float64{{0, 100, 200, 500}, {0, 4, 5}},
 				isCumulative: []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{
@@ -320,7 +320,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			},
 			inMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100, 200, 500}, {4, 5}},
+				metricValues: [][]float64{{100, 200, 500}, {0, 4, 5}},
 				isCumulative: []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{


### PR DESCRIPTION
**Description:**

Drops the first metric point in the cumulativetodelta processor for monotonic, cumulative metrics

**Link to tracking Issue:** 

#17190
#18053

**Testing:** 

`go test ./...`

**Documentation:** 

changelog entry