### PR TITLE
[extension/healthcheckextension] Add response_body configuration option

### DIFF
--- a/.chloggen/healthcheck-response-body.yaml
+++ b/.chloggen/healthcheck-response-body.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: healthcheckextension
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `static_response_body` configuration option that allows specifying a specific response body
+note: Add `response_body` configuration option that allows specifying a specific response body
 
 # One or more tracking issues related to the change
 issues: [18824]

--- a/.chloggen/healthcheck-static-response-body.yaml
+++ b/.chloggen/healthcheck-static-response-body.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: healthcheckextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `static_response_body` configuration option that allows specifying a specific response body
+
+# One or more tracking issues related to the change
+issues: [18824]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/extension/healthcheckextension/README.md
+++ b/extension/healthcheckextension/README.md
@@ -19,6 +19,7 @@ The following settings are required:
 
 - `endpoint` (default = 0.0.0.0:13133): Address to publish the health check status. For full list of `HTTPServerSettings` refer [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp).
 - `path` (default = "/"): Specifies the path to be configured for the health check server.
+- `static_response_body` (default = ""): Specifies a static body that overrides the default response returned by the health check service. 
 - `check_collector_pipeline:` (optional): Settings of collector pipeline health check
     - `enabled` (default = false): Whether enable collector pipeline check or not
     - `interval` (default = "5m"): Time interval to check the number of failures

--- a/extension/healthcheckextension/README.md
+++ b/extension/healthcheckextension/README.md
@@ -19,7 +19,7 @@ The following settings are required:
 
 - `endpoint` (default = 0.0.0.0:13133): Address to publish the health check status. For full list of `HTTPServerSettings` refer [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp).
 - `path` (default = "/"): Specifies the path to be configured for the health check server.
-- `static_response_body` (default = ""): Specifies a static body that overrides the default response returned by the health check service. 
+- `response_body` (default = ""): Specifies a static body that overrides the default response returned by the health check service. 
 - `check_collector_pipeline:` (optional): Settings of collector pipeline health check
     - `enabled` (default = false): Whether enable collector pipeline check or not
     - `interval` (default = "5m"): Time interval to check the number of failures

--- a/extension/healthcheckextension/config.go
+++ b/extension/healthcheckextension/config.go
@@ -32,6 +32,11 @@ type Config struct {
 	// The default path is "/".
 	Path string `mapstructure:"path"`
 
+	// StaticResponseBody represents the body of the response returned by the health check service.
+	// This is override the default response that it would return.
+	// The default value is ""
+	StaticResponseBody string `mapstructure:"static_response_body"`
+
 	// CheckCollectorPipeline contains the list of settings of collector pipeline health check
 	CheckCollectorPipeline checkCollectorPipelineSettings `mapstructure:"check_collector_pipeline"`
 }

--- a/extension/healthcheckextension/config.go
+++ b/extension/healthcheckextension/config.go
@@ -23,6 +23,16 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 )
 
