### PR TITLE
[receiver/oracledb] return -1 if max tablespace size is not set

### DIFF
--- a/.chloggen/oracledb-max-tablespace-size-unset.yaml
+++ b/.chloggen/oracledb-max-tablespace-size-unset.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: oracledbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: return -1 if max tablespace size is not set
+
+# One or more tracking issues related to the change
+issues: [18670]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/oracledb-max-tablespace-size-unset.yaml
+++ b/.chloggen/oracledb-max-tablespace-size-unset.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: oracledbreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: return -1 if max tablespace size is not set
+note: record a value of -1 for `oracledb.tablespace_size.limit` if the max tablespace size is not set
 
 # One or more tracking issues related to the change
 issues: [18670]

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -1804,13 +1804,8 @@ func (mb *MetricsBuilder) RecordOracledbSessionsUsageDataPoint(ts pcommon.Timest
 }
 
 // RecordOracledbTablespaceSizeLimitDataPoint adds a data point to oracledb.tablespace_size.limit metric.
-func (mb *MetricsBuilder) RecordOracledbTablespaceSizeLimitDataPoint(ts pcommon.Timestamp, inputVal string, tablespaceNameAttributeValue string) error {
-	val, err := strconv.ParseInt(inputVal, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse int64 for OracledbTablespaceSizeLimit, value was %s: %w", inputVal, err)
-	}
+func (mb *MetricsBuilder) RecordOracledbTablespaceSizeLimitDataPoint(ts pcommon.Timestamp, val int64, tablespaceNameAttributeValue string) {
 	mb.metricOracledbTablespaceSizeLimit.recordDataPoint(mb.startTime, ts, val, tablespaceNameAttributeValue)
-	return nil
 }
 
 // RecordOracledbTablespaceSizeUsageDataPoint adds a data point to oracledb.tablespace_size.usage metric.

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -136,7 +136,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordOracledbTablespaceSizeLimitDataPoint(ts, "1", "attr-val")
+			mb.RecordOracledbTablespaceSizeLimitDataPoint(ts, 1, "attr-val")
 
 			defaultMetricsCount++
 			allMetricsCount++

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -216,7 +216,6 @@ metrics:
     enabled: true
     gauge:
       value_type: int
-      input_type: string
     unit: By
   oracledb.tablespace_size.usage:
     attributes:

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -270,13 +270,13 @@ func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 			for _, row := range rows {
 				tablespaceName := row["TABLESPACE_NAME"]
 				var val int64
-				if row["VALUE"] == "" {
+				inputVal := row["VALUE"]
+				if inputVal == "" {
 					val = -1
-					fmt.Println("")
 				} else {
-					val, err = strconv.ParseInt(row["VALUE"], 10, 64)
+					val, err = strconv.ParseInt(inputVal, 10, 64)
 					if err != nil {
-						scrapeErrors = append(scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbTablespaceSizeLimit, value was %s: %w", row["VALUE"], err))
+						scrapeErrors = append(scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbTablespaceSizeLimit, value was %s: %w", inputVal, err))
 					}
 				}
 				s.metricsBuilder.RecordOracledbTablespaceSizeLimitDataPoint(now, val, tablespaceName)

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -271,15 +271,19 @@ func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				tablespaceName := row["TABLESPACE_NAME"]
 				var val int64
 				inputVal := row["VALUE"]
+				valueOk := true
 				if inputVal == "" {
 					val = -1
 				} else {
 					val, err = strconv.ParseInt(inputVal, 10, 64)
 					if err != nil {
 						scrapeErrors = append(scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbTablespaceSizeLimit, value was %s: %w", inputVal, err))
+						valueOk = false
 					}
 				}
-				s.metricsBuilder.RecordOracledbTablespaceSizeLimitDataPoint(now, val, tablespaceName)
+				if valueOk {
+					s.metricsBuilder.RecordOracledbTablespaceSizeLimitDataPoint(now, val, tablespaceName)
+				}
 			}
 		}
 	}

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -269,10 +269,17 @@ func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 			now := pcommon.NewTimestampFromTime(time.Now())
 			for _, row := range rows {
 				tablespaceName := row["TABLESPACE_NAME"]
-				err := s.metricsBuilder.RecordOracledbTablespaceSizeLimitDataPoint(now, row["VALUE"], tablespaceName)
-				if err != nil {
-					scrapeErrors = append(scrapeErrors, err)
+				var val int64
+				if row["VALUE"] == "" {
+					val = -1
+					fmt.Println("")
+				} else {
+					val, err = strconv.ParseInt(row["VALUE"], 10, 64)
+					if err != nil {
+						scrapeErrors = append(scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbTablespaceSizeLimit, value was %s: %w", row["VALUE"], err))
+					}
 				}
+				s.metricsBuilder.RecordOracledbTablespaceSizeLimitDataPoint(now, val, tablespaceName)
 			}
 		}
 	}

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -271,19 +271,16 @@ func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				tablespaceName := row["TABLESPACE_NAME"]
 				var val int64
 				inputVal := row["VALUE"]
-				valueOk := true
 				if inputVal == "" {
 					val = -1
 				} else {
 					val, err = strconv.ParseInt(inputVal, 10, 64)
 					if err != nil {
 						scrapeErrors = append(scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbTablespaceSizeLimit, value was %s: %w", inputVal, err))
-						valueOk = false
+						continue
 					}
 				}
-				if valueOk {
-					s.metricsBuilder.RecordOracledbTablespaceSizeLimitDataPoint(now, val, tablespaceName)
-				}
+				s.metricsBuilder.RecordOracledbTablespaceSizeLimitDataPoint(now, val, tablespaceName)
 			}
 		}
 	}

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -99,6 +99,23 @@ func TestScraper_Scrape(t *testing.T) {
 				}}
 			},
 		},
