### PR TITLE
[receiver/hostmetrics] Have the hostmetrics receiver file system scraper use more debug messages

### DIFF
--- a/.chloggen/enhance-hostmetrics-filesystem-log-level.yaml
+++ b/.chloggen/enhance-hostmetrics-filesystem-log-level.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Have the hostmetrics receiver file system scraper use more debug messages
+
+# One or more tracking issues related to the change
+issues: [18236]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Log a debug message instead of an error if the collector does not 
+  have the permissions to access a locked drive on the host. We do not want to 
+  log an error message on every poll for this case.

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/disk"
@@ -27,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata"
 )
@@ -84,7 +86,15 @@ func (s *scraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 		if len(partitions) == 0 {
 			return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 		}
-		errors.AddPartial(0, fmt.Errorf("failed collecting partitions information: %w", err))
+		if strings.Contains(strings.ToLower(err.Error()), "locked") {
+			// Log a debug message instead of an error message if a drive is
+			// locked and unavailable. For this particular case, we do not want
+			// to log an error message on every poll.
+			// See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18236
+			s.settings.Logger.Debug("failed collecting locked partitions information: %w", zap.Error(err))
+		} else {
+			errors.AddPartial(0, fmt.Errorf("failed collecting partitions information: %w", err))
+		}
 	}
 
 	usages := make([]*deviceUsage, 0, len(partitions))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
If a locked drive exists on a host, the file system scraper can pollute the logs with errors you can not filter out. This change makes these types of error messages go to the debug level. This was a customer ask. See related ticket for more details.

**Link to tracking Issue:**
[[receiver/hostmetrics] change the log level when filesystem fails to scrape patition #18236
](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18236)

**Testing:**
Tested manually.