### PR TITLE
[exporter/sentry] Map environment config

### DIFF
--- a/.chloggen/add-env-to-sentry-exporter.yaml
+++ b/.chloggen/add-env-to-sentry-exporter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sentry/sentryexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `env` configuration option that allows specifying env for transaction.
+
+# One or more tracking issues related to the change
+issues: [18694]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/add-env-to-sentry-exporter.yaml
+++ b/.chloggen/add-env-to-sentry-exporter.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: sentry/sentryexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `env` configuration option that allows specifying env for transaction.
+note: Add `environment` configuration option that allows specifying env for transaction.
 
 # One or more tracking issues related to the change
 issues: [18694]

--- a/exporter/sentryexporter/README.md
+++ b/exporter/sentryexporter/README.md
@@ -13,6 +13,7 @@ For more details about distributed tracing in Sentry, please view [our documenta
 The following configuration options are supported:
 
 - `dsn`: The DSN tells the exporter where to send the events. You can find a Sentry project DSN in the “Client Keys” section of the “Project Settings” section of a Sentry project.
+- `env`: When the value is set, it will set the event environment tag, so the event can be filtered accordingly in Sentry.
 - `insecure_skip_verify`: If it is set to true, then ssl certificates will not be checked. Useful for test purposes, as well as for Sentry installations deployed in private clouds.
 
 Example:
@@ -21,6 +22,7 @@ Example:
 exporters:
   sentry:
     dsn: https://key@host/path/42
+    env: prod
     insecure_skip_verify: true
 ```
 

--- a/exporter/sentryexporter/README.md
+++ b/exporter/sentryexporter/README.md
@@ -13,7 +13,7 @@ For more details about distributed tracing in Sentry, please view [our documenta
 The following configuration options are supported:
 
 - `dsn`: The DSN tells the exporter where to send the events. You can find a Sentry project DSN in the “Client Keys” section of the “Project Settings” section of a Sentry project.
-- `env`: When the value is set, it will set the event environment tag, so the event can be filtered accordingly in Sentry.
+- `environment`: When the value is set, it will set the event environment tag, so the event can be filtered accordingly in Sentry. Note that this applies to every single event that is processed by the Sentry Exporter.
 - `insecure_skip_verify`: If it is set to true, then ssl certificates will not be checked. Useful for test purposes, as well as for Sentry installations deployed in private clouds.
 
 Example:
@@ -22,7 +22,7 @@ Example:
 exporters:
   sentry:
     dsn: https://key@host/path/42
-    env: prod
+    environment: prod
     insecure_skip_verify: true
 ```
 

--- a/exporter/sentryexporter/config.go
+++ b/exporter/sentryexporter/config.go
@@ -14,12 +14,26 @@
 
 package sentryexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter"
 
+import (
+	"errors"
+)
+
 // Config defines the configuration for the Sentry Exporter.
 type Config struct {
 	// DSN to report transaction to Sentry. If the DSN is not set, no trace will be sent to Sentry.
 	DSN string `mapstructure:"dsn"`
-	// ENV is a Sentry-supported tag that you can (and should) add. It's intended to refer deployments' environment such as development, staging, or production.
-	ENV string `mapstructure:"env"`
+	// The deployment environment name, such as production or staging.
+	// Environments are case sensitive. The environment name can't contain newlines, spaces or forward slashes,
+	// can't be the string "None", or exceed 64 characters.
+	Environment string `mapstructure:"environment"`
 	// InsecureSkipVerify controls whether the client verifies the Sentry server certificate chain
 	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify"`
+}
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	if cfg.Environment == "None" || len(cfg.Environment) > 64 {
+		return errors.New("can't be string \"None\" or exceed 64 characters")
+	}
+	return nil
 }

--- a/exporter/sentryexporter/config.go
+++ b/exporter/sentryexporter/config.go
@@ -18,6 +18,8 @@ package sentryexporter // import "github.com/open-telemetry/opentelemetry-collec
 type Config struct {
 	// DSN to report transaction to Sentry. If the DSN is not set, no trace will be sent to Sentry.
 	DSN string `mapstructure:"dsn"`
+	// ENV is a Sentry-supported tag that you can (and should) add. It's intended to refer deployments' environment such as development, staging, or production.
+	ENV string `mapstructure:"env"`
 	// InsecureSkipVerify controls whether the client verifies the Sentry server certificate chain
 	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify"`
 }

--- a/exporter/sentryexporter/config_test.go
+++ b/exporter/sentryexporter/config_test.go
@@ -41,8 +41,8 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(typeStr, "2"),
 			expected: &Config{
-				DSN: "https://key@host/path/42",
-				ENV: "prod",
+				DSN:         "https://key@host/path/42",
+				Environment: "prod",
 			},
 		},
 	}

--- a/exporter/sentryexporter/config_test.go
+++ b/exporter/sentryexporter/config_test.go
@@ -42,6 +42,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(typeStr, "2"),
 			expected: &Config{
 				DSN: "https://key@host/path/42",
+				ENV: "prod",
 			},
 		},
 	}

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -480,8 +480,8 @@ func CreateSentryExporter(config *Config, set exporter.CreateSettings) (exporter
 	transport := newSentryTransport()
 
 	clientOptions := sentry.ClientOptions{
-		Dsn: 		 config.DSN,
-		Environment: config.ENV,
+		Dsn:         config.DSN,
+		Environment: config.Environment,
 	}
 
 	if config.InsecureSkipVerify {

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -481,6 +481,7 @@ func CreateSentryExporter(config *Config, set exporter.CreateSettings) (exporter
 
 	clientOptions := sentry.ClientOptions{
 		Dsn: config.DSN,
+		Environment: config.ENV,
 	}
 
 	if config.InsecureSkipVerify {

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -480,7 +480,7 @@ func CreateSentryExporter(config *Config, set exporter.CreateSettings) (exporter
 	transport := newSentryTransport()
 
 	clientOptions := sentry.ClientOptions{
-		Dsn: config.DSN,
+		Dsn: 		 config.DSN,
 		Environment: config.ENV,
 	}
 

--- a/exporter/sentryexporter/testdata/config.yaml
+++ b/exporter/sentryexporter/testdata/config.yaml
@@ -1,3 +1,4 @@
 sentry:
 sentry/2:
   dsn: https://key@host/path/42
+  env: prod

--- a/exporter/sentryexporter/testdata/config.yaml
+++ b/exporter/sentryexporter/testdata/config.yaml
@@ -1,4 +1,4 @@
 sentry:
 sentry/2:
   dsn: https://key@host/path/42
-  env: prod
+  environment: prod


### PR DESCRIPTION
**Description:**
Adding a feature - added environment config to allow sentry exporter to have environment, based on the sentry SDK documentation https://docs.sentry.io/platforms/go/configuration/environments/

**Link to tracking Issue:**
Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18694

**Testing:**
Added config test for exporter sentry

**Documentation:**
Updated README and godocs.