### PR TITLE
[pkg/pdatautil] Fixed panic in nested map hashing

### DIFF
--- a/.chloggen/pdatautil-map-hash-panic.yaml
+++ b/.chloggen/pdatautil-map-hash-panic.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/pdatautil
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a potential panic that could occur while hashing nested maps.
+
+# One or more tracking issues related to the change
+issues: [18910]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/pdatautil/hash.go
+++ b/pkg/pdatautil/hash.go
@@ -86,6 +86,8 @@ func (hw *hashWriter) writeMapHash(m pcommon.Map) {
 	// For each recursive call into this function we want to preserve the previous buffer state
 	// while also adding new keys to the buffer. nextIndex is the index of the first new key
 	// added to the buffer for this call of the function.
+	// This also works for the first non-recursive call of this function because the buffer is always empty
+	// on the first call due to it being cleared of any added keys at then end of the function.
 	nextIndex := len(hw.keysBuf)
 
 	m.Range(func(k string, v pcommon.Value) bool {

--- a/pkg/pdatautil/hash.go
+++ b/pkg/pdatautil/hash.go
@@ -44,7 +44,6 @@ var (
 type hashWriter struct {
 	h       hash.Hash
 	strBuf  []byte
-	keysBuf []string
 	sumHash []byte
 	numBuf  []byte
 }
@@ -53,7 +52,6 @@ func newHashWriter() *hashWriter {
 	return &hashWriter{
 		h:       xxhash.New(),
 		strBuf:  make([]byte, 0, 128),
-		keysBuf: make([]string, 0, 16),
 		sumHash: make([]byte, 0, 16),
 		numBuf:  make([]byte, 8),
 	}
@@ -83,13 +81,13 @@ func ValueHash(v pcommon.Value) [16]byte {
 }
 
 func (hw *hashWriter) writeMapHash(m pcommon.Map) {
-	hw.keysBuf = hw.keysBuf[:0]
+	keysBuf := make([]string, 0, m.Len())
 	m.Range(func(k string, v pcommon.Value) bool {
-		hw.keysBuf = append(hw.keysBuf, k)
+		keysBuf = append(keysBuf, k)
 		return true
 	})
-	sort.Strings(hw.keysBuf)
-	for _, k := range hw.keysBuf {
+	sort.Strings(keysBuf)
+	for _, k := range keysBuf {
 		v, _ := m.Get(k)
 		hw.strBuf = hw.strBuf[:0]
 		hw.strBuf = append(hw.strBuf, keyPrefix...)

--- a/pkg/pdatautil/hash_test.go
+++ b/pkg/pdatautil/hash_test.go
@@ -137,7 +137,7 @@ func TestMapHash(t *testing.T) {
 }
 
 // TestMapHashPanic tests a very specific case where a panic can occur with nested maps.
-// Outline in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18910
+// Outlined in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18910
 func TestMapHashPanic(t *testing.T) {
 	m := pcommon.NewMap()
 	m.PutInt("a", 1)
@@ -148,7 +148,7 @@ func TestMapHashPanic(t *testing.T) {
 	// nestedMap is alphabetically second in parent map
 	nestedMap := m.PutEmptyMap("b")
 
-	// nestedMap is index 1 in parent when keys are sorted so we need at least 3 keys in this to ensure the next iteration of parent tries to find a key at "a3"
+	// nestedMap is at index 1 in parent when keys are sorted so we need at least 3 keys in this to ensure the next iteration of parent tries to find a key at "a3"
 	nestedMap.PutInt("a1", 1)
 	nestedMap.PutInt("a2", 1)
 	nestedMap.PutInt("a3", 1)


### PR DESCRIPTION
**Description:**
Fixes #18910

Changed how the `keysBuf` works so that nested maps will append their keys to the buffer for that recursion then they will be removed before the recursion exist.  This allows keeping a single buffer while also protecting ensure recursion doesn't pollute the buffer order.

**Link to tracking Issue:** #18910

**Testing:** Added a unit test that could replicate the panic in the old code.