### PR TITLE
[pkg/ottl] Switch ErrorMode to string

### DIFF
--- a/.chloggen/ottl-switch-error-mode-to-string.yaml
+++ b/.chloggen/ottl-switch-error-mode-to-string.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: switch ErrorMode to be a string instead of an int
+
+# One or more tracking issues related to the change
+issues: [18692]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -17,18 +17,30 @@ package ottl // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/alecthomas/participle/v2"
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 )
 
-type ErrorMode int
+type ErrorMode string
 
 const (
-	IgnoreError ErrorMode = iota
-	PropagateError
+	IgnoreError    ErrorMode = "ignore"
+	PropagateError ErrorMode = "propagate"
 )
+
+func (e *ErrorMode) UnmarshalText(text []byte) error {
+	str := ErrorMode(strings.ToLower(string(text)))
+	switch str {
+	case IgnoreError, PropagateError:
+		*e = str
+		return nil
+	default:
+		return fmt.Errorf("unknown error mode %v", str)
+	}
+}
 
 type Parser[K any] struct {
 	functions         map[string]interface{}


### PR DESCRIPTION
**Description:** 

Switch `ottl.ErrorMode` to a string "enum" instead of an int enum.  I found the string version easier to work with when actually using the type in config structs.

**Link to tracking Issue:** <Issue number if applicable>

relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16519

**Testing:** <Describe what testing was performed and which tests were added.>

ran tests