### PR TITLE
[pkg/ottl] Support referencing matched capture groups in replace_pattern

### DIFF
--- a/.chloggen/ottl-replace-capture-groups.yaml
+++ b/.chloggen/ottl-replace-capture-groups.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ability to reference matched capture groups in `replace_pattern()` and `replace_all_patterns()`
+
+# One or more tracking issues related to the change
+issues: [18610]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change affects all processors that use OTTL (i.e. `transformprocessor`, `routingprocessor`, and `filterprocessor`).

--- a/.chloggen/ottl-replace-capture-groups.yaml
+++ b/.chloggen/ottl-replace-capture-groups.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: pkg/ottl
@@ -15,3 +15,5 @@ issues: [18610]
 # Use pipe (|) for multiline entries.
 subtext: |
   This change affects all processors that use OTTL (i.e. `transformprocessor`, `routingprocessor`, and `filterprocessor`).
+  This is a breaking change in the rare scenario that the `$` character is currently used in a replacement string.
+  To output a literal `$` in a replacement string it must now be escaped with an additional `$`.

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -347,7 +347,7 @@ Examples:
 - `replace_all_patterns(attributes, "key", "^kube_([0-9A-Za-z]+_)", "k8s.$$1.")`
 
 Note that when using OTTL within the collector's configuration file, `$` must be escaped to `$$` to bypass
-environment variable substitution logic. If using OTTL outside of collector configuration, `$` should not be escaped.
+environment variable substitution logic. To input a literal `$` from the configuration file, use `$$$`. If using OTTL outside of collector configuration, `$` should not be escaped and a literal `$` can be entered using `$$`.
 
 ### replace_pattern
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -338,6 +338,9 @@ The `replace_all_patterns` function replaces any segments in a string value or k
 
 If one or more sections of `target` match `regex` they will get replaced with `replacement`.
 
