### PR TITLE
[chore] remove realpath usage

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -10,7 +10,7 @@ else
 endif
 
 # SRC_ROOT is the top of the source tree.
-SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+SRC_ROOT := $(shell git rev-parse --show-toplevel)
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""


### PR DESCRIPTION
Trying to fix installation of tools on windows. It looks like SRC_ROOT isn't working as it is on windows:

```
/usr/bin/sh: line 1: /internal/tools/tools.go: No such file or directory
```

See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/4113006957/jobs/7098614011

Signed-off-by: Alex Boten <aboten@lightstep.com>
