### PR TITLE
[chore] Fix typo in regex parser doc

### DIFF
--- a/pkg/stanza/docs/operators/regex_parser.md
+++ b/pkg/stanza/docs/operators/regex_parser.md
@@ -55,7 +55,7 @@ Configuration:
   "body": {
     "message": "Host=127.0.0.1, Type=HTTP"
   },
-  "attributes:" {
+  "attributes": {
     "host": "127.0.0.1",
     "type": "HTTP"
   }


### PR DESCRIPTION
**Description:**
This PR fixed a typo in the regex_parser operator doc.

**Link to tracking Issue:** None

**Testing:** None

**Documentation:** None