### PR TITLE
[pkg/stanza] Condense Converter logic to improve memory usage

### DIFF
--- a/.chloggen/stanza-condense-converter-batching.yaml
+++ b/.chloggen/stanza-condense-converter-batching.yaml
@@ -1,0 +1,10 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reduced `Converter` memory footprint by condensing the `aggregationLoop` logic into `workerLoop`.
+# One or more tracking issues related to the change
+issues: [18411]

--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -121,12 +121,6 @@ func (c *Converter) OutChannel() <-chan plog.Logs {
 	return c.pLogsChan
 }
 
-type workerItem struct {
-	Resource   map[string]interface{}
-	LogRecord  plog.LogRecord
-	ResourceID uint64
-}
-
 // workerLoop is responsible for obtaining log entries from Batch() calls,
 // converting them to plog.LogRecords batched by Resource, and sending them
 // on flushChan.
@@ -172,10 +166,11 @@ func (c *Converter) workerLoop() {
 				upsertToMap(resourceAttrs, resource.Attributes())
 
 				ills := rls.ScopeLogs()
+				sls := ills.AppendEmpty()
 
 				// Convert standard entries into plogs for the resource
 				for _, e := range resourceEntries {
-					lr := ills.AppendEmpty().LogRecords().AppendEmpty()
+					lr := sls.LogRecords().AppendEmpty()
 					convertInto(e, lr)
 				}
 			}


### PR DESCRIPTION
**Description:** Condensed the `aggregationLoop` logic into the `workerLoop` to reduce the memory footprint of the converter. More details in the linked issue.

**Link to tracking Issue:** Resolves #18411 

**Testing:** No unit test changes were needed. See linked issue for test run data.