### PR TITLE
[exporter/loadbalancingexporter] batch before exporting in load balancer

### DIFF
--- a/.chloggen/improve-loadbalancer-performance.yaml
+++ b/.chloggen/improve-loadbalancer-performance.yaml
@@ -5,8 +5,7 @@ change_type: enhancement
 component: loadbalancingexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
-Add batching for each endpoint in the loadbalancingexporter.
+note: Add batching for each endpoint in the loadbalancingexporter.
 
 # One or more tracking issues related to the change
 issues: [17173]

--- a/.chloggen/improve-loadbalancer-performance.yaml
+++ b/.chloggen/improve-loadbalancer-performance.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: loadbalancingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+Add batching for each endpoint in the loadbalancingexporter.
+
+# One or more tracking issues related to the change
+issues: [17173]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -76,25 +76,45 @@ func (e *logExporterImp) Shutdown(context.Context) error {
 
 func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	var errs error
+    endpointToLogData := make(map[string]plog.Logs)
 	batches := batchpersignal.SplitLogs(ld)
-	for _, batch := range batches {
-		errs = multierr.Append(errs, e.consumeLog(ctx, batch))
+
+    // Map the logs to their respective endpoints.
+	for batch := range batches {
+        // Each batch contains at most one trace ID.
+        traceID := traceIDFromLogs(ld)
+        balancingKey := traceID
+        if traceID == pcommon.NewTraceIDEmpty() {
+            // every log may not contain a traceID
+            // generate a random traceID as balancingKey
+            // so the log can be routed to a random backend
+            balancingKey = random()
+        }
+
+	    endpoint := e.loadBalancer.Endpoint(balancingKey[:])
+        if _, ok := endpointToLogData[endpoint]; ok {
+            // append
+            for i := 0; i < batches[batch].ResourceLogs().Len(); i++ {
+                batches[batch].ResourceLogs().At(i).CopyTo(endpointToLogData[endpoint].ResourceLogs().AppendEmpty())
+            }
+        } else {
+            newLog := plog.NewLogs()
+            for i := 0; i < batches[batch].ResourceLogs().Len(); i++ {
+                batches[batch].ResourceLogs().At(i).CopyTo(newLog.ResourceLogs().AppendEmpty())
+            }
+            endpointToLogData[endpoint] = newLog
+        }
 	}
+
+    // Send the logs off by endpoint.
+    for endpoint, logs := range(endpointToLogData) {
+        errs = multierr.Append(errs, e.consumeLog(ctx, logs, endpoint))
+    }
 
 	return errs
 }
 
-func (e *logExporterImp) consumeLog(ctx context.Context, ld plog.Logs) error {
-	traceID := traceIDFromLogs(ld)
-	balancingKey := traceID
-	if traceID == pcommon.NewTraceIDEmpty() {
-		// every log may not contain a traceID
-		// generate a random traceID as balancingKey
-		// so the log can be routed to a random backend
-		balancingKey = random()
-	}
-
-	endpoint := e.loadBalancer.Endpoint(balancingKey[:])
+func (e *logExporterImp) consumeLog(ctx context.Context, ld plog.Logs, endpoint string) error {
 	exp, err := e.loadBalancer.Exporter(endpoint)
 	if err != nil {
 		return err

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -94,14 +94,10 @@ func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		endpoint := e.loadBalancer.Endpoint(balancingKey[:])
 		if _, ok := endpointToLogData[endpoint]; ok {
 			// append
-			for i := 0; i < batches[batch].ResourceLogs().Len(); i++ {
-				batches[batch].ResourceLogs().At(i).CopyTo(endpointToLogData[endpoint].ResourceLogs().AppendEmpty())
-			}
+			batches[batch].ResourceLogs().MoveAndAppendTo(endpointToLogData[endpoint].ResourceLogs())
 		} else {
 			newLog := plog.NewLogs()
-			for i := 0; i < batches[batch].ResourceLogs().Len(); i++ {
-				batches[batch].ResourceLogs().At(i).CopyTo(newLog.ResourceLogs().AppendEmpty())
-			}
+			batches[batch].ResourceLogs().MoveAndAppendTo(newLog.ResourceLogs())
 			endpointToLogData[endpoint] = newLog
 		}
 	}

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -231,7 +231,8 @@ func TestLogBatchWithTwoTraces(t *testing.T) {
 
 	// verify
 	assert.NoError(t, err)
-	assert.Len(t, sink.AllLogs(), 2)
+	assert.Len(t, sink.AllLogs(), 1)
+    assert.Equal(t, sink.LogRecordCount(), 2)
 }
 
 func TestNoLogsInBatch(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -232,7 +232,7 @@ func TestLogBatchWithTwoTraces(t *testing.T) {
 	// verify
 	assert.NoError(t, err)
 	assert.Len(t, sink.AllLogs(), 1)
-    assert.Equal(t, sink.LogRecordCount(), 2)
+	assert.Equal(t, sink.LogRecordCount(), 2)
 }
 
 func TestNoLogsInBatch(t *testing.T) {

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -99,15 +99,10 @@ func (e *traceExporterImp) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 		for rid := range routingIDs {
 			endpoint := e.loadBalancer.Endpoint([]byte(rid))
 			if _, ok := endpointToTraceData[endpoint]; ok {
-				// append
-				for i := 0; i < batches[batch].ResourceSpans().Len(); i++ {
-					batches[batch].ResourceSpans().At(i).CopyTo(endpointToTraceData[endpoint].ResourceSpans().AppendEmpty())
-				}
+				batches[batch].ResourceSpans().MoveAndAppendTo(endpointToTraceData[endpoint].ResourceSpans())
 			} else {
 				newTrace := ptrace.NewTraces()
-				for i := 0; i < batches[batch].ResourceSpans().Len(); i++ {
-					batches[batch].ResourceSpans().At(i).CopyTo(newTrace.ResourceSpans().AppendEmpty())
-				}
+				batches[batch].ResourceSpans().MoveAndAppendTo(newTrace.ResourceSpans())
 				endpointToTraceData[endpoint] = newTrace
 			}
 		}

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -355,7 +355,7 @@ func TestBatchWithTwoTraces(t *testing.T) {
 	// verify
 	assert.NoError(t, err)
 	assert.Len(t, sink.AllTraces(), 1)
-    assert.Equal(t, sink.SpanCount(), 2)
+	assert.Equal(t, sink.SpanCount(), 2)
 }
 
 func TestNoTracesInBatch(t *testing.T) {

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -354,7 +354,8 @@ func TestBatchWithTwoTraces(t *testing.T) {
 
 	// verify
 	assert.NoError(t, err)
-	assert.Len(t, sink.AllTraces(), 2)
+	assert.Len(t, sink.AllTraces(), 1)
+    assert.Equal(t, sink.SpanCount(), 2)
 }
 
 func TestNoTracesInBatch(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Some users (including myself) have had issues with the loadbalancingexporter [failing](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17173) on high loads. This is because the current code calls the underlying exporter for each span, in the case of traces, and each unit in the case of logs. This results in a lot of calls to the underlying exporter, when a lot of the calls could be consolidated since they are sending to the same backend. This PR batches the data by endpoint before calling any underlying exporter in order to reduce the overall overhead of each call.

**Link to tracking Issue:** [17173](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17173)

**Testing:** 
I changed a few of the tests so that the results are not many pdata.Traces or plogs.Logs going to the backend, but rather one large pdata.Traces or plogs.Logs.

**Documentation:**
No documentation changes.