### PR TITLE
[receiver/k8sobjects] setting observed timestamp

### DIFF
--- a/.chloggen/k8sobjectsreceiver-fix-observedtimestamp.yaml
+++ b/.chloggen/k8sobjectsreceiver-fix-observedtimestamp.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sobjectsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure that the observed timestamp is set.
+
+# One or more tracking issues related to the change
+issues: [18700]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/k8sobjectsreceiver-fix-observedtimestamp.yaml
+++ b/.chloggen/k8sobjectsreceiver-fix-observedtimestamp.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: 'bug_fix'
+change_type: 'enhancement'
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: k8sobjectsreceiver

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -125,7 +125,7 @@ func (kr *k8sobjectsreceiver) startPull(ctx context.Context, config *K8sObjectsC
 			if err != nil {
 				kr.setting.Logger.Error("error in pulling object", zap.String("resource", config.gvr.String()), zap.Error(err))
 			} else if len(objects.Items) > 0 {
-				logs := pullObjectsToLogData(objects, config)
+				logs := pullObjectsToLogData(objects, time.Now(), config)
 				obsCtx := kr.obsrecv.StartLogsOp(ctx)
 				err = kr.consumer.ConsumeLogs(obsCtx, logs)
 				kr.obsrecv.EndLogsOp(obsCtx, typeStr, logs.LogRecordCount(), err)
@@ -162,7 +162,7 @@ func (kr *k8sobjectsreceiver) startWatch(ctx context.Context, config *K8sObjects
 				kr.setting.Logger.Warn("Watch channel closed unexpectedly", zap.String("resource", config.gvr.String()))
 				return
 			}
-			logs := watchObjectsToLogData(&data, config)
+			logs := watchObjectsToLogData(&data, time.Now(), config)
 
 			obsCtx := kr.obsrecv.StartLogsOp(ctx)
 			err := kr.consumer.ConsumeLogs(obsCtx, logs)

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata.go
@@ -26,7 +26,7 @@ import (
 
 type attrUpdaterFunc func(pcommon.Map)
 
-func watchObjectsToLogData(event *watch.Event, config *K8sObjectsConfig) plog.Logs {
+func watchObjectsToLogData(event *watch.Event, observedAt time.Time, config *K8sObjectsConfig) plog.Logs {
 	udata := event.Object.(*unstructured.Unstructured)
 	ul := unstructured.UnstructuredList{
 		Items: []unstructured.Unstructured{{
@@ -37,7 +37,7 @@ func watchObjectsToLogData(event *watch.Event, config *K8sObjectsConfig) plog.Lo
 		}},
 	}
 
-	return unstructuredListToLogData(&ul, config, func(attrs pcommon.Map) {
+	return unstructuredListToLogData(&ul, observedAt, config, func(attrs pcommon.Map) {
 		objectMeta := udata.Object["metadata"].(map[string]interface{})
 		name := objectMeta["name"].(string)
 		if name != "" {
@@ -47,11 +47,11 @@ func watchObjectsToLogData(event *watch.Event, config *K8sObjectsConfig) plog.Lo
 	})
 }
 
-func pullObjectsToLogData(event *unstructured.UnstructuredList, config *K8sObjectsConfig) plog.Logs {
-	return unstructuredListToLogData(event, config)
+func pullObjectsToLogData(event *unstructured.UnstructuredList, observedAt time.Time, config *K8sObjectsConfig) plog.Logs {
+	return unstructuredListToLogData(event, observedAt, config)
 }
 
-func unstructuredListToLogData(event *unstructured.UnstructuredList, config *K8sObjectsConfig, attrUpdaters ...attrUpdaterFunc) plog.Logs {
+func unstructuredListToLogData(event *unstructured.UnstructuredList, observedAt time.Time, config *K8sObjectsConfig, attrUpdaters ...attrUpdaterFunc) plog.Logs {
 	out := plog.NewLogs()
 	resourceLogs := out.ResourceLogs()
 	namespaceResourceMap := make(map[string]plog.LogRecordSlice)
@@ -69,7 +69,7 @@ func unstructuredListToLogData(event *unstructured.UnstructuredList, config *K8s
 			namespaceResourceMap[e.GetNamespace()] = logSlice
 		}
 		record := logSlice.AppendEmpty()
-		record.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		record.SetObservedTimestamp(pcommon.NewTimestampFromTime(observedAt))
 
 		attrs := record.Attributes()
 		attrs.PutStr("k8s.resource.name", config.gvr.Resource)

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata.go
@@ -15,6 +15,8 @@
 package k8sobjectsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver"
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	semconv "go.opentelemetry.io/collector/semconv/v1.9.0"
@@ -67,6 +69,7 @@ func unstructuredListToLogData(event *unstructured.UnstructuredList, config *K8s
 			namespaceResourceMap[e.GetNamespace()] = logSlice
 		}
 		record := logSlice.AppendEmpty()
+		record.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 
 		attrs := record.Attributes()
 		attrs.PutStr("k8s.resource.name", config.gvr.Resource)

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
@@ -17,6 +17,7 @@ package k8sobjectsreceiver // import "github.com/open-telemetry/opentelemetry-co
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,7 @@ func TestUnstructuredListToLogData(t *testing.T) {
 				Resource: "pods",
 			},
 		}
-		logs := pullObjectsToLogData(&objects, config)
+		logs := pullObjectsToLogData(&objects, time.Now(), config)
 
 		assert.Equal(t, logs.LogRecordCount(), 4)
 
@@ -86,7 +87,7 @@ func TestUnstructuredListToLogData(t *testing.T) {
 			},
 		}
 
-		logs := pullObjectsToLogData(&objects, config)
+		logs := pullObjectsToLogData(&objects, time.Now(), config)
 
 		assert.Equal(t, logs.LogRecordCount(), 3)
 
@@ -123,7 +124,7 @@ func TestUnstructuredListToLogData(t *testing.T) {
 			},
 		}
 
-		logs := watchObjectsToLogData(event, config)
+		logs := watchObjectsToLogData(event, time.Now(), config)
 
 		assert.Equal(t, logs.LogRecordCount(), 1)
 
@@ -162,7 +163,8 @@ func TestUnstructuredListToLogData(t *testing.T) {
 			},
 		}
 
-		logs := watchObjectsToLogData(event, config)
+		observedAt := time.Now()
+		logs := watchObjectsToLogData(event, observedAt, config)
 
 		assert.Equal(t, logs.LogRecordCount(), 1)
 
@@ -173,6 +175,7 @@ func TestUnstructuredListToLogData(t *testing.T) {
 		assert.Equal(t, rl.ScopeLogs().Len(), 1)
 		assert.Equal(t, logRecords.Len(), 1)
 		assert.Greater(t, logRecords.At(0).ObservedTimestamp().AsTime().Unix(), int64(0))
+		assert.Equal(t, logRecords.At(0).ObservedTimestamp().AsTime().Unix(), observedAt.Unix())
 	})
 
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Currently, the k8sobjects receiver is not setting the observed timestamp to the produced logs, and some platforms may not ingest data since the timestamp and observed timestamp are not present.

Some exporters may reject the logs without an associated timestamp.

**Link to tracking Issue:** #18700 

**Testing:** I'm adding a test to ensure the observed timestamp is present

**Documentation:** <Describe the documentation added.> N/A