+type ResponseBodySettings struct {
+	// Healthy represents the body of the response returned when the collector is healthy.
+	// The default value is ""
+	Healthy string `mapstructure:"healthy"`
+
+	// Unhealthy represents the body of the response returned when the collector is unhealthy.
+	// The default value is ""
+	Unhealthy string `mapstructure:"unhealthy"`
+}
+
 // Config has the configuration for the extension enabling the health check
 // extension, used to report the health status of the service.
 type Config struct {
@@ -32,10 +42,9 @@ type Config struct {
 	// The default path is "/".
 	Path string `mapstructure:"path"`
 
-	// StaticResponseBody represents the body of the response returned by the health check service when the collector is healthy.
+	// ResponseBody represents the body of the response returned by the health check service.
 	// This overrides the default response that it would return.
-	// The default value is ""
-	StaticResponseBody string `mapstructure:"static_response_body"`
+	ResponseBody *ResponseBodySettings `mapstructure:"response_body"`
 
 	// CheckCollectorPipeline contains the list of settings of collector pipeline health check
 	CheckCollectorPipeline checkCollectorPipelineSettings `mapstructure:"check_collector_pipeline"`

--- a/extension/healthcheckextension/config.go
+++ b/extension/healthcheckextension/config.go
@@ -32,8 +32,8 @@ type Config struct {
 	// The default path is "/".
 	Path string `mapstructure:"path"`
 
-	// StaticResponseBody represents the body of the response returned by the health check service.
-	// This is override the default response that it would return.
+	// StaticResponseBody represents the body of the response returned by the health check service when the collector is healthy.
+	// This overrides the default response that it would return.
 	// The default value is ""
 	StaticResponseBody string `mapstructure:"static_response_body"`
 

--- a/extension/healthcheckextension/config_test.go
+++ b/extension/healthcheckextension/config_test.go
@@ -53,6 +53,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 				Path:                   "/",
+				StaticResponseBody:     "",
 			},
 		},
 		{

--- a/extension/healthcheckextension/config_test.go
+++ b/extension/healthcheckextension/config_test.go
@@ -53,7 +53,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 				Path:                   "/",
-				StaticResponseBody:     "",
+				ResponseBody:           nil,
 			},
 		},
 		{

--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -115,15 +115,14 @@ func (hc *healthCheckExtension) baseHandler() http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			if hc.state.Get() == healthcheck.Ready {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(hc.config.ResponseBody.Healthy))
+				_, _ = w.Write([]byte(hc.config.ResponseBody.Healthy))
 			} else {
 				w.WriteHeader(http.StatusServiceUnavailable)
-				w.Write([]byte(hc.config.ResponseBody.Unhealthy))
+				_, _ = w.Write([]byte(hc.config.ResponseBody.Unhealthy))
 			}
 		})
-	} else {
-		return hc.state.Handler()
 	}
+	return hc.state.Handler()
 }
 
 // new handler function used for check collector pipeline
@@ -132,12 +131,12 @@ func (hc *healthCheckExtension) checkCollectorPipelineHandler() http.Handler {
 		if hc.check() && hc.state.Get() == healthcheck.Ready {
 			w.WriteHeader(http.StatusOK)
 			if hc.config.ResponseBody != nil {
-				w.Write([]byte(hc.config.ResponseBody.Healthy))
+				_, _ = w.Write([]byte(hc.config.ResponseBody.Healthy))
 			}
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
 			if hc.config.ResponseBody != nil {
-				w.Write([]byte(hc.config.ResponseBody.Unhealthy))
+				_, _ = w.Write([]byte(hc.config.ResponseBody.Unhealthy))
 			}
 		}
 	})

--- a/extension/healthcheckextension/healthcheckextension_test.go
+++ b/extension/healthcheckextension/healthcheckextension_test.go
@@ -45,347 +45,302 @@ func ensureServerRunning(url string) func() bool {
 	}
 }
 
