### PR TITLE
[exporter/datadog] Run API key validation in separate goroutine

### DIFF
--- a/.chloggen/datadogexporter-run-api-validation-separately.yaml
+++ b/.chloggen/datadogexporter-run-api-validation-separately.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Run API key validation on Datadog exporter in separate goroutine
+
+# One or more tracking issues related to the change
+issues: [18238]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/logs_exporter.go
+++ b/exporter/datadogexporter/logs_exporter.go
@@ -59,8 +59,7 @@ func newLogsExporter(ctx context.Context, params exporter.CreateSettings, cfg *C
 	}
 	// validate the apiKey
 	if cfg.API.FailOnInvalidKey {
-		err := <-errchan
-		if err != nil {
+		if err := <-errchan; err != nil {
 			return nil, err
 		}
 	}

--- a/exporter/datadogexporter/logs_exporter.go
+++ b/exporter/datadogexporter/logs_exporter.go
@@ -45,21 +45,24 @@ type logsExporter struct {
 func newLogsExporter(ctx context.Context, params exporter.CreateSettings, cfg *Config, onceMetadata *sync.Once, sourceProvider source.Provider) (*logsExporter, error) {
 	// create Datadog client
 	// validation endpoint is provided by Metrics
-	var err error
+	errchan := make(chan error)
 	if isMetricExportV2Enabled() {
 		apiClient := clientutil.CreateAPIClient(
 			params.BuildInfo,
 			cfg.Metrics.TCPAddr.Endpoint,
 			cfg.TimeoutSettings,
 			cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify)
-		err = clientutil.ValidateAPIKey(ctx, string(cfg.API.Key), params.Logger, apiClient)
+		go func() { errchan <- clientutil.ValidateAPIKey(ctx, string(cfg.API.Key), params.Logger, apiClient) }()
 	} else {
 		client := clientutil.CreateZorkianClient(string(cfg.API.Key), cfg.Metrics.TCPAddr.Endpoint)
-		err = clientutil.ValidateAPIKeyZorkian(params.Logger, client)
+		go func() { errchan <- clientutil.ValidateAPIKeyZorkian(params.Logger, client) }()
 	}
 	// validate the apiKey
-	if err != nil && cfg.API.FailOnInvalidKey {
-		return nil, err
+	if cfg.API.FailOnInvalidKey {
+		err := <-errchan
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	s := logs.NewSender(cfg.Logs.TCPAddr.Endpoint, params.Logger, cfg.TimeoutSettings, cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify, cfg.Logs.DumpPayloads, string(cfg.API.Key))

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -78,8 +78,7 @@ func newTracesExporter(ctx context.Context, params exporter.CreateSettings, cfg 
 		exp.client = client
 	}
 	if cfg.API.FailOnInvalidKey {
-		err := <-errchan
-		if err != nil {
+		if err := <-errchan; err != nil {
 			return nil, err
 		}
 	}

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -63,22 +63,25 @@ func newTracesExporter(ctx context.Context, params exporter.CreateSettings, cfg 
 		sourceProvider: sourceProvider,
 	}
 	// client to send running metric to the backend & perform API key validation
+	errchan := make(chan error)
 	if isMetricExportV2Enabled() {
 		apiClient := clientutil.CreateAPIClient(
 			params.BuildInfo,
 			cfg.Metrics.TCPAddr.Endpoint,
 			cfg.TimeoutSettings,
 			cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify)
-		if err := clientutil.ValidateAPIKey(ctx, string(cfg.API.Key), params.Logger, apiClient); err != nil && cfg.API.FailOnInvalidKey {
-			return nil, err
-		}
+		go func() { errchan <- clientutil.ValidateAPIKey(ctx, string(cfg.API.Key), params.Logger, apiClient) }()
 		exp.metricsAPI = datadogV2.NewMetricsApi(apiClient)
 	} else {
 		client := clientutil.CreateZorkianClient(string(cfg.API.Key), cfg.Metrics.TCPAddr.Endpoint)
-		if err := clientutil.ValidateAPIKeyZorkian(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
+		go func() { errchan <- clientutil.ValidateAPIKeyZorkian(params.Logger, client) }()
+		exp.client = client
+	}
+	if cfg.API.FailOnInvalidKey {
+		err := <-errchan
+		if err != nil {
 			return nil, err
 		}
-		exp.client = client
 	}
 	return exp, nil
 }


### PR DESCRIPTION
**Description:**
Run API key validation on Datadog exporter in separate goroutine

More context: see https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13732 and https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18238

**Link to tracking Issue:** 
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18238