### PR TITLE
[processor/k8sattributesprocessor] fix doc formatting

### DIFF
--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -27,21 +27,22 @@
 // Each sources rule is specified as a pair of `from` (representing the rule type) and `name` (representing the attribute name if `From` is set to `resource_attribute`).
 // Following rule types are available:
 //
-//	from: "connection" - takes the IP attribute from connection context (if available)
-//	from: "resource_attribute" - allows to specify the attribute name to lookup up in the list of attributes of the received Resource.
-//	                             Semantic convention should be used for naming.
+//	     from: "connection" - takes the IP attribute from connection context (if available)
+//	     from: "resource_attribute" - allows to specify the attribute name to lookup up in the list of attributes of the received Resource.
+//		                             Semantic convention should be used for naming.
 //
 // Pod association configuration.
-// pod_association:
-//   - sources:
-//   - from: resource_attribute
-//     name: k8s.pod.ip
-//     # below association matches for pair `k8s.pod.name` and `k8s.namespace.name`
-//   - sources:
-//   - from: resource_attribute
-//     name: k8s.pod.name
-//   - from: resource_attribute
-//     name: k8s.namespace.name
+//
+//	pod_association:
+//	  - sources:
+//	      - from: resource_attribute
+//	        name: k8s.pod.ip
+//	  # below association matches for pair `k8s.pod.name` and `k8s.namespace.name`
+//	  - sources:
+//	      - from: resource_attribute
+//	        name: k8s.pod.name
+//	      - from: resource_attribute
+//	        name: k8s.namespace.name
 //
 // If Pod association rules are not configured resources are associated with metadata only by connection's IP Address.
 //
@@ -78,23 +79,24 @@
 // The "from" field has only two possible values "pod" and "namespace" and defaults to "pod" if none is specified.
 //
 // A few examples to use this config are as follows:
-// annotations:
-//   - tag_name: a1 # extracts value of annotation from pods with key `annotation-one` and inserts it as a tag with key `a1`
-//     key: annotation-one
-//     from: pod
-//   - tag_name: a2 # extracts value of annotation from namespaces with key `annotation-two` with regexp and inserts it as a tag with key `a2`
-//     key: annotation-two
-//     regex: field=(?P<value>.+)
-//     from: namespace
 //
-// labels:
-//   - tag_name: l1 # extracts value of label from namespaces with key `label1` and inserts it as a tag with key `l1`
-//     key: label1
-//     from: namespace
-//   - tag_name: l2 # extracts value of label from pods with key `label2` with regexp and inserts it as a tag with key `l2`
-//     key: label2
-//     regex: field=(?P<value>.+)
-//     from: pod
+//	annotations:
+//	  - tag_name: a1 # extracts value of annotation from pods with key `annotation-one` and inserts it as a tag with key `a1`
+//	    key: annotation-one
+//	    from: pod
+//	  - tag_name: a2 # extracts value of annotation from namespaces with key `annotation-two` with regexp and inserts it as a tag with key `a2`
+//	    key: annotation-two
+//	    regex: field=(?P<value>.+)
+//	    from: namespace
+//
+//	labels:
+//	  - tag_name: l1 # extracts value of label from namespaces with key `label1` and inserts it as a tag with key `l1`
+//	    key: label1
+//	    from: namespace
+//	  - tag_name: l2 # extracts value of label from pods with key `label2` with regexp and inserts it as a tag with key `l2`
+//	    key: label2
+//	    regex: field=(?P<value>.+)
+//	    from: pod
 //
 // # RBAC
 //

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -27,9 +27,9 @@
 // Each sources rule is specified as a pair of `from` (representing the rule type) and `name` (representing the attribute name if `From` is set to `resource_attribute`).
 // Following rule types are available:
 //
-//	     from: "connection" - takes the IP attribute from connection context (if available)
-//	     from: "resource_attribute" - allows to specify the attribute name to lookup up in the list of attributes of the received Resource.
-//		                             Semantic convention should be used for naming.
+//	from: "connection" - takes the IP attribute from connection context (if available)
+//	from: "resource_attribute" - allows to specify the attribute name to lookup up in the list of attributes of the received Resource.
+//	                             Semantic convention should be used for naming.
 //
 // Pod association configuration.
 //


### PR DESCRIPTION
**Description:** 

Fix formatting/rendering for code blocks in godoc to conform to https://go.dev/doc/comment
k8sattributes points users to https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor which currently incorrectly renders some unindented blocks of example config.

**Link to tracking Issue:** 

**Testing:** look at docs

**Documentation:** 