-func TestHealthCheckExtensionUsageWithoutCheckCollectorPipeline(t *testing.T) {
-	config := Config{
-		HTTPServerSettings: confighttp.HTTPServerSettings{
-			Endpoint: testutil.GetAvailableLocalAddress(t),
-		},
-		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
-		Path:                   "/",
-		ResponseBody:           nil,
-	}
-
-	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
-	require.NotNil(t, hcExt)
-
-	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
-
-	// Give a chance for the server goroutine to run.
-	runtime.Gosched()
-
-	client := &http.Client{}
-	url := "http://" + config.Endpoint
-
-	resp0, err := client.Get(url)
-	require.NoError(t, err)
-	defer resp0.Body.Close()
-	require.Equal(t, http.StatusServiceUnavailable, resp0.StatusCode)
-	body0, err := io.ReadAll(resp0.Body)
-	require.NoError(t, err)
-	require.Contains(t, string(body0), expectedBodyNotReady)
-
-	require.NoError(t, hcExt.Ready())
-
-	resp1, err := client.Get(url)
-	require.NoError(t, err)
-	defer resp1.Body.Close()
-	require.Equal(t, http.StatusOK, resp1.StatusCode)
-	body1, err := io.ReadAll(resp1.Body)
-	require.NoError(t, err)
-	require.Contains(t, string(body1), expectedBodyReady)
-
-	require.NoError(t, hcExt.NotReady())
-
-	resp2, err := client.Get(url)
-	require.NoError(t, err)
-	defer resp2.Body.Close()
-	require.Equal(t, http.StatusServiceUnavailable, resp2.StatusCode)
-	body2, err := io.ReadAll(resp2.Body)
-	require.NoError(t, err)
-	require.Contains(t, string(body2), expectedBodyNotReady)
+type teststep struct {
+	step               func(*healthCheckExtension) error
+	expectedStatusCode int
+	expectedBody       string
 }
 
-func TestHealthCheckExtensionUsageWithCustomizedPathWithoutCheckCollectorPipeline(t *testing.T) {
-	config := Config{
-		HTTPServerSettings: confighttp.HTTPServerSettings{
-			Endpoint: testutil.GetAvailableLocalAddress(t),
+func TestHealthCheckExtensionUsage(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    Config
+		teststeps []teststep
+	}{
+		{
+			name: "WithoutCheckCollectorPipeline",
+			config: Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: testutil.GetAvailableLocalAddress(t),
+				},
+				CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
+				Path:                   "/",
+				ResponseBody:           nil,
+			},
+			teststeps: []teststep{
+				{
+					expectedStatusCode: http.StatusServiceUnavailable,
+					expectedBody:       expectedBodyNotReady,
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.Ready() },
+					expectedStatusCode: http.StatusOK,
+					expectedBody:       expectedBodyReady,
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.NotReady() },
+					expectedStatusCode: http.StatusServiceUnavailable,
+					expectedBody:       expectedBodyNotReady,
+				},
+			},
 		},
-		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
-		Path:                   "/health",
-	}
-
-	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
-	require.NotNil(t, hcExt)
-
-	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
-	require.Eventuallyf(t, ensureServerRunning(config.Endpoint), 30*time.Second, 1*time.Second, "Failed to start the testing server.")
-
-	client := &http.Client{}
-	url := "http://" + config.Endpoint + config.Path
-	resp0, err := client.Get(url)
-	require.NoError(t, err)
-	require.NoError(t, resp0.Body.Close(), "Must be able to close the response")
-
-	require.Equal(t, http.StatusServiceUnavailable, resp0.StatusCode)
-
-	require.NoError(t, hcExt.Ready())
-	resp1, err := client.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp1.StatusCode)
-	require.NoError(t, resp1.Body.Close(), "Must be able to close the response")
-
-	require.NoError(t, hcExt.NotReady())
-	resp2, err := client.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusServiceUnavailable, resp2.StatusCode)
-	require.NoError(t, resp2.Body.Close(), "Must be able to close the response")
-}
-
-func TestHealthCheckExtensionUsageWithCustomStaticResponseBodyWithoutCheckCollectorPipeline(t *testing.T) {
-	config := Config{
-		HTTPServerSettings: confighttp.HTTPServerSettings{
-			Endpoint: testutil.GetAvailableLocalAddress(t),
+		{
+			name: "WithCustomizedPathWithoutCheckCollectorPipeline",
+			config: Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: testutil.GetAvailableLocalAddress(t),
+				},
+				CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
+				Path:                   "/health",
+			},
+			teststeps: []teststep{
+				{
+					expectedStatusCode: http.StatusServiceUnavailable,
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.Ready() },
+					expectedStatusCode: http.StatusOK,
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.NotReady() },
+					expectedStatusCode: http.StatusServiceUnavailable,
+				},
+			},
 		},
