### PR TITLE
[cmd/mdatagen] support map and slice attrs

### DIFF
--- a/.chloggen/mdatagenSupportMapAndSliceAttrs.yaml
+++ b/.chloggen/mdatagenSupportMapAndSliceAttrs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for slice and map attributes.
+
+# One or more tracking issues related to the change
+issues: [18272]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/mdatagen/documentation.md
+++ b/cmd/mdatagen/documentation.md
@@ -29,6 +29,8 @@ The metric will be become optional soon.
 | string_attr | Attribute with any string value. | Any Str |
 | state | Integer attribute with overridden name. | Any Int |
 | enum_attr | Attribute with a known set of string values. | Str: ``red``, ``green``, ``blue`` |
+| slice_attr | Attribute with a slice value. | Any Slice |
+| map_attr | Attribute with a map value. | Any Map |
 
 ### default.metric.to_be_removed
 
@@ -69,6 +71,8 @@ metrics:
 
 | Name | Description | Values | Enabled |
 | ---- | ----------- | ------ | ------- |
+| map.resource.attr | Resource attribute with a map value. | Any Map | true |
 | optional.resource.attr | Explicitly disabled ResourceAttribute. | Any Str | false |
+| slice.resource.attr | Resource attribute with a slice value. | Any Slice | true |
 | string.enum.resource.attr | Resource attribute with a known set of string values. | Str: ``one``, ``two`` | true |
 | string.resource.attr | Resource attribute with any string value. | Any Str | true |

--- a/cmd/mdatagen/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/metadata/generated_metrics.go
@@ -60,15 +60,23 @@ type ResourceAttributeSettings struct {
 
 // ResourceAttributesSettings provides settings for testreceiver metrics.
 type ResourceAttributesSettings struct {
+	MapResourceAttr        ResourceAttributeSettings `mapstructure:"map.resource.attr"`
 	OptionalResourceAttr   ResourceAttributeSettings `mapstructure:"optional.resource.attr"`
+	SliceResourceAttr      ResourceAttributeSettings `mapstructure:"slice.resource.attr"`
 	StringEnumResourceAttr ResourceAttributeSettings `mapstructure:"string.enum.resource.attr"`
 	StringResourceAttr     ResourceAttributeSettings `mapstructure:"string.resource.attr"`
 }
 
 func DefaultResourceAttributesSettings() ResourceAttributesSettings {
 	return ResourceAttributesSettings{
+		MapResourceAttr: ResourceAttributeSettings{
+			Enabled: true,
+		},
 		OptionalResourceAttr: ResourceAttributeSettings{
 			Enabled: false,
+		},
+		SliceResourceAttr: ResourceAttributeSettings{
+			Enabled: true,
 		},
 		StringEnumResourceAttr: ResourceAttributeSettings{
 			Enabled: true,
@@ -126,7 +134,7 @@ func (m *metricDefaultMetric) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue string) {
+func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue string, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -137,6 +145,8 @@ func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
 	dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
+	dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
+	dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -349,11 +359,29 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 // ResourceMetricsOption applies changes to provided resource metrics.
 type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
 
+// WithMapResourceAttr sets provided value as "map.resource.attr" attribute for current resource.
+func WithMapResourceAttr(val map[string]any) ResourceMetricsOption {
+	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+		if ras.MapResourceAttr.Enabled {
+			rm.Resource().Attributes().PutEmptyMap("map.resource.attr").FromRaw(val)
+		}
+	}
+}
+
 // WithOptionalResourceAttr sets provided value as "optional.resource.attr" attribute for current resource.
 func WithOptionalResourceAttr(val string) ResourceMetricsOption {
 	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
 		if ras.OptionalResourceAttr.Enabled {
 			rm.Resource().Attributes().PutStr("optional.resource.attr", val)
+		}
+	}
+}
+
+// WithSliceResourceAttr sets provided value as "slice.resource.attr" attribute for current resource.
+func WithSliceResourceAttr(val []any) ResourceMetricsOption {
+	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+		if ras.SliceResourceAttr.Enabled {
+			rm.Resource().Attributes().PutEmptySlice("slice.resource.attr").FromRaw(val)
 		}
 	}
 }
@@ -438,8 +466,8 @@ func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 }
 
 // RecordDefaultMetricDataPoint adds a data point to default.metric metric.
