### PR TITLE
support k8s.pod.hostname

### DIFF
--- a/.chloggen/k8sprocessor-hostname.yaml
+++ b/.chloggen/k8sprocessor-hostname.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow using k8s.pod.hostname to refer to pod.spec.hostname
+
+# One or more tracking issues related to the change
+issues: [18494]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 <!-- next version -->
 
+## v0.72.0
+
+### 💡 Enhancements 💡
+- `k8sattributesprocessor`: support pod.spec.hostname (#18494)
+
 ## v0.71.0
 
 ### 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@
 
 <!-- next version -->
 
-## v0.72.0
-
-### 💡 Enhancements 💡
-- `k8sattributesprocessor`: support pod.spec.hostname (#18494)
-
 ## v0.71.0
 
 ### 🛑 Breaking changes 🛑

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -288,6 +288,10 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 		tags[conventions.AttributeK8SPodName] = pod.Name
 	}
 
+	if c.Rules.PodHostName {
+		tags[tagHostName] = pod.Spec.Hostname
+	}
+
 	if c.Rules.Namespace {
 		tags[conventions.AttributeK8SNamespaceName] = pod.GetNamespace()
 	}

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -536,6 +536,7 @@ func TestExtractionRules(t *testing.T) {
 		},
 		Spec: api_v1.PodSpec{
 			NodeName: "node1",
+			Hostname: "host1",
 		},
 		Status: api_v1.PodStatus{
 			PodIP: "1.1.1.1",
@@ -633,18 +634,20 @@ func TestExtractionRules(t *testing.T) {
 	}, {
 		name: "metadata",
 		rules: ExtractionRules{
-			Deployment: true,
-			Namespace:  true,
-			PodName:    true,
-			PodUID:     true,
-			Node:       true,
-			StartTime:  true,
+			Deployment:  true,
+			Namespace:   true,
+			PodName:     true,
+			PodUID:      true,
+			PodHostName: true,
+			Node:        true,
+			StartTime:   true,
 		},
 		attributes: map[string]string{
 			"k8s.deployment.name": "auth-service",
 			"k8s.namespace.name":  "ns1",
 			"k8s.node.name":       "node1",
 			"k8s.pod.name":        "auth-service-abc12-xyz3",
+			"k8s.pod.hostname":    "host1",
 			"k8s.pod.uid":         "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 			"k8s.pod.start_time":  pod.GetCreationTimestamp().String(),
 		},

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -32,6 +32,7 @@ const (
 	ignoreAnnotation string = "opentelemetry.io/k8s-processor/ignore"
 	tagNodeName             = "k8s.node.name"
 	tagStartTime            = "k8s.pod.start_time"
+	tagHostName             = "k8s.pod.hostname"
 	// MetadataFromPod is used to specify to extract metadata/labels/annotations from pod
 	MetadataFromPod = "pod"
 	// MetadataFromNamespace is used to specify to extract metadata/labels/annotations from namespace
@@ -192,6 +193,7 @@ type ExtractionRules struct {
 	Namespace          bool
 	PodName            bool
 	PodUID             bool
+	PodHostName        bool
 	ReplicaSetID       bool
 	ReplicaSetName     bool
 	StatefulSetUID     bool

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -40,6 +40,7 @@ const (
 	metadataNode       = "node"
 	// Will be removed when new fields get merged to https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go
 	metadataPodStartTime = "k8s.pod.start_time"
+	specPodHostName      = "k8s.pod.hostname"
 	// This one was deprecated, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9886
 	deprecatedMetadataCluster = "cluster"
 )
@@ -94,6 +95,8 @@ func withExtractMetadata(fields ...string) option {
 				p.rules.PodName = true
 			case metadataPodUID, conventions.AttributeK8SPodUID:
 				p.rules.PodUID = true
+			case specPodHostName:
+				p.rules.PodHostName = true
 			case metadataStartTime, metadataPodStartTime:
 				p.rules.StartTime = true
 			case metadataDeployment, conventions.AttributeK8SDeploymentName:


### PR DESCRIPTION
**Description:** 
Spans from our client contain a host attribute, which is pod's hostname in the metadata.
And the bad news is pod's name is a little different from hostname.

We want to associate pod metadata based on the host attribute. Based on k8s documents, pod.spec.hostname might be different with pod.name. refer to https://github.com/alburthoffman/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/internal/kube/client.go#L288

But since k8s processor only support pod name, we could not do this.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18494

**Testing:** modify test case to cover this.