### PR TITLE
[receiver/awsecscontainermetricsreceiver] Fix possible sigsegv in shutdown

### DIFF
--- a/.chloggen/ecsCMshutdown.yaml
+++ b/.chloggen/ecsCMshutdown.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsecscontainermetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix possible sig sev that could happen during component shutdown.
+
+# One or more tracking issues related to the change
+issues: [18736]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/awsecscontainermetricsreceiver/receiver.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver.go
@@ -79,7 +79,9 @@ func (aecmr *awsEcsContainerMetricsReceiver) Start(ctx context.Context, host com
 
 // Shutdown stops the awsecscontainermetricsreceiver receiver.
 func (aecmr *awsEcsContainerMetricsReceiver) Shutdown(context.Context) error {
-	aecmr.cancel()
+	if aecmr.cancel != nil {
+		aecmr.cancel()
+	}
 	return nil
 }
 


### PR DESCRIPTION
**Description:** Fix possible sigsev error that could occur during shutdown if component was not correctly initialized. 

**Link to tracking Issue:** Reported in ADOT downstream repository https://github.com/aws-observability/aws-otel-collector/issues/982#issuecomment-1433216191