-		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
-		Path:                   "/",
-		ResponseBody:           &ResponseBodySettings{Healthy: "OK"},
-	}
-
-	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
-	require.NotNil(t, hcExt)
-
-	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
-	require.Eventuallyf(t, ensureServerRunning(config.Endpoint), 30*time.Second, 1*time.Second, "Failed to start the testing server.")
-
-	client := &http.Client{}
-	url := "http://" + config.Endpoint + config.Path
-	resp0, err := client.Get(url)
-	require.NoError(t, err)
-	body0, err := io.ReadAll(resp0.Body)
-	require.NoError(t, err)
-	require.Empty(t, body0)
-	require.NoError(t, resp0.Body.Close(), "Must be able to close the response")
-	require.Equal(t, http.StatusServiceUnavailable, resp0.StatusCode)
-
-	require.NoError(t, hcExt.Ready())
-
-	resp1, err := client.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp1.StatusCode)
-	body1, err := io.ReadAll(resp1.Body)
-	require.NoError(t, err)
-	require.Equal(t, body1, []byte("OK"))
-	require.NoError(t, resp1.Body.Close(), "Must be able to close the response")
-
-	require.NoError(t, hcExt.NotReady())
-
-	resp2, err := client.Get(url)
-	require.NoError(t, err)
-	body2, err := io.ReadAll(resp2.Body)
-	require.NoError(t, err)
-	require.Empty(t, body2)
-	require.Equal(t, http.StatusServiceUnavailable, resp2.StatusCode)
-	require.NoError(t, resp2.Body.Close(), "Must be able to close the response")
-}
-
-func TestHealthCheckExtensionUsageWithCheckCollectorPipeline(t *testing.T) {
-	config := Config{
-		HTTPServerSettings: confighttp.HTTPServerSettings{
-			Endpoint: testutil.GetAvailableLocalAddress(t),
+		{
+			name: "WithBothCustomResponseBodyWithoutCheckCollectorPipeline",
+			config: Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: testutil.GetAvailableLocalAddress(t),
+				},
+				CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
+				Path:                   "/",
+				ResponseBody:           &ResponseBodySettings{Healthy: "ALL OK", Unhealthy: "NOT OK"},
+			},
+			teststeps: []teststep{
+				{
+					expectedStatusCode: http.StatusServiceUnavailable,
+					expectedBody:       "NOT OK",
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.Ready() },
+					expectedStatusCode: http.StatusOK,
+					expectedBody:       "ALL OK",
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.NotReady() },
+					expectedStatusCode: http.StatusServiceUnavailable,
+					expectedBody:       "NOT OK",
+				},
+			},
 		},
-		CheckCollectorPipeline: checkCollectorPipelineSettings{
-			Enabled:                  true,
-			Interval:                 "5m",
-			ExporterFailureThreshold: 1,
+		{
+			name: "WithHealthyCustomResponseBodyWithoutCheckCollectorPipeline",
+			config: Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: testutil.GetAvailableLocalAddress(t),
+				},
+				CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
+				Path:                   "/",
+				ResponseBody:           &ResponseBodySettings{Healthy: "ALL OK"},
+			},
+			teststeps: []teststep{
+				{
+					expectedStatusCode: http.StatusServiceUnavailable,
+					expectedBody:       "",
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.Ready() },
+					expectedStatusCode: http.StatusOK,
+					expectedBody:       "ALL OK",
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.NotReady() },
+					expectedStatusCode: http.StatusServiceUnavailable,
+					expectedBody:       "",
+				},
+			},
 		},
