### PR TITLE
[exporter/awsxray] Add additional information to user-agent string

### DIFF
--- a/.chloggen/xray-exporter-user-agent.yaml
+++ b/.chloggen/xray-exporter-user-agent.yaml
@@ -5,7 +5,7 @@ change_type: 'enhancement'
 component: 'awsxrayexporter'
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Reformatted and imporoved accuracy of data captured in user agent string in the AWS X-Ray exporter"
+note: "Reformatted and improved accuracy of data captured in user agent string in the AWS X-Ray exporter"
 
 # One or more tracking issues related to the change
 issues: []

--- a/.chloggen/xray-exporter-user-agent.yaml
+++ b/.chloggen/xray-exporter-user-agent.yaml
@@ -8,7 +8,7 @@ component: 'awsxrayexporter'
 note: "Reformatted and improved accuracy of data captured in user agent string in the AWS X-Ray exporter"
 
 # One or more tracking issues related to the change
-issues: []
+issues: [18264]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/xray-exporter-user-agent.yaml
+++ b/.chloggen/xray-exporter-user-agent.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'awsxrayexporter'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Reformatted and imporoved accuracy of data captured in user agent string in the AWS X-Ray exporter"
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsxrayexporter/xray_client_test.go
+++ b/exporter/awsxrayexporter/xray_client_test.go
@@ -45,4 +45,8 @@ func TestUserAgent(t *testing.T) {
 
 	x.Handlers.Build.Run(req)
 	assert.Contains(t, req.HTTPRequest.UserAgent(), "test-collector-contrib/1.0")
+	assert.Contains(t, req.HTTPRequest.UserAgent(), "xray-otel-exporter/")
+	assert.Contains(t, req.HTTPRequest.UserAgent(), "exec_env/")
+	assert.Contains(t, req.HTTPRequest.UserAgent(), "OS/")
+
 }

--- a/exporter/awsxrayexporter/xray_client_test.go
+++ b/exporter/awsxrayexporter/xray_client_test.go
@@ -46,7 +46,7 @@ func TestUserAgent(t *testing.T) {
 	x.Handlers.Build.Run(req)
 	assert.Contains(t, req.HTTPRequest.UserAgent(), "test-collector-contrib/1.0")
 	assert.Contains(t, req.HTTPRequest.UserAgent(), "xray-otel-exporter/")
-	assert.Contains(t, req.HTTPRequest.UserAgent(), "exec_env/")
+	assert.Contains(t, req.HTTPRequest.UserAgent(), "exec-env/")
 	assert.Contains(t, req.HTTPRequest.UserAgent(), "OS/")
 
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This PR reformats the structure of the user-agent string in the x-ray exporter and captures relevant information (agent version, AWS execution environment if any, and OS data) to be used in the X-Ray backend. This change is being implemented consistently across all x-ray agents, please see[ similar PR in X-Ray daemon](https://github.com/aws/aws-xray-daemon/pull/188). 
**Link to tracking Issue:** <Issue number if applicable> N/A

**Testing:** <Describe what testing was performed and which tests were added.>
Testing using the AWS SDK logging to ensure user-agent in request is modified correctly. 

Current user-agent:
```
aws-sdk-go/1.44.62 (go1.19; linux; amd64) exec-env/AWS_ECS_FARGATE xray/1.0 (AWS_ECS_FARGATE)
```

New user-agent:
```
aws-sdk-go/1.44.62 (go1.19.5; linux; amd64) xray-otel-exporter/0.70.0 exec-env/UNKNOWN OS/linux-amd64
```

**Documentation:** <Describe the documentation added.>
N/A