### PR TITLE
[translator/loki] add default labels job and instance

### DIFF
--- a/.chloggen/lokiexporter-add-default-labels.yaml
+++ b/.chloggen/lokiexporter-add-default-labels.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: translator/loki
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added default labels `job=service.namespace/service.name` and `instance=service.instance.id` to log record to send to Loki
+
+# One or more tracking issues related to the change
+issues: [18500]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/lokiexporter/README.md
+++ b/exporter/lokiexporter/README.md
@@ -98,6 +98,24 @@ processors:
 Currently, Loki does not support labels with dots. 
 That’s why to add Loki label based on `event.domain` OTLP attribute we need to specify two actions. The first one inserts a new attribute `event_domain` from the OTLP attribute `event.domain`. The second one is a hint for Loki, specifying that the `event_domain` attribute should be placed as a Loki label.
 The same approach is applicable to placing Loki labels from resource attribute `service.name`.
+
+Default labels:
+- `job=service.namespace/service.name`
+- `instance=service.instance.id`
+- `exporter=OTLP`
+
+`exporter=OTLP` is always set.
+
+If `service.name` and `service.namespace` are present then `job=service.namespace/service.name` is set
+
+If `service.name` is present and `service.namespace` is not present then `job=service.name` is set
+
+If `service.name` is not present and `service.namespace` is present then `job` label is not set
+
+If `service.instance.id` is present then `instance=service.instance.id` is set
+
+If `service.instance.id` is not present then `instance` label is not set
+
 ## Tenant information
 
 It is recommended to use the [`header_setter`](../../extension/headerssetterextension/README.md) extension to configure the tenant information to send to Loki. In case a static tenant

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -37,10 +37,17 @@ const (
 	formatLogfmt string = "logfmt"
 )
 
-var defaultExporterLabels = model.LabelSet{"exporter": "OTLP"}
-
 func convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map) model.LabelSet {
-	out := defaultExporterLabels
+	out := model.LabelSet{"exporter": "OTLP"}
+
+	// Map service.namespace + service.name to job
+	if job, ok := extractJob(resAttrs); ok {
+		out[model.JobLabel] = model.LabelValue(job)
+	}
+	// Map service.instance.id to instance
+	if instance, ok := extractInstance(resAttrs); ok {
+		out[model.InstanceLabel] = model.LabelValue(instance)
+	}
 
 	if resourcesToLabel, found := resAttrs.Get(hintResources); found {
 		labels := convertAttributesToLabels(resAttrs, resourcesToLabel)

--- a/pkg/translator/loki/convert_test.go
+++ b/pkg/translator/loki/convert_test.go
@@ -32,7 +32,7 @@ func TestConvertAttributesAndMerge(t *testing.T) {
 	}{
 		{
 			desc:     "empty attributes should have at least the default labels",
-			expected: defaultExporterLabels,
+			expected: model.LabelSet{"exporter": "OTLP"},
 		},
 		{
 			desc: "selected log attribute should be included",
@@ -97,6 +97,46 @@ func TestConvertAttributesAndMerge(t *testing.T) {
 			},
 			expected: model.LabelSet{
 				"exporter": "overridden",
+			},
+		},
+		{
+			desc: "it should add service.namespace/service.name as job label if both of them are present",
+			resAttrs: map[string]interface{}{
+				"service.namespace": "my-service-namespace",
+				"service.name":      "my-service-name",
+			},
+			expected: model.LabelSet{
+				"exporter": "OTLP",
+				"job":      "my-service-namespace/my-service-name",
+			},
+		},
+		{
+			desc: "it should add service.name as job label if service.namespace is missing",
+			resAttrs: map[string]interface{}{
+				"service.name": "my-service-name",
+			},
+			expected: model.LabelSet{
+				"exporter": "OTLP",
+				"job":      "my-service-name",
+			},
+		},
+		{
+			desc: "it shouldn't add service.namespace as job label if service.name is missing",
+			resAttrs: map[string]interface{}{
+				"service.namespace": "my-service-namespace",
+			},
+			expected: model.LabelSet{
+				"exporter": "OTLP",
+			},
+		},
+		{
+			desc: "it should add service.instance.id as instance label if service.instance.id is present",
+			resAttrs: map[string]interface{}{
+				"service.instance.id": "my-service-instance-id",
+			},
+			expected: model.LabelSet{
+				"exporter": "OTLP",
+				"instance": "my-service-instance-id",
 			},
 		},
 	}

--- a/pkg/translator/loki/go.mod
+++ b/pkg/translator/loki/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/prometheus/common v0.39.0
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector/pdata v1.0.0-rc5
+	go.opentelemetry.io/collector/semconv v0.71.0
 )
 
 require (

--- a/pkg/translator/loki/go.sum
+++ b/pkg/translator/loki/go.sum
@@ -43,6 +43,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opentelemetry.io/collector/pdata v1.0.0-rc5 h1:1tKD0TTY9WKRmSAwuUPuDKftCp878HdRVvpeIvRs4Os=
 go.opentelemetry.io/collector/pdata v1.0.0-rc5/go.mod h1:tdtk7rlxCzv1uph4CNonu31jW7mqWF9llUzCYqRaWD8=
+go.opentelemetry.io/collector/semconv v0.71.0 h1:g2bMdtciW2BmKximUxaF0L962U/EIlH9ms3iOGblCKE=
+go.opentelemetry.io/collector/semconv v0.71.0/go.mod h1:UAp+qAMqEXOD0eEBmWJ3IJ5+LkF7zVTgmfufwpHmL8w=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=

--- a/pkg/translator/loki/utils.go
+++ b/pkg/translator/loki/utils.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loki // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki"
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+)
+
+func extractInstance(attributes pcommon.Map) (string, bool) {
+	// Map service.instance.id to instance
+	if inst, ok := attributes.Get(conventions.AttributeServiceInstanceID); ok {
+		return inst.AsString(), true
+	}
+	return "", false
+}
+
+func extractJob(attributes pcommon.Map) (string, bool) {
+	// Map service.namespace + service.name to job
+	if serviceName, ok := attributes.Get(conventions.AttributeServiceName); ok {
+		job := serviceName.AsString()
+		if serviceNamespace, ok := attributes.Get(conventions.AttributeServiceNamespace); ok {
+			job = fmt.Sprintf("%s/%s", serviceNamespace.AsString(), job)
+		}
+		return job, true
+	}
+	return "", false
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Default labels 
`job = service.namespace/service.name`
`instance = service.instance.id`
are set.
The aim of this change is to add a correlation between metrics and logs

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18500

**Documentation:** <Describe the documentation added.>
updated lokiexporter README