### PR TITLE
[receiver/datadog] Add telemetry.sdk.* resource attributes

### DIFF
--- a/receiver/datadogreceiver/translator.go
+++ b/receiver/datadogreceiver/translator.go
@@ -37,11 +37,11 @@ func addResourceData(req *http.Request, rs *pcommon.Resource) {
 	attrs.PutStr("telemetry.sdk.name", "Datadog")
 	ddTracerVersion := req.Header.Get("Datadog-Meta-Tracer-Version")
 	if ddTracerVersion != "" {
-		attrs.PutStr("telemetry.sdk.version", "Datadog-"+req.Header.Get("Datadog-Meta-Tracer-Version"))
+		attrs.PutStr("telemetry.sdk.version", "Datadog-"+ddTracerVersion)
 	}
 	ddTracerLang := req.Header.Get("Datadog-Meta-Lang")
 	if ddTracerLang != "" {
-		attrs.PutStr("telemetry.sdk.language", req.Header.Get("Datadog-Meta-Lang"))
+		attrs.PutStr("telemetry.sdk.language", ddTracerLang)
 	}
 }
 

--- a/receiver/datadogreceiver/translator.go
+++ b/receiver/datadogreceiver/translator.go
@@ -35,8 +35,14 @@ func addResourceData(req *http.Request, rs *pcommon.Resource) {
 	attrs.Clear()
 	attrs.EnsureCapacity(3)
 	attrs.PutStr("telemetry.sdk.name", "Datadog")
-	attrs.PutStr("telemetry.sdk.version", "Datadog-"+req.Header.Get("Datadog-Meta-Tracer-Version"))
-	attrs.PutStr("telemetry.sdk.language", req.Header.Get("Datadog-Meta-Lang"))
+	ddTracerVersion := req.Header.Get("Datadog-Meta-Tracer-Version")
+	if ddTracerVersion != "" {
+		attrs.PutStr("telemetry.sdk.version", "Datadog-"+req.Header.Get("Datadog-Meta-Tracer-Version"))
+	}
+	ddTracerLang := req.Header.Get("Datadog-Meta-Lang")
+	if ddTracerLang != "" {
+		attrs.PutStr("telemetry.sdk.language", req.Header.Get("Datadog-Meta-Lang"))
+	}
 }
 
 func toTraces(payload *pb.TracerPayload, req *http.Request) ptrace.Traces {


### PR DESCRIPTION
**Description:** 

Adds `telemetry.sdk` resource attributes to the trace data that comes in. We found these helpful in [an experimental fork](https://github.com/honeycombio/opentelemetry-collector-configs/tree/main/datadogreceiver).

**Link to tracking Issue:**

N/A

**Testing:**

There's no testing in this change, but these attributes were used in internal testing and they showed up where you'd expect them to.

**Documentation:** 

N/A