### PR TITLE
marking jaeger exporters as deprecated

### DIFF
--- a/.chloggen/codeboten_deprecate-jaeger-exporters.yaml
+++ b/.chloggen/codeboten_deprecate-jaeger-exporters.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: jaegerexporter, jaegerthrifthttpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  marking jaeger exporters as deprecated
+
+# One or more tracking issues related to the change
+issues: [18503]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/jaegerexporter/README.md
+++ b/exporter/jaegerexporter/README.md
@@ -1,13 +1,13 @@
-# Jaeger gRPC Exporter
-
+# Deprecated Jaeger gRPC Exporter
 
 | Status                   |                   |
 | ------------------------ |-------------------|
-| Stability                | [beta]            |
+| Stability                | [deprecated]            |
 | Supported pipeline types | traces            |
 | Distributions            | [core], [contrib] |
 
-Exports data via gRPC to [Jaeger](https://www.jaegertracing.io/) destinations.
+This exporter is being deprecated and will be removed in July 2023 as Jaeger support OTLP directly. Exports
+data via gRPC to [Jaeger](https://www.jaegertracing.io/) destinations.
 By default, this exporter requires TLS and offers queued retry capabilities.
 
 ## Getting Started
@@ -53,7 +53,6 @@ Several helper files are leveraged to provide additional capabilities automatica
 - [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
 - [Queuing, retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
 
-[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
+[deprecated]:https://github.com/open-telemetry/opentelemetry-collector#deprecated
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [core]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
-

--- a/exporter/jaegerexporter/README.md
+++ b/exporter/jaegerexporter/README.md
@@ -6,8 +6,9 @@
 | Supported pipeline types | traces            |
 | Distributions            | [core], [contrib] |
 
-This exporter is being deprecated and will be removed in July 2023 as Jaeger support OTLP directly. Exports
-data via gRPC to [Jaeger](https://www.jaegertracing.io/) destinations.
+This exporter is being deprecated and will be removed in July 2023 as Jaeger support OTLP directly. 
+
+Exports data via gRPC to [Jaeger](https://www.jaegertracing.io/) destinations.
 By default, this exporter requires TLS and offers queued retry capabilities.
 
 ## Getting Started

--- a/exporter/jaegerexporter/factory.go
+++ b/exporter/jaegerexporter/factory.go
@@ -16,26 +16,28 @@ package jaegerexporter // import "github.com/open-telemetry/opentelemetry-collec
 
 import (
 	"context"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.uber.org/zap"
 )
 
 const (
 	// The value of "type" key in configuration.
 	typeStr = "jaeger"
-	// The stability level of the exporter.
-	stability = component.StabilityLevelBeta
 )
+
+var once sync.Once
 
 // NewFactory creates a factory for Jaeger exporter
 func NewFactory() exporter.Factory {
 	return exporter.NewFactory(
 		typeStr,
 		createDefaultConfig,
-		exporter.WithTraces(createTracesExporter, stability))
+		exporter.WithTraces(createTracesExporter, component.StabilityLevelDeprecated))
 }
 
 func createDefaultConfig() component.Config {
@@ -50,12 +52,18 @@ func createDefaultConfig() component.Config {
 	}
 }
 
+func logDeprecation(logger *zap.Logger) {
+	once.Do(func() {
+		logger.Warn("jaeger exporter is deprecated and will be removed in July 2023. See https://github.com/open-telemetry/opentelemetry-specification/pull/2858 for more details.")
+	})
+}
+
 func createTracesExporter(
 	_ context.Context,
 	set exporter.CreateSettings,
 	config component.Config,
 ) (exporter.Traces, error) {
-
+	logDeprecation(set.Logger)
 	expCfg := config.(*Config)
 	return newTracesExporter(expCfg, set)
 }

--- a/exporter/jaegerexporter/go.mod
+++ b/exporter/jaegerexporter/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: jaeger exporter is deprecated and will be removed in July 2023. See https://github.com/open-telemetry/opentelemetry-specification/pull/2858 for more details.
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter
 
 go 1.18

--- a/exporter/jaegerthrifthttpexporter/README.md
+++ b/exporter/jaegerthrifthttpexporter/README.md
@@ -1,12 +1,13 @@
-# Jaeger Thrift Exporter
+# Deprecated Jaeger Thrift Exporter
 
 | Status                   |           |
 | ------------------------ |-----------|
-| Stability                | [beta]    |
+| Stability                | [deprecated]    |
 | Supported pipeline types | traces    |
 | Distributions            | [contrib] |
 
-This exporter supports sending trace data to [Jaeger](https://www.jaegertracing.io) over Thrift HTTP.
+This exporter is being deprecated and will be removed in July 2023 as Jaeger support OTLP directly. This exporter
+supports sending trace data to [Jaeger](https://www.jaegertracing.io) over Thrift HTTP.
 
 *WARNING:* The [Jaeger gRPC Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/jaegerexporter) is the recommended one for exporting traces from an OpenTelemetry Collector to Jaeger. This Jaeger Thrift Exporter should only be used to export traces to a Jaeger Collector that is unable to expose the [gRPC API](https://www.jaegertracing.io/docs/1.27/apis/#protobuf-via-grpc-stable).
 
@@ -40,5 +41,5 @@ with detailed sample configurations [here](testdata/config.yaml).
 This exporter also offers proxy support as documented
 [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter#proxy-support).
 
-[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
+[deprecated]:https://github.com/open-telemetry/opentelemetry-collector#deprecated
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/jaegerthrifthttpexporter/README.md
+++ b/exporter/jaegerthrifthttpexporter/README.md
@@ -6,8 +6,9 @@
 | Supported pipeline types | traces    |
 | Distributions            | [contrib] |
 
-This exporter is being deprecated and will be removed in July 2023 as Jaeger support OTLP directly. This exporter
-supports sending trace data to [Jaeger](https://www.jaegertracing.io) over Thrift HTTP.
+This exporter is being deprecated and will be removed in July 2023 as Jaeger support OTLP directly.
+
+This exporter supports sending trace data to [Jaeger](https://www.jaegertracing.io) over Thrift HTTP.
 
 *WARNING:* The [Jaeger gRPC Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/jaegerexporter) is the recommended one for exporting traces from an OpenTelemetry Collector to Jaeger. This Jaeger Thrift Exporter should only be used to export traces to a Jaeger Collector that is unable to expose the [gRPC API](https://www.jaegertracing.io/docs/1.27/apis/#protobuf-via-grpc-stable).
 

--- a/exporter/jaegerthrifthttpexporter/factory.go
+++ b/exporter/jaegerthrifthttpexporter/factory.go
@@ -16,26 +16,28 @@ package jaegerthrifthttpexporter // import "github.com/open-telemetry/openteleme
 
 import (
 	"context"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.uber.org/zap"
 )
 
 const (
 	// The value of "type" key in configuration.
 	typeStr = "jaeger_thrift"
-	// The stability level of the exporter.
-	stability = component.StabilityLevelBeta
 )
+
+var once sync.Once
 
 // NewFactory creates a factory for Jaeger Thrift over HTTP exporter.
 func NewFactory() exporter.Factory {
 	return exporter.NewFactory(
 		typeStr,
 		createDefaultConfig,
-		exporter.WithTraces(createTracesExporter, stability))
+		exporter.WithTraces(createTracesExporter, component.StabilityLevelDeprecated))
 }
 
 func createDefaultConfig() component.Config {
@@ -46,13 +48,18 @@ func createDefaultConfig() component.Config {
 	}
 }
 
+func logDeprecation(logger *zap.Logger) {
+	once.Do(func() {
+		logger.Warn("jaeger_thrift exporter is deprecated and will be removed in July 2023. See https://github.com/open-telemetry/opentelemetry-specification/pull/2858 for more details.")
+	})
+}
+
 func createTracesExporter(
 	_ context.Context,
 	set exporter.CreateSettings,
 	config component.Config,
 ) (exporter.Traces, error) {
-
+	logDeprecation(set.Logger)
 	expCfg := config.(*Config)
-
 	return newTracesExporter(expCfg, set)
 }

--- a/exporter/jaegerthrifthttpexporter/go.mod
+++ b/exporter/jaegerthrifthttpexporter/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: jaeger exporter is deprecated and will be removed in July 2023. See https://github.com/open-telemetry/opentelemetry-specification/pull/2858 for more details.
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerthrifthttpexporter
 
 go 1.18

--- a/exporter/jaegerthrifthttpexporter/go.mod
+++ b/exporter/jaegerthrifthttpexporter/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.71.0
 	go.opentelemetry.io/collector/consumer v0.71.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rc5
+	go.uber.org/zap v1.24.0
 )
 
 require (
@@ -48,7 +49,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.13.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect


### PR DESCRIPTION
As per the change in the spec https://github.com/open-telemetry/opentelemetry-specification/pull/2858, support for Jaeger exporters is being deprecated. We should start announcing the deprecation of the jaeger exporters to give users time to migrate.

Signed-off-by: Alex Boten <aboten@lightstep.com>
