### PR TITLE
[exporter/awscloudwatchlogs] Flush logs on the exporter shutdown

### DIFF
--- a/.chloggen/cwlogs-exporter-fix-shutdown.yaml
+++ b/.chloggen/cwlogs-exporter-fix-shutdown.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/awscloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Flush logs on the exporter shutdown
+
+# One or more tracking issues related to the change
+issues: [18518]

--- a/exporter/awscloudwatchlogsexporter/exporter_test.go
+++ b/exporter/awscloudwatchlogsexporter/exporter_test.go
@@ -174,9 +174,9 @@ func TestConsumeLogs(t *testing.T) {
 	logPusher := new(mockPusher)
 	logPusher.On("AddLogEntry", nil).Return("").Once()
 	logPusher.On("ForceFlush", nil).Return("").Twice()
-	exp.(*exporter).pusher = logPusher
-	require.NoError(t, exp.(*exporter).ConsumeLogs(ctx, ld))
-	require.NoError(t, exp.Shutdown(ctx))
+	exp.pusher = logPusher
+	require.NoError(t, exp.consumeLogs(ctx, ld))
+	require.NoError(t, exp.shutdown(ctx))
 }
 
 func TestNewExporterWithoutRegionErr(t *testing.T) {


### PR DESCRIPTION
The exporter implements the `exporter.Traces` interface but the implementation is not being used, `exporterhelper.NewLogsExporter` is applied instead. This change removes the implementation and moves the methods to `NewLogsExporter` options. This enables the Shutdown method which is currently ignored
