### PR TITLE
[exporter/azuremonitor] Add resource attributes, instrumentation scope and cloud tags to Azure Monitor exporter for logs

### DIFF
--- a/.chloggen/fix_resource-attributes-logs.yaml
+++ b/.chloggen/fix_resource-attributes-logs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'azuremonitorexporter'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Ensure that resource attributes, instrumentation scope and cloud tags are exported to Azure Monitor for logs"
+
+# One or more tracking issues related to the change
+issues: [18525]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/azuremonitorexporter/log_to_envelope.go
+++ b/exporter/azuremonitorexporter/log_to_envelope.go
@@ -29,7 +29,7 @@ type logPacker struct {
 	logger *zap.Logger
 }
 
-func (packer *logPacker) LogRecordToEnvelope(logRecord plog.LogRecord) *contracts.Envelope {
+func (packer *logPacker) LogRecordToEnvelope(logRecord plog.LogRecord, resource pcommon.Resource, instrumentationScope pcommon.InstrumentationScope) *contracts.Envelope {
 	envelope := contracts.NewEnvelope()
 	envelope.Tags = make(map[string]string)
 	envelope.Time = toTime(timestampFromLogRecord(logRecord)).Format(time.RFC3339Nano)
@@ -51,6 +51,11 @@ func (packer *logPacker) LogRecordToEnvelope(logRecord plog.LogRecord) *contract
 	data.BaseData = messageData
 	data.BaseType = messageData.BaseType()
 	envelope.Data = data
+
+	resourceAttributes := resource.Attributes()
+	applyResourcesToDataProperties(messageData.Properties, resourceAttributes)
+	applyInstrumentationScopeValueToDataProperties(messageData.Properties, instrumentationScope)
+	applyCloudTagsToEnvelope(envelope, resourceAttributes)
 
 	packer.sanitize(func() []string { return messageData.Sanitize() })
 	packer.sanitize(func() []string { return envelope.Sanitize() })

--- a/exporter/azuremonitorexporter/logexporter.go
+++ b/exporter/azuremonitorexporter/logexporter.go
@@ -35,10 +35,12 @@ func (exporter *logExporter) onLogData(context context.Context, logData plog.Log
 
 	for i := 0; i < resourceLogs.Len(); i++ {
 		scopeLogs := resourceLogs.At(i).ScopeLogs()
+		resource := resourceLogs.At(i).Resource()
 		for j := 0; j < scopeLogs.Len(); j++ {
 			logs := scopeLogs.At(j).LogRecords()
+			scope := scopeLogs.At(j).Scope()
 			for k := 0; k < logs.Len(); k++ {
-				envelope := logPacker.LogRecordToEnvelope(logs.At(k))
+				envelope := logPacker.LogRecordToEnvelope(logs.At(k), resource, scope)
 				envelope.IKey = string(exporter.config.InstrumentationKey)
 				exporter.transportChannel.Send(envelope)
 			}

--- a/exporter/azuremonitorexporter/logexporter_test.go
+++ b/exporter/azuremonitorexporter/logexporter_test.go
@@ -83,7 +83,7 @@ func TestLogRecordToEnvelope(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logRecord := tt.logRecord
 			logPacker := getLogPacker()
-			envelope := logPacker.LogRecordToEnvelope(logRecord)
+			envelope := logPacker.LogRecordToEnvelope(logRecord, getResource(), getScope())
 
 			require.NotNil(t, envelope)
 			assert.Equal(t, defaultEnvelopeName, envelope.Name)


### PR DESCRIPTION
**Description:**

Fixes #18525

The Azure Monitor exporter did not export [resource attributes](https://opentelemetry.io/docs/reference/specification/logs/data-model/#field-resource) and [instrumentation scope](https://opentelemetry.io/docs/reference/specification/logs/data-model/#field-instrumentationscope) as `customDimensions` to Application Insights. To achieve more parity with respect to how traces and metrics are exported, this PR also applies cloud tags by invoking `applyCloudTagsToEnvelope` to the log records.

**Link to tracking Issue:** #18525

**Testing:** Manual testing with Application Insights, automated testing through unit tests.

**Documentation:** No documentation added