### PR TITLE
[receiver/awsxray] set required AttributeServiceName

### DIFF
--- a/.chloggen/set-attribute-service-name.yaml
+++ b/.chloggen/set-attribute-service-name.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "set `service.name` attribute"
+
+# One or more tracking issues related to the change
+issues: [18480]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/awsxrayreceiver/internal/translator/translator.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator.go
@@ -199,6 +199,8 @@ func populateResource(seg *awsxray.Segment, rs pcommon.Resource) {
 	attrs.Clear()
 	attrs.EnsureCapacity(initAttrCapacity)
 
+	addString(seg.Name, conventions.AttributeServiceName, attrs)
+
 	addAWSToResource(seg.AWS, attrs)
 	addSdkToResource(seg, attrs)
 	if seg.Service != nil {

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -85,6 +85,7 @@ func TestTranslation(t *testing.T) {
 			samplePath: filepath.Join("../../../../internal/aws/xray", "testdata", "serverSample.txt"),
 			expectedResourceAttrs: func(seg *awsxray.Segment) map[string]interface{} {
 				return map[string]interface{}{
+					conventions.AttributeServiceName:          *seg.Name,
 					conventions.AttributeCloudProvider:        conventions.AttributeCloudProviderAWS,
 					conventions.AttributeTelemetrySDKVersion:  *seg.AWS.XRay.SDKVersion,
 					conventions.AttributeTelemetrySDKName:     *seg.AWS.XRay.SDK,
@@ -126,6 +127,7 @@ func TestTranslation(t *testing.T) {
 			samplePath: filepath.Join("../../../../internal/aws/xray", "testdata", "ddbSample.txt"),
 			expectedResourceAttrs: func(seg *awsxray.Segment) map[string]interface{} {
 				return map[string]interface{}{
+					conventions.AttributeServiceName:          *seg.Name,
 					conventions.AttributeCloudProvider:        conventions.AttributeCloudProviderAWS,
 					conventions.AttributeTelemetrySDKVersion:  *seg.AWS.XRay.SDKVersion,
 					conventions.AttributeTelemetrySDKName:     *seg.AWS.XRay.SDK,
@@ -528,6 +530,7 @@ func TestTranslation(t *testing.T) {
 			samplePath: filepath.Join("../../../../internal/aws/xray", "testdata", "awsMissingAwsField.txt"),
 			expectedResourceAttrs: func(seg *awsxray.Segment) map[string]interface{} {
 				return map[string]interface{}{
+					conventions.AttributeServiceName:   *seg.Name,
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
@@ -563,6 +566,7 @@ func TestTranslation(t *testing.T) {
 			samplePath: filepath.Join("../../../../internal/aws/xray", "testdata", "awsValidAwsFields.txt"),
 			expectedResourceAttrs: func(seg *awsxray.Segment) map[string]interface{} {
 				return map[string]interface{}{
+					conventions.AttributeServiceName:           *seg.Name,
 					conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderAWS,
 					conventions.AttributeCloudAccountID:        *seg.AWS.AccountID,
 					conventions.AttributeCloudAvailabilityZone: *seg.AWS.EC2.AvailabilityZone,
@@ -612,6 +616,7 @@ func TestTranslation(t *testing.T) {
 			samplePath: filepath.Join("../../../../internal/aws/xray", "testdata", "minCauseIsExceptionId.txt"),
 			expectedResourceAttrs: func(seg *awsxray.Segment) map[string]interface{} {
 				return map[string]interface{}{
+					conventions.AttributeServiceName:   *seg.Name,
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
@@ -665,6 +670,7 @@ func TestTranslation(t *testing.T) {
 			samplePath: filepath.Join("../../../../internal/aws/xray", "testdata", "indepSubsegment.txt"),
 			expectedResourceAttrs: func(seg *awsxray.Segment) map[string]interface{} {
 				return map[string]interface{}{
+					conventions.AttributeServiceName:   *seg.Name,
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
@@ -708,6 +714,7 @@ func TestTranslation(t *testing.T) {
 			samplePath: filepath.Join("../../../../internal/aws/xray", "testdata", "indepSubsegmentWithContentLengthString.txt"),
 			expectedResourceAttrs: func(seg *awsxray.Segment) map[string]interface{} {
 				return map[string]interface{}{
+					conventions.AttributeServiceName:   *seg.Name,
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
@@ -752,6 +759,7 @@ func TestTranslation(t *testing.T) {
 			samplePath: filepath.Join("../../../../internal/aws/xray", "testdata", "indepSubsegmentWithSql.txt"),
 			expectedResourceAttrs: func(seg *awsxray.Segment) map[string]interface{} {
 				return map[string]interface{}{
+					conventions.AttributeServiceName:   *seg.Name,
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},


### PR DESCRIPTION
**Description:** Set required AttributeServiceName attribute.
According to [OpenTelemetry specification](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/#service), the requirement level of `service.name` attribute is Required.

**Link to tracking Issue:** #18480

**Testing:** Verify with a unit test that service.name is set

**Documentation:** None