### PR TITLE
Support kafka-exporter synchronous and asynchronous sending

### DIFF
--- a/examples/demo/otel-collector-config.yaml
+++ b/examples/demo/otel-collector-config.yaml
@@ -2,73 +2,26 @@ receivers:
   otlp:
     protocols:
       grpc:
-      http:
-        cors:
-          allowed_origins:
-            - "*"
-          allowed_headers:
-            - "*"
-          max_age: 7200
-
-  jaeger:
-    protocols:
-      grpc:
-      thrift_binary:
-      thrift_compact:
-      thrift_http:
-
-  zipkin:
-
-
 
 exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+    const_labels:
+      label1: value1
+
   logging:
-    loglevel: debug
 
-  file:
-    path: /Users/hai/GolandProjects/opentelemetry-collector-contrib/examples/demo/trace.json
-  kafka/traces:
-    topic: skywalking-otlpspans
-    brokers:
-      - 9.134.107.155:9092
-    producer:
-      #1mb
-      max_message_bytes: 10000000
-    protocol_version: 2.0.0
-    metadata:
-      retry:
-        max: 0
-    timeout: 5s
-    retry_on_failure:
-      enabled: false
-    sending_queue:
-      enabled: true
-      num_consumers: 10
-      queue_size: 50000
+  zipkin:
+    endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
+    format: proto
 
-  kafka/logs:
-    topic: otel_logs
-    brokers:
-      - 9.134.107.155:9092
-    producer:
-      #1mb
-      max_message_bytes: 10000000
-    protocol_version: 2.0.0
-    metadata:
-      retry:
-        max: 0
-    timeout: 5s
-    retry_on_failure:
-      enabled: false
-    sending_queue:
-      enabled: true
-      num_consumers: 10
-      queue_size: 50000
+  jaeger:
+    endpoint: jaeger-all-in-one:14250
+    tls:
+      insecure: true
 
 processors:
   batch:
-    send_batch_size: 128
-    timeout: 100ms
 
 extensions:
   health_check:
@@ -78,16 +31,13 @@ extensions:
     endpoint: :55679
 
 service:
-  extensions: [ pprof, zpages, health_check ]
+  extensions: [pprof, zpages, health_check]
   pipelines:
     traces:
-      receivers: [ otlp ]
-      processors: [ batch ]
-      exporters: [logging,kafka/traces ]
-    logs:
-      receivers: [ otlp ]
-      processors: [ batch ]
-      exporters: [ logging ]
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, zipkin, jaeger]
     metrics:
-      receivers: [ otlp ]
-      exporters: [ file ]
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, prometheus]

--- a/examples/demo/otel-collector-config.yaml
+++ b/examples/demo/otel-collector-config.yaml
@@ -2,26 +2,73 @@ receivers:
   otlp:
     protocols:
       grpc:
-
-exporters:
-  prometheus:
-    endpoint: "0.0.0.0:8889"
-    const_labels:
-      label1: value1
-
-  logging:
-
-  zipkin:
-    endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
-    format: proto
+      http:
+        cors:
+          allowed_origins:
+            - "*"
+          allowed_headers:
+            - "*"
+          max_age: 7200
 
   jaeger:
-    endpoint: jaeger-all-in-one:14250
-    tls:
-      insecure: true
+    protocols:
+      grpc:
+      thrift_binary:
+      thrift_compact:
+      thrift_http:
+
+  zipkin:
+
+
+
+exporters:
+  logging:
+    loglevel: debug
+
+  file:
+    path: /Users/hai/GolandProjects/opentelemetry-collector-contrib/examples/demo/trace.json
+  kafka/traces:
+    topic: skywalking-otlpspans
+    brokers:
+      - 9.134.107.155:9092
+    producer:
+      #1mb
+      max_message_bytes: 10000000
+    protocol_version: 2.0.0
+    metadata:
+      retry:
+        max: 0
+    timeout: 5s
+    retry_on_failure:
+      enabled: false
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 50000
+
+  kafka/logs:
+    topic: otel_logs
+    brokers:
+      - 9.134.107.155:9092
+    producer:
+      #1mb
+      max_message_bytes: 10000000
+    protocol_version: 2.0.0
+    metadata:
+      retry:
+        max: 0
+    timeout: 5s
+    retry_on_failure:
+      enabled: false
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 50000
 
 processors:
   batch:
