### PR TITLE
{exporter/datadog,processor/datadog}: bump datadog-agent dependencies

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -237,9 +237,9 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.6.2 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.73 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
-	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
+	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.43.0-rc.3 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -499,12 +499,12 @@ github.com/DataDog/agent-payload/v5 v5.0.73 h1:fnCnAR+nWY+q//fBZSab4cDFFng0scPEf
 github.com/DataDog/agent-payload/v5 v5.0.73/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:vilzDJudtBAAgCjFsOnq4PZDBsVG8YbJCfmNJ8XTIvw=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:o+rJy3B2o+Zb+wCgLSkMlkD7EiUEA5Q63cid53fZkQY=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:oZBOhjzFOhAQ4J+v+3OZYt5V2btaBuMUbhJ5l628TOI=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:UlflhZfqZFDQKiIZYBQAC4kawTkMn5s27OYviNHJEf4=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:ZrKp3lGN73CucXaqGV89/a1kduMqOgCRuLfZpqxSngo=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:jH+R74p8Kqpu8PPr8H7YbeXNb9jfqOGRnTjngUYofMQ=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:WX9D8cWfWbt1hDvh1t9DuY2rEq1apIkCAFn29O+91MU=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:VVMDDibJxYEkwcLdZBT2g8EHKpbMT4JdOhRbQ9GdjbM=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:wJQSexgYk50q2pmiS/Dadx3cN8Ze35To7awXw5JtILE=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:s9UB8GJn92OWJrnDYTw8pYjx7VmfQVgrexq21EpHEnQ=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:8w10VdqwZBMX1GMm1JHARipjXew+VVbdaNUaTE27n98=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:FoLytWtX6e1s4X7C1P0F/OUAd9ibclwNYiy86B/aEW8=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:dCU5wtokXCUXcJVIL6ZAGFWhx6G8aQ5P20vZ5N2ECV4=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:Yy59y4UyxYL8h4rxZzh8QGgxUFm+kCFMvs8WUXqF/go=
 github.com/DataDog/datadog-agent/pkg/util/log v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:eqOCvamJLxvQvF6vp25xmFByyoxjSh0hEQtCiGBY88A=

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -216,9 +216,9 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.6.1 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.73 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
-	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
+	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.43.0-rc.3 // indirect

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -495,12 +495,12 @@ github.com/DataDog/agent-payload/v5 v5.0.73 h1:fnCnAR+nWY+q//fBZSab4cDFFng0scPEf
 github.com/DataDog/agent-payload/v5 v5.0.73/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:vilzDJudtBAAgCjFsOnq4PZDBsVG8YbJCfmNJ8XTIvw=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:o+rJy3B2o+Zb+wCgLSkMlkD7EiUEA5Q63cid53fZkQY=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:oZBOhjzFOhAQ4J+v+3OZYt5V2btaBuMUbhJ5l628TOI=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:UlflhZfqZFDQKiIZYBQAC4kawTkMn5s27OYviNHJEf4=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:ZrKp3lGN73CucXaqGV89/a1kduMqOgCRuLfZpqxSngo=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:jH+R74p8Kqpu8PPr8H7YbeXNb9jfqOGRnTjngUYofMQ=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:WX9D8cWfWbt1hDvh1t9DuY2rEq1apIkCAFn29O+91MU=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:VVMDDibJxYEkwcLdZBT2g8EHKpbMT4JdOhRbQ9GdjbM=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:wJQSexgYk50q2pmiS/Dadx3cN8Ze35To7awXw5JtILE=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:s9UB8GJn92OWJrnDYTw8pYjx7VmfQVgrexq21EpHEnQ=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:8w10VdqwZBMX1GMm1JHARipjXew+VVbdaNUaTE27n98=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:FoLytWtX6e1s4X7C1P0F/OUAd9ibclwNYiy86B/aEW8=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:dCU5wtokXCUXcJVIL6ZAGFWhx6G8aQ5P20vZ5N2ECV4=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:Yy59y4UyxYL8h4rxZzh8QGgxUFm+kCFMvs8WUXqF/go=
 github.com/DataDog/datadog-agent/pkg/util/log v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:eqOCvamJLxvQvF6vp25xmFByyoxjSh0hEQtCiGBY88A=

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.73
-	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c
-	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c
+	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4
+	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4
 	github.com/DataDog/datadog-api-client-go/v2 v2.9.0
 	github.com/DataDog/gohai v0.0.0-20220718130825-1776f9beb9cc
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.1.0

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -51,12 +51,12 @@ github.com/DataDog/agent-payload/v5 v5.0.73 h1:fnCnAR+nWY+q//fBZSab4cDFFng0scPEf
 github.com/DataDog/agent-payload/v5 v5.0.73/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:vilzDJudtBAAgCjFsOnq4PZDBsVG8YbJCfmNJ8XTIvw=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:o+rJy3B2o+Zb+wCgLSkMlkD7EiUEA5Q63cid53fZkQY=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:oZBOhjzFOhAQ4J+v+3OZYt5V2btaBuMUbhJ5l628TOI=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:UlflhZfqZFDQKiIZYBQAC4kawTkMn5s27OYviNHJEf4=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:ZrKp3lGN73CucXaqGV89/a1kduMqOgCRuLfZpqxSngo=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:jH+R74p8Kqpu8PPr8H7YbeXNb9jfqOGRnTjngUYofMQ=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:WX9D8cWfWbt1hDvh1t9DuY2rEq1apIkCAFn29O+91MU=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:VVMDDibJxYEkwcLdZBT2g8EHKpbMT4JdOhRbQ9GdjbM=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:wJQSexgYk50q2pmiS/Dadx3cN8Ze35To7awXw5JtILE=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:s9UB8GJn92OWJrnDYTw8pYjx7VmfQVgrexq21EpHEnQ=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:8w10VdqwZBMX1GMm1JHARipjXew+VVbdaNUaTE27n98=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:FoLytWtX6e1s4X7C1P0F/OUAd9ibclwNYiy86B/aEW8=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:dCU5wtokXCUXcJVIL6ZAGFWhx6G8aQ5P20vZ5N2ECV4=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:Yy59y4UyxYL8h4rxZzh8QGgxUFm+kCFMvs8WUXqF/go=
 github.com/DataDog/datadog-agent/pkg/util/log v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:eqOCvamJLxvQvF6vp25xmFByyoxjSh0hEQtCiGBY88A=