-func (mb *MetricsBuilder) RecordDefaultMetricDataPoint(ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue AttributeEnumAttr) {
-	mb.metricDefaultMetric.recordDataPoint(mb.startTime, ts, val, stringAttrAttributeValue, overriddenIntAttrAttributeValue, enumAttrAttributeValue.String())
+func (mb *MetricsBuilder) RecordDefaultMetricDataPoint(ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue AttributeEnumAttr, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any) {
+	mb.metricDefaultMetric.recordDataPoint(mb.startTime, ts, val, stringAttrAttributeValue, overriddenIntAttrAttributeValue, enumAttrAttributeValue.String(), sliceAttrAttributeValue, mapAttrAttributeValue)
 }
 
 // RecordDefaultMetricToBeRemovedDataPoint adds a data point to default.metric.to_be_removed metric.

--- a/cmd/mdatagen/internal/metadata/testdata/config.yaml
+++ b/cmd/mdatagen/internal/metadata/testdata/config.yaml
@@ -8,7 +8,11 @@ all_set:
     optional.metric:
       enabled: true
   resource_attributes:
+    map.resource.attr:
+      enabled: true
     optional.resource.attr:
+      enabled: true
+    slice.resource.attr:
       enabled: true
     string.enum.resource.attr:
       enabled: true
@@ -23,7 +27,11 @@ none_set:
     optional.metric:
       enabled: false
   resource_attributes:
+    map.resource.attr:
+      enabled: false
     optional.resource.attr:
+      enabled: false
+    slice.resource.attr:
       enabled: false
     string.enum.resource.attr:
       enabled: false

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -65,6 +65,10 @@ func (mvt *ValueType) UnmarshalText(text []byte) error {
 		mvt.ValueType = pcommon.ValueTypeBool
 	case "bytes":
 		mvt.ValueType = pcommon.ValueTypeBytes
+	case "slice":
+		mvt.ValueType = pcommon.ValueTypeSlice
+	case "map":
+		mvt.ValueType = pcommon.ValueTypeMap
 	default:
 		return fmt.Errorf("invalid type: %q", vtStr)
 	}
@@ -89,6 +93,10 @@ func (mvt ValueType) Primitive() string {
 		return "bool"
 	case pcommon.ValueTypeBytes:
 		return "[]byte"
+	case pcommon.ValueTypeSlice:
+		return "[]any"
+	case pcommon.ValueTypeMap:
+		return "map[string]any"
 	default:
 		return ""
 	}
@@ -105,9 +113,9 @@ func (mvt ValueType) TestValue() string {
 	case pcommon.ValueTypeBool:
 		return "true"
 	case pcommon.ValueTypeMap:
-		return `pcommon.NewMap()`
+		return `map[string]any{"onek": "onev", "twok": "twov"}`
 	case pcommon.ValueTypeSlice:
-		return `pcommon.NewSlice()`
+		return `[]any{"one", "two"}`
 	}
 	return ""
 }

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -56,6 +56,20 @@ func Test_loadMetadata(t *testing.T) {
 							ValueType: pcommon.ValueTypeStr,
 						},
 					},
