### PR TITLE
[chore] [exporter/file] Remove unused consumer interfaces implementation

### DIFF
--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -78,9 +79,10 @@ func createTracesExporter(
 		ctx,
 		set,
 		cfg,
-		fe.Unwrap().(*fileExporter).ConsumeTraces,
+		fe.Unwrap().(*fileExporter).consumeTraces,
 		exporterhelper.WithStart(fe.Start),
 		exporterhelper.WithShutdown(fe.Shutdown),
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 	)
 }
 
@@ -101,9 +103,10 @@ func createMetricsExporter(
 		ctx,
 		set,
 		cfg,
-		fe.Unwrap().(*fileExporter).ConsumeMetrics,
+		fe.Unwrap().(*fileExporter).consumeMetrics,
 		exporterhelper.WithStart(fe.Start),
 		exporterhelper.WithShutdown(fe.Shutdown),
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 	)
 }
 
@@ -124,9 +127,10 @@ func createLogsExporter(
 		ctx,
 		set,
 		cfg,
-		fe.Unwrap().(*fileExporter).ConsumeLogs,
+		fe.Unwrap().(*fileExporter).consumeLogs,
 		exporterhelper.WithStart(fe.Start),
 		exporterhelper.WithShutdown(fe.Shutdown),
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 	)
 }
 

--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -61,11 +60,7 @@ type fileExporter struct {
 	exporter   exportFunc
 }
 
-func (e *fileExporter) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
-}
-
-func (e *fileExporter) ConsumeTraces(_ context.Context, td ptrace.Traces) error {
+func (e *fileExporter) consumeTraces(_ context.Context, td ptrace.Traces) error {
 	buf, err := e.tracesMarshaler.MarshalTraces(td)
 	if err != nil {
 		return err
@@ -74,7 +69,7 @@ func (e *fileExporter) ConsumeTraces(_ context.Context, td ptrace.Traces) error 
 	return e.exporter(e, buf)
 }
 
-func (e *fileExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
+func (e *fileExporter) consumeMetrics(_ context.Context, md pmetric.Metrics) error {
 	buf, err := e.metricsMarshaler.MarshalMetrics(md)
 	if err != nil {
 		return err
@@ -83,7 +78,7 @@ func (e *fileExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) err
 	return e.exporter(e, buf)
 }
 
-func (e *fileExporter) ConsumeLogs(_ context.Context, ld plog.Logs) error {
+func (e *fileExporter) consumeLogs(_ context.Context, ld plog.Logs) error {
 	buf, err := e.logsMarshaler.MarshalLogs(ld)
 	if err != nil {
 		return err

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -131,8 +131,8 @@ func TestFileTracesExporter(t *testing.T) {
 
 			td := testdata.GenerateTracesTwoSpansSameResource()
 			assert.NoError(t, fe.Start(context.Background(), componenttest.NewNopHost()))
-			assert.NoError(t, fe.ConsumeTraces(context.Background(), td))
-			assert.NoError(t, fe.ConsumeTraces(context.Background(), td))
+			assert.NoError(t, fe.consumeTraces(context.Background(), td))
+			assert.NoError(t, fe.consumeTraces(context.Background(), td))
 			assert.NoError(t, fe.Shutdown(context.Background()))
 
 			fi, err := os.Open(fe.path)
@@ -174,7 +174,7 @@ func TestFileTracesExporterError(t *testing.T) {
 
 	td := testdata.GenerateTracesTwoSpansSameResource()
 	// Cannot call Start since we inject directly the WriterCloser.
-	assert.Error(t, fe.ConsumeTraces(context.Background(), td))
+	assert.Error(t, fe.consumeTraces(context.Background(), td))
 	assert.NoError(t, fe.Shutdown(context.Background()))
 }
 
@@ -265,8 +265,8 @@ func TestFileMetricsExporter(t *testing.T) {
 
 			md := testdata.GenerateMetricsTwoMetrics()
 			assert.NoError(t, fe.Start(context.Background(), componenttest.NewNopHost()))
-			assert.NoError(t, fe.ConsumeMetrics(context.Background(), md))
-			assert.NoError(t, fe.ConsumeMetrics(context.Background(), md))
+			assert.NoError(t, fe.consumeMetrics(context.Background(), md))
+			assert.NoError(t, fe.consumeMetrics(context.Background(), md))
 			assert.NoError(t, fe.Shutdown(context.Background()))
 
 			fi, err := os.Open(fe.path)
@@ -310,7 +310,7 @@ func TestFileMetricsExporterError(t *testing.T) {
 
 	md := testdata.GenerateMetricsTwoMetrics()
 	// Cannot call Start since we inject directly the WriterCloser.
-	assert.Error(t, fe.ConsumeMetrics(context.Background(), md))
+	assert.Error(t, fe.consumeMetrics(context.Background(), md))
 	assert.NoError(t, fe.Shutdown(context.Background()))
 }
 
@@ -401,8 +401,8 @@ func TestFileLogsExporter(t *testing.T) {
 
 			ld := testdata.GenerateLogsTwoLogRecordsSameResource()
 			assert.NoError(t, fe.Start(context.Background(), componenttest.NewNopHost()))
-			assert.NoError(t, fe.ConsumeLogs(context.Background(), ld))
-			assert.NoError(t, fe.ConsumeLogs(context.Background(), ld))
+			assert.NoError(t, fe.consumeLogs(context.Background(), ld))
+			assert.NoError(t, fe.consumeLogs(context.Background(), ld))
 			assert.NoError(t, fe.Shutdown(context.Background()))
 
 			fi, err := os.Open(fe.path)
@@ -444,23 +444,8 @@ func TestFileLogsExporterErrors(t *testing.T) {
 
 	ld := testdata.GenerateLogsTwoLogRecordsSameResource()
 	// Cannot call Start since we inject directly the WriterCloser.
-	assert.Error(t, fe.ConsumeLogs(context.Background(), ld))
+	assert.Error(t, fe.consumeLogs(context.Background(), ld))
 	assert.NoError(t, fe.Shutdown(context.Background()))
-}
-
-func Test_fileExporter_Capabilities(t *testing.T) {
-	path := tempFileName(t)
-	fe := &fileExporter{
-		path:       path,
-		formatType: formatTypeJSON,
-		file: &lumberjack.Logger{
-			Filename: path,
-		},
-		metricsMarshaler: metricsMarshalers[formatTypeJSON],
-		exporter:         exportMessageAsLine,
-	}
-	require.NotNil(t, fe)
-	require.NotNil(t, fe.Capabilities())
 }
 
 func TestExportMessageAsBuffer(t *testing.T) {


### PR DESCRIPTION
The exporter uses `exporterhelper.New[Metrics|Traces|Logs]Exporter` helpers, implementation of `consumer.[Metrics|Traces|Logs]` interface is not being used, in particular `Capabilities()` method is ignored.

SImilar to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18608