### PR TITLE
[processor/filter] Deprecate non-ottl configuration

### DIFF
--- a/.chloggen/fp-deprecate-old-configs.yaml
+++ b/.chloggen/fp-deprecate-old-configs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filterprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecation warning for all non-OTTL configuration options. Use OTTL configuration options instead. All non-OTTL configuration options will be removed in 0.74.0.
+
+# One or more tracking issues related to the change
+issues: [18613]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -6,6 +6,10 @@
 | Supported pipeline types | metrics, logs, traces |
 | Distributions            | [core], [contrib]     |
 
+For OTTL conditions configuration see [OTTL](#ottl).
+**All other configuration options have been deprecated and will be removed in 0.74.0.**
+For all other options, continue reading.
+
 The filter processor can be configured to include or exclude:
 
 - Logs, based on OTTL conditions or resource attributes using the `strict` or `regexp` match types
@@ -15,8 +19,6 @@ The filter processor can be configured to include or exclude:
 - Data points based on OTTL conditions
 - Spans based on OTTL conditions or span names and resource attributes, all with full regex support
 - Span Events based on OTTL conditions.
-
-For OTTL conditions configuration see [OTTL](#ottl).  For all other options, continue reading.
 
 It takes a pipeline type, of which `logs` `metrics`, and `traces` are supported, followed
 by an action:

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -36,7 +36,7 @@ type Config struct {
 
 	Logs LogFilters `mapstructure:"logs"`
 
-	// Deprecated: [v0.74.0] use TraceFilters instead
+	// Deprecated: [v0.72.0] use TraceFilters instead
 	Spans filterconfig.MatchConfig `mapstructure:"spans"`
 
 	Traces TraceFilters `mapstructure:"traces"`
@@ -47,17 +47,17 @@ type MetricFilters struct {
 	// Include match properties describe metrics that should be included in the Collector Service pipeline,
 	// all other metrics should be dropped from further processing.
 	// If both Include and Exclude are specified, Include filtering occurs first.
-	// Deprecated: [v0.74.0] use MetricConditions instead
+	// Deprecated: [v0.72.0] use MetricConditions instead
 	Include *filtermetric.MatchProperties `mapstructure:"include"`
 
 	// Exclude match properties describe metrics that should be excluded from the Collector Service pipeline,
 	// all other metrics should be included.
 	// If both Include and Exclude are specified, Include filtering occurs first.
-	// Deprecated: [v0.74.0] use MetricConditions instead
+	// Deprecated: [v0.72.0] use MetricConditions instead
 	Exclude *filtermetric.MatchProperties `mapstructure:"exclude"`
 
 	// RegexpConfig specifies options for the Regexp match type
-	// Deprecated: [v0.74.0] use MetricConditions instead
+	// Deprecated: [v0.72.0] use MetricConditions instead
 	RegexpConfig *regexp.Config `mapstructure:"regexp"`
 
 	// MetricConditions is a list of OTTL conditions for an ottlmetric context.
@@ -89,12 +89,12 @@ type LogFilters struct {
 	// Include match properties describe logs that should be included in the Collector Service pipeline,
 	// all other logs should be dropped from further processing.
 	// If both Include and Exclude are specified, Include filtering occurs first.
-	// Deprecated: [v0.74.0] use LogConditions instead
+	// Deprecated: [v0.72.0] use LogConditions instead
 	Include *LogMatchProperties `mapstructure:"include"`
 	// Exclude match properties describe logs that should be excluded from the Collector Service pipeline,
 	// all other logs should be included.
 	// If both Include and Exclude are specified, Include filtering occurs first.
-	// Deprecated: [v0.74.0] use LogConditions instead
+	// Deprecated: [v0.72.0] use LogConditions instead
 	Exclude *LogMatchProperties `mapstructure:"exclude"`
 
 	// LogConditions is a list of OTTL conditions for an ottllog context.
@@ -104,7 +104,7 @@ type LogFilters struct {
 }
 
 // LogMatchType specifies the strategy for matching against `plog.Log`s.
-// Deprecated: [v0.74.0] use LogConditions instead
+// Deprecated: [v0.72.0] use LogConditions instead
 type LogMatchType string
 
 // These are the MatchTypes that users can specify for filtering
@@ -168,7 +168,7 @@ var severityToNumber = map[string]plog.SeverityNumber{
 var errInvalidSeverity = errors.New("not a valid severity")
 
 // logSeverity is a type that represents a SeverityNumber as a string
-// Deprecated: [v0.74.0] use LogConditions instead
+// Deprecated: [v0.72.0] use LogConditions instead
 type logSeverity string
 
 // validate checks that the logSeverity is valid
@@ -193,7 +193,7 @@ func (l logSeverity) severityNumber() plog.SeverityNumber {
 
 // LogMatchProperties specifies the set of properties in a log to match against and the
 // type of string pattern matching to use.
-// Deprecated: [v0.74.0] use LogConditions instead
+// Deprecated: [v0.72.0] use LogConditions instead
 type LogMatchProperties struct {
 	// LogMatchType specifies the type of matching desired
 	LogMatchType LogMatchType `mapstructure:"match_type"`
@@ -257,7 +257,7 @@ func (lmp LogMatchProperties) matchProperties() *filterconfig.MatchProperties {
 	return mp
 }
 
-// Deprecated: [v0.74.0] use LogConditions instead
+// Deprecated: [v0.72.0] use LogConditions instead
 type LogSeverityNumberMatchProperties struct {
 	// Min is the minimum severity needed for the log record to match.
 	// This corresponds to the short names specified here:

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -36,6 +36,7 @@ type Config struct {
 
 	Logs LogFilters `mapstructure:"logs"`
 
+	// Deprecated: [v0.74.0] use TraceFilters instead
 	Spans filterconfig.MatchConfig `mapstructure:"spans"`
 
 	Traces TraceFilters `mapstructure:"traces"`
@@ -46,14 +47,17 @@ type MetricFilters struct {
 	// Include match properties describe metrics that should be included in the Collector Service pipeline,
 	// all other metrics should be dropped from further processing.
 	// If both Include and Exclude are specified, Include filtering occurs first.
+	// Deprecated: [v0.74.0] use MetricConditions instead
 	Include *filtermetric.MatchProperties `mapstructure:"include"`
 
 	// Exclude match properties describe metrics that should be excluded from the Collector Service pipeline,
 	// all other metrics should be included.
 	// If both Include and Exclude are specified, Include filtering occurs first.
+	// Deprecated: [v0.74.0] use MetricConditions instead
 	Exclude *filtermetric.MatchProperties `mapstructure:"exclude"`
 
 	// RegexpConfig specifies options for the Regexp match type
+	// Deprecated: [v0.74.0] use MetricConditions instead
 	RegexpConfig *regexp.Config `mapstructure:"regexp"`
 
 	// MetricConditions is a list of OTTL conditions for an ottlmetric context.
@@ -85,10 +89,12 @@ type LogFilters struct {
 	// Include match properties describe logs that should be included in the Collector Service pipeline,
 	// all other logs should be dropped from further processing.
 	// If both Include and Exclude are specified, Include filtering occurs first.
+	// Deprecated: [v0.74.0] use LogConditions instead
 	Include *LogMatchProperties `mapstructure:"include"`
 	// Exclude match properties describe logs that should be excluded from the Collector Service pipeline,
 	// all other logs should be included.
 	// If both Include and Exclude are specified, Include filtering occurs first.
+	// Deprecated: [v0.74.0] use LogConditions instead
 	Exclude *LogMatchProperties `mapstructure:"exclude"`
 
 	// LogConditions is a list of OTTL conditions for an ottllog context.
@@ -98,6 +104,7 @@ type LogFilters struct {
 }
 
 // LogMatchType specifies the strategy for matching against `plog.Log`s.
+// Deprecated: [v0.74.0] use LogConditions instead
 type LogMatchType string
 
 // These are the MatchTypes that users can specify for filtering
@@ -161,6 +168,7 @@ var severityToNumber = map[string]plog.SeverityNumber{
 var errInvalidSeverity = errors.New("not a valid severity")
 
 // logSeverity is a type that represents a SeverityNumber as a string
+// Deprecated: [v0.74.0] use LogConditions instead
 type logSeverity string
 
 // validate checks that the logSeverity is valid
@@ -185,6 +193,7 @@ func (l logSeverity) severityNumber() plog.SeverityNumber {
 
 // LogMatchProperties specifies the set of properties in a log to match against and the
 // type of string pattern matching to use.
+// Deprecated: [v0.74.0] use LogConditions instead
 type LogMatchProperties struct {
 	// LogMatchType specifies the type of matching desired
 	LogMatchType LogMatchType `mapstructure:"match_type"`
@@ -248,6 +257,7 @@ func (lmp LogMatchProperties) matchProperties() *filterconfig.MatchProperties {
 	return mp
 }
 
+// Deprecated: [v0.74.0] use LogConditions instead
 type LogSeverityNumberMatchProperties struct {
 	// Min is the minimum severity needed for the log record to match.
 	// This corresponds to the short names specified here:

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -111,7 +111,7 @@ func createTracesProcessor(
 	oCfg := cfg.(*Config)
 	if oCfg.Spans.Include != nil || oCfg.Spans.Exclude != nil {
 		set.Logger.Warn(
-			"The span `include` and `exclude` configuration options have been deprecated and will be removed in 0.74.0. Use `traces.span` instead.",
+			"The span `include` and `exclude` configuration options have been deprecated and will be removed in 0.74.0. Use `traces::span` instead.",
 			zap.Any("include", oCfg.Spans.Include),
 			zap.Any("exclude", oCfg.Spans.Exclude),
 		)

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -16,6 +16,7 @@ package filterprocessor // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"context"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -16,11 +16,11 @@ package filterprocessor // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"context"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/zap"
 )
 
 const (
@@ -53,7 +53,15 @@ func createMetricsProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
 ) (processor.Metrics, error) {
-	fp, err := newFilterMetricProcessor(set.TelemetrySettings, cfg.(*Config))
+	oCfg := cfg.(*Config)
+	if oCfg.Metrics.Include != nil || oCfg.Metrics.Exclude != nil {
+		set.Logger.Warn(
+			"The metric `include` and `exclude` configuration options have been deprecated and will be removed in 0.74.0. Use `metric` instead.",
+			zap.Any("include", oCfg.Metrics.Include),
+			zap.Any("exclude", oCfg.Metrics.Exclude),
+		)
+	}
+	fp, err := newFilterMetricProcessor(set.TelemetrySettings, oCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +80,15 @@ func createLogsProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Logs,
 ) (processor.Logs, error) {
-	fp, err := newFilterLogsProcessor(set.TelemetrySettings, cfg.(*Config))
+	oCfg := cfg.(*Config)
+	if oCfg.Logs.Include != nil || oCfg.Logs.Exclude != nil {
+		set.Logger.Warn(
+			"The log `include` and `exclude` configuration options have been deprecated and will be removed in 0.74.0. Use `log_record` instead.",
+			zap.Any("include", oCfg.Logs.Include),
+			zap.Any("exclude", oCfg.Logs.Exclude),
+		)
+	}
+	fp, err := newFilterLogsProcessor(set.TelemetrySettings, oCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +107,15 @@ func createTracesProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Traces,
 ) (processor.Traces, error) {
-	fp, err := newFilterSpansProcessor(set.TelemetrySettings, cfg.(*Config))
+	oCfg := cfg.(*Config)
+	if oCfg.Spans.Include != nil || oCfg.Spans.Exclude != nil {
+		set.Logger.Warn(
+			"The span `include` and `exclude` configuration options have been deprecated and will be removed in 0.74.0. Use `traces.span` instead.",
+			zap.Any("include", oCfg.Spans.Include),
+			zap.Any("exclude", oCfg.Spans.Exclude),
+		)
+	}
+	fp, err := newFilterSpansProcessor(set.TelemetrySettings, oCfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description:** 
Deprecates all non-OTTL configuration options.  Since this is a pretty serious deprecation, I'm planning for 0.74.0 to be the removal release.  This give users 2 full release cycles (4 weeks), to update their configs.

I added warnings during initialization to call out the deprecations.

**Issue**
Works towards https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18642

**Testing:**
Ran the collector locally to see the warnings.

**Documentation:**
Updated README to call our deprecation.