+The `replacement` string can refer to matched groups using [regexp.Expand syntax](https://pkg.go.dev/regexp#Regexp.Expand).
+Note that `$` may need to be escaped to avoid getting consumed by config file environment variable replacement.
+
 Examples:
 
 - `replace_all_patterns(attributes, "value", "/account/\\d{4}", "/account/{accountId}")`
@@ -352,6 +355,9 @@ The `replace_pattern` function allows replacing all string sections that match a
 `target` is a path expression to a telemetry field. `regex` is a regex string indicating a segment to replace. `replacement` is a string.
 
 If one or more sections of `target` match `regex` they will get replaced with `replacement`.
+
+The `replacement` string can refer to matched groups using [regexp.Expand syntax](https://pkg.go.dev/regexp#Regexp.Expand).
+Note that `$` may need to be escaped to avoid getting consumed by config file environment variable replacement. 
 
 Examples:
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -356,13 +356,23 @@ The `replace_pattern` function allows replacing all string sections that match a
 
 If one or more sections of `target` match `regex` they will get replaced with `replacement`.
 
-The `replacement` string can refer to matched groups using [regexp.Expand syntax](https://pkg.go.dev/regexp#Regexp.Expand).
-Note that `$` may need to be escaped to avoid getting consumed by config file environment variable replacement. 
+The `replacement` string can refer to matched groups using [regexp.Expand syntax](https://pkg.go.dev/regexp#Regexp.Expand). 
 
 Examples:
 
 - `replace_pattern(resource.attributes["process.command_line"], "password\\=[^\\s]*(\\s?)", "password=***")`
+- `replace_pattern(name, "^kube_([0-9A-Za-z]+_)", "k8s.$1.")` 
 
+Note that when using OTTL within the collector's configuration file, `$` may need to be escaped to `$$` to bypass
+the environment variable substitution logic.  For example:
+
+```yaml
+transform:
+  metric_statements:
+  - context: metric
+    statements:
+    - replace_pattern(name, "kube_([0-9A-Za-z]+_)", "k8s.$$1.")
+```
 
 ### replace_match
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -31,7 +31,7 @@ They manipulate the OTTL grammar value into a form that will make working with t
 
 Converters:
 - Are pure functions.  They should never change the underlying telemetry and the same inputs should always result in the same output.
-- Always return something.  
+- Always return something.
 
 List of available Converters:
 - [Concat](#concat)
@@ -347,7 +347,8 @@ Examples:
 - `replace_all_patterns(attributes, "key", "^kube_([0-9A-Za-z]+_)", "k8s.$$1.")`
 
 Note that when using OTTL within the collector's configuration file, `$` must be escaped to `$$` to bypass
-environment variable substitution logic. To input a literal `$` from the configuration file, use `$$$`. If using OTTL outside of collector configuration, `$` should not be escaped and a literal `$` can be entered using `$$`.
+environment variable substitution logic. To input a literal `$` from the configuration file, use `$$$`.
+If using OTTL outside of collector configuration, `$` should not be escaped and a literal `$` can be entered using `$$`.
 
 ### replace_pattern
 
@@ -359,15 +360,16 @@ The `replace_pattern` function allows replacing all string sections that match a
 
 If one or more sections of `target` match `regex` they will get replaced with `replacement`.
 
-The `replacement` string can refer to matched groups using [regexp.Expand syntax](https://pkg.go.dev/regexp#Regexp.Expand). 
+The `replacement` string can refer to matched groups using [regexp.Expand syntax](https://pkg.go.dev/regexp#Regexp.Expand).
 
 Examples:
 
 - `replace_pattern(resource.attributes["process.command_line"], "password\\=[^\\s]*(\\s?)", "password=***")`
-- `replace_pattern(name, "^kube_([0-9A-Za-z]+_)", "k8s.$$1.")` 
+- `replace_pattern(name, "^kube_([0-9A-Za-z]+_)", "k8s.$$1.")`
 
 Note that when using OTTL within the collector's configuration file, `$` must be escaped to `$$` to bypass
-environment variable substitution logic. If using OTTL outside of collector configuration, `$` should not be escaped.
+environment variable substitution logic. To input a literal `$` from the configuration file, use `$$$`.
+If using OTTL outside of collector configuration, `$` should not be escaped and a literal `$` can be entered using `$$`.
 
 ### replace_match
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -339,12 +339,15 @@ The `replace_all_patterns` function replaces any segments in a string value or k
 If one or more sections of `target` match `regex` they will get replaced with `replacement`.
 
 The `replacement` string can refer to matched groups using [regexp.Expand syntax](https://pkg.go.dev/regexp#Regexp.Expand).
-Note that `$` may need to be escaped to avoid getting consumed by config file environment variable replacement.
 
 Examples:
 
 - `replace_all_patterns(attributes, "value", "/account/\\d{4}", "/account/{accountId}")`
 - `replace_all_patterns(attributes, "key", "/account/\\d{4}", "/account/{accountId}")`
+- `replace_all_patterns(attributes, "key", "^kube_([0-9A-Za-z]+_)", "k8s.$$1.")`
+
+Note that when using OTTL within the collector's configuration file, `$` must be escaped to `$$` to bypass
+environment variable substitution logic. If using OTTL outside of collector configuration, `$` should not be escaped.
 
 ### replace_pattern
 
@@ -361,18 +364,10 @@ The `replacement` string can refer to matched groups using [regexp.Expand syntax
 Examples:
 
 - `replace_pattern(resource.attributes["process.command_line"], "password\\=[^\\s]*(\\s?)", "password=***")`
-- `replace_pattern(name, "^kube_([0-9A-Za-z]+_)", "k8s.$1.")` 
+- `replace_pattern(name, "^kube_([0-9A-Za-z]+_)", "k8s.$$1.")` 
 
-Note that when using OTTL within the collector's configuration file, `$` may need to be escaped to `$$` to bypass
-the environment variable substitution logic.  For example:
-
-```yaml
-transform:
-  metric_statements:
-  - context: metric
-    statements:
-    - replace_pattern(name, "kube_([0-9A-Za-z]+_)", "k8s.$$1.")
-```
+Note that when using OTTL within the collector's configuration file, `$` must be escaped to `$$` to bypass
+environment variable substitution logic. If using OTTL outside of collector configuration, `$` should not be escaped.
 
 ### replace_match
 

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -56,7 +56,7 @@ func ReplaceAllPatterns[K any](target ottl.GetSetter[K], mode string, regexPatte
 			switch mode {
 			case modeValue:
 				if compiledPattern.MatchString(originalValue.Str()) {
-					updatedString := compiledPattern.ReplaceAllLiteralString(originalValue.Str(), replacement)
+					updatedString := compiledPattern.ReplaceAllString(originalValue.Str(), replacement)
 					updated.PutStr(key, updatedString)
 				} else {
 					updated.PutStr(key, originalValue.Str())

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -124,6 +124,19 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test.3", "goodbye world1 and world2")
 			},
 		},
+		{
+			name:        "expand capturing groups",
+			target:      target,
+			mode:        modeValue,
+			pattern:     `world(\d)`,
+			replacement: "world-$1",
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.Clear()
+				expectedMap.PutStr("test", "hello world")
+				expectedMap.PutStr("test2", "hello")
+				expectedMap.PutStr("test3", "goodbye world-1 and world-2")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -137,6 +137,19 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test3", "goodbye world-1 and world-2")
 			},
 		},
+		{
+			name:        "replacement with literal $",
+			target:      target,
+			mode:        modeValue,
+			pattern:     `world(\d)`,
+			replacement: "$$world-$1",
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.Clear()
+				expectedMap.PutStr("test", "hello world")
+				expectedMap.PutStr("test2", "hello")
+				expectedMap.PutStr("test3", "goodbye $world-1 and $world-2")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -37,7 +37,7 @@ func ReplacePattern[K any](target ottl.GetSetter[K], regexPattern string, replac
 		}
 		if originalValStr, ok := originalVal.(string); ok {
 			if compiledPattern.MatchString(originalValStr) {
-				updatedStr := compiledPattern.ReplaceAllLiteralString(originalValStr, replacement)
+				updatedStr := compiledPattern.ReplaceAllString(originalValStr, replacement)
 				err = target.Set(ctx, tCtx, updatedStr)
 				if err != nil {
 					return nil, err

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -78,7 +78,7 @@ func Test_replacePattern(t *testing.T) {
 			pattern:     `(\w+)=(\w+)`,
 			replacement: "$1:$2",
 			want: func(expectedValue pcommon.Value) {
-				expectedValue.SetStr("application passwd:sensitivedtata otherarg:notsensitive key1 key2 ")
+				expectedValue.SetStr("application passwd:sensitivedtata otherarg:notsensitive key1 key2")
 			},
 		},
 		{

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -81,6 +81,15 @@ func Test_replacePattern(t *testing.T) {
 				expectedValue.SetStr("application passwd:sensitivedtata otherarg:notsensitive key1 key2 ")
 			},
 		},
+		{
+			name:        "replacement with literal $",
+			target:      target,
+			pattern:     `passwd\=[^\s]*(\s?)`,
+			replacement: "passwd=$$$$$$ ",
+			want: func(expectedValue pcommon.Value) {
+				expectedValue.SetStr("application passwd=$$$ otherarg=notsensitive key1 key2")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -72,6 +72,15 @@ func Test_replacePattern(t *testing.T) {
 				expectedValue.SetStr("application passwd=sensitivedtata otherarg=notsensitive **** **** ")
 			},
 		},
+		{
+			name:        "expand capturing groups",
+			target:      target,
+			pattern:     `(\w+)=(\w+)`,
+			replacement: "$1:$2",
+			want: func(expectedValue pcommon.Value) {
+				expectedValue.SetStr("application passwd:sensitivedtata otherarg:notsensitive key1 key2 ")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Use `ReplaceAllString()` instead of `ReplaceAllLiteralString()` to allow referencing matched capture groups in replacement

**Link to tracking Issue:** <Issue number if applicable>
#18610

**Testing:** <Describe what testing was performed and which tests were added.>
Added unit tests.

**Documentation:** <Describe the documentation added.>
Updated README