### PR TITLE
[pkg/ottl] Update OTTL docs

### DIFF
--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -94,7 +94,7 @@ Literals are literal interpretations of the Value into a Go value.  Accepted lit
 - Ints.  Ints are represented by any digit, optionally prepended by plus (`+`) or minus (`-`). Internally the OTTL represents all ints as `int64`
 - Floats.  Floats are represented by digits separated by a dot (`.`), optionally prepended by plus (`+`) or minus (`-`). The leading digit is optional. Internally the OTTL represents all Floats as `float64`.
 - Bools.  Bools are represented by the exact strings `true` and `false`.
-- Nil.  Nil is represented by the exact strings `nil`.
+- Nil.  Nil is represented by the exact string `nil`.
 - Byte slices.  Byte slices are represented via a hex string prefaced with `0x`
 
 Example Literals

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -77,7 +77,7 @@ Example Paths
 #### Lists
 
 A List Value comprises a sequence of Values.
-Currently, list can only be created by the grammar to be using in functions or conditions;
+Currently, list can only be created by the grammar to be used in functions or conditions;
 the grammar does not provide an accessor to individual list entries.
 
 Example List Values:

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -65,7 +65,7 @@ A Path Value is a reference to a telemetry field.  Paths are made up of lowercas
 - Dots (`.`) are used to separate nested fields.
 - Square brackets and keys (`["key"]`) are used to access values within maps.
 
-When accessing a map's value, if the given key does not exist `nil` will be returned.
+When accessing a map's value, if the given key does not exist, `nil` will be returned.
 This can be used to check for the presence of a key within a map within a [Boolean Expression](#boolean_expressions).
 
 Example Paths

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -66,7 +66,7 @@ A Path Value is a reference to a telemetry field.  Paths are made up of lowercas
 - Square brackets and keys (`["key"]`) are used to access values within maps.
 
 When accessing a map's value, if the given key does not exist `nil` will be returned.
-This can be used to check for the present of a key within a map within a [Boolean Expression](#boolean_expressions).
+This can be used to check for the presence of a key within a map within a [Boolean Expression](#boolean_expressions).
 
 Example Paths
 - `name`

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -63,7 +63,10 @@ A Path Value is a reference to a telemetry field.  Paths are made up of lowercas
 
 - Identifiers are used to map to a telemetry field.
 - Dots (`.`) are used to separate nested fields.
-- Square brackets and keys (`["key"]`) are used to access maps or slices.
+- Square brackets and keys (`["key"]`) are used to access values within maps.
+
+When accessing a map's value, if the given key does not exist `nil` will be returned.
+This can be used to check for the present of a key within a map within a [Boolean Expression](#boolean_expressions).
 
 Example Paths
 - `name`
@@ -74,6 +77,8 @@ Example Paths
 #### Lists
 
 A List Value comprises a sequence of Values.
+Currently, list can only be created by the grammar to be using in functions or conditions;
+the grammar does not provide an accessor to individual list entries.
 
 Example List Values:
 - `[]`
@@ -89,7 +94,7 @@ Literals are literal interpretations of the Value into a Go value.  Accepted lit
 - Ints.  Ints are represented by any digit, optionally prepended by plus (`+`) or minus (`-`). Internally the OTTL represents all ints as `int64`
 - Floats.  Floats are represented by digits separated by a dot (`.`), optionally prepended by plus (`+`) or minus (`-`). The leading digit is optional. Internally the OTTL represents all Floats as `float64`.
 - Bools.  Bools are represented by the exact strings `true` and `false`.
-- Nil.  Nil is represented by the exact string `nil`.
+- Nil.  Nil is represented by the exact strings `nil`.
 - Byte slices.  Byte slices are represented via a hex string prefaced with `0x`
 
 Example Literals
@@ -179,7 +184,7 @@ The valid operators are:
 Booleans can be negated with the `not` keyword such as
 - `not true`
 - `not name == "foo"`   
-  `not (IsMatch(name, "http_.*") == true and kind > 0)`
+- `not (IsMatch(name, "http_.*") == true and kind > 0)`
 
 ### Comparison Rules
 
@@ -202,6 +207,12 @@ A `not equal` notation in the table below means that the "!=" operator returns t
 | string    | not equal   | not equal           | not equal           | normal (compared as Go strings) | not equal                | not equal              |
 | Bytes     | not equal   | not equal           | not equal           | not equal                       | byte-for-byte comparison | []byte(nil) == nil     |
 | nil       | not equal   | not equal           | not equal           | not equal                       | []byte(nil) == nil       | true for equality only |
+
+Examples:
+- `name == "a name"`
+- `1 < 2`
+- `attributes["custom-attr"] != nil`
+- `IsMatch(resource.attributes["host.name"], "pod-*") == true`
 
 ## Accessing signal telemetry
 
@@ -279,13 +290,6 @@ logs:
   delete(resource.attributes["process.command_line"])
 ```
 
-### Drop specific telemetry
-
-```
-metrics:
-  drop() where attributes["http.target"] == "/health"
-```
-
 ### Attach information from resource into telemetry
 
 ```
@@ -301,14 +305,6 @@ traces:
   set(attributes["whose_fault"], "ours") where attributes["http.status"] == 500
 ```
 
-### Group spans by trace ID
-
-```
-traces:
-  group_by(trace_id, 2m)
-```
-
-
 ### Update a spans ID
 
 ```
@@ -318,16 +314,16 @@ traces:
   set(span_id, SpanID(0x0000000000000000))
 ```
 
-### Create utilization metric from base metrics.
-
-```
-metrics:
-  create_gauge("pod.cpu.utilized", read_gauge("pod.cpu.usage") / read_gauge("node.cpu.limit")
-```
-
 ### Convert metric name to snake case
 
 ```
 metrics:
   set(metric.name, ConvertCase(metric.name, "snake"))
+```
+
+### Check if an attribute exists
+
+```
+traces:
+  set(attributes["test-passed"], true) where attributes["target-attribute"] != nil
 ```


### PR DESCRIPTION
**Description:** 

Updates the OTTL docs to:
- Explicitly instruct how to check for the presence of an attribute
- Remove examples with functions not included in ottlfunc
- Fix incorrect reference to slice accessor