### PR TITLE
[processor/spanmetricsprocessor] Support set metrics namespace.

### DIFF
--- a/.chloggen/sapnmetricsprocessor-support-namespace.yaml
+++ b/.chloggen/sapnmetricsprocessor-support-namespace.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add namespace configuration for support set namespace in metrics.
+
+# One or more tracking issues related to the change
+issues: [18679, ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/sapnmetricsprocessor-support-namespace.yaml
+++ b/.chloggen/sapnmetricsprocessor-support-namespace.yaml
@@ -5,10 +5,10 @@ change_type: enhancement
 component: spanmetricsprocessor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add namespace configuration for support set namespace in metrics.
+note: Support set namespace for generated metric.
 
 # One or more tracking issues related to the change
-issues: [18679, ]
+issues: [18679]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -64,6 +64,7 @@ The following settings can be optionally configured:
 - `aggregation_temporality`: Defines the aggregation temporality of the generated metrics. 
   One of either `AGGREGATION_TEMPORALITY_CUMULATIVE` or `AGGREGATION_TEMPORALITY_DELTA`.
   - Default: `AGGREGATION_TEMPORALITY_CUMULATIVE`
+- `namespace`: Defines the namespace of the generated metrics. If `namespace` provided, generated metric name will be added `namespace.` prefix.
 
 ## Examples
 

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -65,6 +65,7 @@ The following settings can be optionally configured:
 - `aggregation_temporality`: Defines the aggregation temporality of the generated metrics. 
   One of either `AGGREGATION_TEMPORALITY_CUMULATIVE` or `AGGREGATION_TEMPORALITY_DELTA`.
   - Default: `AGGREGATION_TEMPORALITY_CUMULATIVE`
+- `namespace`: Defines the namespace of the generated metrics. If `namespace` provided, generated metric name will be added `namespace.` prefix.
 
 ## Examples
 

--- a/processor/spanmetricsprocessor/config.go
+++ b/processor/spanmetricsprocessor/config.go
@@ -71,9 +71,6 @@ type Config struct {
 
 	// Namespace is the namespace to use for the metrics.
 	Namespace string `mapstructure:"namespace"`
-
-	// Normalized if enabled, using OpenTelemetry specification.
-	Normalized bool `mapstructure:"normalized"`
 }
 
 // GetAggregationTemporality converts the string value given in the config into a AggregationTemporality.

--- a/processor/spanmetricsprocessor/config.go
+++ b/processor/spanmetricsprocessor/config.go
@@ -40,7 +40,6 @@ type Dimension struct {
 
 // Config defines the configuration options for spanmetricsprocessor.
 type Config struct {
-
 	// MetricsExporter is the name of the metrics exporter to use to ship metrics.
 	MetricsExporter string `mapstructure:"metrics_exporter"`
 
@@ -69,6 +68,12 @@ type Config struct {
 
 	// MetricsEmitInterval is the time period between when metrics are flushed or emitted to the configured MetricsExporter.
 	MetricsFlushInterval time.Duration `mapstructure:"metrics_flush_interval"`
+
+	// Namespace is the namespace to use for the metrics.
+	Namespace string `mapstructure:"namespace"`
+
+	// Normalized if enabled, using OpenTelemetry specification.
+	Normalized bool `mapstructure:"normalized"`
 }
 
 // GetAggregationTemporality converts the string value given in the config into a AggregationTemporality.

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -335,7 +335,7 @@ func (p *processorImp) buildMetrics() pmetric.Metrics {
 // into the given instrumentation library metrics.
 func (p *processorImp) collectLatencyMetrics(ilm pmetric.ScopeMetrics) {
 	mLatency := ilm.Metrics().AppendEmpty()
-	mLatency.SetName(buildMetricName(p.config.Namespace, metricLatency, p.config.Normalized))
+	mLatency.SetName(buildMetricName(p.config.Namespace, metricLatency))
 	mLatency.SetUnit("ms")
 	mLatency.SetEmptyHistogram().SetAggregationTemporality(p.config.GetAggregationTemporality())
 	dps := mLatency.Histogram().DataPoints()
@@ -363,7 +363,7 @@ func (p *processorImp) collectLatencyMetrics(ilm pmetric.ScopeMetrics) {
 // into the given instrumentation library metrics.
 func (p *processorImp) collectCallMetrics(ilm pmetric.ScopeMetrics) {
 	mCalls := ilm.Metrics().AppendEmpty()
-	mCalls.SetName(buildMetricName(p.config.Namespace, metricCallsTotal, p.config.Normalized))
+	mCalls.SetName(buildMetricName(p.config.Namespace, metricCallsTotal))
 	mCalls.SetEmptySum().SetIsMonotonic(true)
 	mCalls.Sum().SetAggregationTemporality(p.config.GetAggregationTemporality())
 	dps := mCalls.Sum().DataPoints()
@@ -581,15 +581,10 @@ func setExemplars(exemplarsData []exemplarData, timestamp pcommon.Timestamp, exe
 	es.CopyTo(exemplars)
 }
 
-// buildMetricName builds the metric name from the namespace and metric name.
-// if normalized is true, the metric name will be normalized concatenating the namespace and metric name with a dot.
-// if normalized is false, the metric name will be concatenated with an underscore.
-func buildMetricName(namespace string, metricName string, normalized bool) string {
+// buildMetricName builds the namespace prefix for the metric name.
+func buildMetricName(namespace string, name string) string {
 	if namespace != "" {
-		if normalized {
-			return namespace + "." + metricName
-		}
-		return namespace + "_" + metricName
+		return namespace + "." + name
 	}
-	return metricName
+	return name
 }

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -45,6 +45,9 @@ const (
 	statusCodeKey      = "status.code" // OpenTelemetry non-standard constant.
 	metricKeySeparator = string(byte(0))
 
+	metricLatency    = "latency"
+	metricCallsTotal = "calls_total"
+
 	defaultDimensionsCacheSize = 1000
 )
 
@@ -332,7 +335,7 @@ func (p *processorImp) buildMetrics() pmetric.Metrics {
 // into the given instrumentation library metrics.
 func (p *processorImp) collectLatencyMetrics(ilm pmetric.ScopeMetrics) {
 	mLatency := ilm.Metrics().AppendEmpty()
-	mLatency.SetName("latency")
+	mLatency.SetName(buildMetricName(p.config.Namespace, metricLatency, p.config.Normalized))
 	mLatency.SetUnit("ms")
 	mLatency.SetEmptyHistogram().SetAggregationTemporality(p.config.GetAggregationTemporality())
 	dps := mLatency.Histogram().DataPoints()
@@ -360,7 +363,7 @@ func (p *processorImp) collectLatencyMetrics(ilm pmetric.ScopeMetrics) {
 // into the given instrumentation library metrics.
 func (p *processorImp) collectCallMetrics(ilm pmetric.ScopeMetrics) {
 	mCalls := ilm.Metrics().AppendEmpty()
-	mCalls.SetName("calls_total")
+	mCalls.SetName(buildMetricName(p.config.Namespace, metricCallsTotal, p.config.Normalized))
 	mCalls.SetEmptySum().SetIsMonotonic(true)
 	mCalls.Sum().SetAggregationTemporality(p.config.GetAggregationTemporality())
 	dps := mCalls.Sum().DataPoints()
@@ -576,4 +579,17 @@ func setExemplars(exemplarsData []exemplarData, timestamp pcommon.Timestamp, exe
 	}
 
 	es.CopyTo(exemplars)
+}
+
+// buildMetricName builds the metric name from the namespace and metric name.
+// if normalized is true, the metric name will be normalized concatenating the namespace and metric name with a dot.
+// if normalized is false, the metric name will be concatenated with an underscore.
+func buildMetricName(namespace string, metricName string, normalized bool) string {
+	if namespace != "" {
+		if normalized {
+			return namespace + "." + metricName
+		}
+		return namespace + "_" + metricName
+	}
+	return metricName
 }

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -1107,18 +1107,15 @@ func TestBuildMetricName(t *testing.T) {
 	tests := []struct {
 		namespace  string
 		metricName string
-		normalized bool
 		expected   string
 	}{
-		{"", "metric", false, "metric"},
-		{"ns", "metric", false, "ns_metric"},
-		{"longer_namespace", "metric", false, "longer_namespace_metric"},
-		{"ns", "metric", true, "ns.metric"},
-		{"longer_namespace", "metric", true, "longer_namespace.metric"},
+		{"", "metric", "metric"},
+		{"ns", "metric", "ns.metric"},
+		{"longer_namespace", "metric", "longer_namespace.metric"},
 	}
 
 	for _, test := range tests {
-		actual := buildMetricName(test.namespace, test.metricName, test.normalized)
+		actual := buildMetricName(test.namespace, test.metricName)
 		assert.Equal(t, test.expected, actual)
 	}
 }

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -1102,3 +1102,23 @@ func TestConsumeTracesEvictedCacheKey(t *testing.T) {
 	wg.Wait()
 	assert.Empty(t, wantDataPointCounts)
 }
+
+func TestBuildMetricName(t *testing.T) {
+	tests := []struct {
+		namespace  string
+		metricName string
+		normalized bool
+		expected   string
+	}{
+		{"", "metric", false, "metric"},
+		{"ns", "metric", false, "ns_metric"},
+		{"longer_namespace", "metric", false, "longer_namespace_metric"},
+		{"ns", "metric", true, "ns.metric"},
+		{"longer_namespace", "metric", true, "longer_namespace.metric"},
+	}
+
+	for _, test := range tests {
+		actual := buildMetricName(test.namespace, test.metricName, test.normalized)
+		assert.Equal(t, test.expected, actual)
+	}
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Add namespace support for spanmetricsprocessor

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18679
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18199

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>

```yaml
processors:
  spanmetrics:
    namespace: traces_spanmetrics
    metrics_exporter: prometheus
```