### PR TITLE
[exporter/splunkhec] Reconnect when server returns 502/429 errors

### DIFF
--- a/.chloggen/splunkhecexporter_reconnect_on_502_429_error.yaml
+++ b/.chloggen/splunkhecexporter_reconnect_on_502_429_error.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reconnect when server returns 502/429 errors.
+
+# One or more tracking issues related to the change
+issues: [18281]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
Do not drain the response body when the exporter receives a 502 or 429 from a load balancer or cluster. It will force the client to create a new connection.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18281

**Testing:**

**Documentation:** <Describe the documentation added.>