-		Path: "/",
-	}
-
-	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
-	require.NotNil(t, hcExt)
-
-	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
-
-	// Give a chance for the server goroutine to run.
-	runtime.Gosched()
-
-	newView := view.View{Name: exporterFailureView}
-
-	currentTime := time.Now()
-	vd1 := &view.Data{
-		View:  &newView,
-		Start: currentTime.Add(-2 * time.Minute),
-		End:   currentTime,
-		Rows:  nil,
-	}
-	vd2 := &view.Data{
-		View:  &newView,
-		Start: currentTime.Add(-1 * time.Minute),
-		End:   currentTime,
-		Rows:  nil,
-	}
-
-	client := &http.Client{}
-	url := "http://" + config.Endpoint
-	resp0, err := client.Get(url)
-	require.NoError(t, err)
-	defer resp0.Body.Close()
-
-	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd1)
-	require.NoError(t, hcExt.Ready())
-	resp1, err := client.Get(url)
-	require.NoError(t, err)
-	defer resp1.Body.Close()
-	require.Equal(t, http.StatusOK, resp1.StatusCode)
-
-	require.NoError(t, hcExt.NotReady())
-	resp2, err := client.Get(url)
-	require.NoError(t, err)
-	defer resp2.Body.Close()
-	require.Equal(t, http.StatusInternalServerError, resp2.StatusCode)
-
-	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd2)
-	require.NoError(t, hcExt.Ready())
-	resp3, err := client.Get(url)
-	require.NoError(t, err)
-	defer resp3.Body.Close()
-	require.Equal(t, http.StatusInternalServerError, resp3.StatusCode)
-}
-
-func TestHealthCheckExtensionUsageWithCustomPathWithCheckCollectorPipeline(t *testing.T) {
-	config := Config{
-		HTTPServerSettings: confighttp.HTTPServerSettings{
-			Endpoint: testutil.GetAvailableLocalAddress(t),
+		{
+			name: "WithUnhealthyCustomResponseBodyWithoutCheckCollectorPipeline",
+			config: Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: testutil.GetAvailableLocalAddress(t),
+				},
+				CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
+				Path:                   "/",
+				ResponseBody:           &ResponseBodySettings{Unhealthy: "NOT OK"},
+			},
+			teststeps: []teststep{
+				{
+					expectedStatusCode: http.StatusServiceUnavailable,
+					expectedBody:       "NOT OK",
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.Ready() },
+					expectedStatusCode: http.StatusOK,
+					expectedBody:       "",
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.NotReady() },
+					expectedStatusCode: http.StatusServiceUnavailable,
+					expectedBody:       "NOT OK",
+				},
+			},
 		},
-		CheckCollectorPipeline: checkCollectorPipelineSettings{
-			Enabled:                  true,
-			Interval:                 "5m",
-			ExporterFailureThreshold: 1,
+		{
+			name: "WithCheckCollectorPipeline",
+			config: Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: testutil.GetAvailableLocalAddress(t),
+				},
+				CheckCollectorPipeline: checkCollectorPipelineSettings{
+					Enabled:                  true,
+					Interval:                 "5m",
+					ExporterFailureThreshold: 1,
+				},
+				Path: "/",
+			},
+			teststeps: []teststep{
+				{
+					expectedStatusCode: http.StatusInternalServerError,
+				},
+				{
+					step: func(hcExt *healthCheckExtension) error {
+						hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, viewData())
+						return hcExt.Ready()
+					},
+					expectedStatusCode: http.StatusOK,
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.NotReady() },
+					expectedStatusCode: http.StatusInternalServerError,
+				},
+				{
+					step: func(hcExt *healthCheckExtension) error {
+						hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, viewData())
+						return hcExt.Ready()
+					},
+					expectedStatusCode: http.StatusInternalServerError,
+				},
+			},
 		},
