### PR TITLE
[receiver/k8sobjects] Allow resource filter on pull mode

### DIFF
--- a/.chloggen/k8sobjectsreceiver-enabling-resource-version-pull.yaml
+++ b/.chloggen/k8sobjectsreceiver-enabling-resource-version-pull.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sobjectsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enabling resource version filter on pull mode
+
+# One or more tracking issues related to the change
+issues: [18828]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/k8sobjectsreceiver/config.go
+++ b/receiver/k8sobjectsreceiver/config.go
@@ -98,10 +98,6 @@ func (c *Config) Validate() error {
 			object.Interval = defaultPullInterval
 		}
 
-		if object.Mode == PullMode && object.ResourceVersion != "" {
-			return fmt.Errorf("resource version is invalid for mode: %v", object.Mode)
-		}
-
 		if object.Mode == WatchMode && object.ResourceVersion == "" {
 			object.ResourceVersion = defaultResourceVersion
 		}

--- a/receiver/k8sobjectsreceiver/config_test.go
+++ b/receiver/k8sobjectsreceiver/config_test.go
@@ -132,10 +132,10 @@ func TestValidateResourceConflict(t *testing.T) {
 	assert.Equal(t, "group2", rCfg.Objects[0].gvr.Group)
 }
 
-func TestInvalidPullConfig(t *testing.T) {
+func TestPullResourceVersion(t *testing.T) {
 	t.Parallel()
 
-	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "invalid_pull_config.yaml"))
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "pull_resource_version_config.yaml"))
 	require.NoError(t, err)
 
 	factory := NewFactory()
@@ -149,11 +149,8 @@ func TestInvalidPullConfig(t *testing.T) {
 	err = component.ValidateConfig(cfg)
 	require.Error(t, err)
 
-	cfg.makeDiscoveryClient = getMockDiscoveryClient
-
-	err = component.ValidateConfig(cfg)
-	require.Error(t, err)
-	require.Equal(t, err.Error(), "resource version is invalid for mode: pull")
+	require.Equal(t, "1", cfg.Objects[0].ResourceVersion)
+	require.Equal(t, "", cfg.Objects[1].ResourceVersion)
 }
 
 func TestWatchResourceVersion(t *testing.T) {

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -117,14 +117,21 @@ func (kr *k8sobjectsreceiver) startPull(ctx context.Context, config *K8sObjectsC
 	kr.stopperChanList = append(kr.stopperChanList, stopperChan)
 	kr.mu.Unlock()
 	ticker := NewTicker(config.Interval)
+	listOption := metav1.ListOptions{
+		FieldSelector: config.FieldSelector,
+		LabelSelector: config.LabelSelector,
+	}
+
+	if config.ResourceVersion != "" {
+		listOption.ResourceVersion = config.ResourceVersion
+		listOption.ResourceVersionMatch = metav1.ResourceVersionMatchExact
+	}
+
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			objects, err := resource.List(ctx, metav1.ListOptions{
-				FieldSelector: config.FieldSelector,
-				LabelSelector: config.LabelSelector,
-			})
+			objects, err := resource.List(ctx, listOption)
 			if err != nil {
 				kr.setting.Logger.Error("error in pulling object", zap.String("resource", config.gvr.String()), zap.Error(err))
 			} else if len(objects.Items) > 0 {

--- a/receiver/k8sobjectsreceiver/testdata/pull_resource_version_config.yaml
+++ b/receiver/k8sobjectsreceiver/testdata/pull_resource_version_config.yaml
@@ -3,4 +3,6 @@ k8sobjects:
     - name: pods
       mode: pull
       resource_version: "1"
+    - name: events
+      mode: pull
     


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As discussed [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18828#discussion_r1113963014) I'm adding support to the resource version filter on pull mode.
**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Filtering not older resources than the specified 

**Documentation:** N/A