### PR TITLE
[docs] fix receiver_creator supported pipelines

### DIFF
--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -3,7 +3,7 @@
 | Status                   |                       |
 |--------------------------|-----------------------|
 | Stability                | [beta]                |
-| Supported pipeline types | logs, metrics, traces |
+| Supported pipeline types | metrics               |
 | Distributions            | [contrib]             |
 
 This receiver can instantiate other receivers at runtime based on whether

--- a/receiver/receivercreator/factory_test.go
+++ b/receiver/receivercreator/factory_test.go
@@ -41,4 +41,9 @@ func TestCreateReceiver(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, component.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
+
+	lReceiver, err := factory.CreateLogsReceiver(context.Background(), params, cfg, nil)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, component.ErrDataTypeIsNotSupported)
+	assert.Nil(t, lReceiver)
 }


### PR DESCRIPTION

**Testing:** Added logs receiver creation test case.

**Documentation:** Remove traces and logs from README's header.

Receiver implements: `receiver.Metric`

Trying a receiver configuration in a logs or traces pipeline returns the following error:
`Error: cannot build pipelines: failed to create "receiver_creator/1" receiver, in pipeline "logs": telemetry type is not supported`