-		Path: "/health",
-	}
-
-	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
-	require.NotNil(t, hcExt)
-
-	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
-
-	// Give a chance for the server goroutine to run.
-	runtime.Gosched()
-	require.Eventuallyf(t, ensureServerRunning(config.Endpoint), 30*time.Second, 1*time.Second, "Failed to start the testing server.")
-
-	newView := view.View{Name: exporterFailureView}
-
-	currentTime := time.Now()
-	vd1 := &view.Data{
-		View:  &newView,
-		Start: currentTime.Add(-2 * time.Minute),
-		End:   currentTime,
-		Rows:  nil,
-	}
-	vd2 := &view.Data{
-		View:  &newView,
-		Start: currentTime.Add(-1 * time.Minute),
-		End:   currentTime,
-		Rows:  nil,
-	}
-
-	client := &http.Client{}
-	url := "http://" + config.Endpoint + config.Path
-	resp0, err := client.Get(url)
-	require.NoError(t, err)
-	require.NoError(t, resp0.Body.Close(), "Must be able to close the response")
-
-	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd1)
-	require.NoError(t, hcExt.Ready())
-	resp1, err := client.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp1.StatusCode)
-	require.NoError(t, resp1.Body.Close(), "Must be able to close the response")
-
-	require.NoError(t, hcExt.NotReady())
-	resp2, err := client.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusInternalServerError, resp2.StatusCode)
-	require.NoError(t, resp2.Body.Close(), "Must be able to close the response")
-
-	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd2)
-	require.NoError(t, hcExt.Ready())
-	resp3, err := client.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusInternalServerError, resp3.StatusCode)
-	require.NoError(t, resp3.Body.Close(), "Must be able to close the response")
-}
-
-func TestHealthCheckExtensionUsageWithCustomStaticResponseBodyWithCheckCollectorPipeline(t *testing.T) {
-	config := Config{
-		HTTPServerSettings: confighttp.HTTPServerSettings{
-			Endpoint: testutil.GetAvailableLocalAddress(t),
+		{
+			name: "WithCustomPathWithCheckCollectorPipeline",
+			config: Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: testutil.GetAvailableLocalAddress(t),
+				},
+				CheckCollectorPipeline: checkCollectorPipelineSettings{
+					Enabled:                  true,
+					Interval:                 "5m",
+					ExporterFailureThreshold: 1,
+				},
+				Path: "/health",
+			},
+			teststeps: []teststep{
+				{
+					expectedStatusCode: http.StatusInternalServerError,
+				},
+				{
+					step: func(hcExt *healthCheckExtension) error {
+						hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, viewData())
+						return hcExt.Ready()
+					},
+					expectedStatusCode: http.StatusOK,
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.NotReady() },
+					expectedStatusCode: http.StatusInternalServerError,
+				},
+				{
+					step: func(hcExt *healthCheckExtension) error {
+						hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, viewData())
+						return hcExt.Ready()
+					},
+					expectedStatusCode: http.StatusInternalServerError,
+				},
+			},
 		},
-		CheckCollectorPipeline: checkCollectorPipelineSettings{
-			Enabled:                  true,
-			Interval:                 "5m",
-			ExporterFailureThreshold: 1,
+		{
+			name: "WithCustomStaticResponseBodyWithCheckCollectorPipeline",
+			config: Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: testutil.GetAvailableLocalAddress(t),
+				},
+				CheckCollectorPipeline: checkCollectorPipelineSettings{
+					Enabled:                  true,
+					Interval:                 "5m",
+					ExporterFailureThreshold: 1,
+				},
+				Path:         "/",
+				ResponseBody: &ResponseBodySettings{Healthy: "ALL OK", Unhealthy: "NOT OK"},
+			},
+			teststeps: []teststep{
+				{
+					expectedStatusCode: http.StatusInternalServerError,
+					expectedBody:       "NOT OK",
+				},
+				{
+					step: func(hcExt *healthCheckExtension) error {
+						hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, viewData())
+						return hcExt.Ready()
+					},
+					expectedStatusCode: http.StatusOK,
+					expectedBody:       "ALL OK",
+				},
+				{
+					step:               func(hcExt *healthCheckExtension) error { return hcExt.NotReady() },
+					expectedStatusCode: http.StatusInternalServerError,
+					expectedBody:       "NOT OK",
+				},
+				{
+					step: func(hcExt *healthCheckExtension) error {
+						hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, viewData())
+						return hcExt.Ready()
+					},
+					expectedStatusCode: http.StatusInternalServerError,
+					expectedBody:       "NOT OK",
+				},
+			},
 		},
