### PR TITLE
[receiver/statsdreceiver] record source address

### DIFF
--- a/.chloggen/statsdreceiver-source-address.yaml
+++ b/.chloggen/statsdreceiver-source-address.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: reciver/statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Metrics emitted by the statsd receiver are batched by source IP address, available in context.
+
+# One or more tracking issues related to the change
+issues: [15290]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/statsdreceiver/protocol/parser.go
+++ b/receiver/statsdreceiver/protocol/parser.go
@@ -15,12 +15,20 @@
 package protocol // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 
 import (
+	"net"
+
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 // Parser is something that can map input StatsD strings to OTLP Metric representations.
 type Parser interface {
 	Initialize(enableMetricType bool, isMonotonicCounter bool, sendTimerHistogram []TimerHistogramMapping) error
-	GetMetrics() pmetric.Metrics
-	Aggregate(line string) error
+	GetMetrics() []BatchMetrics
+	Aggregate(line string, addr net.Addr) error
+}
+
+type BatchMetrics struct {
+	Info    client.Info
+	Metrics pmetric.Metrics
 }

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -17,11 +17,13 @@ package protocol // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/lightstep/go-expohisto/structure"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -80,16 +82,31 @@ var defaultObserverCategory = ObserverCategory{
 
 // StatsDParser supports the Parse method for parsing StatsD messages with Tags.
 type StatsDParser struct {
+	instruments        map[string]instruments
+	enableMetricType   bool
+	isMonotonicCounter bool
+	timerEvents        ObserverCategory
+	histogramEvents    ObserverCategory
+	lastIntervalTime   time.Time
+}
+
+type instruments struct {
+	addr                   net.Addr
 	gauges                 map[statsDMetricDescription]pmetric.ScopeMetrics
 	counters               map[statsDMetricDescription]pmetric.ScopeMetrics
 	summaries              map[statsDMetricDescription]summaryMetric
 	histograms             map[statsDMetricDescription]histogramMetric
 	timersAndDistributions []pmetric.ScopeMetrics
-	enableMetricType       bool
-	isMonotonicCounter     bool
-	timerEvents            ObserverCategory
-	histogramEvents        ObserverCategory
-	lastIntervalTime       time.Time
+}
+
+func newInstruments(addr net.Addr) instruments {
+	return instruments{
+		addr:       addr,
+		gauges:     make(map[statsDMetricDescription]pmetric.ScopeMetrics),
+		counters:   make(map[statsDMetricDescription]pmetric.ScopeMetrics),
+		summaries:  make(map[statsDMetricDescription]summaryMetric),
+		histograms: make(map[statsDMetricDescription]histogramMetric),
+	}
 }
 
 type sampleValue struct {
@@ -138,11 +155,7 @@ func (t MetricType) FullName() TypeName {
 
 func (p *StatsDParser) resetState(when time.Time) {
 	p.lastIntervalTime = when
-	p.gauges = make(map[statsDMetricDescription]pmetric.ScopeMetrics)
-	p.counters = make(map[statsDMetricDescription]pmetric.ScopeMetrics)
-	p.timersAndDistributions = nil
-	p.summaries = make(map[statsDMetricDescription]summaryMetric)
-	p.histograms = make(map[statsDMetricDescription]histogramMetric)
+	p.instruments = make(map[string]instruments)
 }
 
 func (p *StatsDParser) Initialize(enableMetricType bool, isMonotonicCounter bool, sendTimerHistogram []TimerHistogramMapping) error {
@@ -175,47 +188,55 @@ func expoHistogramConfig(opts HistogramConfig) structure.Config {
 }
 
 // GetMetrics gets the metrics preparing for flushing and reset the state.
-func (p *StatsDParser) GetMetrics() pmetric.Metrics {
-	metrics := pmetric.NewMetrics()
-	rm := metrics.ResourceMetrics().AppendEmpty()
-
-	for _, metric := range p.gauges {
-		metric.CopyTo(rm.ScopeMetrics().AppendEmpty())
-	}
-
-	for _, metric := range p.timersAndDistributions {
-		metric.CopyTo(rm.ScopeMetrics().AppendEmpty())
-	}
-
+func (p *StatsDParser) GetMetrics() []BatchMetrics {
+	batchMetrics := make([]BatchMetrics, 0, len(p.instruments))
 	now := timeNowFunc()
+	for _, instrument := range p.instruments {
+		batch := BatchMetrics{
+			Info: client.Info{
+				Addr: instrument.addr,
+			},
+			Metrics: pmetric.NewMetrics(),
+		}
+		rm := batch.Metrics.ResourceMetrics().AppendEmpty()
+		for _, metric := range instrument.gauges {
+			metric.CopyTo(rm.ScopeMetrics().AppendEmpty())
+		}
 
-	for _, metric := range p.counters {
-		setTimestampsForCounterMetric(metric, p.lastIntervalTime, now)
-		metric.CopyTo(rm.ScopeMetrics().AppendEmpty())
-	}
+		for _, metric := range instrument.timersAndDistributions {
+			metric.CopyTo(rm.ScopeMetrics().AppendEmpty())
+		}
 
-	for desc, summaryMetric := range p.summaries {
-		buildSummaryMetric(
-			desc,
-			summaryMetric,
-			p.lastIntervalTime,
-			now,
-			statsDDefaultPercentiles,
-			rm.ScopeMetrics().AppendEmpty(),
-		)
-	}
+		for _, metric := range instrument.counters {
+			setTimestampsForCounterMetric(metric, p.lastIntervalTime, now)
+			metric.CopyTo(rm.ScopeMetrics().AppendEmpty())
+		}
 
-	for desc, histogramMetric := range p.histograms {
-		buildHistogramMetric(
-			desc,
-			histogramMetric,
-			p.lastIntervalTime,
-			now,
-			rm.ScopeMetrics().AppendEmpty(),
-		)
+		for desc, summaryMetric := range instrument.summaries {
+			buildSummaryMetric(
+				desc,
+				summaryMetric,
+				p.lastIntervalTime,
+				now,
+				statsDDefaultPercentiles,
+				rm.ScopeMetrics().AppendEmpty(),
+			)
+		}
+
+		for desc, histogramMetric := range instrument.histograms {
+			buildHistogramMetric(
+				desc,
+				histogramMetric,
+				p.lastIntervalTime,
+				now,
+				rm.ScopeMetrics().AppendEmpty(),
+			)
+		}
+
+		batchMetrics = append(batchMetrics, batch)
 	}
 	p.resetState(now)
-	return metrics
+	return batchMetrics
 }
 
 var timeNowFunc = time.Now
@@ -231,31 +252,39 @@ func (p *StatsDParser) observerCategoryFor(t MetricType) ObserverCategory {
 }
 
 // Aggregate for each metric line.
-func (p *StatsDParser) Aggregate(line string) error {
+func (p *StatsDParser) Aggregate(line string, addr net.Addr) error {
 	parsedMetric, err := parseMessageToMetric(line, p.enableMetricType)
 	if err != nil {
 		return err
 	}
+
+	addrKey := addrToKey(addr)
+	instrument, ok := p.instruments[addrKey]
+	if !ok {
+		instrument = newInstruments(addr)
+	}
+	defer func() { p.instruments[addrKey] = instrument }()
+
 	switch parsedMetric.description.metricType {
 	case GaugeType:
-		_, ok := p.gauges[parsedMetric.description]
+		_, ok := instrument.gauges[parsedMetric.description]
 		if !ok {
-			p.gauges[parsedMetric.description] = buildGaugeMetric(parsedMetric, timeNowFunc())
+			instrument.gauges[parsedMetric.description] = buildGaugeMetric(parsedMetric, timeNowFunc())
 		} else {
 			if parsedMetric.addition {
-				point := p.gauges[parsedMetric.description].Metrics().At(0).Gauge().DataPoints().At(0)
+				point := instrument.gauges[parsedMetric.description].Metrics().At(0).Gauge().DataPoints().At(0)
 				point.SetDoubleValue(point.DoubleValue() + parsedMetric.gaugeValue())
 			} else {
-				p.gauges[parsedMetric.description] = buildGaugeMetric(parsedMetric, timeNowFunc())
+				instrument.gauges[parsedMetric.description] = buildGaugeMetric(parsedMetric, timeNowFunc())
 			}
 		}
 
 	case CounterType:
-		_, ok := p.counters[parsedMetric.description]
+		_, ok := instrument.counters[parsedMetric.description]
 		if !ok {
-			p.counters[parsedMetric.description] = buildCounterMetric(parsedMetric, p.isMonotonicCounter)
+			instrument.counters[parsedMetric.description] = buildCounterMetric(parsedMetric, p.isMonotonicCounter)
 		} else {
-			point := p.counters[parsedMetric.description].Metrics().At(0).Sum().DataPoints().At(0)
+			point := instrument.counters[parsedMetric.description].Metrics().At(0).Sum().DataPoints().At(0)
 			point.SetIntValue(point.IntValue() + parsedMetric.counterValue())
 		}
 
@@ -263,16 +292,16 @@ func (p *StatsDParser) Aggregate(line string) error {
 		category := p.observerCategoryFor(parsedMetric.description.metricType)
 		switch category.method {
 		case GaugeObserver:
-			p.timersAndDistributions = append(p.timersAndDistributions, buildGaugeMetric(parsedMetric, timeNowFunc()))
+			instrument.timersAndDistributions = append(instrument.timersAndDistributions, buildGaugeMetric(parsedMetric, timeNowFunc()))
 		case SummaryObserver:
 			raw := parsedMetric.sampleValue()
-			if existing, ok := p.summaries[parsedMetric.description]; !ok {
-				p.summaries[parsedMetric.description] = summaryMetric{
+			if existing, ok := instrument.summaries[parsedMetric.description]; !ok {
+				instrument.summaries[parsedMetric.description] = summaryMetric{
 					points:  []float64{raw.value},
 					weights: []float64{raw.count},
 				}
 			} else {
-				p.summaries[parsedMetric.description] = summaryMetric{
+				instrument.summaries[parsedMetric.description] = summaryMetric{
 					points:  append(existing.points, raw.value),
 					weights: append(existing.weights, raw.count),
 				}
@@ -280,13 +309,13 @@ func (p *StatsDParser) Aggregate(line string) error {
 		case HistogramObserver:
 			raw := parsedMetric.sampleValue()
 			var agg *histogramStructure
-			if existing, ok := p.histograms[parsedMetric.description]; ok {
+			if existing, ok := instrument.histograms[parsedMetric.description]; ok {
 				agg = existing.agg
 			} else {
 				agg = new(histogramStructure)
 				agg.Init(category.histogramConfig)
 
-				p.histograms[parsedMetric.description] = histogramMetric{
+				instrument.histograms[parsedMetric.description] = histogramMetric{
 					agg: agg,
 				}
 			}
@@ -387,4 +416,8 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 	}
 
 	return result, nil
+}
+
+func addrToKey(addr net.Addr) string {
+	return addr.Network() + "_" + addr.String()
 }

--- a/receiver/statsdreceiver/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser_test.go
@@ -16,6 +16,7 @@ package protocol
 
 import (
 	"errors"
+	"net"
 	"testing"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 )
 
 func Test_ParseMessageToMetric(t *testing.T) {
-
 	tests := []struct {
 		name       string
 		input      string
@@ -235,7 +235,6 @@ func Test_ParseMessageToMetric(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			got, err := parseMessageToMetric(tt.input, false)
 
 			if tt.err != nil {
@@ -249,7 +248,6 @@ func Test_ParseMessageToMetric(t *testing.T) {
 }
 
 func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
-
 	tests := []struct {
 		name       string
 		input      string
@@ -424,7 +422,6 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			got, err := parseMessageToMetric(tt.input, true)
 
 			if tt.err != nil {
@@ -441,7 +438,8 @@ func testStatsDMetric(
 	name string, asFloat float64,
 	addition bool, metricType MetricType,
 	sampleRate float64, labelKeys []string,
-	labelValue []string) statsDMetric {
+	labelValue []string,
+) statsDMetric {
 	if len(labelKeys) > 0 {
 		var kvs []attribute.KeyValue
 		var sortable attribute.Sortable
@@ -666,15 +664,83 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 			p := &StatsDParser{}
 			assert.NoError(t, p.Initialize(false, false, []TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
 			p.lastIntervalTime = time.Unix(611, 0)
+			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
+			addrKey := addrToKey(addr)
 			for _, line := range tt.input {
-				err = p.Aggregate(line)
+				err = p.Aggregate(line, addr)
 			}
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
 			} else {
-				assert.Equal(t, tt.expectedGauges, p.gauges)
-				assert.Equal(t, tt.expectedCounters, p.counters)
-				assert.Equal(t, tt.expectedTimer, p.timersAndDistributions)
+				assert.Equal(t, tt.expectedGauges, p.instruments[addrKey].gauges)
+				assert.Equal(t, tt.expectedCounters, p.instruments[addrKey].counters)
+				assert.Equal(t, tt.expectedTimer, p.instruments[addrKey].timersAndDistributions)
+			}
+		})
+	}
+}
+
+func TestStatsDParser_AggregateByAddress(t *testing.T) {
+	tests := []struct {
+		name           string
+		addresses      []net.Addr
+		input          [][]string
+		expectedGauges []map[statsDMetricDescription]pmetric.ScopeMetrics
+	}{
+		{
+			name: "two addresses",
+			addresses: []net.Addr{
+				&net.UDPAddr{IP: []byte{1, 2, 3, 4}, Port: 5678},
+				&net.UDPAddr{IP: []byte{255, 254, 253, 252}, Port: 251},
+			},
+			input: [][]string{
+				{
+					"statsdTestMetric1:1|g|#mykey:myvalue",
+					"statsdTestMetric2:2|g|#mykey:myvalue",
+					"statsdTestMetric1:+1|g|#mykey:myvalue",
+					"statsdTestMetric1:+100|g|#mykey:myvalue",
+					"statsdTestMetric1:+10000|g|#mykey:myvalue",
+					"statsdTestMetric2:+5|g|#mykey:myvalue",
+					"statsdTestMetric2:+500|g|#mykey:myvalue",
+				}, {
+					"statsdTestMetric1:1|g|#mykey:myvalue",
+					"statsdTestMetric2:2|g|#mykey:myvalue",
+					"statsdTestMetric1:+1|g|#mykey:myvalue",
+					"statsdTestMetric1:+100|g|#mykey:myvalue",
+					"statsdTestMetric1:+10000|g|#mykey:myvalue",
+					"statsdTestMetric2:+5|g|#mykey:myvalue",
+					"statsdTestMetric2:+500|g|#mykey:myvalue",
+				},
+			},
+			expectedGauges: []map[statsDMetricDescription]pmetric.ScopeMetrics{
+				{
+					testDescription("statsdTestMetric1", "g",
+						[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), time.Unix(711, 0)),
+					testDescription("statsdTestMetric2", "g",
+						[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric2", 507, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), time.Unix(711, 0)),
+				},
+				{
+					testDescription("statsdTestMetric1", "g",
+						[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), time.Unix(711, 0)),
+					testDescription("statsdTestMetric2", "g",
+						[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric2", 507, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), time.Unix(711, 0)),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &StatsDParser{}
+			assert.NoError(t, p.Initialize(true, false, []TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
+			p.lastIntervalTime = time.Unix(611, 0)
+			for i, addr := range tt.addresses {
+				for _, line := range tt.input[i] {
+					assert.NoError(t, p.Aggregate(line, addr))
+				}
+			}
+			for i, addr := range tt.addresses {
+				addrKey := addrToKey(addr)
+				assert.Equal(t, tt.expectedGauges[i], p.instruments[addrKey].gauges)
 			}
 		})
 	}
@@ -735,14 +801,16 @@ func TestStatsDParser_AggregateWithMetricType(t *testing.T) {
 			p := &StatsDParser{}
 			assert.NoError(t, p.Initialize(true, false, []TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
 			p.lastIntervalTime = time.Unix(611, 0)
+			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
+			addrKey := addrToKey(addr)
 			for _, line := range tt.input {
-				err = p.Aggregate(line)
+				err = p.Aggregate(line, addr)
 			}
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
 			} else {
-				assert.Equal(t, tt.expectedGauges, p.gauges)
-				assert.Equal(t, tt.expectedCounters, p.counters)
+				assert.Equal(t, tt.expectedGauges, p.instruments[addrKey].gauges)
+				assert.Equal(t, tt.expectedCounters, p.instruments[addrKey].counters)
 			}
 		})
 	}
@@ -783,14 +851,16 @@ func TestStatsDParser_AggregateWithIsMonotonicCounter(t *testing.T) {
 			p := &StatsDParser{}
 			assert.NoError(t, p.Initialize(false, true, []TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
 			p.lastIntervalTime = time.Unix(611, 0)
+			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
+			addrKey := addrToKey(addr)
 			for _, line := range tt.input {
-				err = p.Aggregate(line)
+				err = p.Aggregate(line, addr)
 			}
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
 			} else {
-				assert.Equal(t, tt.expectedGauges, p.gauges)
-				assert.Equal(t, tt.expectedCounters, p.counters)
+				assert.Equal(t, tt.expectedGauges, p.instruments[addrKey].gauges)
+				assert.Equal(t, tt.expectedCounters, p.instruments[addrKey].counters)
 			}
 		})
 	}
@@ -878,13 +948,15 @@ func TestStatsDParser_AggregateTimerWithSummary(t *testing.T) {
 			var err error
 			p := &StatsDParser{}
 			assert.NoError(t, p.Initialize(false, false, []TimerHistogramMapping{{StatsdType: "timer", ObserverType: "summary"}, {StatsdType: "histogram", ObserverType: "summary"}}))
+			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
+			addrKey := addrToKey(addr)
 			for _, line := range tt.input {
-				err = p.Aggregate(line)
+				err = p.Aggregate(line, addr)
 			}
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
 			} else {
-				assert.EqualValues(t, tt.expectedSummaries, p.summaries)
+				assert.EqualValues(t, tt.expectedSummaries, p.instruments[addrKey].summaries)
 			}
 		})
 	}
@@ -896,9 +968,15 @@ func TestStatsDParser_Initialize(t *testing.T) {
 	teststatsdDMetricdescription := statsDMetricDescription{
 		name:       "test",
 		metricType: "g",
-		attrs:      *attribute.EmptySet()}
-	p.gauges[teststatsdDMetricdescription] = pmetric.ScopeMetrics{}
-	assert.Equal(t, 1, len(p.gauges))
+		attrs:      *attribute.EmptySet(),
+	}
+	addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
+	addrKey := addrToKey(addr)
+	instrument := newInstruments(addr)
+	instrument.gauges[teststatsdDMetricdescription] = pmetric.ScopeMetrics{}
+	p.instruments[addrKey] = instrument
+	assert.Equal(t, 1, len(p.instruments))
+	assert.Equal(t, 1, len(p.instruments[addrKey].gauges))
 	assert.Equal(t, GaugeObserver, p.timerEvents.method)
 	assert.Equal(t, GaugeObserver, p.histogramEvents.method)
 }
@@ -906,23 +984,23 @@ func TestStatsDParser_Initialize(t *testing.T) {
 func TestStatsDParser_GetMetricsWithMetricType(t *testing.T) {
 	p := &StatsDParser{}
 	assert.NoError(t, p.Initialize(true, false, []TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
-	p.gauges[testDescription("statsdTestMetric1", "g",
-		[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"})] =
-		buildGaugeMetric(testStatsDMetric("testGauge1", 1, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), time.Unix(711, 0))
-	p.gauges[testDescription("statsdTestMetric1", "g",
-		[]string{"mykey2", "metric_type"}, []string{"myvalue2", "gauge"})] =
-		buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "g", 0, []string{"mykey2", "metric_type"}, []string{"myvalue2", "gauge"}), time.Unix(711, 0))
-	p.counters[testDescription("statsdTestMetric1", "g",
-		[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"})] =
-		buildCounterMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), false)
-	p.timersAndDistributions = append(p.timersAndDistributions, buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "ms", 0, []string{"mykey2", "metric_type"}, []string{"myvalue2", "gauge"}), time.Unix(711, 0)))
-	p.summaries = map[statsDMetricDescription]summaryMetric{
+	instrument := newInstruments(nil)
+	instrument.gauges[testDescription("statsdTestMetric1", "g",
+		[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"})] = buildGaugeMetric(testStatsDMetric("testGauge1", 1, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), time.Unix(711, 0))
+	instrument.gauges[testDescription("statsdTestMetric1", "g",
+		[]string{"mykey2", "metric_type"}, []string{"myvalue2", "gauge"})] = buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "g", 0, []string{"mykey2", "metric_type"}, []string{"myvalue2", "gauge"}), time.Unix(711, 0))
+	instrument.counters[testDescription("statsdTestMetric1", "g",
+		[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"})] = buildCounterMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), false)
+	instrument.timersAndDistributions = append(instrument.timersAndDistributions, buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "ms", 0, []string{"mykey2", "metric_type"}, []string{"myvalue2", "gauge"}), time.Unix(711, 0)))
+	instrument.summaries = map[statsDMetricDescription]summaryMetric{
 		testDescription("statsdTestMetric1", "h",
 			[]string{"mykey"}, []string{"myvalue"}): {
 			points:  []float64{1, 1, 10, 20},
 			weights: []float64{1, 1, 1, 1},
-		}}
-	metrics := p.GetMetrics()
+		},
+	}
+	p.instruments[""] = instrument
+	metrics := p.GetMetrics()[0].Metrics
 	assert.Equal(t, 5, metrics.ResourceMetrics().At(0).ScopeMetrics().Len())
 }
 
@@ -980,12 +1058,13 @@ func TestStatsDParser_Mappings(t *testing.T) {
 
 			assert.NoError(t, p.Initialize(false, false, tc.mapping))
 
-			assert.NoError(t, p.Aggregate("H:10|h"))
-			assert.NoError(t, p.Aggregate("T:10|ms"))
+			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
+			assert.NoError(t, p.Aggregate("H:10|h", addr))
+			assert.NoError(t, p.Aggregate("T:10|ms", addr))
 
 			typeNames := map[string]string{}
 
-			metrics := p.GetMetrics()
+			metrics := p.GetMetrics()[0].Metrics
 			ilm := metrics.ResourceMetrics().At(0).ScopeMetrics()
 			for i := 0; i < ilm.Len(); i++ {
 				ilms := ilm.At(i).Metrics()
@@ -1216,12 +1295,13 @@ func TestStatsDParser_AggregateTimerWithHistogram(t *testing.T) {
 			var err error
 			p := &StatsDParser{}
 			assert.NoError(t, p.Initialize(false, false, tt.mapping))
+			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
 			for _, line := range tt.input {
-				err = p.Aggregate(line)
+				err = p.Aggregate(line, addr)
 				assert.NoError(t, err)
 			}
 			var nodiffs []*metricstestutil.MetricDiff
-			assert.Equal(t, nodiffs, metricstestutil.DiffMetrics(nodiffs, tt.expected, p.GetMetrics()))
+			assert.Equal(t, nodiffs, metricstestutil.DiffMetrics(nodiffs, tt.expected, p.GetMetrics()[0].Metrics))
 		})
 	}
 }

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -92,9 +93,13 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 		return err
 	}
 	r.server = server
-	var transferChan = make(chan string, 10)
+	transferChan := make(chan transport.Metric, 10)
 	ticker := time.NewTicker(r.config.AggregationInterval)
-	err = r.parser.Initialize(r.config.EnableMetricType, r.config.IsMonotonicCounter, r.config.TimerHistogramMapping)
+	err = r.parser.Initialize(
+		r.config.EnableMetricType,
+		r.config.IsMonotonicCounter,
+		r.config.TimerHistogramMapping,
+	)
 	if err != nil {
 		return err
 	}
@@ -109,12 +114,13 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 		for {
 			select {
 			case <-ticker.C:
-				metrics := r.parser.GetMetrics()
-				if metrics.ResourceMetrics().At(0).ScopeMetrics().Len() > 0 {
-					r.Flush(ctx, metrics, r.nextConsumer)
+				batchMetrics := r.parser.GetMetrics()
+				for _, batch := range batchMetrics {
+					ctx := client.NewContext(ctx, batch.Info)
+					r.Flush(ctx, batch.Metrics, r.nextConsumer)
 				}
-			case rawMetric := <-transferChan:
-				_ = r.parser.Aggregate(rawMetric)
+			case metric := <-transferChan:
+				_ = r.parser.Aggregate(metric.Raw, metric.Addr)
 			case <-ctx.Done():
 				ticker.Stop()
 				return

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -116,8 +116,8 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 			case <-ticker.C:
 				batchMetrics := r.parser.GetMetrics()
 				for _, batch := range batchMetrics {
-					ctx := client.NewContext(ctx, batch.Info)
-					r.Flush(ctx, batch.Metrics, r.nextConsumer)
+					batchCtx := client.NewContext(ctx, batch.Info)
+					r.Flush(batchCtx, batch.Metrics, r.nextConsumer)
 				}
 			case metric := <-transferChan:
 				_ = r.parser.Aggregate(metric.Raw, metric.Addr)

--- a/receiver/statsdreceiver/transport/server.go
+++ b/receiver/statsdreceiver/transport/server.go
@@ -17,15 +17,14 @@ package transport // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"context"
 	"errors"
+	"net"
 
 	"go.opentelemetry.io/collector/consumer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 )
 
-var (
-	errNilListenAndServeParameters = errors.New("no parameter of ListenAndServe can be nil")
-)
+var errNilListenAndServeParameters = errors.New("no parameter of ListenAndServe can be nil")
 
 // Server abstracts the type of transport being used and offer an
 // interface to handle serving clients over that transport.
@@ -37,12 +36,17 @@ type Server interface {
 		p protocol.Parser,
 		mc consumer.Metrics,
 		r Reporter,
-		transferChan chan<- string,
+		transferChan chan<- Metric,
 	) error
 
 	// Close stops any running ListenAndServe, however, it waits for any
 	// data already received to be parsed and sent to the next consumer.
 	Close() error
+}
+
+type Metric struct {
+	Raw  string
+	Addr net.Addr
 }
 
 // Reporter is used to report (via zPages, logs, metrics, etc) the events

--- a/receiver/statsdreceiver/transport/server_test.go
+++ b/receiver/statsdreceiver/transport/server_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func Test_Server_ListenAndServe(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		buildServerFn func(addr string) (Server, error)
@@ -76,7 +75,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			p := &protocol.StatsDParser{}
 			require.NoError(t, err)
 			mr := NewMockReporter(1)
-			var transferChan = make(chan string, 10)
+			transferChan := make(chan Metric, 10)
 
 			wgListenAndServe := sync.WaitGroup{}
 			wgListenAndServe.Add(1)

--- a/receiver/statsdreceiver/transport/udp_server.go
+++ b/receiver/statsdreceiver/transport/udp_server.go
@@ -50,7 +50,7 @@ func (u *udpServer) ListenAndServe(
 	parser protocol.Parser,
 	nextConsumer consumer.Metrics,
 	reporter Reporter,
-	transferChan chan<- string,
+	transferChan chan<- Metric,
 ) error {
 	if parser == nil || nextConsumer == nil || reporter == nil {
 		return errNilListenAndServeParameters
@@ -60,11 +60,11 @@ func (u *udpServer) ListenAndServe(
 
 	buf := make([]byte, 65527) // max size for udp packet body (assuming ipv6)
 	for {
-		n, _, err := u.packetConn.ReadFrom(buf)
+		n, addr, err := u.packetConn.ReadFrom(buf)
 		if n > 0 {
 			bufCopy := make([]byte, n)
 			copy(bufCopy, buf)
-			u.handlePacket(bufCopy, transferChan)
+			u.handlePacket(bufCopy, addr, transferChan)
 		}
 		if err != nil {
 			u.reporter.OnDebugf("UDP Transport (%s) - ReadFrom error: %v",
@@ -87,7 +87,8 @@ func (u *udpServer) Close() error {
 
 func (u *udpServer) handlePacket(
 	data []byte,
-	transferChan chan<- string,
+	addr net.Addr,
+	transferChan chan<- Metric,
 ) {
 	buf := bytes.NewBuffer(data)
 	for {
@@ -100,7 +101,7 @@ func (u *udpServer) handlePacket(
 		}
 		line := strings.TrimSpace(string(bytes))
 		if line != "" {
-			transferChan <- line
+			transferChan <- Metric{line, addr}
 		}
 	}
 }


### PR DESCRIPTION
**Description:** 

A new config key `source_address_key`, if set, will be used to record the address of the sender of incoming metrics.

**Link to tracking Issue:** 

#15290

**Testing:** 

Added new test cases for differentiating metrics by source address

**Documentation:**

Updated readme for new config key