+    send_batch_size: 128
+    timeout: 100ms
 
 extensions:
   health_check:
@@ -31,13 +78,16 @@ extensions:
     endpoint: :55679
 
 service:
-  extensions: [pprof, zpages, health_check]
+  extensions: [ pprof, zpages, health_check ]
   pipelines:
     traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [logging, zipkin, jaeger]
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [logging,kafka/traces ]
+    logs:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ logging ]
     metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [logging, prometheus]
+      receivers: [ otlp ]
+      exporters: [ file ]

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -16,6 +16,7 @@ The following settings are required:
 The following settings can be optionally configured:
 - `brokers` (default = localhost:9092): The list of kafka brokers
 - `topic` (default = otlp_spans for traces, otlp_metrics for metrics, otlp_logs for logs): The name of the kafka topic to export to.
+- `send_type` (default = sync|async): The sendType of the kafka send mode.
 - `encoding` (default = otlp_proto): The encoding of the traces sent to kafka. All available encodings:
   - `otlp_proto`: payload is Protobuf serialized from `ExportTraceServiceRequest` if set as a traces exporter or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs.
   - `otlp_json`:  ** EXPERIMENTAL ** payload is JSON serialized from `ExportTraceServiceRequest` if set as a traces exporter or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs. 

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -48,6 +48,9 @@ type Config struct {
 
 	// Authentication defines used authentication mechanism.
 	Authentication Authentication `mapstructure:"auth"`
+
+	// sendType Kafka send type by async or sync
+	sendType string `mapstructure:sendType`
 }
 
 // Metadata defines configuration for retrieving metadata from the broker.

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -49,8 +49,8 @@ type Config struct {
 	// Authentication defines used authentication mechanism.
 	Authentication Authentication `mapstructure:"auth"`
 
-	// sendType Kafka send type by async or sync
-	sendType string `mapstructure:sendType`
+	// SendType Kafka send type by async or sync
+	SendType string `mapstructure:"send_type"`
 }
 
 // Metadata defines configuration for retrieving metadata from the broker.

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -59,6 +59,7 @@ func TestLoadConfig(t *testing.T) {
 					QueueSize:    10,
 				},
 				Topic:    "spans",