-		Path:         "/",
-		ResponseBody: &ResponseBodySettings{Healthy: "OK"},
 	}
 
-	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
-	require.NotNil(t, hcExt)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hcExt := newServer(tt.config, componenttest.NewNopTelemetrySettings())
+			require.NotNil(t, hcExt)
 
-	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
+			require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
+			t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
 
-	// Give a chance for the server goroutine to run.
-	runtime.Gosched()
-	require.Eventuallyf(t, ensureServerRunning(config.Endpoint), 30*time.Second, 1*time.Second, "Failed to start the testing server.")
+			// Give a chance for the server goroutine to run.
+			runtime.Gosched()
+			require.Eventuallyf(t, ensureServerRunning(tt.config.Endpoint), 30*time.Second, 1*time.Second, "Failed to start the testing server.")
 
-	newView := view.View{Name: exporterFailureView}
+			client := &http.Client{}
+			url := "http://" + tt.config.Endpoint + tt.config.Path
 
-	currentTime := time.Now()
-	vd1 := &view.Data{
-		View:  &newView,
-		Start: currentTime.Add(-2 * time.Minute),
-		End:   currentTime,
-		Rows:  nil,
+			for _, ts := range tt.teststeps {
+				if ts.step != nil {
+					require.NoError(t, ts.step(hcExt))
+				}
+
+				resp, err := client.Get(url)
+				require.NoError(t, err)
+
+				if ts.expectedStatusCode != 0 {
+					require.Equal(t, ts.expectedStatusCode, resp.StatusCode)
+				}
+				if ts.expectedBody != "" {
+					body, err := io.ReadAll(resp.Body)
+					require.NoError(t, err)
+					require.Contains(t, string(body), ts.expectedBody)
+				}
+				require.NoError(t, resp.Body.Close(), "Must be able to close the response")
+			}
+		})
 	}
-	vd2 := &view.Data{
-		View:  &newView,
-		Start: currentTime.Add(-1 * time.Minute),
-		End:   currentTime,
-		Rows:  nil,
-	}
-
-	client := &http.Client{}
-	url := "http://" + config.Endpoint + config.Path
-	resp0, err := client.Get(url)
-	require.NoError(t, err)
-	body0, err := io.ReadAll(resp0.Body)
-	require.NoError(t, err)
-	require.Empty(t, body0)
-	require.NoError(t, resp0.Body.Close(), "Must be able to close the response")
-
-	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd1)
-	require.NoError(t, hcExt.Ready())
-	resp1, err := client.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp1.StatusCode)
-	body1, err := io.ReadAll(resp1.Body)
-	require.NoError(t, err)
-	require.Equal(t, body1, []byte("OK"))
-	require.NoError(t, resp1.Body.Close(), "Must be able to close the response")
-
-	require.NoError(t, hcExt.NotReady())
-	resp2, err := client.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusInternalServerError, resp2.StatusCode)
-	body2, err := io.ReadAll(resp2.Body)
-	require.NoError(t, err)
-	require.Empty(t, body2)
-	require.NoError(t, resp2.Body.Close(), "Must be able to close the response")
-
-	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd2)
-	require.NoError(t, hcExt.Ready())
-	resp3, err := client.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusInternalServerError, resp3.StatusCode)
-	require.NoError(t, resp3.Body.Close(), "Must be able to close the response")
 }
 
 func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
@@ -459,6 +414,17 @@ func TestHealthCheckShutdownWithoutStart(t *testing.T) {
 	require.NotNil(t, hcExt)
 
 	require.NoError(t, hcExt.Shutdown(context.Background()))
+}
+
+func viewData() *view.Data {
+	currentTime := time.Now()
+	vd := &view.Data{
+		View:  &view.View{Name: exporterFailureView},
+		Start: currentTime.Add(-1 * time.Minute),
+		End:   currentTime,
+		Rows:  nil,
+	}
+	return vd
 }
 
 // assertNoErrorHost implements a component.Host that asserts that there were no errors.

