### PR TITLE
[processor/transform] Remove unused structs

### DIFF
--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -30,16 +30,6 @@ type Config struct {
 	LogStatements    []common.ContextStatements `mapstructure:"log_statements"`
 }
 
-type OTTLConfig struct {
-	Traces  SignalConfig `mapstructure:"traces"`
-	Metrics SignalConfig `mapstructure:"metrics"`
-	Logs    SignalConfig `mapstructure:"logs"`
-}
-
-type SignalConfig struct {
-	Statements []string `mapstructure:"statements"`
-}
-
 var _ component.Config = (*Config)(nil)
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
**Description:** 
Removes unused structs from the transformprocessor's config.  These have been deprecated since the move to ContextStatements and were missed during https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16773.