### PR TITLE
[chore] Add doc for regex parser cache

### DIFF
--- a/pkg/stanza/docs/operators/regex_parser.md
+++ b/pkg/stanza/docs/operators/regex_parser.md
@@ -8,17 +8,18 @@ This operator makes use of [Go regular expression](https://github.com/google/re2
 
 ### Configuration Fields
 
-| Field         | Default          | Description |
-| ---           | ---              | ---         |
-| `id`          | `regex_parser`   | A unique identifier for the operator. |
-| `output`      | Next in pipeline | The connected operator(s) that will receive all outbound entries. |
-| `regex`       | required         | A [Go regular expression](https://github.com/google/re2/wiki/Syntax). The named capture groups will be extracted as fields in the parsed body. |
-| `parse_from`  | `body`           | The [field](../types/field.md) from which the value will be parsed. |
-| `parse_to`    | `attributes`     | The [field](../types/field.md) to which the value will be parsed. |
-| `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
-| `if`          |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
-| `timestamp`   | `nil`            | An optional [timestamp](../types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator. |
-| `severity`    | `nil`            | An optional [severity](../types/severity.md) block which will parse a severity field before passing the entry to the output operator. |
+| Field        | Default          | Description                                                                                                                                                                                                                           |
+|--------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`         | `regex_parser`   | A unique identifier for the operator.                                                                                                                                                                                                 |
+| `output`     | Next in pipeline | The connected operator(s) that will receive all outbound entries.                                                                                                                                                                     |
+| `regex`      | required         | A [Go regular expression](https://github.com/google/re2/wiki/Syntax). The named capture groups will be extracted as fields in the parsed body.                                                                                        |
+| `parse_from` | `body`           | The [field](../types/field.md) from which the value will be parsed.                                                                                                                                                                   |
+| `parse_to`   | `attributes`     | The [field](../types/field.md) to which the value will be parsed.                                                                                                                                                                     |
+| `on_error`   | `send`           | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md).                                                                                                                                         |
+| `if`         |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
+| `timestamp`  | `nil`            | An optional [timestamp](../types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator.                                                                                              |
+| `severity`   | `nil`            | An optional [severity](../types/severity.md) block which will parse a severity field before passing the entry to the output operator.                                                                                                 |
+| `cache`      | `nil`            | An optional [cache](../types/cache.md) block which will enable a memory cache for parsing the same input repeatedly.                                                                                                                  |
 
 ### Example Configurations
 

--- a/pkg/stanza/docs/types/cache.md
+++ b/pkg/stanza/docs/types/cache.md
@@ -1,0 +1,34 @@
+# Parsing Cache
+Caching is useful when regex is used to parse the same input repeatedly.
+
+The cache is thread safe by leveraging read / write mutex. Reads will lock the mutex with a read lock, while writes will block all operations with a lock.
+
+When the cache is full, the oldest entry is removed to make room for the new entry.
+
+> Note: The cache only works for [regex_parser](../operators/regex_parser.md) as for now.
+
+### Internal Rate Limiting
+This process allows improperly configured cache's to perform similar to regex by avoiding the cache entirely.
+
+For example: A kubernetes cluster with 200 active log files will cause a cache of size 10 to "thrash". The cache will avoid locking (and blocking all reads) when eviction rates are too high.
+
+The internal rate limiting is achieved with a new limiter interface.
+The limiter tracks number of cache evictions during an interval.
+The limiter's count is incremented for every cache eviction.
+When the limiter's count reaches the limiter's limit, the throttled() method will return true.
+The cache's add() method will skip adding (and locking) when the limiter is throttled.
+
+### `cache` parameters
+| Field     | Default   | Description            |
+|-----------|-----------|------------------------|
+| `size`    | 0         | The size of the cache. |
+
+### Examples
+#### Enable cache for regex parser
+```yaml
+- type: regex_parser
+  parse_from: body.message
+  regex: '^Host=(?P<host>[^,]+), Type=(?P<type>.*)$'
+  cache:
+    size: 100
+```


### PR DESCRIPTION
**Description:**
This PR added documentation for the regex parser cache. The descriptions were originally posted by @jsirianni at https://github.com/open-telemetry/opentelemetry-log-collection/pull/440

**Link to tracking Issue:** None

**Testing:** None

**Documentation:** None