### PR TITLE
[receiver/promtail] Deprecate promtail receiver

### DIFF
--- a/.chloggen/deprecate-promtail-receiver.yaml
+++ b/.chloggen/deprecate-promtail-receiver.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: promtailreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate promtail receiver
+
+# One or more tracking issues related to the change
+issues: [18474, 18493]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Promtail receiver in its current implementation has a dependency on Loki that leads to a huge amount of |
+  dependencies. It is getting difficult to maintain those dependencies. That's why the decision to |
+  deprecate and remove promtail receiver was made

--- a/receiver/promtailreceiver/README.md
+++ b/receiver/promtailreceiver/README.md
@@ -1,8 +1,8 @@
-# Promtail Receiver
+# Deprecated Promtail Receiver
 
 | Status                   |           |
 | ------------------------ |-----------|
-| Stability                | [alpha]   |
+| Stability                | [deprecated]   |
 | Supported pipeline types | logs      |
 | Distributions            | [contrib] |
 
@@ -87,6 +87,6 @@ CGO_ENABLED=1 go build ./cmd/otelcontribcol --tags=promtail_journal_enabled
 
 [sc]: https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs
 
-[alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
+[deprecated]: https://github.com/open-telemetry/opentelemetry-collector#deprecated
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/receiver/promtailreceiver/factory.go
+++ b/receiver/promtailreceiver/factory.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	typeStr   = "promtail"
-	stability = component.StabilityLevelAlpha
+	stability = component.StabilityLevelDeprecated
 )
 
 // NewFactory creates a factory for promtail receiver

--- a/receiver/promtailreceiver/go.mod
+++ b/receiver/promtailreceiver/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: promtail receiver is deprecated and will be removed in future versions.
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/promtailreceiver
 
 go 1.18


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Promtail receiver in its current implementation has a dependency on Loki that leads to a huge amount of
dependencies. It is getting difficult to maintain those dependencies. That's why the decision to
deprecate and remove promtail receiver was made
