### PR TITLE
[exporter/datadog] Enable retries when exporting usage metrics in Datadog traces exporter

### DIFF
--- a/.chloggen/datadogexporter-enable-retry-in-host-metric-export.yaml
+++ b/.chloggen/datadogexporter-enable-retry-in-host-metric-export.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: datadogexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Enable retries in exportHostMetrics in Datadog traces_exporter
+note: Datadog trace exporter will now retry sending usage metrics when it fails
 
 # One or more tracking issues related to the change
 issues: [18238]

--- a/.chloggen/datadogexporter-enable-retry-in-host-metric-export.yaml
+++ b/.chloggen/datadogexporter-enable-retry-in-host-metric-export.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable retries in exportHostMetrics in Datadog traces_exporter
+
+# One or more tracking issues related to the change
+issues: [18238]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -49,17 +49,20 @@ type traceExporter struct {
 	onceMetadata   *sync.Once            // onceMetadata ensures that metadata is sent only once across all exporters
 	agent          *agent.Agent          // agent processes incoming traces
 	sourceProvider source.Provider       // is able to source the origin of a trace (hostname, container, etc)
+	retrier        *clientutil.Retrier   // retrier handles retries on requests
 }
 
 func newTracesExporter(ctx context.Context, params exporter.CreateSettings, cfg *Config, onceMetadata *sync.Once, sourceProvider source.Provider, agent *agent.Agent) (*traceExporter, error) {
+	scrubber := scrub.NewScrubber()
 	exp := &traceExporter{
 		params:         params,
 		cfg:            cfg,
 		ctx:            ctx,
 		agent:          agent,
 		onceMetadata:   onceMetadata,
-		scrubber:       scrub.NewScrubber(),
+		scrubber:       scrubber,
 		sourceProvider: sourceProvider,
+		retrier:        clientutil.NewRetrier(params.Logger, cfg.RetrySettings, scrubber),
 	}
 	// client to send running metric to the backend & perform API key validation
 	errchan := make(chan error)
@@ -135,8 +138,11 @@ func (exp *traceExporter) exportHostMetrics(ctx context.Context, hosts map[strin
 			}
 			series = append(series, ms...)
 		}
-		ctx = clientutil.GetRequestContext(ctx, string(exp.cfg.API.Key))
-		_, _, err = exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: series})
+		_, err = exp.retrier.DoWithRetries(ctx, func(context.Context) error {
+			ctx = clientutil.GetRequestContext(ctx, string(exp.cfg.API.Key))
+			_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: series})
+			return clientutil.WrapError(merr, httpresp)
+		})
 	} else {
 		series := make([]zorkian.Metric, 0, len(hosts)+len(tags))
 		for host := range hosts {
@@ -149,7 +155,9 @@ func (exp *traceExporter) exportHostMetrics(ctx context.Context, hosts map[strin
 			}
 			series = append(series, ms...)
 		}
-		err = exp.client.PostMetrics(series)
+		_, err = exp.retrier.DoWithRetries(ctx, func(context.Context) error {
+			return exp.client.PostMetrics(series)
+		})
 	}
 	if err != nil {
 		exp.params.Logger.Error("Error posting hostname/tags series", zap.Error(err))

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -119,11 +119,11 @@ func (exp *traceExporter) consumeTraces(
 		}
 	}
 
-	exp.exportHostMetrics(ctx, hosts, tags)
+	exp.exportUsageMetrics(ctx, hosts, tags)
 	return nil
 }
 
-func (exp *traceExporter) exportHostMetrics(ctx context.Context, hosts map[string]struct{}, tags map[string]struct{}) {
+func (exp *traceExporter) exportUsageMetrics(ctx context.Context, hosts map[string]struct{}, tags map[string]struct{}) {
 	now := pcommon.NewTimestampFromTime(time.Now())
 	var err error
 	if isMetricExportV2Enabled() {
@@ -139,8 +139,8 @@ func (exp *traceExporter) exportHostMetrics(ctx context.Context, hosts map[strin
 			series = append(series, ms...)
 		}
 		_, err = exp.retrier.DoWithRetries(ctx, func(context.Context) error {
-			ctx = clientutil.GetRequestContext(ctx, string(exp.cfg.API.Key))
-			_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: series})
+			ctx2 := clientutil.GetRequestContext(ctx, string(exp.cfg.API.Key))
+			_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx2, datadogV2.MetricPayload{Series: series})
 			return clientutil.WrapError(merr, httpresp)
 		})
 	} else {


### PR DESCRIPTION
**Description:** 
Enable retries in exportHostMetrics in Datadog traces_exporter. This may help eliminate temporary networking error etc. in metrics export. In addition, in metrics_exporter, retries are always enabled in metrics export: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/f5e42bf6772aa8f916053eae6fdc1b3502a83090/exporter/datadogexporter/metrics_exporter.go#L227 `exportHostMetrics` should follow the same pattern.