### PR TITLE
[pkg/ottl] Update type getters to error on nil

### DIFF
--- a/.chloggen/ottl-change-type-getters-to-error-on-nil.yaml
+++ b/.chloggen/ottl-change-type-getters-to-error-on-nil.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change typed getters to error on nil
+
+# One or more tracking issues related to the change
+issues: [18735]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -90,30 +90,31 @@ func (l *listGetter[K]) Get(ctx context.Context, tCtx K) (interface{}, error) {
 }
 
 type StringGetter[K any] interface {
-	Get(ctx context.Context, tCtx K) (*string, error)
+	Get(ctx context.Context, tCtx K) (string, error)
 }
 
 type IntGetter[K any] interface {
-	Get(ctx context.Context, tCtx K) (*int64, error)
+	Get(ctx context.Context, tCtx K) (int64, error)
 }
 
 type StandardTypeGetter[K any, T any] struct {
 	Getter func(ctx context.Context, tCtx K) (interface{}, error)
 }
 
-func (g StandardTypeGetter[K, T]) Get(ctx context.Context, tCtx K) (*T, error) {
+func (g StandardTypeGetter[K, T]) Get(ctx context.Context, tCtx K) (T, error) {
+	var v T
 	val, err := g.Getter(ctx, tCtx)
 	if err != nil {
-		return nil, err
+		return v, err
 	}
 	if val == nil {
-		return nil, nil
+		return v, fmt.Errorf("expected %T but got nil", v)
 	}
 	v, ok := val.(T)
 	if !ok {
-		return nil, fmt.Errorf("expected %T but got %T", v, val)
+		return v, fmt.Errorf("expected %T but got %T", v, val)
 	}
-	return &v, nil
+	return v, nil
 }
 
 func (p *Parser[K]) newGetter(val value) (Getter[K], error) {

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -347,6 +347,16 @@ func Test_StandardTypeGetter(t *testing.T) {
 			valid:            false,
 			expectedErrorMsg: "expected string but got bool",
 		},
+		{
+			name: "nil",
+			getter: StandardTypeGetter[interface{}, string]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected string but got nil",
+		},
 	}
 
 	for _, tt := range tests {
@@ -354,7 +364,7 @@ func Test_StandardTypeGetter(t *testing.T) {
 			val, err := tt.getter.Get(context.Background(), nil)
 			if tt.valid {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.want, *val)
+				assert.Equal(t, tt.want, val)
 			} else {
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}


### PR DESCRIPTION
**Description:** 
Updates the type getters to be stricter, erroring on nil instead of returning nil.

While working on updating ConvertCase to using a StringGetter I realized that by allowing nil we had not committed to the strictness with typed getters that we should've.

The goal of the typed getters and new error mode is to allow functions to be strict with errors without breaking future statements (IgnoreError mode).  By allowing `nil` we put ourselves in a strange situation where `ConvertCase(10, "upper")` would return an error but `ConvertCase(nil, "upper")` wouldn't.  When used in combination with other functions,  our outcome would be inconsistent.

If used with an `int`, `set(attributes["test"], ConvertCase(10, "upper"))` would cause an error, resulting in the "test" attribute not being set.  If used with `nil`, `set(attributes["test"], ConvertCase(nil, "upper"))` would not error and would set "test" to `nil`.  But this is inconsistent.  `nil` is not a string and so we can't convert but we don't error and we end up mutating the telemetry.

If a real life scenario where you might be converting an attribute that isn't present what should happen.  Should `set(attributes["an attribute that doesn't exist"], ConvertCase(attributes["an attribute that doesn't exist"], "upper"))` actually set the attribute "an attribute that doesn't exist" to `nil` or should it error?  I'm proposing it is more proper to error and not transmute the telemetry.  With `error_mode=ignore` we can still move on to the next statement.

When used in a condition it feels inappropriate to allow `ConvertCase` to return nil, which is what happens if we don't strictly error on `nil`.  If we return `nil` then we end up doing an invalid comparison in my mind as we have a value we shouldn't have.  I propose it is better to let the condition error, evaluate to false, and move on to the next statement.

I believe this sentiment is applicable to all Converter functions.  Converter functions should reliably returned a changed value as that is their strict intention.

**Link to tracking Issue:** 

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16519

**Testing:** 

Updated tests

**Additional Info**

Since the initial typed getter implementation hasn't been released yet I think I don't think this needs to be considered a breaking change