### PR TITLE
[chore] Rename e2e test and make them run on main branch and tags

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,9 +1,12 @@
-name: Test Kubernetes Related Components
+name: e2e-tests
 
 on:
-  pull_request:
+  push:
     branches:
       - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
 
 jobs:
   kubernetes-test:


### PR DESCRIPTION
A follow-up after adding an initial version of k8s e2e tests