### PR TITLE
[translator/prometheusremotewrite] add metric name to error message

### DIFF
--- a/.chloggen/prometheusremotewrite-add-metric-name-to-error-message-when-invalid.yaml
+++ b/.chloggen/prometheusremotewrite-add-metric-name-to-error-message-when-invalid.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: translator/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add metric name to error message when invalid
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Exporter prometheusremotewrite doesn't support non-cumulative monotonic, histogram, and summary OTLP metrics.
+  Added metric name to error message when the unsupported metrics get dropped.

--- a/.chloggen/prometheusremotewrite-add-metric-name-to-error-message-when-invalid.yaml
+++ b/.chloggen/prometheusremotewrite-add-metric-name-to-error-message-when-invalid.yaml
@@ -8,7 +8,7 @@ component: translator/prometheusremotewrite
 note: Add metric name to error message when invalid
 
 # One or more tracking issues related to the change
-issues: []
+issues: [18292]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -55,7 +55,7 @@ func FromMetrics(md pmetric.Metrics, settings Settings) (tsMap map[string]*promp
 				mostRecentTimestamp = maxTimestamp(mostRecentTimestamp, mostRecentTimestampInMetric(metric))
 
 				if !isValidAggregationTemporality(metric) {
-					errs = multierr.Append(errs, fmt.Errorf("invalid temporality and type combination for %s metric", metric.Name()))
+					errs = multierr.Append(errs, fmt.Errorf("invalid temporality and type combination for metric %q", metric.Name()))
 					continue
 				}
 

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -55,7 +55,7 @@ func FromMetrics(md pmetric.Metrics, settings Settings) (tsMap map[string]*promp
 				mostRecentTimestamp = maxTimestamp(mostRecentTimestamp, mostRecentTimestampInMetric(metric))
 
 				if !isValidAggregationTemporality(metric) {
-					errs = multierr.Append(errs, fmt.Errorf("invalid temporality and type combination. %s is dropped", metric.Name()))
+					errs = multierr.Append(errs, fmt.Errorf("invalid temporality and type combination for %s metric", metric.Name()))
 					continue
 				}
 

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -55,7 +55,7 @@ func FromMetrics(md pmetric.Metrics, settings Settings) (tsMap map[string]*promp
 				mostRecentTimestamp = maxTimestamp(mostRecentTimestamp, mostRecentTimestampInMetric(metric))
 
 				if !isValidAggregationTemporality(metric) {
-					errs = multierr.Append(errs, errors.New("invalid temporality and type combination"))
+					errs = multierr.Append(errs, fmt.Errorf("invalid temporality and type combination. %s is dropped", metric.Name()))
 					continue
 				}
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Right now when using Prometheus remote write exporter some metrics that are not supported by the exporter are dropped:
```
⚠️ Non-cumulative monotonic, histogram, and summary OTLP metrics are dropped by this exporter.
```
At the moment, it gets logged and it also propagates into metrics but there is no way to tell which metrics are affected.
Because of that, I would like to suggest adding the metric name to the error message which gets logged so we can tell which metrics are being dropped.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Tested in our testing environment with locally built image, example log line:
```
opentelemetry-cluster-5f9cc5d595-pbcf8 opentelemetry-collector 2023-02-06T13:59:01.448Z	error	exporterhelper/queued_retry.go:394	Exporting failed. The error is not retryable. Dropping data.	{"kind": "exporter", "data_type": "metrics", "name": "prometheusremotewrite", "error": "Permanent error: invalid temporality and type combination. system.network.dropped is dropped; invalid temporality and type combination. system.network.io is dropped; invalid temporality and type combination. system.network.packets is dropped", "dropped_items": 200}
```

**Documentation:** <Describe the documentation added.>