### PR TITLE
[chore] translator/loki. Extract LogToLokiEntry to separate public method

### DIFF
--- a/pkg/translator/loki/logs_to_loki.go
+++ b/pkg/translator/loki/logs_to_loki.go
@@ -63,14 +63,13 @@ func LogsToLokiRequests(ld plog.Logs) map[string]PushRequest {
 	rls := ld.ResourceLogs()
 	for i := 0; i < rls.Len(); i++ {
 		ills := rls.At(i).ScopeLogs()
+		resource := rls.At(i).Resource()
 
 		for j := 0; j < ills.Len(); j++ {
 			logs := ills.At(j).LogRecords()
 			scope := ills.At(j).Scope()
 			for k := 0; k < logs.Len(); k++ {
 				log := logs.At(k)
-				resource := rls.At(i).Resource()
-
 				entry, err := LogToLokiEntry(log, resource, scope)
 				tenant := entry.Tenant
 

--- a/pkg/translator/loki/logs_to_loki.go
+++ b/pkg/translator/loki/logs_to_loki.go
@@ -126,18 +126,20 @@ func LogsToLokiRequests(ld plog.Logs) map[string]PushRequest {
 	return requests
 }
 
+// PushEntry is Loki log entry enriched with labels and tenant
 type PushEntry struct {
 	Entry  *push.Entry
 	Labels model.LabelSet
 	Tenant string
 }
 
+// LogToLokiEntry converts LogRecord into Loki log entry enriched with labels and tenant
 func LogToLokiEntry(lr plog.LogRecord, rl pcommon.Resource, scope pcommon.InstrumentationScope) (*PushEntry, error) {
-	// similarly, we may remove attributes, so change only our version
+	// we may remove attributes, so change only our version
 	log := plog.NewLogRecord()
 	lr.CopyTo(log)
 
-	// we may remove attributes, so we make a copy and change our version
+	// similarly, we may remove attributes, so we make a copy and change our version
 	resource := pcommon.NewResource()
 	rl.CopyTo(resource)
 
@@ -145,8 +147,6 @@ func LogToLokiEntry(lr plog.LogRecord, rl pcommon.Resource, scope pcommon.Instru
 	addLogLevelAttributeAndHint(log)
 
 	format := getFormatFromFormatHint(log.Attributes(), resource.Attributes())
-
-	// resolve tenant and get/create a push request group
 	tenant := getTenantFromTenantHint(log.Attributes(), resource.Attributes())
 
 	mergedLabels := convertAttributesAndMerge(log.Attributes(), resource.Attributes())

--- a/pkg/translator/loki/logs_to_loki_test.go
+++ b/pkg/translator/loki/logs_to_loki_test.go
@@ -17,9 +17,12 @@ package loki // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 )
@@ -607,6 +610,244 @@ func TestLogsToLoki(t *testing.T) {
 			assert.Equal(t, tC.expectedLabel, pushRequest.Streams[0].Labels)
 			assert.Len(t, entries, ld.LogRecordCount())
 			assert.ElementsMatch(t, tC.expectedLines, entriesLines)
+		})
+	}
+}
+
+func TestLogToLokiEntry(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		timestamp            time.Time
+		severity             plog.SeverityNumber
+		levelAttribute       string
+		res                  map[string]interface{}
+		attrs                map[string]interface{}
+		hints                map[string]interface{}
+		instrumentationScope *instrumentationScope
+		expected             *PushEntry
+		err                  error
+	}{
+		{
+			name:      "with attribute to label and regular attribute",
+			timestamp: time.Unix(0, 1677592916000000000),
+			attrs: map[string]interface{}{
+				"host.name":   "guarana",
+				"http.status": 200,
+			},
+			hints: map[string]interface{}{
+				hintAttributes: "host.name",
+			},
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      `{"attributes":{"http.status":200}}`,
+				},
+				Labels: model.LabelSet{
+					"exporter":  "OTLP",
+					"host.name": "guarana",
+				},
+			},
+			err: nil,
+		},
+		{
+			name:      "with resource to label and regular resource",
+			timestamp: time.Unix(0, 1677592916000000000),
+			res: map[string]interface{}{
+				"host.name": "guarana",
+				"region.az": "eu-west-1a",
+			},
+			hints: map[string]interface{}{
+				hintResources: "host.name",
+			},
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      `{"resources":{"region.az":"eu-west-1a"}}`,
+				},
+				Labels: model.LabelSet{
+					"exporter":  "OTLP",
+					"host.name": "guarana",
+				},
+			},
+		},
+		{
+			name:      "with logfmt format",
+			timestamp: time.Unix(0, 1677592916000000000),
+			attrs: map[string]interface{}{
+				"host.name":   "guarana",
+				"http.status": 200,
+			},
+			hints: map[string]interface{}{
+				hintAttributes: "host.name",
+				hintFormat:     formatLogfmt,
+			},
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      `attribute_http.status=200`,
+				},
+				Labels: model.LabelSet{
+					"exporter":  "OTLP",
+					"host.name": "guarana",
+				},
+			},
+		},
+		{
+			name:      "with severity to label",
+			timestamp: time.Unix(0, 1677592916000000000),
+			severity:  plog.SeverityNumberDebug4,
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      "{}",
+				},
+				Labels: model.LabelSet{
+					"exporter": "OTLP",
+					"level":    "DEBUG4",
+				},
+			},
+		},
+		{
+			name:           "with severity, already existing level",
+			timestamp:      time.Unix(0, 1677592916000000000),
+			severity:       plog.SeverityNumberDebug4,
+			levelAttribute: "dummy",
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      "{}",
+				},
+				Labels: model.LabelSet{
+					"exporter": "OTLP",
+					"level":    "dummy",
+				},
+			},
+		},
+		{
+			name:      "with tenant in attributes",
+			timestamp: time.Unix(0, 1677592916000000000),
+			attrs: map[string]interface{}{
+				hintTenant:  "tenant.id",
+				"tenant.id": "1",
+			},
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      "{}",
+				},
+				Labels: model.LabelSet{
+					"exporter":  "OTLP",
+					"tenant.id": "1",
+				},
+				Tenant: "1",
+			},
+		},
+		{
+			name:      "with tenant in resources",
+			timestamp: time.Unix(0, 1677592916000000000),
+			res: map[string]interface{}{
+				hintTenant:  "tenant.id",
+				"tenant.id": "1",
+			},
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      "{}",
+				},
+				Labels: model.LabelSet{
+					"exporter":  "OTLP",
+					"tenant.id": "1",
+				},
+				Tenant: "1",
+			},
+		},
+		{
+			name:      "if tenant set in resources and attributes, the one in resource should win",
+			timestamp: time.Unix(0, 1677592916000000000),
+			res: map[string]interface{}{
+				hintTenant:  "tenant.id",
+				"tenant.id": "1",
+			},
+			attrs: map[string]interface{}{
+				hintTenant:  "tenant.id",
+				"tenant.id": "2",
+			},
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      "{}",
+				},
+				Labels: model.LabelSet{
+					"exporter":  "OTLP",
+					"tenant.id": "1",
+				},
+				Tenant: "1",
+			},
+		},
+		{
+			name:      "with instrumentation scope",
+			timestamp: time.Unix(0, 1677592916000000000),
+			instrumentationScope: &instrumentationScope{
+				Name:    "otlp",
+				Version: "v1",
+			},
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      `{"instrumentation_scope":{"name":"otlp","version":"v1"}}`,
+				},
+				Labels: model.LabelSet{
+					"exporter": "OTLP",
+				},
+			},
+		},
+		{
+			name:      "with unknown format hint",
+			timestamp: time.Unix(0, 1677592916000000000),
+			hints: map[string]interface{}{
+				hintFormat: "my-format",
+			},
+			expected: &PushEntry{
+				Entry: nil,
+				Labels: model.LabelSet{
+					"exporter": "OTLP",
+				},
+			},
+			err: fmt.Errorf("invalid format %s. Expected one of: %s, %s", "my-format", formatJSON, formatLogfmt),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			lr := plog.NewLogRecord()
+			lr.SetTimestamp(pcommon.NewTimestampFromTime(tt.timestamp))
+
+			err := lr.Attributes().FromRaw(tt.attrs)
+			require.NoError(t, err)
+			for k, v := range tt.hints {
+				lr.Attributes().PutStr(k, fmt.Sprintf("%v", v))
+			}
+
+			scope := pcommon.NewInstrumentationScope()
+			if tt.instrumentationScope != nil {
+				scope.SetName(tt.instrumentationScope.Name)
+				scope.SetVersion(tt.instrumentationScope.Version)
+			}
+
+			resource := pcommon.NewResource()
+			err = resource.Attributes().FromRaw(tt.res)
+			require.NoError(t, err)
+			for k, v := range tt.hints {
+				resource.Attributes().PutStr(k, fmt.Sprintf("%v", v))
+			}
+			lr.SetSeverityNumber(tt.severity)
+			if len(tt.levelAttribute) > 0 {
+				lr.Attributes().PutStr(levelAttributeName, tt.levelAttribute)
+			}
+
+			log, err := LogToLokiEntry(lr, resource, scope)
+			assert.Equal(t, tt.err, err)
+			assert.Equal(t, tt.expected, log)
 		})
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Extracted `LogToLokiEntry` from `LogsToLokiRequests` to allow Grafana Agent to reuse it