### PR TITLE
[chore] update prepare script to run tidy and update builder config

### DIFF
--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -14,6 +14,14 @@ find . -name "*.bak" -type f -delete
 git add versions.yaml
 git commit -m "update version.yaml ${CANDIDATE_BETA}"
 
+sed -i.bak "s/${CURRENT_BETA}/${CANDIDATE_BETA}/g" ./cmd/oteltestbedcol/builder-config.yaml
+sed -i.bak "s/${CURRENT_BETA}/${CANDIDATE_BETA}/g" ./cmd/otelcontribcol/builder-config.yaml
+find . -name "*.bak" -type f -delete
+make genotelcontribcol
+make genoteltestbedcol
+git add .
+git commit -m "builder config changes ${CANDIDATE_BETA}" || (echo "no builder config changes to commit")
+
 make multimod-prerelease
 git add .
 git commit -m "make multimod-prerelease changes ${CANDIDATE_BETA}" || (echo "no multimod changes to commit")
@@ -22,6 +30,9 @@ make multimod-sync
 git add .
 git commit -m "make multimod-sync changes ${CANDIDATE_BETA}" || (echo "no multimod changes to commit")
 
+make gotidy
+git add .
+git commit -m "make gotidy changes ${CANDIDATE_BETA}" || (echo "no gotidy changes to commit")
 make otelcontribcol
 
 git push origin "${BRANCH}"


### PR DESCRIPTION
This ensures builder config files are updated as part of the pre-release PR.

Running `gotidy` as the last step as it caused issues in the last 2 releases.