### PR TITLE
[pkg/ottl] ConvertCase dot for dot.separated.names

### DIFF
--- a/.chloggen/ottl-convertcase-dot.yaml
+++ b/.chloggen/ottl-convertcase-dot.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: ConvertCase now supports `dot` for dot.separated.names
+
+# One or more tracking issues related to the change
+issues: [18084]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -80,6 +80,7 @@ If the `target` is not a string or does not exist, the `ConvertCase` factory fun
 - `upper`: Converts the `target` string to uppercase (e.g. `my_metric` to `MY_METRIC`)
 - `snake`: Converts the `target` string to snakecase (e.g. `myMetric` to `my_metric`)
 - `camel`: Converts the `target` string to camelcase (e.g. `my_metric` to `MyMetric`)
+- `dot`: Converts the `target` string to dottedcase (e.g. `my_metric` to `my.metric`)
 
 If `toCase` is any value other than the options above, the `ConvertCase` factory function will return an error during collector startup.
 

--- a/pkg/ottl/ottlfuncs/func_convert_case.go
+++ b/pkg/ottl/ottlfuncs/func_convert_case.go
@@ -25,13 +25,12 @@ import (
 )
 
 func ConvertCase[K any](target ottl.Getter[K], toCase string) (ottl.ExprFunc[K], error) {
-	if toCase != "lower" && toCase != "upper" && toCase != "snake" && toCase != "camel" {
-		return nil, fmt.Errorf("invalid case: %s, allowed cases are: lower, upper, snake, camel", toCase)
+	if toCase != "lower" && toCase != "upper" && toCase != "snake" && toCase != "camel" && toCase != "dot" {
+		return nil, fmt.Errorf("invalid case: %s, allowed cases are: lower, upper, snake, camel, dot", toCase)
 	}
 
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		val, err := target.Get(ctx, tCtx)
-
 		if err != nil {
 			return nil, err
 		}
@@ -58,6 +57,10 @@ func ConvertCase[K any](target ottl.Getter[K], toCase string) (ottl.ExprFunc[K],
 			// Convert string to camel case (some_name -> SomeName)
 			case "camel":
 				return strcase.ToCamel(valStr), nil
+
+			// Convert string to dot case (some_name -> some.name)
+			case "dot":
+				return strcase.ToDelimited(valStr, '.'), nil
 
 			default:
 				return nil, fmt.Errorf("error handling unexpected case: %s", toCase)

--- a/pkg/ottl/ottlfuncs/func_convert_case_test.go
+++ b/pkg/ottl/ottlfuncs/func_convert_case_test.go
@@ -104,7 +104,7 @@ func Test_convertCase(t *testing.T) {
 			expected: "SimpleString",
 		},
 		{
-			name: "snake noop already snake case",
+			name: "camel noop already camel case",
 			target: &ottl.StandardGetSetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "SimpleString", nil
@@ -114,7 +114,7 @@ func Test_convertCase(t *testing.T) {
 			expected: "SimpleString",
 		},
 		{
-			name: "snake hyphens",
+			name: "camel hyphens",
 			target: &ottl.StandardGetSetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "simple-string", nil
@@ -124,7 +124,17 @@ func Test_convertCase(t *testing.T) {
 			expected: "SimpleString",
 		},
 		{
-			name: "snake nil",
+			name: "camel dot",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCx interface{}) (interface{}, error) {
+					return "simple.string", nil
+				},
+			},
+			toCase:   "camel",
+			expected: "SimpleString",
+		},
+		{
+			name: "camel nil",
 			target: &ottl.StandardGetSetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return nil, nil
@@ -134,7 +144,68 @@ func Test_convertCase(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "snake empty string",
+			name: "camel empty string",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "", nil
+				},
+			},
+			toCase:   "camel",
+			expected: "",
+		},
+		// dot case
+		{
+			name: "dot simple convert",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "simple_string", nil
+				},
+			},
+			toCase:   "dot",
+			expected: "simple.string",
+		},
+		{
+			name: "dot noop already dot case",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "simple.string", nil
+				},
+			},
+			toCase:   "dot",
+			expected: "simple.string",
+		},
+		{
+			name: "dot hyphens",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "simple-string", nil
+				},
+			},
+			toCase:   "dot",
+			expected: "simple.string",
+		},
+		{
+			name: "dot mixed",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "complex-string_ofMixedTXTCasing", nil
+				},
+			},
+			toCase:   "dot",
+			expected: "complex.string.of.mixed.txt.casing",
+		},
+		{
+			name: "dot nil",
+			target: &ottl.StandardGetSetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			toCase:   "dot",
+			expected: nil,
+		},
+		{
+			name: "dot empty string",
 			target: &ottl.StandardGetSetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "", nil


### PR DESCRIPTION
**Description:** 

ConvertCase learns a new case `dot` for dot.separated.names

**Link to tracking Issue:** 

#18084

**Testing:**

copied and converted tests from camelcase (also fixed camelcase subtest names)

**Documentation:** 

updated readme to reflect new supported case