### PR TITLE
receiver_creator: don't embed endpoint field in unsupported configs

### DIFF
--- a/.chloggen/rcendpointfieldcheck.yaml
+++ b/.chloggen/rcendpointfieldcheck.yaml
@@ -13,4 +13,4 @@ issues: [7381]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: Also adds backticked expansion support for more config forms

--- a/.chloggen/rcendpointfieldcheck.yaml
+++ b/.chloggen/rcendpointfieldcheck.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver_creator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: No longer attempt to add observer target to `endpoint` if underlying receiver config doesn't support it.
+
+# One or more tracking issues related to the change
+issues: [7381]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -62,6 +62,11 @@ config:
    endpoint: '`endpoint`:8080'
 ```
 
+If your target receiver provides an `endpoint` config field and you aren't
+manually setting it like the above example, the observer endpoint target value
+will automatically be sourced. If no `endpoint` field is available you are
+required to specify any necessary fields.
+
 **receivers.resource_attributes**
 
 ```yaml

--- a/receiver/receivercreator/go.mod
+++ b/receiver/receivercreator/go.mod
@@ -56,7 +56,6 @@ require (
 	github.com/shirou/gopsutil/v3 v3.23.1 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect

--- a/receiver/receivercreator/observerhandler.go
+++ b/receiver/receivercreator/observerhandler.go
@@ -30,6 +30,13 @@ var (
 	_ observer.Notify = (*observerHandler)(nil)
 )
 
+const (
+	// tmpSetEndpointConfigKey denotes the observerHandler (not the user) has set an "endpoint" target field
+	// in resolved configuration. Used to determine if the field should be removed when the created receiver
+	// doesn't expose such a field.
+	tmpSetEndpointConfigKey = "<tmp.receiver.creator.automatically.set.endpoint.field>"
+)
+
 // observerHandler manages endpoint change notifications.
 type observerHandler struct {
 	sync.Mutex
@@ -102,15 +109,17 @@ func (obs *observerHandler) OnAdd(added []observer.Endpoint) {
 				continue
 			}
 
-			discoveredConfig := userConfigMap{}
-
-			// If user didn't set endpoint set to default value.
+			discoveredCfg := userConfigMap{}
+			// If user didn't set endpoint set to default value as well as
+			// flag indicating we've done this for later validation.
 			if _, ok := resolvedConfig[endpointConfigKey]; !ok {
-				discoveredConfig[endpointConfigKey] = e.Target
+				discoveredCfg[endpointConfigKey] = e.Target
+				discoveredCfg[tmpSetEndpointConfigKey] = struct{}{}
 			}
 
-			resolvedDiscoveredConfig, err := expandMap(discoveredConfig, env)
-
+			// Though not necessary with contrib provided observers, nothing is stopping custom
+			// ones from using expr in their Target values.
+			discoveredConfig, err := expandMap(discoveredCfg, env)
 			if err != nil {
 				obs.params.TelemetrySettings.Logger.Error("unable to resolve discovered config", zap.String("receiver", template.id.String()), zap.Error(err))
 				continue
@@ -147,7 +156,7 @@ func (obs *observerHandler) OnAdd(added []observer.Endpoint) {
 					config:     resolvedConfig,
 					endpointID: e.ID,
 				},
-				resolvedDiscoveredConfig,
+				discoveredConfig,
 				resourceEnhancer,
 			)
 

--- a/receiver/receivercreator/observerhandler.go
+++ b/receiver/receivercreator/observerhandler.go
@@ -103,7 +103,7 @@ func (obs *observerHandler) OnAdd(added []observer.Endpoint) {
 				zap.String("endpoint", e.Target),
 				zap.String("endpoint_id", string(e.ID)))
 
-			resolvedConfig, err := expandMap(template.config, env)
+			resolvedConfig, err := expandConfig(template.config, env)
 			if err != nil {
 				obs.params.TelemetrySettings.Logger.Error("unable to resolve template config", zap.String("receiver", template.id.String()), zap.Error(err))
 				continue
@@ -119,7 +119,7 @@ func (obs *observerHandler) OnAdd(added []observer.Endpoint) {
 
 			// Though not necessary with contrib provided observers, nothing is stopping custom
 			// ones from using expr in their Target values.
-			discoveredConfig, err := expandMap(discoveredCfg, env)
+			discoveredConfig, err := expandConfig(discoveredCfg, env)
 			if err != nil {
 				obs.params.TelemetrySettings.Logger.Error("unable to resolve discovered config", zap.String("receiver", template.id.String()), zap.Error(err))
 				continue

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -18,155 +18,250 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/otelcol"
+	"go.opentelemetry.io/collector/otelcol/otelcoltest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
 
-type mockRunner struct {
-	mock.Mock
-}
-
-func (run *mockRunner) start(
-	receiver receiverConfig,
-	discoveredConfig userConfigMap,
-	nextConsumer consumer.Metrics,
-) (component.Component, error) {
-	args := run.Called(receiver, discoveredConfig, nextConsumer)
-	return args.Get(0).(component.Component), args.Error(1)
-}
-
-func (run *mockRunner) shutdown(rcvr component.Component) error {
-	args := run.Called(rcvr)
-	return args.Error(0)
-}
-
-var _ runner = (*mockRunner)(nil)
-
 func TestOnAdd(t *testing.T) {
-	runner := &mockRunner{}
+	for _, test := range []struct {
+		name                   string
+		receiverTemplateID     component.ID
+		receiverTemplateConfig userConfigMap
+		expectedReceiverType   component.Component
+		expectedReceiverConfig component.Config
+		expectedError          string
+	}{
+		{
+			name:                   "dynamically set with supported endpoint",
+			receiverTemplateID:     component.NewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateConfig: userConfigMap{"int_field": 12345678},
+			expectedReceiverType:   &nopWithEndpointReceiver{},
+			expectedReceiverConfig: &nopWithEndpointConfig{
+				IntField: 12345678,
+				Endpoint: "localhost:1234",
+			},
+		},
+		{
+			name:                   "inherits supported endpoint",
+			receiverTemplateID:     component.NewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateConfig: userConfigMap{"endpoint": "some.endpoint"},
+			expectedReceiverType:   &nopWithEndpointReceiver{},
+			expectedReceiverConfig: &nopWithEndpointConfig{
+				IntField: 1234,
+				Endpoint: "some.endpoint",
+			},
+		},
+		{
+			name:                   "not dynamically set with unsupported endpoint",
+			receiverTemplateID:     component.NewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateConfig: userConfigMap{"int_field": 23456789, "not_endpoint": "not.an.endpoint"},
+			expectedReceiverType:   &nopWithoutEndpointReceiver{},
+			expectedReceiverConfig: &nopWithoutEndpointConfig{
+				IntField:    23456789,
+				NotEndpoint: "not.an.endpoint",
+			},
+		},
+		{
+			name:                   "inherits unsupported endpoint",
+			receiverTemplateID:     component.NewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateConfig: userConfigMap{"endpoint": "unsupported.endpoint"},
+			expectedError:          "failed to load \"without.endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			rcvrCfg := receiverConfig{
+				id:         test.receiverTemplateID,
+				config:     test.receiverTemplateConfig,
+				endpointID: portEndpoint.ID,
+			}
+			cfg.receiverTemplates = map[string]receiverTemplate{
+				rcvrCfg.id.String(): {
+					receiverConfig:     rcvrCfg,
+					rule:               portRule,
+					Rule:               `type == "port"`,
+					ResourceAttributes: map[string]interface{}{},
+				},
+			}
 
-	set := receivertest.NewNopCreateSettings()
-	set.ID = component.NewIDWithName("name", "1")
-	rcvrCfg := receiverConfig{id: set.ID, config: userConfigMap{"foo": "bar"}, endpointID: portEndpoint.ID}
-	cfg := createDefaultConfig().(*Config)
-	cfg.receiverTemplates = map[string]receiverTemplate{
-		"name/1": {rcvrCfg, "", map[string]interface{}{}, newRuleOrPanic(`type == "port"`)},
+			handler, mr := newObserverHandler(t, cfg)
+			handler.OnAdd([]observer.Endpoint{
+				portEndpoint,
+				unsupportedEndpoint,
+			})
+
+			if test.expectedError != "" {
+				assert.Equal(t, 0, handler.receiversByEndpointID.Size())
+				require.Error(t, mr.lastError)
+				require.EqualError(t, mr.lastError, test.expectedError)
+				require.Nil(t, mr.startedComponent)
+				return
+			}
+
+			assert.Equal(t, 1, handler.receiversByEndpointID.Size())
+			require.NoError(t, mr.lastError)
+			require.NotNil(t, mr.startedComponent)
+
+			var actualConfig component.Config
+			switch v := mr.startedComponent.(type) {
+			case *nopWithEndpointReceiver:
+				require.NotNil(t, v)
+				actualConfig = v.cfg
+			case *nopWithoutEndpointReceiver:
+				require.NotNil(t, v)
+				actualConfig = v.cfg
+			default:
+				t.Fatalf("unexpected startedComponent: %T", v)
+			}
+			require.Equal(t, test.expectedReceiverConfig, actualConfig)
+		})
 	}
-	handler := &observerHandler{
-		params:                set,
-		config:                cfg,
-		receiversByEndpointID: receiverMap{},
-		runner:                runner,
-	}
-
-	runner.On(
-		"start",
-		rcvrCfg,
-		userConfigMap{endpointConfigKey: "localhost:1234"},
-		mock.IsType(&resourceEnhancer{}),
-	).Return(&nopWithEndpointReceiver{}, nil)
-
-	handler.OnAdd([]observer.Endpoint{
-		portEndpoint,
-		unsupportedEndpoint,
-	})
-
-	runner.AssertExpectations(t)
-	assert.Equal(t, 1, handler.receiversByEndpointID.Size())
 }
 
 func TestOnRemove(t *testing.T) {
-	runner := &mockRunner{}
-	rcvr := &nopWithEndpointReceiver{}
-	set := receivertest.NewNopCreateSettings()
-	set.ID = component.NewID(typeStr)
-	handler := &observerHandler{
-		params:                set,
-		config:                createDefaultConfig().(*Config),
-		receiversByEndpointID: receiverMap{},
-		runner:                runner,
+	cfg := createDefaultConfig().(*Config)
+	rcvrCfg := receiverConfig{
+		id:         component.NewIDWithName("with.endpoint", "some.name"),
+		config:     userConfigMap{"endpoint": "some.endpoint"},
+		endpointID: portEndpoint.ID,
 	}
+	cfg.receiverTemplates = map[string]receiverTemplate{
+		rcvrCfg.id.String(): {
+			receiverConfig:     rcvrCfg,
+			rule:               portRule,
+			Rule:               `type == "port"`,
+			ResourceAttributes: map[string]interface{}{},
+		},
+	}
+	handler, r := newObserverHandler(t, cfg)
+	handler.OnAdd([]observer.Endpoint{portEndpoint})
 
-	handler.receiversByEndpointID.Put("port-1", rcvr)
-
-	runner.On("shutdown", rcvr).Return(nil)
+	rcvr := r.startedComponent
+	require.NotNil(t, rcvr)
+	require.NoError(t, r.lastError)
 
 	handler.OnRemove([]observer.Endpoint{portEndpoint})
 
-	runner.AssertExpectations(t)
 	assert.Equal(t, 0, handler.receiversByEndpointID.Size())
+	require.Same(t, rcvr, r.shutdownComponent)
+	require.NoError(t, r.lastError)
 }
 
 func TestOnChange(t *testing.T) {
-	runner := &mockRunner{}
-	set := receivertest.NewNopCreateSettings()
-	set.ID = component.NewIDWithName("name", "1")
-	rcvrCfg := receiverConfig{id: set.ID, config: userConfigMap{"foo": "bar"}, endpointID: portEndpoint.ID}
-	oldRcvr := &nopWithEndpointReceiver{}
-	newRcvr := &nopWithEndpointReceiver{}
 	cfg := createDefaultConfig().(*Config)
+	rcvrCfg := receiverConfig{
+		id:         component.NewIDWithName("with.endpoint", "some.name"),
+		config:     userConfigMap{"endpoint": "some.endpoint"},
+		endpointID: portEndpoint.ID,
+	}
 	cfg.receiverTemplates = map[string]receiverTemplate{
-		"name/1": {rcvrCfg, "", map[string]interface{}{}, newRuleOrPanic(`type == "port"`)},
+		rcvrCfg.id.String(): {
+			receiverConfig:     rcvrCfg,
+			rule:               portRule,
+			Rule:               `type == "port"`,
+			ResourceAttributes: map[string]interface{}{},
+		},
 	}
-	handler := &observerHandler{
-		params:                set,
-		config:                cfg,
-		receiversByEndpointID: receiverMap{},
-		runner:                runner,
-	}
+	handler, r := newObserverHandler(t, cfg)
+	handler.OnAdd([]observer.Endpoint{portEndpoint})
 
-	handler.receiversByEndpointID.Put("port-1", oldRcvr)
-
-	runner.On("shutdown", oldRcvr).Return(nil)
-	runner.On(
-		"start",
-		rcvrCfg,
-		userConfigMap{endpointConfigKey: "localhost:1234"},
-		mock.IsType(&resourceEnhancer{}),
-	).Return(newRcvr, nil)
+	origRcvr := r.startedComponent
+	require.NotNil(t, origRcvr)
+	require.NoError(t, r.lastError)
 
 	handler.OnChange([]observer.Endpoint{portEndpoint})
 
-	runner.AssertExpectations(t)
+	require.NoError(t, r.lastError)
+	assert.Same(t, origRcvr, r.shutdownComponent)
+
+	newRcvr := r.startedComponent
+	require.NotSame(t, origRcvr, newRcvr)
+	require.NotNil(t, newRcvr)
+
 	assert.Equal(t, 1, handler.receiversByEndpointID.Size())
 	assert.Same(t, newRcvr, handler.receiversByEndpointID.Get("port-1")[0])
 }
 
-func TestDynamicConfig(t *testing.T) {
-	runner := &mockRunner{}
-	set := receivertest.NewNopCreateSettings()
-	set.ID = component.NewIDWithName("name", "1")
-	cfg := createDefaultConfig().(*Config)
-	cfg.receiverTemplates = map[string]receiverTemplate{
-		"name/1": {
-			receiverConfig: receiverConfig{id: set.ID, config: userConfigMap{"endpoint": "`endpoint`:6379"}, endpointID: podEndpoint.ID},
-			Rule:           `type == "pod"`,
-			rule:           newRuleOrPanic("type == \"pod\""),
-		},
-	}
-	handler := &observerHandler{
-		params:                set,
-		config:                cfg,
-		receiversByEndpointID: receiverMap{},
-		runner:                runner,
-	}
-	runner.On(
-		"start",
-		receiverConfig{
-			id:         component.NewIDWithName("name", "1"),
-			config:     userConfigMap{endpointConfigKey: "localhost:6379"},
-			endpointID: podEndpoint.ID,
-		},
-		userConfigMap{},
-		mock.IsType(&resourceEnhancer{}),
-	).Return(&nopWithEndpointReceiver{}, nil)
-	handler.OnAdd([]observer.Endpoint{
-		podEndpoint,
-	})
+type mockRunner struct {
+	receiverRunner
+	startedComponent  component.Component
+	shutdownComponent component.Component
+	lastError         error
+}
 
-	runner.AssertExpectations(t)
+func (r *mockRunner) start(
+	receiver receiverConfig,
+	discoveredConfig userConfigMap,
+	nextConsumer consumer.Metrics,
+) (component.Component, error) {
+	r.startedComponent, r.lastError = r.receiverRunner.start(receiver, discoveredConfig, nextConsumer)
+	return r.startedComponent, r.lastError
+}
+
+func (r *mockRunner) shutdown(rcvr component.Component) error {
+	r.shutdownComponent = rcvr
+	r.lastError = r.receiverRunner.shutdown(rcvr)
+	return r.lastError
+}
+
+var _ component.Host = (*mockHost)(nil)
+
+type mockHost struct {
+	t         *testing.T
+	factories otelcol.Factories
+}
+
+func newMockHost(t *testing.T) *mockHost {
+	factories, err := otelcoltest.NopFactories()
+	require.Nil(t, err)
+	factories.Receivers["with.endpoint"] = &nopWithEndpointFactory{Factory: receivertest.NewNopFactory()}
+	factories.Receivers["without.endpoint"] = &nopWithoutEndpointFactory{Factory: receivertest.NewNopFactory()}
+	return &mockHost{t: t, factories: factories}
+}
+
+func (m *mockHost) ReportFatalError(err error) {
+	m.t.Fatal("ReportFatalError", err)
+}
+
+func (m *mockHost) GetFactory(kind component.Kind, componentType component.Type) component.Factory {
+	require.Equal(m.t, component.KindReceiver, kind, "mockhost can only retrieve receiver factories")
+	return m.factories.Receivers[componentType]
+}
+
+func (m *mockHost) GetExtensions() map[component.ID]component.Component {
+	m.t.Fatal("GetExtensions")
+	return nil
+}
+
+func (m *mockHost) GetExporters() map[component.DataType]map[component.ID]component.Component {
+	m.t.Fatal("GetExporters")
+	return nil
+}
+
+func newMockRunner(t *testing.T) *mockRunner {
+	return &mockRunner{
+		receiverRunner: receiverRunner{
+			params:      receivertest.NewNopCreateSettings(),
+			idNamespace: component.NewIDWithName("some.type", "some.name"),
+			host:        newMockHost(t),
+		},
+	}
+}
+
+func newObserverHandler(t *testing.T, config *Config) (*observerHandler, *mockRunner) {
+	set := receivertest.NewNopCreateSettings()
+	set.ID = component.NewIDWithName("some.type", "some.name")
+	mr := newMockRunner(t)
+	return &observerHandler{
+		params:                set,
+		config:                config,
+		receiversByEndpointID: receiverMap{},
+		runner:                mr,
+	}, mr
 }

--- a/receiver/receivercreator/rules_test.go
+++ b/receiver/receivercreator/rules_test.go
@@ -23,14 +23,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
 
-func newRuleOrPanic(s string) rule {
-	r, err := newRule(s)
-	if err != nil {
-		panic(err)
-	}
-	return r
-}
-
 func Test_ruleEval(t *testing.T) {
 	type args struct {
 		ruleStr  string


### PR DESCRIPTION
**Description:**
Fixing a bug - These changes add embedded config `endpoint` field validation to the receiver creator so that it doesn't try to set the field for a config that doesn't support it. Also including a small refactor of the expansion logic to support more formats like those of the prometheus receiver.

**Link to tracking Issue:**
#7381

**Testing:**
Updates existing observer handler tests to be more exhaustive than mock method call validation checks and adds more coverage for expansion suite.

**Documentation:**
Updated readme to describe the updated behavior.