+				SendType: defaultSendType,
 				Encoding: "otlp_proto",
 				Brokers:  []string{"foo:123", "bar:456"},
 				Authentication: Authentication{

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -108,6 +108,7 @@ func createDefaultConfig() component.Config {
 		Brokers:         []string{defaultBroker},
 		// using an empty topic to track when it has not been set by user, default is based on traces or metrics.
 		Topic:    "",
+		SendType: defaultSendType,
 		Encoding: defaultEncoding,
 		Metadata: Metadata{
 			Full: defaultMetadataFull,
@@ -143,8 +144,8 @@ func (f *kafkaExporterFactory) createTracesExporter(
 	if oCfg.Encoding == "otlp_json" {
 		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
 	}
-	if oCfg.sendType == "" {
-		oCfg.sendType = defaultSendType
+	if oCfg.SendType == "" {
+		oCfg.SendType = defaultSendType
 	}
 	exp, err := newTracesExporter(oCfg, set, f.tracesMarshalers)
 	if err != nil {
@@ -176,8 +177,8 @@ func (f *kafkaExporterFactory) createMetricsExporter(
 	if oCfg.Encoding == "otlp_json" {
 		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
 	}
-	if oCfg.sendType == "" {
-		oCfg.sendType = defaultSendType
+	if oCfg.SendType == "" {
+		oCfg.SendType = defaultSendType
 	}
 	exp, err := newMetricsExporter(oCfg, set, f.metricsMarshalers)
 	if err != nil {
@@ -209,8 +210,8 @@ func (f *kafkaExporterFactory) createLogsExporter(
 	if oCfg.Encoding == "otlp_json" {
 		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
 	}
-	if oCfg.sendType == "" {
-		oCfg.sendType = defaultSendType
+	if oCfg.SendType == "" {
+		oCfg.SendType = defaultSendType
 	}
 	exp, err := newLogsExporter(oCfg, set, f.logsMarshalers)
 	if err != nil {

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -48,6 +48,7 @@ const (
 	defaultCompression = "none"
 	// default from sarama.NewConfig()
 	defaultFluxMaxMessages = 0
+	defaultSendType        = Sync
 )
 
 // FactoryOption applies changes to kafkaExporterFactory.
@@ -142,6 +143,9 @@ func (f *kafkaExporterFactory) createTracesExporter(
 	if oCfg.Encoding == "otlp_json" {
 		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
 	}
+	if oCfg.sendType == "" {
+		oCfg.sendType = defaultSendType
+	}
 	exp, err := newTracesExporter(oCfg, set, f.tracesMarshalers)
 	if err != nil {
 		return nil, err
@@ -172,6 +176,9 @@ func (f *kafkaExporterFactory) createMetricsExporter(
 	if oCfg.Encoding == "otlp_json" {
 		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
 	}
+	if oCfg.sendType == "" {
+		oCfg.sendType = defaultSendType
+	}
 	exp, err := newMetricsExporter(oCfg, set, f.metricsMarshalers)
 	if err != nil {
 		return nil, err
@@ -201,6 +208,9 @@ func (f *kafkaExporterFactory) createLogsExporter(
 	}
 	if oCfg.Encoding == "otlp_json" {
 		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
+	}
+	if oCfg.sendType == "" {
+		oCfg.sendType = defaultSendType
 	}
 	exp, err := newLogsExporter(oCfg, set, f.logsMarshalers)
 	if err != nil {

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -109,11 +109,7 @@ func NewAsyncKafkaProducer(config Config, logger *zap.Logger) (KafkaProducer, er
 }
 
 func (k *SyncKafkaProducer) SendMessages(msg []*sarama.ProducerMessage) error {
-	err := k.producer.SendMessages(msg)
-	if err != nil {
-		return err
-	}
-	return nil
+	return k.producer.SendMessages(msg)
 }
 
 func (k *SyncKafkaProducer) Close() error {

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/Shopify/sarama"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
@@ -29,10 +28,193 @@ import (
 )
 
 var errUnrecognizedEncoding = fmt.Errorf("unrecognized encoding")
+var kafkaAddressError = errors.New("kafka address is error")
+
+const (
+	Sync  = "Sync"
+	Async = "Async"
+)
+
+type KafkaProducer interface {
+	NewKafkaProducer(config Config, logger *zap.Logger) error
+	SendMessages(value []*sarama.ProducerMessage) error
+	Close() error
+}
+
+type KafkaConfig struct {
+	addressList []string
+	topic       string
+	config      *sarama.Config
+	logger      *zap.Logger
+}
+
+func NewProducer(config Config, logger *zap.Logger) (KafkaProducer, error) {
+	var producer KafkaProducer
+	if config.sendType == "" {
+		config.sendType = Sync
+	}
+	switch config.sendType {
+	case Sync:
+		producer = &SyncKafkaProducer{}
+	case Async:
+		producer = &AsyncKafkaProducer{}
+	default:
+		fmt.Println("kafka sendType error please choose sync or async")
+		return nil, errors.New("kafka sendType error please choose sync or async")
+	}
+	err := producer.NewKafkaProducer(config, logger)
+	if err != nil {
+		fmt.Println("new kafka producer error")
+		return nil, err
+	}
+	return producer, nil
+}
+
+type SyncKafkaProducer struct {
+	KafkaConfig *KafkaConfig
+	producer    sarama.SyncProducer
+	logger      *zap.Logger
+}
+
+func (k *SyncKafkaProducer) NewKafkaProducer(config Config, logger *zap.Logger) error {
+	conf, err := NewProducerByMessage(config, logger)
+	if err != nil {
+		return err
+	}
+	k.KafkaConfig = conf
+	k.producer, err = sarama.NewSyncProducer(conf.addressList, k.KafkaConfig.config)
+	if err != nil {
+		fmt.Println("sarama.NewSyncProducer err", err)
+		return err
+	}
+	return nil
+}
+
+func (k *SyncKafkaProducer) SendMessages(msg []*sarama.ProducerMessage) error {
+	err := k.producer.SendMessages(msg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (k *SyncKafkaProducer) Close() error {
+	err := k.producer.Close()
+	if err != nil {
+		fmt.Println("sarama.NewSyncProducer close err")
+		return err
+	}
+	return nil
+}
+
+type AsyncKafkaProducer struct {
+	KafkaConfig *KafkaConfig
+	producer    sarama.AsyncProducer
+	logger      *zap.Logger
+}
+
+func (k *AsyncKafkaProducer) Close() error {
+	k.producer.AsyncClose()
+	return nil
+}
+
+func (k *AsyncKafkaProducer) NewKafkaProducer(config Config, logger *zap.Logger) error {
+	conf, err := NewProducerByMessage(config, logger)
+	if err != nil {
+		return err
+	}
+	k.KafkaConfig = conf
+	k.Run()
+	k.logger = logger
+	return nil
+}
+
+func NewProducerByMessage(config Config, logger *zap.Logger) (*KafkaConfig, error) {
+	c := sarama.NewConfig()
+	// These setting are required by the sarama implementation.
+	c.Producer.Return.Successes = true
+	c.Producer.Return.Errors = true
+	// Wait only the local commit to succeed before responding.
+	c.Producer.RequiredAcks = config.Producer.RequiredAcks
+	// Because sarama does not accept a Context for every message, set the Timeout here.
+	c.Producer.Timeout = config.Timeout
+	c.Metadata.Full = config.Metadata.Full
+	c.Metadata.Retry.Max = config.Metadata.Retry.Max
+	c.Metadata.Retry.Backoff = config.Metadata.Retry.Backoff
+	c.Producer.MaxMessageBytes = config.Producer.MaxMessageBytes
+	c.Producer.Flush.MaxMessages = config.Producer.FlushMaxMessages
+
+	if config.ProtocolVersion != "" {
+		version, err := sarama.ParseKafkaVersion(config.ProtocolVersion)
+		if err != nil {
+			return nil, err
+		}
+		c.Version = version
+	}
+
+	if err := ConfigureAuthentication(config.Authentication, c); err != nil {
+		return nil, err
+	}
+
+	compression, err := saramaProducerCompressionCodec(config.Producer.Compression)
+	if err != nil {
+		return nil, err
+	}
+	c.Producer.Compression = compression
+	if err := ConfigureAuthentication(config.Authentication, c); err != nil {
+		return nil, err
+	}
+	return &KafkaConfig{
+		addressList: config.Brokers,
+		topic:       config.Topic,
+		config:      c,
+		logger:      logger,
+	}, nil
+}
+
+func (k *AsyncKafkaProducer) SendMessages(value []*sarama.ProducerMessage) error {
+	if k.producer == nil {
+		k.Run()
+	}
+	k.producer.Input() <- value[0]
+	return nil
+
+}
+func (k *AsyncKafkaProducer) Run() {
+	if k == nil || k.KafkaConfig == nil {
+		return
+	}
+	producer, err := sarama.NewAsyncProducer(k.KafkaConfig.addressList, k.KafkaConfig.config)
+	if err != nil {
+		k.logger.Warn("sarama.NewAsyncProducer err")
+		return
+	}
+	if producer == nil {
+		k.logger.Warn("sarama.NewSyncProducer is null")
+		return
+	}
+	k.producer = producer
+	go func(p sarama.AsyncProducer) {
+		err := p.Errors()
+		success := p.Successes()
+		for {
+			select {
+			case rc := <-err:
+				if rc != nil {
+					k.logger.Warn("SendMessages kafka data error", zap.Error(rc.Unwrap()))
+				}
+			case res := <-success:
+				if res != nil {
+					k.logger.Debug("SendMessages kafka data success")
+				}
+			}
+		}
+	}(producer)
+}
 
 // kafkaTracesProducer uses sarama to produce trace messages to Kafka.
 type kafkaTracesProducer struct {
-	producer  sarama.SyncProducer
+	producer  KafkaProducer
 	topic     string
 	marshaler TracesMarshaler
 	logger    *zap.Logger
@@ -71,7 +253,7 @@ func (e *kafkaTracesProducer) Close(context.Context) error {
 
 // kafkaMetricsProducer uses sarama to produce metrics messages to kafka
 type kafkaMetricsProducer struct {
-	producer  sarama.SyncProducer
+	producer  KafkaProducer
 	topic     string
 	marshaler MetricsMarshaler
 	logger    *zap.Logger
@@ -101,7 +283,7 @@ func (e *kafkaMetricsProducer) Close(context.Context) error {
 
 // kafkaLogsProducer uses sarama to produce logs messages to kafka
 type kafkaLogsProducer struct {
-	producer  sarama.SyncProducer
+	producer  KafkaProducer
 	topic     string
 	marshaler LogsMarshaler
 	logger    *zap.Logger
@@ -129,51 +311,51 @@ func (e *kafkaLogsProducer) Close(context.Context) error {
 	return e.producer.Close()
 }
 
-func newSaramaProducer(config Config) (sarama.SyncProducer, error) {
-	c := sarama.NewConfig()
-	// These setting are required by the sarama.SyncProducer implementation.
-	c.Producer.Return.Successes = true
-	c.Producer.Return.Errors = true
-	c.Producer.RequiredAcks = config.Producer.RequiredAcks
-	// Because sarama does not accept a Context for every message, set the Timeout here.
-	c.Producer.Timeout = config.Timeout
-	c.Metadata.Full = config.Metadata.Full
-	c.Metadata.Retry.Max = config.Metadata.Retry.Max
-	c.Metadata.Retry.Backoff = config.Metadata.Retry.Backoff
-	c.Producer.MaxMessageBytes = config.Producer.MaxMessageBytes
-	c.Producer.Flush.MaxMessages = config.Producer.FlushMaxMessages
-
-	if config.ProtocolVersion != "" {
-		version, err := sarama.ParseKafkaVersion(config.ProtocolVersion)
-		if err != nil {
-			return nil, err
-		}
-		c.Version = version
-	}
-
-	if err := ConfigureAuthentication(config.Authentication, c); err != nil {
-		return nil, err
-	}
-
-	compression, err := saramaProducerCompressionCodec(config.Producer.Compression)
-	if err != nil {
-		return nil, err
-	}
-	c.Producer.Compression = compression
-
-	producer, err := sarama.NewSyncProducer(config.Brokers, c)
-	if err != nil {
-		return nil, err
-	}
-	return producer, nil
-}
+//func newSaramaProducer(config Config) (sarama.SyncProducer, error) {
+//	c := sarama.NewConfig()
+//	// These setting are required by the sarama.SyncProducer implementation.
+//	c.Producer.Return.Successes = true
+//	c.Producer.Return.Errors = true
+//	c.Producer.RequiredAcks = config.Producer.RequiredAcks
+//	// Because sarama does not accept a Context for every message, set the Timeout here.
+//	c.Producer.Timeout = config.Timeout
+//	c.Metadata.Full = config.Metadata.Full
+//	c.Metadata.Retry.Max = config.Metadata.Retry.Max
+//	c.Metadata.Retry.Backoff = config.Metadata.Retry.Backoff
+//	c.Producer.MaxMessageBytes = config.Producer.MaxMessageBytes
+//	c.Producer.Flush.MaxMessages = config.Producer.FlushMaxMessages
+//
+//	if config.ProtocolVersion != "" {
+//		version, err := sarama.ParseKafkaVersion(config.ProtocolVersion)
+//		if err != nil {
+//			return nil, err
+//		}
+//		c.Version = version
+//	}
+//
+//	if err := ConfigureAuthentication(config.Authentication, c); err != nil {
+//		return nil, err
+//	}
+//
+//	compression, err := saramaProducerCompressionCodec(config.Producer.Compression)
+//	if err != nil {
+//		return nil, err
+//	}
+//	c.Producer.Compression = compression
+//
+//	producer, err := sarama.NewSyncProducer(config.Brokers, c)
+//	if err != nil {
+//		return nil, err
+//	}
+//	return producer, nil
+//}
 
 func newMetricsExporter(config Config, set exporter.CreateSettings, marshalers map[string]MetricsMarshaler) (*kafkaMetricsProducer, error) {
 	marshaler := marshalers[config.Encoding]
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
-	producer, err := newSaramaProducer(config)
+	producer, err := NewProducer(config, set.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +375,7 @@ func newTracesExporter(config Config, set exporter.CreateSettings, marshalers ma
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
-	producer, err := newSaramaProducer(config)
+	producer, err := NewProducer(config, set.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +392,7 @@ func newLogsExporter(config Config, set exporter.CreateSettings, marshalers map[
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
-	producer, err := newSaramaProducer(config)
+	producer, err := NewProducer(config, set.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -31,8 +31,8 @@ var errUnrecognizedEncoding = fmt.Errorf("unrecognized encoding")
 var kafkaAddressError = errors.New("kafka address is error")
 
 const (
-	Sync  = "Sync"
-	Async = "Async"
+	Sync  = "sync"
+	Async = "async"
 )
 
 type KafkaProducer interface {
@@ -50,17 +50,17 @@ type KafkaConfig struct {
 
 func NewProducer(config Config, logger *zap.Logger) (KafkaProducer, error) {
 	var producer KafkaProducer
-	if config.sendType == "" {
-		config.sendType = Sync
+	if config.SendType == "" {
+		config.SendType = Sync
 	}
-	switch config.sendType {
+	switch config.SendType {
 	case Sync:
 		producer = &SyncKafkaProducer{}
 	case Async:
 		producer = &AsyncKafkaProducer{}
 	default:
-		fmt.Println("kafka sendType error please choose sync or async")
-		return nil, errors.New("kafka sendType error please choose sync or async")
+		fmt.Println("kafka SendType error please choose sync or async")
+		return nil, errors.New("kafka SendType error please choose sync or async")
 	}
 	err := producer.NewKafkaProducer(config, logger)
 	if err != nil {

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -137,9 +137,10 @@ func TestNewExporter_err_compression(t *testing.T) {
 
 func TestTracesPusher(t *testing.T) {
 	c := sarama.NewConfig()
-	producer := mocks.NewSyncProducer(t, c)
-	producer.ExpectSendMessageAndSucceed()
+	syncProducer := mocks.NewSyncProducer(t, c)
+	syncProducer.ExpectSendMessageAndSucceed()
 
+	producer := &SyncKafkaProducer{nil, syncProducer, nil}
 	p := kafkaTracesProducer{
 		producer:  producer,
 		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding),
@@ -153,9 +154,10 @@ func TestTracesPusher(t *testing.T) {
 
 func TestTracesPusher_err(t *testing.T) {
 	c := sarama.NewConfig()
-	producer := mocks.NewSyncProducer(t, c)
+	syncProducer := mocks.NewSyncProducer(t, c)
 	expErr := fmt.Errorf("failed to send")
-	producer.ExpectSendMessageAndFail(expErr)
+	syncProducer.ExpectSendMessageAndFail(expErr)
+	producer := &SyncKafkaProducer{nil, syncProducer, nil}
 
 	p := kafkaTracesProducer{
 		producer:  producer,
@@ -184,8 +186,9 @@ func TestTracesPusher_marshal_error(t *testing.T) {
 
 func TestMetricsDataPusher(t *testing.T) {
 	c := sarama.NewConfig()
-	producer := mocks.NewSyncProducer(t, c)
-	producer.ExpectSendMessageAndSucceed()
+	syncProducer := mocks.NewSyncProducer(t, c)
+	syncProducer.ExpectSendMessageAndSucceed()
+	producer := &SyncKafkaProducer{nil, syncProducer, nil}
 
 	p := kafkaMetricsProducer{
 		producer:  producer,
@@ -200,9 +203,10 @@ func TestMetricsDataPusher(t *testing.T) {
 
 func TestMetricsDataPusher_err(t *testing.T) {
 	c := sarama.NewConfig()
-	producer := mocks.NewSyncProducer(t, c)
+	syncProducer := mocks.NewSyncProducer(t, c)
 	expErr := fmt.Errorf("failed to send")
-	producer.ExpectSendMessageAndFail(expErr)
+	syncProducer.ExpectSendMessageAndFail(expErr)
+	producer := &SyncKafkaProducer{nil, syncProducer, nil}
 
 	p := kafkaMetricsProducer{
 		producer:  producer,
@@ -231,8 +235,9 @@ func TestMetricsDataPusher_marshal_error(t *testing.T) {
 
 func TestLogsDataPusher(t *testing.T) {
 	c := sarama.NewConfig()
-	producer := mocks.NewSyncProducer(t, c)
-	producer.ExpectSendMessageAndSucceed()
+	syncProducer := mocks.NewSyncProducer(t, c)
+	syncProducer.ExpectSendMessageAndSucceed()
+	producer := &SyncKafkaProducer{nil, syncProducer, nil}
 
 	p := kafkaLogsProducer{
 		producer:  producer,
@@ -247,9 +252,10 @@ func TestLogsDataPusher(t *testing.T) {
 
 func TestLogsDataPusher_err(t *testing.T) {
 	c := sarama.NewConfig()
-	producer := mocks.NewSyncProducer(t, c)
+	syncProducer := mocks.NewSyncProducer(t, c)
 	expErr := fmt.Errorf("failed to send")
-	producer.ExpectSendMessageAndFail(expErr)
+	syncProducer.ExpectSendMessageAndFail(expErr)
+	producer := &SyncKafkaProducer{nil, syncProducer, nil}
 
 	p := kafkaLogsProducer{
 		producer:  producer,

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -139,8 +139,9 @@ func TestTracesPusher(t *testing.T) {
 	c := sarama.NewConfig()
 	syncProducer := mocks.NewSyncProducer(t, c)
 	syncProducer.ExpectSendMessageAndSucceed()
+	logger, _ := zap.NewDevelopment()
 
-	producer := &SyncKafkaProducer{nil, syncProducer, nil}
+	producer := &SyncKafkaProducer{syncProducer, logger}
 	p := kafkaTracesProducer{
 		producer:  producer,
 		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding),
@@ -157,7 +158,9 @@ func TestTracesPusher_err(t *testing.T) {
 	syncProducer := mocks.NewSyncProducer(t, c)
 	expErr := fmt.Errorf("failed to send")
 	syncProducer.ExpectSendMessageAndFail(expErr)
-	producer := &SyncKafkaProducer{nil, syncProducer, nil}
+	logger, _ := zap.NewDevelopment()
+
+	producer := &SyncKafkaProducer{syncProducer, logger}
 
 	p := kafkaTracesProducer{
 		producer:  producer,
@@ -188,7 +191,8 @@ func TestMetricsDataPusher(t *testing.T) {
 	c := sarama.NewConfig()
 	syncProducer := mocks.NewSyncProducer(t, c)
 	syncProducer.ExpectSendMessageAndSucceed()
-	producer := &SyncKafkaProducer{nil, syncProducer, nil}
+	logger, _ := zap.NewDevelopment()
+	producer := &SyncKafkaProducer{syncProducer, logger}
 
 	p := kafkaMetricsProducer{
 		producer:  producer,
@@ -206,7 +210,9 @@ func TestMetricsDataPusher_err(t *testing.T) {
 	syncProducer := mocks.NewSyncProducer(t, c)
 	expErr := fmt.Errorf("failed to send")
 	syncProducer.ExpectSendMessageAndFail(expErr)
-	producer := &SyncKafkaProducer{nil, syncProducer, nil}
+	logger, _ := zap.NewDevelopment()
+
+	producer := &SyncKafkaProducer{syncProducer, logger}
 
 	p := kafkaMetricsProducer{
 		producer:  producer,
@@ -237,7 +243,9 @@ func TestLogsDataPusher(t *testing.T) {
 	c := sarama.NewConfig()
 	syncProducer := mocks.NewSyncProducer(t, c)
 	syncProducer.ExpectSendMessageAndSucceed()
-	producer := &SyncKafkaProducer{nil, syncProducer, nil}
+	logger, _ := zap.NewDevelopment()
+
+	producer := &SyncKafkaProducer{syncProducer, logger}
 
 	p := kafkaLogsProducer{
 		producer:  producer,
@@ -255,7 +263,9 @@ func TestLogsDataPusher_err(t *testing.T) {
 	syncProducer := mocks.NewSyncProducer(t, c)
 	expErr := fmt.Errorf("failed to send")
 	syncProducer.ExpectSendMessageAndFail(expErr)
-	producer := &SyncKafkaProducer{nil, syncProducer, nil}
+	logger, _ := zap.NewDevelopment()
+
+	producer := &SyncKafkaProducer{syncProducer, logger}
 
 	p := kafkaLogsProducer{
 		producer:  producer,


### PR DESCRIPTION
**Description:** In logs and traces scenarios, kafka asynchronous sending has a very good throughput, so I added a sendType feature, which uses sync sending by default