+		{
+			name: "bad value on tablespace",
+			dbclientFn: func(db *sql.DB, s string, logger *zap.Logger) dbClient {
+				if s == tablespaceMaxSpaceSQL {
+					return &fakeDbClient{Responses: [][]metricRow{
+						{
+							{"TABLESPACE_NAME": "SYS", "VALUE": "1024"},
+							{"TABLESPACE_NAME": "FOO", "VALUE": "ert"},
+						},
+					}}
+				}
+				return &fakeDbClient{Responses: [][]metricRow{
+					queryResponses[s],
+				}}
+			},
+			errWanted: `failed to parse int64 for OracledbTablespaceSizeLimit, value was ert: strconv.ParseInt: parsing "ert": invalid syntax`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -51,68 +51,86 @@ var queryResponses = map[string][]metricRow{
 }
 
 func TestScraper_Scrape(t *testing.T) {
-	metricsBuilder := metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings(), receivertest.NewNopCreateSettings())
 
-	scrpr := scraper{
-		logger:         zap.NewNop(),
-		metricsBuilder: metricsBuilder,
-		dbProviderFunc: func() (*sql.DB, error) {
-			return nil, nil
-		},
-		clientProviderFunc: func(db *sql.DB, s string, logger *zap.Logger) dbClient {
-			return &fakeDbClient{
-				Responses: [][]metricRow{
-					queryResponses[s],
-				},
-			}
-		},
-		id:              component.ID{},
-		metricsSettings: metadata.DefaultMetricsSettings(),
-	}
-	err := scrpr.start(context.Background(), componenttest.NewNopHost())
-	defer func() {
-		assert.NoError(t, scrpr.shutdown(context.Background()))
-	}()
-	require.NoError(t, err)
-	m, err := scrpr.scrape(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, 16, m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
-	name, ok := m.ResourceMetrics().At(0).Resource().Attributes().Get("oracledb.instance.name")
-	assert.True(t, ok)
-	assert.Equal(t, "", name.Str())
-}
-
-func TestPartial_InvalidScrape(t *testing.T) {
-	metricsBuilder := metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings(), receivertest.NewNopCreateSettings())
-
-	scrpr := scraper{
-		logger:         zap.NewNop(),
-		metricsBuilder: metricsBuilder,
-		dbProviderFunc: func() (*sql.DB, error) {
-			return nil, nil
-		},
-		clientProviderFunc: func(db *sql.DB, s string, logger *zap.Logger) dbClient {
-			if s == tablespaceUsageSQL {
-				return &fakeDbClient{Responses: [][]metricRow{
-					{
-						{},
+	tests := []struct {
+		name       string
+		dbclientFn func(db *sql.DB, s string, logger *zap.Logger) dbClient
+		errWanted  string
+	}{
+		{
+			name: "valid",
+			dbclientFn: func(db *sql.DB, s string, logger *zap.Logger) dbClient {
+				return &fakeDbClient{
+					Responses: [][]metricRow{
+						queryResponses[s],
 					},
-				}}
-			}
-			return &fakeDbClient{Responses: [][]metricRow{
-				queryResponses[s],
-			}}
+				}
+			},
 		},
-		id:              component.ID{},
-		metricsSettings: metadata.DefaultMetricsSettings(),
+		{
+			name: "bad tablespace usage",
+			dbclientFn: func(db *sql.DB, s string, logger *zap.Logger) dbClient {
+				if s == tablespaceUsageSQL {
+					return &fakeDbClient{Responses: [][]metricRow{
+						{
+							{},
+						},
+					}}
+				}
+				return &fakeDbClient{Responses: [][]metricRow{
+					queryResponses[s],
+				}}
+			},
+			errWanted: `failed to parse int64 for OracledbTablespaceSizeUsage, value was : strconv.ParseInt: parsing "": invalid syntax`,
+		},
+		{
+			name: "no limit on tablespace",
+			dbclientFn: func(db *sql.DB, s string, logger *zap.Logger) dbClient {
+				if s == tablespaceMaxSpaceSQL {
+					return &fakeDbClient{Responses: [][]metricRow{
+						{
+							{"TABLESPACE_NAME": "SYS", "VALUE": "1024"},
+							{"TABLESPACE_NAME": "FOO", "VALUE": ""},
+						},
+					}}
+				}
+				return &fakeDbClient{Responses: [][]metricRow{
+					queryResponses[s],
+				}}
+			},
+		},
 	}
-	err := scrpr.start(context.Background(), componenttest.NewNopHost())
-	defer func() {
-		assert.NoError(t, scrpr.shutdown(context.Background()))
-	}()
-	require.NoError(t, err)
-	_, err = scrpr.scrape(context.Background())
-	require.Error(t, err)
-	require.True(t, scrapererror.IsPartialScrapeError(err))
-	require.EqualError(t, err, `failed to parse int64 for OracledbTablespaceSizeUsage, value was : strconv.ParseInt: parsing "": invalid syntax`)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metricsBuilder := metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings(), receivertest.NewNopCreateSettings())
+
+			scrpr := scraper{
+				logger:         zap.NewNop(),
+				metricsBuilder: metricsBuilder,
+				dbProviderFunc: func() (*sql.DB, error) {
+					return nil, nil
+				},
+				clientProviderFunc: test.dbclientFn,
+				id:                 component.ID{},
+				metricsSettings:    metadata.DefaultMetricsSettings(),
+			}
+			err := scrpr.start(context.Background(), componenttest.NewNopHost())
+			defer func() {
+				assert.NoError(t, scrpr.shutdown(context.Background()))
+			}()
+			require.NoError(t, err)
+			m, err := scrpr.scrape(context.Background())
+			if test.errWanted != "" {
+				require.True(t, scrapererror.IsPartialScrapeError(err))
+				require.EqualError(t, err, test.errWanted)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, 16, m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+			}
+			name, ok := m.ResourceMetrics().At(0).Resource().Attributes().Get("oracledb.instance.name")
+			assert.True(t, ok)
+			assert.Equal(t, "", name.Str())
+		})
+	}
+
 }


### PR DESCRIPTION
**Description:**
Rather than reporting an error, return -1 if the metric representing the tablespace max size is not set.

**Link to tracking Issue:**
Fixes #18670

**Testing:**
Unit test.

**Documentation:**
N/A