### PR TITLE
[chore] [processor/cumulativetodelta]: cleanup non-monotonic sums references

### DIFF
--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -125,8 +125,8 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool) {
 			prevValue := state.PrevPoint.FloatValue
 			delta := value - prevValue
 
-			// Detect reset on a monotonic counter
-			if metricID.MetricIsMonotonic && value < prevValue {
+			// Detect reset (non-monotonic sums are not converted)
+			if value < prevValue {
 				delta = value
 			}
 
@@ -136,8 +136,8 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool) {
 			prevValue := state.PrevPoint.IntValue
 			delta := value - prevValue
 
-			// Detect reset on a monotonic counter
-			if metricID.MetricIsMonotonic && value < prevValue {
+			// Detect reset (non-monotonic sums are not converted)
+			if value < prevValue {
 				delta = value
 			}
 

--- a/processor/cumulativetodeltaprocessor/processor.go
+++ b/processor/cumulativetodeltaprocessor/processor.go
@@ -169,10 +169,6 @@ func (ctdp *cumulativeToDeltaProcessor) convertDataPoints(in interface{}, baseId
 				Value:    point,
 			}
 			delta, valid := ctdp.deltaCalculator.Convert(trackingPoint)
-
-			// When converting non-monotonic cumulative counters,
-			// the first data point is omitted since the initial
-			// reference is not assumed to be zero
 			if !valid {
 				return true
 			}

--- a/processor/cumulativetodeltaprocessor/processor_test.go
+++ b/processor/cumulativetodeltaprocessor/processor_test.go
@@ -353,7 +353,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			},
 			inMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100, 200, 500}, {4, 5}},
+				metricValues: [][]float64{{0, 100, 200, 500}, {4, 5}},
 				isCumulative: []bool{true, true},
 				isMonotonic:  []bool{true, false},
 			}),

--- a/processor/cumulativetodeltaprocessor/processor_test.go
+++ b/processor/cumulativetodeltaprocessor/processor_test.go
@@ -37,6 +37,7 @@ type testSumMetric struct {
 	metricNames  []string
 	metricValues [][]float64
 	isCumulative []bool
+	isMonotonic  []bool
 }
 
 type testHistogramMetric struct {
@@ -72,11 +73,13 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100}, {4}},
 				isCumulative: []bool{true, true},
+				isMonotonic:  []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100}, {4}},
 				isCumulative: []bool{true, true},
+				isMonotonic:  []bool{true, true},
 			}),
 		},
 		{
@@ -92,11 +95,13 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{0, 100, 200, 500}, {4}},
 				isCumulative: []bool{true, true},
+				isMonotonic:  []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100, 100, 300}, {4}},
 				isCumulative: []bool{false, true},
+				isMonotonic:  []bool{true, true},
 			}),
 		},
 		{
@@ -112,11 +117,13 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{0, 100, 200, math.NaN()}, {4}},
 				isCumulative: []bool{true, true},
+				isMonotonic:  []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100, 100, math.NaN()}, {4}},
 				isCumulative: []bool{false, true},
+				isMonotonic:  []bool{true, true},
 			}),
 		},
 		{
@@ -139,11 +146,13 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100}, {4}},
 				isCumulative: []bool{true, true},
+				isMonotonic:  []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100}, {4}},
 				isCumulative: []bool{true, true},
+				isMonotonic:  []bool{true, true},
 			}),
 		},
 		{
@@ -295,11 +304,13 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{0, 100, 200, 500}, {0, 4, 5}},
 				isCumulative: []bool{true, true},
+				isMonotonic:  []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100, 100, 300}, {4, 1}},
 				isCumulative: []bool{false, false},
+				isMonotonic:  []bool{true, true},
 			}),
 		},
 		{
@@ -322,11 +333,35 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100, 200, 500}, {0, 4, 5}},
 				isCumulative: []bool{true, true},
+				isMonotonic:  []bool{true, true},
 			}),
 			outMetrics: generateTestSumMetrics(testSumMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100, 200, 500}, {4, 1}},
 				isCumulative: []bool{true, false},
+				isMonotonic:  []bool{true, true},
+			}),
+		},
+		{
+			name: "cumulative_to_delta_remove_non_monotonic",
+			include: MatchMetrics{
+				Metrics: []string{".*"},
+				Config: filterset.Config{
+					MatchType:    "regexp",
+					RegexpConfig: nil,
+				},
+			},
+			inMetrics: generateTestSumMetrics(testSumMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100, 200, 500}, {4, 5}},
+				isCumulative: []bool{true, true},
+				isMonotonic:  []bool{true, false},
+			}),
+			outMetrics: generateTestSumMetrics(testSumMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100, 100, 300}, {4, 5}},
+				isCumulative: []bool{false, true},
+				isMonotonic:  []bool{true, true},
 			}),
 		},
 	}
@@ -435,7 +470,7 @@ func generateTestSumMetrics(tm testSumMetric) pmetric.Metrics {
 		m := ms.AppendEmpty()
 		m.SetName(name)
 		sum := m.SetEmptySum()
-		sum.SetIsMonotonic(true)
+		sum.SetIsMonotonic(tm.isMonotonic[i])
 
 		if tm.isCumulative[i] {
 			sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)


### PR DESCRIPTION
**Description:** <Describe what has changed.>

As stated in the docs, non-monotonic sums are not converted by the processors but there are some references to non-monotonic sums in the processor that could be a bit confusing.

This PR extends the processor tests to check that non-monotonic sums are not converted and removes some of those references.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

- New test case added to cover not-monotonic sums not being converted

```
❯ go test ./... -race
ok      github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor  0.488s
ok      github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor/internal/tracking        0.366s       
```


**Documentation:** <Describe the documentation added.>