### PR TITLE
[exporter/file] add unbuffered flag to control file buffering

### DIFF
--- a/.chloggen/add-buffered-flag.yaml
+++ b/.chloggen/add-buffered-flag.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: fileexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add parameter (`unbuffered`) to turn optionally off the file buffering.
+
+# One or more tracking issues related to the change
+issues: [18251]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -57,7 +57,7 @@ Telemetry data is compressed according to the `compression` setting.
 
 Currently, `fileexporter` support the `zstd` compression algorithm, and we will support more compression algorithms in the future.
 
-##  File Format 
+##  File Format
 
 Telemetry data is encoded according to the `format` setting and then written to the file.
 
@@ -66,12 +66,20 @@ When `format` is json and `compression` is none , telemetry data is written to f
 Otherwise, when using `proto` format or any kind of encoding, each encoded object is preceded by 4 bytes (an unsigned 32 bit integer) which represent the number of bytes contained in the encoded object.When we need read the messages back in, we read the size, then read the bytes into a separate buffer, then parse from that buffer.
 
 
+##  Buffering
+
+By default, writes to the output file (when rotation is not used) are buffered. This can be turned off by setting the `unbuffered` parameter to `true`. The default value is `false`. This will be ignored when file rotation is used.
+
 ## Example:
 
 ```yaml
 exporters:
   file/no_rotation:
     path: ./foo
+
+  file/no_rotation_unbuffered:
+    path: ./foo
+    unbuffered: true
 
   file/rotation_with_default_settings:
     path: ./foo

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -44,6 +44,11 @@ type Config struct {
 	// Compression Codec used to export telemetry data
 	// Supported compression algorithms:`zstd`
 	Compression string `mapstructure:"compression"`
+
+	// Unbuffered indicates whether to use buffering
+	// or not when writing to files. Default is false.
+	// Ignored when file rotation is used.
+	Unbuffered bool `mapstructure:"unbuffered"`
 }
 
 // Rotation an option to rolling log files

--- a/exporter/fileexporter/config_test.go
+++ b/exporter/fileexporter/config_test.go
@@ -36,6 +36,26 @@ func TestLoadConfig(t *testing.T) {
 		errorMessage string
 	}{
 		{
+			id: component.NewIDWithName(typeStr, "no_rotation"),
+			expected: &Config{
+				Path:        "./foo",
+				Rotation:    nil,
+				FormatType:  formatTypeJSON,
+				Compression: "",
+				Unbuffered:  false,
+			},
+		},
+		{
+			id: component.NewIDWithName(typeStr, "no_rotation_unbuffered"),
+			expected: &Config{
+				Path:        "./foo",
+				Rotation:    nil,
+				FormatType:  formatTypeJSON,
+				Compression: "",
+				Unbuffered:  true,
+			},
+		},
+		{
 			id: component.NewIDWithName(typeStr, "2"),
 			expected: &Config{
 				Path: "./filename.json",
@@ -46,6 +66,7 @@ func TestLoadConfig(t *testing.T) {
 					LocalTime:    true,
 				},
 				FormatType: formatTypeJSON,
+				Unbuffered: false,
 			},
 		},
 		{

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -150,6 +150,9 @@ func buildFileWriter(cfg *Config) (io.WriteCloser, error) {
 		if err != nil {
 			return nil, err
 		}
+		if cfg.Unbuffered {
+			return f, nil
+		}
 		return newBufferedWriteCloser(f), nil
 	}
 	return &lumberjack.Logger{

--- a/exporter/fileexporter/testdata/config.yaml
+++ b/exporter/fileexporter/testdata/config.yaml
@@ -24,6 +24,9 @@ file/3:
 
 file/no_rotation:
   path: ./foo
+file/no_rotation_unbuffered:
+  path: ./foo
+  unbuffered: true
 file/rotation_with_default_settings:
   path: ./foo
   rotation:


### PR DESCRIPTION
**Description:** Added an `unbuffered` flag to the configuration to allow users to turn on/off the file buffering. 

**Link to tracking Issue:** #18251

**Testing:** Add configuration unit tests and ensured that everything passed.

**Documentation:** Updated the README with the new parameter and added an example.