### PR TITLE
[processor/cumulativetodelta] drop data points with NoRecordedValue

### DIFF
--- a/.chloggen/cumulativetodelta-novaluerecorded.yaml
+++ b/.chloggen/cumulativetodelta-novaluerecorded.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cumulativetodeltaprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Data points with the NoValueRecorded flag set are no longer considered in calculating deltas.
+
+# One or more tracking issues related to the change
+issues: [18766]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** 

Ignore/drop data points which set the NoValueRecorded flag.
These were previously erroneously treated as counter resets.

Slack thread for context:
https://cloud-native.slack.com/archives/C033BJ8BASU/p1676547069465219

**Link to tracking Issue:** 

**Testing:**

Add and run tests.
Run fork in company internal deployment

**Documentation:**

changelog