### PR TITLE
[receiver/awscloudwatch] fix limit discovery exceeding API limits

### DIFF
--- a/.chloggen/cloudwatch-logs-paginate-discovery-in-fifties.yaml
+++ b/.chloggen/cloudwatch-logs-paginate-discovery-in-fifties.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'awscloudwatchreceiver'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes issue where limit per discovery request could be configured to exceed API limitations.
+
+# One or more tracking issues related to the change
+issues: [18293]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The request now always sets a limit of 50

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -36,7 +36,7 @@ This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/devel
 `autodiscover` and `named` are ways to control and filter which log groups and log streams which are collected from. They are mutually exclusive and are incompatible to be configured at the same time.
 
 - `autodiscover`
-  - `limit`: (optional; default = 50) Limits the number of discovered log groups.
+  - `limit`: (optional; default = 50) Limits the number of discovered log groups. This does not limit how large each API call to discover the log groups will be.
   - `prefix`: (optional) A prefix for log groups to limit the number of log groups discovered.
     - if omitted, all log streams up to the limit are collected from
   - `streams`: (optional) If `streams` is omitted, then all streams will be attempted to retrieve events from.


### PR DESCRIPTION
**Description:** Seems the API has a limit of how many Log Groups can be retrieved per request of `DescribeLgoGroups` 

I initially interpreted the max could be higher based off this comment

https://github.com/aws/aws-sdk-go/blob/740c2dd94c8d75423d045be60a10384107376268/service/cloudwatchlogs/api.go#L6589-L6591

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** Resolves #18293

**Testing:** Added a unit test that tests the next token logic

**Documentation:** <Describe the documentation added.>