+					"slice.resource.attr": {
+						Description: "Resource attribute with a slice value.",
+						Enabled:     true,
+						Type: ValueType{
+							ValueType: pcommon.ValueTypeSlice,
+						},
+					},
+					"map.resource.attr": {
+						Description: "Resource attribute with a map value.",
+						Enabled:     true,
+						Type: ValueType{
+							ValueType: pcommon.ValueTypeMap,
+						},
+					},
 				},
 				Attributes: map[attributeName]attribute{
 					"enum_attr": {
@@ -85,7 +99,20 @@ func Test_loadMetadata(t *testing.T) {
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeBool,
 						},
-					}},
+					},
+					"slice_attr": {
+						Description: "Attribute with a slice value.",
+						Type: ValueType{
+							ValueType: pcommon.ValueTypeSlice,
+						},
+					},
+					"map_attr": {
+						Description: "Attribute with a map value.",
+						Type: ValueType{
+							ValueType: pcommon.ValueTypeMap,
+						},
+					},
+				},
 				Metrics: map[metricName]metric{
 					"default.metric": {
 						Enabled:               true,
@@ -100,7 +127,7 @@ func Test_loadMetadata(t *testing.T) {
 							Aggregated:      Aggregated{Aggregation: pmetric.AggregationTemporalityCumulative},
 							Mono:            Mono{Monotonic: true},
 						},
-						Attributes: []attributeName{"string_attr", "overridden_int_attr", "enum_attr"},
+						Attributes: []attributeName{"string_attr", "overridden_int_attr", "enum_attr", "slice_attr", "map_attr"},
 					},
 					"optional.metric": {
 						Enabled:     false,

--- a/cmd/mdatagen/metadata.yaml
+++ b/cmd/mdatagen/metadata.yaml
@@ -21,6 +21,16 @@ resource_attributes:
     type: string
     enabled: false
 
+  slice.resource.attr:
+    description: Resource attribute with a slice value.
+    type: slice
+    enabled: true
+
+  map.resource.attr:
+    description: Resource attribute with a map value.
+    type: map 
+    enabled: true
+
 attributes:
   string_attr:
     description: Attribute with any string value.
@@ -40,6 +50,14 @@ attributes:
     description: Attribute with a boolean value.
     type: bool
 
+  slice_attr:
+    description: Attribute with a slice value.
+    type: slice
+
+  map_attr:
+    description: Attribute with a map value.
+    type: map
+
 metrics:
   default.metric:
     enabled: true
@@ -50,7 +68,7 @@ metrics:
       value_type: int
       monotonic: true
       aggregation: cumulative
-    attributes: [string_attr, overridden_int_attr, enum_attr]
+    attributes: [string_attr, overridden_int_attr, enum_attr, slice_attr, map_attr]
     warnings:
       if_enabled_not_set: This metric will be disabled by default soon.
 

--- a/cmd/mdatagen/metric-metadata.yaml
+++ b/cmd/mdatagen/metric-metadata.yaml
@@ -15,7 +15,7 @@ resource_attributes:
     # Optional: array of attribute values if they are static values (currently, only string type is supported).
     enum:
     # Required: attribute value type.
-    type: <string|int|double|bool|bytes>
+    type: <string|int|double|bool|bytes|slice|map>
 
 # Optional: map of attribute definitions with the key being the attribute name and value
 # being described below.
@@ -29,7 +29,7 @@ attributes:
     # Optional: array of attribute values if they are static values (currently, only string type is supported).
     enum:
     # Required: attribute value type.
-    type: <string|int|double|bool|bytes>
+    type: <string|int|double|bool|bytes|slice|map>
 
 # Required: map of metric names with the key being the metric name and value
 # being described below.

--- a/cmd/mdatagen/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/templates/metrics.go.tmpl
@@ -147,6 +147,10 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	{{- range $metric.Attributes }}
 	{{- if eq (attributeInfo .).Type.Primitive "[]byte" }}
 	dp.Attributes().PutEmptyBytes("{{ attributeName . }}").FromRaw({{ .RenderUnexported }}AttributeValue)
+	{{- else if eq (attributeInfo .).Type.Primitive "[]any" }}
+	dp.Attributes().PutEmptySlice("{{ attributeName . }}").FromRaw({{ .RenderUnexported }}AttributeValue)
+	{{- else if eq (attributeInfo .).Type.Primitive "map[string]any" }}
+	dp.Attributes().PutEmptyMap("{{ attributeName . }}").FromRaw({{ .RenderUnexported }}AttributeValue)
 	{{- else }}
 	dp.Attributes().Put{{ (attributeInfo .).Type }}("{{ attributeName .}}", {{ .RenderUnexported }}AttributeValue)
 	{{- end }}
@@ -285,6 +289,10 @@ func With{{ $name.Render }}(val {{ $attr.Type.Primitive }}) ResourceMetricsOptio
 		if ras.{{ $name.Render }}.Enabled {
 			{{- if eq $attr.Type.Primitive "[]byte" }}
 			rm.Resource().Attributes().PutEmptyBytes("{{ attributeName $name}}").FromRaw(val)
+			{{- else if eq $attr.Type.Primitive "[]any" }}
+			rm.Resource().Attributes().PutEmptySlice("{{ attributeName $name}}").FromRaw(val)
+			{{- else if eq $attr.Type.Primitive "map[string]any" }}
+			rm.Resource().Attributes().PutEmptyMap("{{ attributeName $name}}").FromRaw(val)
 			{{- else }}
 			rm.Resource().Attributes().Put{{ $attr.Type }}("{{ attributeName $name}}", val)
 			{{- end }}

--- a/cmd/mdatagen/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/templates/metrics_test.go.tmpl
@@ -115,6 +115,8 @@ func TestMetricsBuilder(t *testing.T) {
 					enabledAttrCount++
 					{{- if $info.Enum }}
 						assert.Equal(t, "{{ index $info.Enum 0 }}", attrVal.Str())
+					{{- else if or (eq $info.Type.String "Slice") (eq $info.Type.String "Map") }}
+						assert.EqualValues(t, {{ $info.Type.TestValue }}, attrVal.{{ $info.Type }}().AsRaw())
 					{{- else }}
 						assert.EqualValues(t, {{ $info.Type.TestValue }}, attrVal.{{ $info.Type }}())
 					{{- end }}
@@ -161,6 +163,8 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.True(t, ok)
 					{{- if (attributeInfo $attr).Enum }}
 					assert.Equal(t, "{{ index (attributeInfo $attr).Enum 0 }}", attrVal.Str())
+					{{- else if or (eq (attributeInfo $attr).Type.String "Slice") (eq (attributeInfo $attr).Type.String "Map")}}
+					assert.EqualValues(t, {{ (attributeInfo $attr).Type.TestValue }}, attrVal.{{ (attributeInfo $attr).Type }}().AsRaw())
 					{{- else }}
 					assert.EqualValues(t, {{ (attributeInfo $attr).Type.TestValue }}, attrVal.{{ (attributeInfo $attr).Type }}())
 					{{- end }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Add slice and map attributes to resource and datapoint attributes.

**Link to tracking Issue:** <Issue number if applicable>
#18272 

**Testing:** <Describe what testing was performed and which tests were added.>
mdatagen existing tests updated, no new tests added. `make mdatagen-test` passed.

**Documentation:** <Describe the documentation added.>
New example in metadata.yml and auto-generated docs.