### PR TITLE
[exporter/splunkhec] Flatten nested attribute map

### DIFF
--- a/.chloggen/splunkhecexporter_flatten_nested_fields.yaml
+++ b/.chloggen/splunkhecexporter_flatten_nested_fields.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Flatten nested attribute map before sending it to splunk as indexed fields.
+
+# One or more tracking issues related to the change
+issues: [17308]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/logdata_to_splunk.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 

--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -484,72 +484,62 @@ func Test_mergeValue(t *testing.T) {
 		key      string
 		val      any
 		expected map[string]any
-		dropped  int
 	}{
 		{
 			name:     "int",
 			key:      "intKey",
 			val:      0,
 			expected: map[string]any{"intKey": 0},
-			dropped:  0,
 		},
 		{
 			name:     "flat_array",
 			key:      "arrayKey",
 			val:      []any{0, 1, 2, 3},
 			expected: map[string]any{"arrayKey": []any{0, 1, 2, 3}},
-			dropped:  0,
 		},
 		{
 			name:     "nested_array",
 			key:      "arrayKey",
 			val:      []any{0, 1, []any{2, 3}},
-			expected: map[string]any{},
-			dropped:  1,
+			expected: map[string]any{"arrayKey": "[0,1,[2,3]]"},
 		},
 		{
 			name:     "array_of_map",
 			key:      "arrayKey",
 			val:      []any{0, 1, map[string]any{"3": 3}},
-			expected: map[string]any{},
-			dropped:  1,
+			expected: map[string]any{"arrayKey": "[0,1,{\"3\":3}]"},
 		},
 		{
 			name:     "flat_map",
 			key:      "mapKey",
 			val:      map[string]any{"1": 1, "2": 2},
 			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2},
-			dropped:  0,
 		},
 		{
 			name:     "nested_map",
 			key:      "mapKey",
 			val:      map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "4": 4}},
 			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3, "mapKey.nested.4": 4},
-			dropped:  0,
 		},
 		{
 			name:     "flat_array_in_nested_map",
 			key:      "mapKey",
 			val:      map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "flat_array": []any{4}}},
 			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3, "mapKey.nested.flat_array": []any{4}},
-			dropped:  0,
 		},
 		{
 			name:     "nested_array_in_nested_map",
 			key:      "mapKey",
 			val:      map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "nested_array": []any{4, []any{5}}}},
-			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3},
-			dropped:  1,
+			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3, "mapKey.nested.nested_array": "[4,[5]]"},
 		},
 	}
 
-	for _, tt := range tests[6:] {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fields := make(map[string]any)
-			dropped := mergeValue(fields, tt.key, tt.val)
+			mergeValue(fields, tt.key, tt.val)
 			assert.Equal(t, tt.expected, fields)
-			assert.Equal(t, tt.dropped, dropped)
 		})
 	}
 

--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -477,3 +477,80 @@ func Test_nanoTimestampToEpochMilliseconds(t *testing.T) {
 	splunkTs = nanoTimestampToEpochMilliseconds(0)
 	assert.True(t, nil == splunkTs)
 }
+
+func Test_mergeValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		val      any
+		expected map[string]any
+		dropped  int
+	}{
+		{
+			name:     "int",
+			key:      "intKey",
+			val:      0,
+			expected: map[string]any{"intKey": 0},
+			dropped:  0,
+		},
+		{
+			name:     "flat_array",
+			key:      "arrayKey",
+			val:      []any{0, 1, 2, 3},
+			expected: map[string]any{"arrayKey": []any{0, 1, 2, 3}},
+			dropped:  0,
+		},
+		{
+			name:     "nested_array",
+			key:      "arrayKey",
+			val:      []any{0, 1, []any{2, 3}},
+			expected: map[string]any{},
+			dropped:  1,
+		},
+		{
+			name:     "array_of_map",
+			key:      "arrayKey",
+			val:      []any{0, 1, map[string]any{"3": 3}},
+			expected: map[string]any{},
+			dropped:  1,
+		},
+		{
+			name:     "flat_map",
+			key:      "mapKey",
+			val:      map[string]any{"1": 1, "2": 2},
+			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2},
+			dropped:  0,
+		},
+		{
+			name:     "nested_map",
+			key:      "mapKey",
+			val:      map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "4": 4}},
+			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3, "mapKey.nested.4": 4},
+			dropped:  0,
+		},
+		{
+			name:     "flat_array_in_nested_map",
+			key:      "mapKey",
+			val:      map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "flat_array": []any{4}}},
+			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3, "mapKey.nested.flat_array": []any{4}},
+			dropped:  0,
+		},
+		{
+			name:     "nested_array_in_nested_map",
+			key:      "mapKey",
+			val:      map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "nested_array": []any{4, []any{5}}}},
+			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3},
+			dropped:  1,
+		},
+	}
+
+	for _, tt := range tests[6:] {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := make(map[string]any)
+			dropped := mergeValue(fields, tt.key, tt.val)
+			assert.Equal(t, tt.expected, fields)
+			assert.Equal(t, tt.dropped, dropped)
+		})
+	}
+
+}


### PR DESCRIPTION
**Description:** 
According to the [Splunk HEC doc](https://docs.splunk.com/Documentation/Splunk/9.0.3/Data/FormateventsforHTTPEventCollector), the fields key specifies a JSON object that contains a flat (not nested) list of explicit custom fields to be defined at index time. 
The current implementations send the nested map or array as it is. It leads to `Error in handling indexed fields` error. 
In this PR, I have added to logic to flatten the nested map and drop nested arrays.


**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17308

**Testing:** Added unit tests
**Documentation:** <Describe the documentation added.>