### PR TITLE
[processor/transformprocessor] Add convert_gauge_to_histogram Function

### DIFF
--- a/.chloggen/transformprocessor-add-convert-gauge-to-histogram.yaml
+++ b/.chloggen/transformprocessor-add-convert-gauge-to-histogram.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: transformprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ability to convert gauge metric into a histogram
+
+# One or more tracking issues related to the change
+issues: [18731]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -162,6 +162,7 @@ In addition to OTTL functions, the processor defines its own functions to help w
 - [convert_gauge_to_sum](#convert_gauge_to_sum)
 - [convert_summary_count_val_to_sum](#convert_summary_count_val_to_sum)
 - [convert_summary_sum_val_to_sum](#convert_summary_sum_val_to_sum)
+- [convert_gauge_to_histogram](#convert_gauge_to_histogram)
 
 ## convert_sum_to_gauge
 
@@ -229,6 +230,23 @@ Examples:
 
 
 - `convert_summary_sum_val_to_sum("cumulative", false)`
+
+## convert_gauge_to_histogram
+
+`convert_gauge_to_histogram(aggregation_temporality, bucket_count, lower_bound, upper_bound )`
+
+The `convert_gauge_to_histogram` function creates a new Histogram metric from the datapoints in a gauge.
+
+`aggregation_temporality` is a string (`"cumulative"` or `"delta"`) representing the desired aggregation temporality of the new metric. `bucket_count` is a integer representing the amount of buckets that will be created for the histogram. `lower_bound` is a float representing an explicit lower bound to create standardized bucket bounds. `upper_bound` is a float representing an explicit upper bound to create standardized bucket bounds. If `lower_bound` and `upper_bound` are equal, they will not be used, and instead the bucket bounds will be inferred based on the min, max, and bucket count.
+
+**NOTE:** This function may cause a metric to break semantics for [Histogram metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#histogram). Use at your own risk.
+
+Examples:
+
+- `convert_gauge_to_histogram("delta", 4, 0.0, 0.0)`
+
+
+- `convert_gauge_to_histogram("cumulative", 10, 0.0, 10.0)`
 
 ## Contributing
 

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram.go
@@ -1,0 +1,175 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+)
+
+func imin(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func imax(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func convertGaugeToHistogram(stringAggTemp string, bucketCount int64, lowerBound float64, upperBound float64) (ottl.ExprFunc[ottldatapoint.TransformContext], error) {
+	var aggTemp pmetric.AggregationTemporality
+	switch stringAggTemp {
+	case "delta":
+		aggTemp = pmetric.AggregationTemporalityDelta
+	case "cumulative":
+		aggTemp = pmetric.AggregationTemporalityCumulative
+	default:
+		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
+	}
+	if bucketCount <= 0 {
+		return nil, fmt.Errorf("Bucket value must be greater than 0. Current value: %s", strconv.Itoa(int(bucketCount)))
+	}
+	return func(_ context.Context, tCtx ottldatapoint.TransformContext) (interface{}, error) {
+		metric := tCtx.GetMetric()
+		if metric.Type() != pmetric.MetricTypeGauge {
+			return nil, nil
+		}
+
+		dps := metric.Gauge().DataPoints()
+		length := dps.Len()
+
+		metric.SetEmptyHistogram().SetAggregationTemporality(aggTemp)
+
+		if length == 0 {
+			return nil, nil
+		}
+
+		histogram := metric.Histogram().DataPoints().AppendEmpty()
+
+		dp := dps.At(0)
+		histogram.SetStartTimestamp(dp.StartTimestamp())
+		histogram.SetTimestamp(dp.Timestamp())
+
+		switch dp.ValueType() {
+		case pmetric.NumberDataPointValueTypeDouble:
+			min := dp.DoubleValue()
+			max := dp.DoubleValue()
+			var sum float64 = dp.DoubleValue()
+
+			for i := 1; i < length; i++ {
+				if dps.At(i).StartTimestamp() < histogram.StartTimestamp() {
+					histogram.SetStartTimestamp(dps.At(i).StartTimestamp())
+				}
+				if dps.At(i).Timestamp() > histogram.Timestamp() {
+					histogram.SetTimestamp(dps.At(i).Timestamp())
+				}
+
+				val := dps.At(i).DoubleValue()
+				min = math.Min(val, min)
+				max = math.Max(val, max)
+				sum += val
+			}
+			histogram.SetMax(max)
+			histogram.SetMin(min)
+			histogram.SetSum(sum)
+			histogram.SetCount(uint64(length))
+
+			if length > 1 {
+				histogram.BucketCounts().FromRaw(make([]uint64, bucketCount))
+				if lowerBound == upperBound {
+					lowerBound = min
+					upperBound = max
+				}
+
+				scale := float64(upperBound-lowerBound) / float64(bucketCount)
+
+				for i := 0; i < dps.Len(); i++ {
+					diff := dps.At(i).DoubleValue() - lowerBound
+					float_index := diff / scale
+					// if it hits on an exact explicit bound, then move it to the bucket below per histogram spec, as the buckets are upper bound inclusive
+					if float_index == float64(int64(float_index)) && int64(float_index) > 0 && int64(float_index) < bucketCount {
+						float_index -= 1
+					}
+					index := int(imin(int64(float_index), bucketCount-1))
+					histogram.BucketCounts().SetAt(index, histogram.BucketCounts().At(index)+1)
+				}
+
+				for i := 1; i < int(bucketCount); i++ {
+					histogram.ExplicitBounds().Append(lowerBound + (scale * float64(i)))
+				}
+			}
+		case pmetric.NumberDataPointValueTypeInt:
+			min := dp.IntValue()
+			max := dp.IntValue()
+			var sum int64 = dp.IntValue()
+
+			for i := 1; i < length; i++ {
+				if dps.At(i).StartTimestamp() < histogram.StartTimestamp() {
+					histogram.SetStartTimestamp(dps.At(i).StartTimestamp())
+				}
+				if dps.At(i).Timestamp() > histogram.Timestamp() {
+					histogram.SetTimestamp(dps.At(i).Timestamp())
+				}
+				val := dps.At(i).IntValue()
+				min = imin(val, min)
+				max = imax(val, max)
+				sum += val
+			}
+			histogram.SetMax(float64(max))
+			histogram.SetMin(float64(min))
+			histogram.SetSum(float64(sum))
+			histogram.SetCount(uint64(length))
+
+			if length > 1 {
+				if lowerBound == upperBound {
+					lowerBound = float64(min)
+					upperBound = float64(max)
+				}
+
+				histogram.BucketCounts().FromRaw(make([]uint64, bucketCount))
+				scale := float64(upperBound-lowerBound) / float64(bucketCount)
+
+				for i := 0; i < dps.Len(); i++ {
+					diff := float64(dps.At(i).IntValue()) - lowerBound
+					float_index := diff / scale
+					// if it hits on an exact explicit bound, then move it to the bucket below per histogram spec, as the buckets are upper bound inclusive
+					if float_index == float64(int64(float_index)) && int64(float_index) > 0 && int64(float_index) < bucketCount {
+						float_index -= 1
+					}
+					index := int(imin(int64(float_index), bucketCount-1))
+					histogram.BucketCounts().SetAt(index, histogram.BucketCounts().At(index)+1)
+				}
+
+				for i := 1; i < int(bucketCount); i++ {
+					histogram.ExplicitBounds().Append(lowerBound + (scale * float64(i)))
+				}
+			}
+		}
+
+		return nil, nil
+	}, nil
+}

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram.go
@@ -53,7 +53,7 @@ func convertGaugeToHistogram(stringAggTemp string, bucketCount int64, lowerBound
 	if bucketCount <= 0 {
 		return nil, fmt.Errorf("Bucket value must be greater than 0. Current value: %s", strconv.Itoa(int(bucketCount)))
 	}
-	if lowerBound > upperBound{
+	if lowerBound > upperBound {
 		return nil, fmt.Errorf("Lower bound must be less than or equal to upper bound.")
 	}
 	return func(_ context.Context, tCtx ottldatapoint.TransformContext) (interface{}, error) {

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram.go
@@ -53,6 +53,9 @@ func convertGaugeToHistogram(stringAggTemp string, bucketCount int64, lowerBound
 	if bucketCount <= 0 {
 		return nil, fmt.Errorf("Bucket value must be greater than 0. Current value: %s", strconv.Itoa(int(bucketCount)))
 	}
+	if lowerBound > upperBound{
+		return nil, fmt.Errorf("Lower bound must be less than or equal to upper bound.")
+	}
 	return func(_ context.Context, tCtx ottldatapoint.TransformContext) (interface{}, error) {
 		metric := tCtx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeGauge {

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram_test.go
@@ -67,8 +67,6 @@ func Test_convertGaugeToHistogram(t *testing.T) {
 		integerGaugeInput.Gauge().DataPoints().AppendEmpty().SetIntValue(dp)
 	}
 
-
-
 	singleGaugeInput := pmetric.NewMetric()
 	singleGaugeInput.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(5.2)
 

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_histogram_test.go
@@ -1,0 +1,395 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+)
+
+func truncate(f float64) float64 {
+	bf := big.NewFloat(0).SetPrec(1000).SetFloat64(f)
+	bu := big.NewFloat(0).SetPrec(1000).SetFloat64(0.001)
+
+	bf.Quo(bf, bu)
+
+	// Truncate:
+	i := big.NewInt(0)
+	bf.Int(i)
+	bf.SetInt(i)
+
+	f, _ = bf.Mul(bf, bu).Float64()
+	return f
+}
+
+// this fixes the float values for clean comparison
+func truncateHistogramValues(histogramMetric pmetric.Metric) {
+	histogramObj := histogramMetric.Histogram()
+	histogram := histogramObj.DataPoints().At(0)
+	histogram.SetMax(truncate(histogram.Max()))
+	histogram.SetMin(truncate(histogram.Min()))
+	histogram.SetSum(truncate(histogram.Sum()))
+	for i := 0; i < histogram.ExplicitBounds().Len(); i++ {
+		histogram.ExplicitBounds().SetAt(i, truncate(histogram.ExplicitBounds().At(i)))
+	}
+}
+func Test_convertGaugeToHistogram(t *testing.T) {
+
+	floatGaugeInput := pmetric.NewMetric()
+	floatGaugeInput.SetEmptyGauge()
+	floatDataPoints := []float64{9.532, 4.3248, 2.329, 7.24, 5.548, 1.762, 9.570}
+	for _, dp := range floatDataPoints {
+		floatGaugeInput.Gauge().DataPoints().AppendEmpty().SetDoubleValue(dp)
+	}
+
+	integerGaugeInput := pmetric.NewMetric()
+	integerGaugeInput.SetEmptyGauge()
+	integerDataPoints := []int64{3, 4, 1, 7, 6, 8, 9}
+	for _, dp := range integerDataPoints {
+		integerGaugeInput.Gauge().DataPoints().AppendEmpty().SetIntValue(dp)
+	}
+
+
+
+	singleGaugeInput := pmetric.NewMetric()
+	singleGaugeInput.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(5.2)
+
+	tests := []struct {
+		name          string
+		stringAggTemp string
+		bucketCount   int64
+		lowerBound    float64
+		upperBound    float64
+		input         pmetric.Metric
+		want          func(pmetric.Metric)
+	}{
+		{
+			name:          "convert gauge with float datapoints to histogram, no bounds",
+			stringAggTemp: "delta",
+			bucketCount:   4,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			input:         floatGaugeInput,
+			want: func(metric pmetric.Metric) {
+				histogram := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
+				metric.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				histogram.SetMin(1.762)
+				histogram.SetMax(9.570)
+				histogram.SetSum(40.3058)
+				histogram.SetCount(7)
+				/*
+					scale: 1.952
+						2		2		1		2
+					|--------|-------|-------|------|
+					1.762    3.714   5.666   7.618  9.570
+				*/
+				histogram.ExplicitBounds().FromRaw([]float64{3.714, 5.666, 7.618})
+				histogram.BucketCounts().FromRaw([]uint64{2, 2, 1, 2})
+			},
+		},
+		{
+			name:          "convert gauge with float datapoints to histogram, with bounds",
+			stringAggTemp: "delta",
+			bucketCount:   4,
+			lowerBound:    0.0,
+			upperBound:    10.0,
+			input:         floatGaugeInput,
+			want: func(metric pmetric.Metric) {
+				histogram := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
+				metric.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				histogram.SetMin(1.762)
+				histogram.SetMax(9.570)
+				histogram.SetSum(40.3058)
+				histogram.SetCount(7)
+				/*
+					scale: 2.5
+						2		1		2		2
+					|--------|-------|-------|------|
+					0        2.5     5       7.5    10
+				*/
+				histogram.ExplicitBounds().FromRaw([]float64{2.5, 5, 7.5})
+				histogram.BucketCounts().FromRaw([]uint64{2, 1, 2, 2})
+			},
+		},
+		{
+			name:          "convert gauge with int datapoints to histogram, no bounds",
+			stringAggTemp: "delta",
+			bucketCount:   4,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			input:         integerGaugeInput,
+			want: func(metric pmetric.Metric) {
+				histogram := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
+				metric.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				histogram.SetMin(1)
+				histogram.SetMax(9)
+				histogram.SetSum(38)
+				histogram.SetCount(7)
+				/*
+					scale: 1.952
+						2		1		2		2
+					|--------|-------|-------|------|
+					1    	 3   	 5   	 7  	9
+				*/
+				histogram.ExplicitBounds().FromRaw([]float64{3, 5, 7})
+				histogram.BucketCounts().FromRaw([]uint64{2, 1, 2, 2})
+			},
+		},
+		{
+			name:          "convert gauge with int datapoints to histogram, with bounds",
+			stringAggTemp: "delta",
+			bucketCount:   4,
+			lowerBound:    0.0,
+			upperBound:    10.0,
+			input:         integerGaugeInput,
+			want: func(metric pmetric.Metric) {
+				histogram := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
+				metric.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				histogram.SetMin(1)
+				histogram.SetMax(9)
+				histogram.SetSum(38)
+				histogram.SetCount(7)
+				/*
+					scale: 2.5
+						1		2		2		2
+					|--------|-------|-------|------|
+					0    	 2.5   	 5   	 7.5  	10
+				*/
+				histogram.ExplicitBounds().FromRaw([]float64{2.5, 5, 7.5})
+				histogram.BucketCounts().FromRaw([]uint64{1, 2, 2, 2})
+			},
+		},
+		{
+			name:          "convert gauge with single datapoint to histogram, no bounds",
+			stringAggTemp: "delta",
+			bucketCount:   4,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			input:         singleGaugeInput,
+			want: func(metric pmetric.Metric) {
+				histogram := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
+				metric.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				histogram.SetMin(5.2)
+				histogram.SetMax(5.2)
+				histogram.SetSum(5.2)
+				histogram.SetCount(1)
+				/*
+					scale: 1.952
+						1		2		1		3
+					|--------|-------|-------|------|
+					1    	 3   	 5   	 7  	9
+				*/
+			},
+		},
+		{
+			name:          "convert gauge with single datapoint to histogram, with bounds",
+			stringAggTemp: "delta",
+			bucketCount:   4,
+			lowerBound:    0.0,
+			upperBound:    10.0,
+			input:         singleGaugeInput,
+			want: func(metric pmetric.Metric) {
+				histogram := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
+				metric.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				histogram.SetMin(5.2)
+				histogram.SetMax(5.2)
+				histogram.SetSum(5.2)
+				histogram.SetCount(1)
+				/*
+					scale: 1.952
+						1		2		1		3
+					|--------|-------|-------|------|
+					1    	 3   	 5   	 7  	9
+				*/
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := pmetric.NewMetric()
+			tt.input.CopyTo(metric)
+
+			ctx := ottldatapoint.NewTransformContext(pmetric.NewNumberDataPoint(), metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
+
+			exprFunc, _ := convertGaugeToHistogram(tt.stringAggTemp, tt.bucketCount, tt.lowerBound, tt.upperBound)
+
+			_, err := exprFunc(nil, ctx)
+			assert.Nil(t, err)
+
+			expected := pmetric.NewMetric()
+			tt.want(expected)
+
+			truncateHistogramValues(metric)
+			truncateHistogramValues(expected)
+
+			assert.Equal(t, expected, metric)
+		})
+	}
+}
+
+func Test_convertGaugeToHistogram_noop(t *testing.T) {
+	sumInput := pmetric.NewMetric()
+	sumInput.SetEmptySum()
+
+	histogramInput := pmetric.NewMetric()
+	histogramInput.SetEmptyHistogram()
+
+	expoHistogramInput := pmetric.NewMetric()
+	expoHistogramInput.SetEmptyHistogram()
+
+	summaryInput := pmetric.NewMetric()
+	summaryInput.SetEmptySummary()
+
+	emptyGaugeInput := pmetric.NewMetric()
+	emptyGaugeInput.SetEmptyGauge()
+
+	tests := []struct {
+		name          string
+		stringAggTemp string
+		bucketCount   int64
+		lowerBound    float64
+		upperBound    float64
+		input         pmetric.Metric
+		want          func(pmetric.Metric)
+	}{
+		{
+			name:          "noop for sum",
+			stringAggTemp: "delta",
+			bucketCount:   5,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			input:         sumInput,
+			want: func(metric pmetric.Metric) {
+				sumInput.CopyTo(metric)
+			},
+		},
+		{
+			name:          "noop for histogram",
+			stringAggTemp: "delta",
+			bucketCount:   5,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			input:         histogramInput,
+			want: func(metric pmetric.Metric) {
+				histogramInput.CopyTo(metric)
+			},
+		},
+		{
+			name:          "noop for exponential histogram",
+			stringAggTemp: "delta",
+			bucketCount:   5,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			input:         expoHistogramInput,
+			want: func(metric pmetric.Metric) {
+				expoHistogramInput.CopyTo(metric)
+			},
+		},
+		{
+			name:          "noop for summary",
+			stringAggTemp: "delta",
+			bucketCount:   5,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			input:         summaryInput,
+			want: func(metric pmetric.Metric) {
+				summaryInput.CopyTo(metric)
+			},
+		},
+		{
+			name:          "convert gauge with no datapoints to histogram",
+			stringAggTemp: "delta",
+			bucketCount:   4,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			input:         emptyGaugeInput,
+			want: func(metric pmetric.Metric) {
+				metric.SetEmptyHistogram()
+				metric.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				/*
+					scale: 1.952
+						1		2		1		3
+					|--------|-------|-------|------|
+					1    	 3   	 5   	 7  	9
+				*/
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := pmetric.NewMetric()
+			tt.input.CopyTo(metric)
+
+			ctx := ottldatapoint.NewTransformContext(pmetric.NewNumberDataPoint(), metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
+
+			exprFunc, _ := convertGaugeToHistogram(tt.stringAggTemp, tt.bucketCount, tt.lowerBound, tt.upperBound)
+
+			_, err := exprFunc(nil, ctx)
+			assert.Nil(t, err)
+
+			expected := pmetric.NewMetric()
+			tt.want(expected)
+			assert.Equal(t, expected, metric)
+		})
+	}
+}
+
+func Test_convertGaugeToHistogram_validation(t *testing.T) {
+	tests := []struct {
+		name          string
+		stringAggTemp string
+		bucketCount   int64
+		lowerBound    float64
+		upperBound    float64
+		wantErrString string
+	}{
+		{
+			name:          "invalid aggregation temporality",
+			stringAggTemp: "not a real aggregation temporality",
+			bucketCount:   2,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			wantErrString: "unknown aggregation temporality: not a real aggregation temporality",
+		},
+		{
+			name:          "negative bucket value",
+			stringAggTemp: "delta",
+			bucketCount:   -5,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			wantErrString: "Bucket value must be greater than 0. Current value: -5",
+		},
+		{
+			name:          "zero bucket value",
+			stringAggTemp: "delta",
+			bucketCount:   0,
+			lowerBound:    0.0,
+			upperBound:    0.0,
+			wantErrString: "Bucket value must be greater than 0. Current value: 0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := convertGaugeToHistogram(tt.stringAggTemp, tt.bucketCount, tt.lowerBound, tt.upperBound)
+			assert.Error(t, err, tt.wantErrString)
+		})
+	}
+}

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -26,6 +26,7 @@ var datapointRegistry = map[string]interface{}{
 	"convert_gauge_to_sum":             convertGaugeToSum,
 	"convert_summary_sum_val_to_sum":   convertSummarySumValToSum,
 	"convert_summary_count_val_to_sum": convertSummaryCountValToSum,
+	"convert_gauge_to_histogram": 		convertGaugeToHistogram,
 }
 
 func init() {

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -26,7 +26,7 @@ var datapointRegistry = map[string]interface{}{
 	"convert_gauge_to_sum":             convertGaugeToSum,
 	"convert_summary_sum_val_to_sum":   convertSummarySumValToSum,
 	"convert_summary_count_val_to_sum": convertSummaryCountValToSum,
-	"convert_gauge_to_histogram": 		convertGaugeToHistogram,
+	"convert_gauge_to_histogram":       convertGaugeToHistogram,
 }
 
 func init() {

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -31,6 +31,7 @@ func Test_DataPointFunctions(t *testing.T) {
 	expected["convert_gauge_to_sum"] = convertGaugeToSum
 	expected["convert_summary_sum_val_to_sum"] = convertSummarySumValToSum
 	expected["convert_summary_count_val_to_sum"] = convertSummaryCountValToSum
+	expected["convert_gauge_to_histogram"] = convertGaugeToHistogram
 
 	actual := DataPointFunctions()
 


### PR DESCRIPTION
**Description:**
Adding a feature - added function converting a gauge to a histogram for the transformprocessor processor. More info on this processor can be found on the readme I added. 

Essentially it calculates min, max, sum, count, and then creates buckets and updates those buckets with the counts based on the data points. Finally, it calculates and adds the explicit bounds for the buckets. It has functionality for both int and float data points.

**Link to tracking Issue:** [18731](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18731)

**Testing:** I added unit tests, covering the following for correctness
- gauge with integer points, with and without upper/lower bounds added
- gauge with float points,  with and without upper/lower bounds added
- gauge with single data point,  with and without upper/lower bounds added
- gauge with no data points (empty)
- validating all no-ops with metrics that weren't gauges
- validating all edge cases with parameters

I also ran basic acceptance tests locally, reproducing the collector situation we intend to use it for and validating the results. 

**Documentation:** Added to the README how to use the function along with examples, as well as explanations for each parameter.

Thanks for your consideration!