--- a/extension/healthcheckextension/healthcheckextension_test.go
+++ b/extension/healthcheckextension/healthcheckextension_test.go
@@ -52,7 +52,7 @@ func TestHealthCheckExtensionUsageWithoutCheckCollectorPipeline(t *testing.T) {
 		},
 		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 		Path:                   "/",
-		StaticResponseBody:     "",
+		ResponseBody:           nil,
 	}
 
 	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
@@ -140,7 +140,7 @@ func TestHealthCheckExtensionUsageWithCustomStaticResponseBodyWithoutCheckCollec
 		},
 		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 		Path:                   "/",
-		StaticResponseBody:     "OK",
+		ResponseBody:           &ResponseBodySettings{Healthy: "OK"},
 	}
 
 	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
@@ -236,14 +236,14 @@ func TestHealthCheckExtensionUsageWithCheckCollectorPipeline(t *testing.T) {
 	resp2, err := client.Get(url)
 	require.NoError(t, err)
 	defer resp2.Body.Close()
-	require.Equal(t, http.StatusServiceUnavailable, resp2.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, resp2.StatusCode)
 
 	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd2)
 	require.NoError(t, hcExt.Ready())
 	resp3, err := client.Get(url)
 	require.NoError(t, err)
 	defer resp3.Body.Close()
-	require.Equal(t, http.StatusServiceUnavailable, resp3.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, resp3.StatusCode)
 }
 
 func TestHealthCheckExtensionUsageWithCustomPathWithCheckCollectorPipeline(t *testing.T) {
@@ -301,14 +301,14 @@ func TestHealthCheckExtensionUsageWithCustomPathWithCheckCollectorPipeline(t *te
 	require.NoError(t, hcExt.NotReady())
 	resp2, err := client.Get(url)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusServiceUnavailable, resp2.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, resp2.StatusCode)
 	require.NoError(t, resp2.Body.Close(), "Must be able to close the response")
 
 	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd2)
 	require.NoError(t, hcExt.Ready())
 	resp3, err := client.Get(url)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusServiceUnavailable, resp3.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, resp3.StatusCode)
 	require.NoError(t, resp3.Body.Close(), "Must be able to close the response")
 }
 
@@ -322,8 +322,8 @@ func TestHealthCheckExtensionUsageWithCustomStaticResponseBodyWithCheckCollector
 			Interval:                 "5m",
 			ExporterFailureThreshold: 1,
 		},
-		Path:               "/",
-		StaticResponseBody: "OK",
+		Path:         "/",
+		ResponseBody: &ResponseBodySettings{Healthy: "OK"},
 	}
 
 	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
@@ -374,7 +374,7 @@ func TestHealthCheckExtensionUsageWithCustomStaticResponseBodyWithCheckCollector
 	require.NoError(t, hcExt.NotReady())
 	resp2, err := client.Get(url)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusServiceUnavailable, resp2.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, resp2.StatusCode)
 	body2, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err)
 	require.Empty(t, body2)
@@ -384,7 +384,7 @@ func TestHealthCheckExtensionUsageWithCustomStaticResponseBodyWithCheckCollector
 	require.NoError(t, hcExt.Ready())
 	resp3, err := client.Get(url)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusServiceUnavailable, resp3.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, resp3.StatusCode)
 	require.NoError(t, resp3.Body.Close(), "Must be able to close the response")
 }
 


### PR DESCRIPTION
**Description:**
Add `esponse_body` configuration option that allows specifying a specific response body

**Link to tracking Issue:** 
Closes #18824 

**Testing:**
Added tests for both handlers (with / without check collector pipeline)

**Documentation:**
Updated README.md and added an entry in the changelog