### PR TITLE
[receiver/googlecloudspanner] feat: table size stats

### DIFF
--- a/.chloggen/googlecloudpsanner-table-size-stats.yaml
+++ b/.chloggen/googlecloudpsanner-table-size-stats.yaml
@@ -2,7 +2,7 @@
 change_type: 'enhancement'
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: googlcloudspannerreceiver
+component: googlecloudspannerreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "adding table size statistics as metrics"

--- a/.chloggen/googlecloudpsanner-table-size-stats.yaml
+++ b/.chloggen/googlecloudpsanner-table-size-stats.yaml
@@ -8,7 +8,7 @@ component: googlcloudspannerreceiver
 note: "adding table size statistics as metrics"
 
 # One or more tracking issues related to the change
-issues: []
+issues: [18689]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/googlecloudpsanner-table-size-stats.yaml
+++ b/.chloggen/googlecloudpsanner-table-size-stats.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlcloudspannerreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "adding table size statistics as metrics"
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
@@ -524,7 +524,7 @@ metadata:
 #
   - name: "hourly table size stats"
     query: "SELECT * FROM SPANNER_SYS.TABLE_SIZES_STATS_1HOUR WHERE INTERVAL_END = @pullTimestamp ORDER BY INTERVAL_END DESC, USED_BYTES DESC"
-    metric_name_prefix: "database/spanner/table_sizes/total/"
+    metric_name_prefix: "database/spanner/table_sizes/top/"
     timestamp_column_name: "INTERVAL_END"
     high_cardinality: true
     labels:

--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
@@ -523,7 +523,7 @@ metadata:
 # -------------------------------------------- Table Size Stats ------------------------------------------------------
 #
   - name: "hourly table size stats"
-    query: "SELECT * FROM SPANNER_SYS.TABLE_SIZES_STATS_1HOUR WHERE INTERVAL_END = @pullTimestamp ORDER BY INTERVAL_END DESC, LOCK_WAIT_SECONDS DESC"
+    query: "SELECT * FROM SPANNER_SYS.TABLE_SIZES_STATS_1HOUR WHERE INTERVAL_END = @pullTimestamp ORDER BY INTERVAL_END DESC, USED_BYTES DESC"
     metric_name_prefix: "database/spanner/table_sizes/total/"
     timestamp_column_name: "INTERVAL_END"
     high_cardinality: true

--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
@@ -519,3 +519,22 @@ metadata:
         data:
           type: "gauge"
         unit: "second"
+#
+# -------------------------------------------- Table Size Stats ------------------------------------------------------
+#
+  - name: "hourly table sizes stats"
+    query: "SELECT * FROM SPANNER_SYS.TABLE_SIZES_STATS_1HOUR WHERE INTERVAL_END = @pullTimestamp ORDER BY INTERVAL_END DESC, LOCK_WAIT_SECONDS DESC"
+    metric_name_prefix: "database/spanner/table_sizes/total/"
+    timestamp_column_name: "INTERVAL_END"
+    high_cardinality: true
+    labels:
+      - name: "table_name"
+        column_name: "TABLE_NAME"
+        value_type: "string"
+    metrics:
+      - name: "used_bytes"
+        column_name: "USED_BYTES"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "byte"

--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
@@ -522,7 +522,7 @@ metadata:
 #
 # -------------------------------------------- Table Size Stats ------------------------------------------------------
 #
-  - name: "hourly table sizes stats"
+  - name: "hourly table size stats"
     query: "SELECT * FROM SPANNER_SYS.TABLE_SIZES_STATS_1HOUR WHERE INTERVAL_END = @pullTimestamp ORDER BY INTERVAL_END DESC, LOCK_WAIT_SECONDS DESC"
     metric_name_prefix: "database/spanner/table_sizes/total/"
     timestamp_column_name: "INTERVAL_END"


### PR DESCRIPTION

**Description:** 
https://cloud.google.com/spanner/docs/introspection/table-sizes-statistics
adding support for exposing table size statistics based on documentation link above

**Link to tracking Issue:**  N/A
**Testing:** 
Tried to run make, but `addlicense` step is not working, and after a bunch of messing with it - it added license to every single file over again.

**Documentation:** Still looking where/if I need to add that