### PR TITLE
Enabled proccessmetrics for MacOS

### DIFF
--- a/.chloggen/procesmetricsmac.yaml
+++ b/.chloggen/procesmetricsmac.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: Process Metrics for Mac
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Enabeling process metrics to be collcted for Mac in the hostmetrics receiver
+note: Enabling process metrics to be collected for Mac in the hostmetrics receiver
 
 # One or more tracking issues related to the change
 issues: [17863]

--- a/.chloggen/procesmetricsmac.yaml
+++ b/.chloggen/procesmetricsmac.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: Process Metrics for Mac
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enabeling process metrics to be collcted for Mac in the hostmetrics receiver
+
+# One or more tracking issues related to the change
+issues: [17863]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -36,8 +36,8 @@ The available scrapers are:
 | [memory]     | All                          | Memory utilization metrics                             |
 | [network]    | All                          | Network interface I/O metrics & TCP connection metrics |
 | [paging]     | All                          | Paging/Swap space utilization and I/O metrics          |
-| [processes]  | Linux & Mac                  | Process count metrics                                  |
-| [process]    | Linux & Windows & Mac        | Per process CPU, Memory, and Disk I/O metrics          |
+| [processes]  | Linux, Mac                   | Process count metrics                                  |
+| [process]    | Linux, Windows, Mac          | Per process CPU, Memory, and Disk I/O metrics          |
 
 [cpu]: ./internal/scraper/cpuscraper/documentation.md
 [disk]: ./internal/scraper/diskscraper/documentation.md

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -36,8 +36,8 @@ The available scrapers are:
 | [memory]     | All                          | Memory utilization metrics                             |
 | [network]    | All                          | Network interface I/O metrics & TCP connection metrics |
 | [paging]     | All                          | Paging/Swap space utilization and I/O metrics          |
-| [processes]  | Linux                        | Process count metrics                                  |
-| [process]    | Linux & Windows              | Per process CPU, Memory, and Disk I/O metrics          |
+| [processes]  | Linux & Mac                  | Process count metrics                                  |
+| [process]    | Linux & Windows & Mac        | Per process CPU, Memory, and Disk I/O metrics          |
 
 [cpu]: ./internal/scraper/cpuscraper/documentation.md
 [disk]: ./internal/scraper/diskscraper/documentation.md

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
@@ -51,7 +51,7 @@ func (f *Factory) CreateMetricsScraper(
 	cfg internal.Config,
 ) (scraperhelper.Scraper, error) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		return nil, errors.New("process scraper only available on Linux or Windows or MacOS")
