### PR TITLE
Adding Azure Monitor Exporter to pipelines in example config

### DIFF
--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -26,7 +26,12 @@ Example:
 ```yaml
 exporters:
   azuremonitor:
-    instrumentation_key: b1cd0778-85fc-4677-a3fa-79d3c23e0efd
+    instrumentation_key: ########-####-####-####-############
+
+service:
+  pipelines:
+    traces:
+      exporters: [azuremonitor, <other-exporters>]
 ```
 
 ## Attribute mapping


### PR DESCRIPTION
**Description:** Adding `azuremonitor` to `pipelines` in the example config.

**Testing:** When I added Azure Monitor Exporter to exporters, no telemetry was sent to Application Insights. I also had to add it to pipelines for it to work, which also matches the documentation in [Kubernetes Deployment](https://opentelemetry.io/docs/demo/kubernetes-deployment/#bring-your-own-backend).