--- a/go.mod
+++ b/go.mod
@@ -223,9 +223,9 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.6.2 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.73 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
-	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
+	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.43.0-rc.3.0.20230206114529-17c7dfde736c // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.43.0-rc.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -499,12 +499,12 @@ github.com/DataDog/agent-payload/v5 v5.0.73 h1:fnCnAR+nWY+q//fBZSab4cDFFng0scPEf
 github.com/DataDog/agent-payload/v5 v5.0.73/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:vilzDJudtBAAgCjFsOnq4PZDBsVG8YbJCfmNJ8XTIvw=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:o+rJy3B2o+Zb+wCgLSkMlkD7EiUEA5Q63cid53fZkQY=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:oZBOhjzFOhAQ4J+v+3OZYt5V2btaBuMUbhJ5l628TOI=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:UlflhZfqZFDQKiIZYBQAC4kawTkMn5s27OYviNHJEf4=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:ZrKp3lGN73CucXaqGV89/a1kduMqOgCRuLfZpqxSngo=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:jH+R74p8Kqpu8PPr8H7YbeXNb9jfqOGRnTjngUYofMQ=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:WX9D8cWfWbt1hDvh1t9DuY2rEq1apIkCAFn29O+91MU=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:VVMDDibJxYEkwcLdZBT2g8EHKpbMT4JdOhRbQ9GdjbM=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:wJQSexgYk50q2pmiS/Dadx3cN8Ze35To7awXw5JtILE=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:s9UB8GJn92OWJrnDYTw8pYjx7VmfQVgrexq21EpHEnQ=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:8w10VdqwZBMX1GMm1JHARipjXew+VVbdaNUaTE27n98=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:FoLytWtX6e1s4X7C1P0F/OUAd9ibclwNYiy86B/aEW8=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:dCU5wtokXCUXcJVIL6ZAGFWhx6G8aQ5P20vZ5N2ECV4=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:Yy59y4UyxYL8h4rxZzh8QGgxUFm+kCFMvs8WUXqF/go=
 github.com/DataDog/datadog-agent/pkg/util/log v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:eqOCvamJLxvQvF6vp25xmFByyoxjSh0hEQtCiGBY88A=

--- a/processor/datadogprocessor/go.mod
+++ b/processor/datadogprocessor/go.mod
@@ -3,8 +3,8 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/datad
 go 1.19
 
 require (
-	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c
-	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c
+	github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4
+	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.71.0

--- a/processor/datadogprocessor/go.sum
+++ b/processor/datadogprocessor/go.sum
@@ -3,12 +3,12 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:vilzDJudtBAAgCjFsOnq4PZDBsVG8YbJCfmNJ8XTIvw=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:o+rJy3B2o+Zb+wCgLSkMlkD7EiUEA5Q63cid53fZkQY=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:oZBOhjzFOhAQ4J+v+3OZYt5V2btaBuMUbhJ5l628TOI=
-github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:UlflhZfqZFDQKiIZYBQAC4kawTkMn5s27OYviNHJEf4=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:ZrKp3lGN73CucXaqGV89/a1kduMqOgCRuLfZpqxSngo=
+github.com/DataDog/datadog-agent/pkg/otlp/model v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:jH+R74p8Kqpu8PPr8H7YbeXNb9jfqOGRnTjngUYofMQ=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:WX9D8cWfWbt1hDvh1t9DuY2rEq1apIkCAFn29O+91MU=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:VVMDDibJxYEkwcLdZBT2g8EHKpbMT4JdOhRbQ9GdjbM=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:wJQSexgYk50q2pmiS/Dadx3cN8Ze35To7awXw5JtILE=
-github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:s9UB8GJn92OWJrnDYTw8pYjx7VmfQVgrexq21EpHEnQ=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4 h1:8w10VdqwZBMX1GMm1JHARipjXew+VVbdaNUaTE27n98=
+github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230221135433-65e01983bba4/go.mod h1:FoLytWtX6e1s4X7C1P0F/OUAd9ibclwNYiy86B/aEW8=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:dCU5wtokXCUXcJVIL6ZAGFWhx6G8aQ5P20vZ5N2ECV4=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3.0.20230206114529-17c7dfde736c/go.mod h1:Yy59y4UyxYL8h4rxZzh8QGgxUFm+kCFMvs8WUXqF/go=
 github.com/DataDog/datadog-agent/pkg/util/log v0.43.0-rc.3.0.20230206114529-17c7dfde736c h1:eqOCvamJLxvQvF6vp25xmFByyoxjSh0hEQtCiGBY88A=


### PR DESCRIPTION
Updated to latest datadog-agent which in turn uses the latest collector dependencies 0.71.0: https://github.com/DataDog/datadog-agent/pull/15637