+		return nil, errors.New("process scraper only available on Linux, Windows, or MacOS")
 	}
 
 	s, err := newProcessScraper(settings, cfg.(*Config))

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
@@ -50,8 +50,8 @@ func (f *Factory) CreateMetricsScraper(
 	settings receiver.CreateSettings,
 	cfg internal.Config,
 ) (scraperhelper.Scraper, error) {
-	if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
-		return nil, errors.New("process scraper only available on Linux or Windows")
+	if runtime.GOOS != "linux" && runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
+		return nil, errors.New("process scraper only available on Linux or Windows or MacOS")
 	}
 
 	s, err := newProcessScraper(settings, cfg.(*Config))

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -15,6 +15,7 @@
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 
 import (
+	"runtime"
 	"strings"
 	"time"
 
@@ -130,7 +131,7 @@ func getProcessHandlesInternal() (processHandles, error) {
 
 func parentPid(handle processHandle, pid int32) (int32, error) {
 	// special case for pid 0
-	if pid == 0 {
+	if pid == 0 || (pid == 1 && runtime.GOOS == "darwin") {
 		return 0, nil
 	}
 	parent, err := handle.Parent()

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -130,7 +130,7 @@ func getProcessHandlesInternal() (processHandles, error) {
 }
 
 func parentPid(handle processHandle, pid int32) (int32, error) {
-	// special case for pid 0
+	// special case for pid 0 and pid 1 in darwin
 	if pid == 0 || (pid == 1 && runtime.GOOS == "darwin") {
 		return 0, nil
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/process"
@@ -273,7 +274,7 @@ func (s *scraper) scrapeAndAppendMemoryUtilizationMetric(now pcommon.Timestamp, 
 }
 
 func (s *scraper) scrapeAndAppendDiskMetrics(now pcommon.Timestamp, handle processHandle) error {
-	if !(s.config.Metrics.ProcessDiskIo.Enabled || s.config.Metrics.ProcessDiskOperations.Enabled) {
+	if !(s.config.Metrics.ProcessDiskIo.Enabled || s.config.Metrics.ProcessDiskOperations.Enabled) || runtime.GOOS == "darwin" {
 		return nil
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_darwin.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_darwin.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+// +build darwin
+
+package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
+
+import (
+	"regexp"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal"
+)
+
+func (s *scraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {
+	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.User, metadata.AttributeStateUser)
+	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.System, metadata.AttributeStateSystem)
+	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.Iowait, metadata.AttributeStateWait)
+}
+
+func (s *scraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.User, metadata.AttributeStateUser)
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.System, metadata.AttributeStateSystem)
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.Iowait, metadata.AttributeStateWait)
+}
+
+func getProcessExecutable(proc processHandle) (*executableMetadata, error) {
+	name, err := proc.Name()
+	if err != nil {
+		return nil, err
+	}
+
+	cmdline, err := proc.Cmdline()
+	if err != nil {
+		return nil, err
+	}
+	regex := regexp.MustCompile(`^\S+`)
+	exe := regex.FindString(cmdline)
+
+	executable := &executableMetadata{name: name, path: exe}
+	return executable, nil
+}
+
+func getProcessCommand(proc processHandle) (*commandMetadata, error) {
+	cmdline, err := proc.Cmdline()
+	if err != nil {
+		return nil, err
+	}
+
+	command := &commandMetadata{command: cmdline, commandLine: cmdline}
+	return command, nil
+
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
@@ -18,20 +18,51 @@
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 
 import (
+	"regexp"
+
 	"github.com/shirou/gopsutil/v3/cpu"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal"
 )
 
-func (s *scraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {}
-
-func (s *scraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {}
-
-func getProcessExecutable(processHandle) (*executableMetadata, error) {
-	return nil, nil
+func (s *scraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {
+	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.User, metadata.AttributeStateUser)
+	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.System, metadata.AttributeStateSystem)
+	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.Iowait, metadata.AttributeStateWait)
 }
 
-func getProcessCommand(processHandle) (*commandMetadata, error) {
-	return nil, nil
+func (s *scraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.User, metadata.AttributeStateUser)
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.System, metadata.AttributeStateSystem)
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.Iowait, metadata.AttributeStateWait)
+}
+
+func getProcessExecutable(proc processHandle) (*executableMetadata, error) {
+	name, err := proc.Name()
+	if err != nil {
+		return nil, err
+	}
+
+	cmdline, err := proc.Cmdline()
+	if err != nil {
+		return nil, err
+	}
+	regex := regexp.MustCompile(`^\S+`)
+	exe := regex.FindString(cmdline)
+
+	executable := &executableMetadata{name: name, path: exe}
+	return executable, nil
+}
+
+func getProcessCommand(proc processHandle) (*commandMetadata, error) {
+	cmdline, err := proc.Cmdline()
+	if err != nil {
+		return nil, err
+	}
+
+	command := &commandMetadata{command: cmdline, commandLine: cmdline}
+	return command, nil
+
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
@@ -12,57 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !linux && !windows
-// +build !linux,!windows
+//go:build !linux && !windows && !darwin
+// +build !linux,!windows,!darwin
 
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 
 import (
-	"regexp"
-
 	"github.com/shirou/gopsutil/v3/cpu"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal"
 )
 
-func (s *scraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {
-	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.User, metadata.AttributeStateUser)
-	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.System, metadata.AttributeStateSystem)
-	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.Iowait, metadata.AttributeStateWait)
+func (s *scraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {}
+
+func (s *scraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {}
+
+func getProcessExecutable(processHandle) (*executableMetadata, error) {
+	return nil, nil
 }
 
-func (s *scraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {
-	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.User, metadata.AttributeStateUser)
-	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.System, metadata.AttributeStateSystem)
-	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.Iowait, metadata.AttributeStateWait)
-}
-
-func getProcessExecutable(proc processHandle) (*executableMetadata, error) {
-	name, err := proc.Name()
-	if err != nil {
-		return nil, err
-	}
-
-	cmdline, err := proc.Cmdline()
-	if err != nil {
-		return nil, err
-	}
-	regex := regexp.MustCompile(`^\S+`)
-	exe := regex.FindString(cmdline)
-
-	executable := &executableMetadata{name: name, path: exe}
-	return executable, nil
-}
-
-func getProcessCommand(proc processHandle) (*commandMetadata, error) {
-	cmdline, err := proc.Cmdline()
-	if err != nil {
-		return nil, err
-	}
-
-	command := &commandMetadata{command: cmdline, commandLine: cmdline}
-	return command, nil
-
+func getProcessCommand(processHandle) (*commandMetadata, error) {
+	return nil, nil
 }


### PR DESCRIPTION
**Description:** 
Adding process metrics for Mac.
Currently, the hostmetrics process metrics receiver is only implemented for windows and linux.

**Link to tracking Issue:** [Issue #17863](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17863)

**Testing:**
- Ran the collector locally on a Mac to make sure the relevant metrics are collected.

**Documentation:** 
- Added Mac as option for processmetrics at `receiver/hostmetricsreceiver/README.md`.